### PR TITLE
Back off the aggressive cmake version requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 #
 
-cmake_minimum_required (VERSION 3.2.3)
+cmake_minimum_required (VERSION 2.8)
 
 # Cmake invocation variables:
 #   CUSTOM_MEMORY_MANAGEMENT - if set to 1, generates the sdk project files with custom memory management enabled, otherwise disables it


### PR DESCRIPTION
The CMakeLists.txt file requires a very recent version of CMake. This is fine on Windows and Mac, but most linux distros are multiple revisions behind the specified version. For example, Ubuntu 14.04 LTS distributes CMake 2.8. Although it is possible to install a newer version of CMake there, there is really no benefit to doing so; nothing in our cmake files appears to need the newer build tool. The build files created by older cmakes work flawlessly for me on Linux.

One caveat with this pull request is that I have only tested the resulting build on Ubuntu 14. If we truly need a newer version of CMake on other platforms, my change might break something.