### PR TITLE
Fixed compiler warning in transfer tests. Updated minimum g++ version…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This SDK has been specifically designed with game dev in mind, but we have also 
 #####Visual Studio
 Visual Studio 2013 (However, if you want default move constructors/operators, this version will not provide them). Later versions of Visual Studio provide a more standards compliant compiler.
 #####GCC
-GCC versions >= GCC 4.8.1
+GCC versions >= GCC 4.9.0
 #####Clang
 Clang versions >= 3.3
 

--- a/aws-cpp-sdk-transfer-tests/TransferTests.cpp
+++ b/aws-cpp-sdk-transfer-tests/TransferTests.cpp
@@ -131,7 +131,7 @@ protected:
         const unsigned cNumExtraChars = 5;
         const unsigned cLettersToRandomize = 26;
         randomizedBucketName = TEST_BUCKET_NAME_BASE;
-        for (auto i = 0; i < cNumExtraChars; ++i)
+        for (unsigned i = 0; i < cNumExtraChars; ++i)
         {
             randomizedBucketName += static_cast<char>('a' + rand() % cLettersToRandomize);
         }


### PR DESCRIPTION
…, due to regex not being fully implemented in 4.8.x.
