### PR TITLE
Changed the type of SQS message's attribute

### DIFF
--- a/aws-cpp-sdk-sqs/include/aws/sqs/model/Message.h
+++ b/aws-cpp-sdk-sqs/include/aws/sqs/model/Message.h
@@ -17,7 +17,6 @@
 #include <aws/core/utils/memory/stl/AWSStreamFwd.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/utils/memory/stl/AWSMap.h>
-#include <aws/sqs/model/QueueAttributeName.h>
 #include <aws/sqs/model/MessageAttributeValue.h>
 
 namespace Aws
@@ -189,57 +188,57 @@ namespace Model
     /*
      <p><code>SenderId</code>, <code>SentTimestamp</code>, <code>ApproximateReceiveCount</code>, and/or <code>ApproximateFirstReceiveTimestamp</code>. <code>SentTimestamp</code> and <code>ApproximateFirstReceiveTimestamp</code> are each returned as an integer representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a> in milliseconds.</p>
     */
-    inline const Aws::Map<QueueAttributeName, Aws::String>& GetAttributes() const{ return m_attributes; }
+    inline const Aws::Map<Aws::String, Aws::String>& GetAttributes() const{ return m_attributes; }
 
     /*
      <p><code>SenderId</code>, <code>SentTimestamp</code>, <code>ApproximateReceiveCount</code>, and/or <code>ApproximateFirstReceiveTimestamp</code>. <code>SentTimestamp</code> and <code>ApproximateFirstReceiveTimestamp</code> are each returned as an integer representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a> in milliseconds.</p>
     */
-    inline void SetAttributes(const Aws::Map<QueueAttributeName, Aws::String>& value) { m_attributesHasBeenSet = true; m_attributes = value; }
+    inline void SetAttributes(const Aws::Map<Aws::String, Aws::String>& value) { m_attributesHasBeenSet = true; m_attributes = value; }
 
     /*
      <p><code>SenderId</code>, <code>SentTimestamp</code>, <code>ApproximateReceiveCount</code>, and/or <code>ApproximateFirstReceiveTimestamp</code>. <code>SentTimestamp</code> and <code>ApproximateFirstReceiveTimestamp</code> are each returned as an integer representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a> in milliseconds.</p>
     */
-    inline void SetAttributes(Aws::Map<QueueAttributeName, Aws::String>&& value) { m_attributesHasBeenSet = true; m_attributes = value; }
+    inline void SetAttributes(Aws::Map<Aws::String, Aws::String>&& value) { m_attributesHasBeenSet = true; m_attributes = value; }
 
     /*
      <p><code>SenderId</code>, <code>SentTimestamp</code>, <code>ApproximateReceiveCount</code>, and/or <code>ApproximateFirstReceiveTimestamp</code>. <code>SentTimestamp</code> and <code>ApproximateFirstReceiveTimestamp</code> are each returned as an integer representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a> in milliseconds.</p>
     */
-    inline Message& WithAttributes(const Aws::Map<QueueAttributeName, Aws::String>& value) { SetAttributes(value); return *this;}
+    inline Message& WithAttributes(const Aws::Map<Aws::String, Aws::String>& value) { SetAttributes(value); return *this;}
 
     /*
      <p><code>SenderId</code>, <code>SentTimestamp</code>, <code>ApproximateReceiveCount</code>, and/or <code>ApproximateFirstReceiveTimestamp</code>. <code>SentTimestamp</code> and <code>ApproximateFirstReceiveTimestamp</code> are each returned as an integer representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a> in milliseconds.</p>
     */
-    inline Message& WithAttributes(Aws::Map<QueueAttributeName, Aws::String>&& value) { SetAttributes(value); return *this;}
+    inline Message& WithAttributes(Aws::Map<Aws::String, Aws::String>&& value) { SetAttributes(value); return *this;}
 
     /*
      <p><code>SenderId</code>, <code>SentTimestamp</code>, <code>ApproximateReceiveCount</code>, and/or <code>ApproximateFirstReceiveTimestamp</code>. <code>SentTimestamp</code> and <code>ApproximateFirstReceiveTimestamp</code> are each returned as an integer representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a> in milliseconds.</p>
     */
-    inline Message& AddAttributes(const QueueAttributeName& key, const Aws::String& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
+    inline Message& AddAttributes(const Aws::String& key, const Aws::String& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
 
     /*
      <p><code>SenderId</code>, <code>SentTimestamp</code>, <code>ApproximateReceiveCount</code>, and/or <code>ApproximateFirstReceiveTimestamp</code>. <code>SentTimestamp</code> and <code>ApproximateFirstReceiveTimestamp</code> are each returned as an integer representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a> in milliseconds.</p>
     */
-    inline Message& AddAttributes(QueueAttributeName&& key, const Aws::String& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
+    inline Message& AddAttributes(Aws::String&& key, const Aws::String& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
 
     /*
      <p><code>SenderId</code>, <code>SentTimestamp</code>, <code>ApproximateReceiveCount</code>, and/or <code>ApproximateFirstReceiveTimestamp</code>. <code>SentTimestamp</code> and <code>ApproximateFirstReceiveTimestamp</code> are each returned as an integer representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a> in milliseconds.</p>
     */
-    inline Message& AddAttributes(const QueueAttributeName& key, Aws::String&& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
+    inline Message& AddAttributes(const Aws::String& key, Aws::String&& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
 
     /*
      <p><code>SenderId</code>, <code>SentTimestamp</code>, <code>ApproximateReceiveCount</code>, and/or <code>ApproximateFirstReceiveTimestamp</code>. <code>SentTimestamp</code> and <code>ApproximateFirstReceiveTimestamp</code> are each returned as an integer representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a> in milliseconds.</p>
     */
-    inline Message& AddAttributes(QueueAttributeName&& key, Aws::String&& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
+    inline Message& AddAttributes(Aws::String&& key, Aws::String&& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
 
     /*
      <p><code>SenderId</code>, <code>SentTimestamp</code>, <code>ApproximateReceiveCount</code>, and/or <code>ApproximateFirstReceiveTimestamp</code>. <code>SentTimestamp</code> and <code>ApproximateFirstReceiveTimestamp</code> are each returned as an integer representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a> in milliseconds.</p>
     */
-    inline Message& AddAttributes(QueueAttributeName&& key, const char* value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
+    inline Message& AddAttributes(Aws::String&& key, const char* value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
 
     /*
      <p><code>SenderId</code>, <code>SentTimestamp</code>, <code>ApproximateReceiveCount</code>, and/or <code>ApproximateFirstReceiveTimestamp</code>. <code>SentTimestamp</code> and <code>ApproximateFirstReceiveTimestamp</code> are each returned as an integer representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a> in milliseconds.</p>
     */
-    inline Message& AddAttributes(const QueueAttributeName& key, const char* value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
+    inline Message& AddAttributes(const Aws::String& key, const char* value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
 
     /*
      <p>An MD5 digest of the non-URL-encoded message attribute string. This can be used to verify that Amazon SQS received the message correctly. Amazon SQS first URL decodes the message before creating the MD5 digest. For information about MD5, go to <a href="http://www.faqs.org/rfcs/rfc1321.html">http://www.faqs.org/rfcs/rfc1321.html</a>.</p>
@@ -340,7 +339,7 @@ namespace Model
     bool m_mD5OfBodyHasBeenSet;
     Aws::String m_body;
     bool m_bodyHasBeenSet;
-    Aws::Map<QueueAttributeName, Aws::String> m_attributes;
+    Aws::Map<Aws::String, Aws::String> m_attributes;
     bool m_attributesHasBeenSet;
     Aws::String m_mD5OfMessageAttributes;
     bool m_mD5OfMessageAttributesHasBeenSet;

--- a/aws-cpp-sdk-sqs/include/aws/sqs/model/ReceiveMessageRequest.h
+++ b/aws-cpp-sdk-sqs/include/aws/sqs/model/ReceiveMessageRequest.h
@@ -17,7 +17,6 @@
 #include <aws/sqs/SQSRequest.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/utils/memory/stl/AWSVector.h>
-#include <aws/sqs/model/QueueAttributeName.h>
 
 namespace Aws
 {
@@ -73,37 +72,37 @@ namespace Model
     /*
      <p>A list of attributes that need to be returned along with each message. </p> <p> The following lists the names and descriptions of the attributes that can be returned: </p> <ul> <li> <code>All</code> - returns all values.</li> <li> <code>ApproximateFirstReceiveTimestamp</code> - returns the time when the message was first received from the queue (epoch time in milliseconds).</li> <li> <code>ApproximateReceiveCount</code> - returns the number of times a message has been received from the queue but not deleted.</li> <li> <code>SenderId</code> - returns the AWS account number (or the IP address, if anonymous access is allowed) of the sender.</li> <li> <code>SentTimestamp</code> - returns the time when the message was sent to the queue (epoch time in milliseconds).</li> </ul>
     */
-    inline const Aws::Vector<QueueAttributeName>& GetAttributeNames() const{ return m_attributeNames; }
+    inline const Aws::Vector<Aws::String>& GetAttributeNames() const{ return m_attributeNames; }
 
     /*
      <p>A list of attributes that need to be returned along with each message. </p> <p> The following lists the names and descriptions of the attributes that can be returned: </p> <ul> <li> <code>All</code> - returns all values.</li> <li> <code>ApproximateFirstReceiveTimestamp</code> - returns the time when the message was first received from the queue (epoch time in milliseconds).</li> <li> <code>ApproximateReceiveCount</code> - returns the number of times a message has been received from the queue but not deleted.</li> <li> <code>SenderId</code> - returns the AWS account number (or the IP address, if anonymous access is allowed) of the sender.</li> <li> <code>SentTimestamp</code> - returns the time when the message was sent to the queue (epoch time in milliseconds).</li> </ul>
     */
-    inline void SetAttributeNames(const Aws::Vector<QueueAttributeName>& value) { m_attributeNamesHasBeenSet = true; m_attributeNames = value; }
+    inline void SetAttributeNames(const Aws::Vector<Aws::String>& value) { m_attributeNamesHasBeenSet = true; m_attributeNames = value; }
 
     /*
      <p>A list of attributes that need to be returned along with each message. </p> <p> The following lists the names and descriptions of the attributes that can be returned: </p> <ul> <li> <code>All</code> - returns all values.</li> <li> <code>ApproximateFirstReceiveTimestamp</code> - returns the time when the message was first received from the queue (epoch time in milliseconds).</li> <li> <code>ApproximateReceiveCount</code> - returns the number of times a message has been received from the queue but not deleted.</li> <li> <code>SenderId</code> - returns the AWS account number (or the IP address, if anonymous access is allowed) of the sender.</li> <li> <code>SentTimestamp</code> - returns the time when the message was sent to the queue (epoch time in milliseconds).</li> </ul>
     */
-    inline void SetAttributeNames(Aws::Vector<QueueAttributeName>&& value) { m_attributeNamesHasBeenSet = true; m_attributeNames = value; }
+    inline void SetAttributeNames(Aws::Vector<Aws::String>&& value) { m_attributeNamesHasBeenSet = true; m_attributeNames = value; }
 
     /*
      <p>A list of attributes that need to be returned along with each message. </p> <p> The following lists the names and descriptions of the attributes that can be returned: </p> <ul> <li> <code>All</code> - returns all values.</li> <li> <code>ApproximateFirstReceiveTimestamp</code> - returns the time when the message was first received from the queue (epoch time in milliseconds).</li> <li> <code>ApproximateReceiveCount</code> - returns the number of times a message has been received from the queue but not deleted.</li> <li> <code>SenderId</code> - returns the AWS account number (or the IP address, if anonymous access is allowed) of the sender.</li> <li> <code>SentTimestamp</code> - returns the time when the message was sent to the queue (epoch time in milliseconds).</li> </ul>
     */
-    inline ReceiveMessageRequest& WithAttributeNames(const Aws::Vector<QueueAttributeName>& value) { SetAttributeNames(value); return *this;}
+    inline ReceiveMessageRequest& WithAttributeNames(const Aws::Vector<Aws::String>& value) { SetAttributeNames(value); return *this;}
 
     /*
      <p>A list of attributes that need to be returned along with each message. </p> <p> The following lists the names and descriptions of the attributes that can be returned: </p> <ul> <li> <code>All</code> - returns all values.</li> <li> <code>ApproximateFirstReceiveTimestamp</code> - returns the time when the message was first received from the queue (epoch time in milliseconds).</li> <li> <code>ApproximateReceiveCount</code> - returns the number of times a message has been received from the queue but not deleted.</li> <li> <code>SenderId</code> - returns the AWS account number (or the IP address, if anonymous access is allowed) of the sender.</li> <li> <code>SentTimestamp</code> - returns the time when the message was sent to the queue (epoch time in milliseconds).</li> </ul>
     */
-    inline ReceiveMessageRequest& WithAttributeNames(Aws::Vector<QueueAttributeName>&& value) { SetAttributeNames(value); return *this;}
+    inline ReceiveMessageRequest& WithAttributeNames(Aws::Vector<Aws::String>&& value) { SetAttributeNames(value); return *this;}
 
     /*
      <p>A list of attributes that need to be returned along with each message. </p> <p> The following lists the names and descriptions of the attributes that can be returned: </p> <ul> <li> <code>All</code> - returns all values.</li> <li> <code>ApproximateFirstReceiveTimestamp</code> - returns the time when the message was first received from the queue (epoch time in milliseconds).</li> <li> <code>ApproximateReceiveCount</code> - returns the number of times a message has been received from the queue but not deleted.</li> <li> <code>SenderId</code> - returns the AWS account number (or the IP address, if anonymous access is allowed) of the sender.</li> <li> <code>SentTimestamp</code> - returns the time when the message was sent to the queue (epoch time in milliseconds).</li> </ul>
     */
-    inline ReceiveMessageRequest& AddAttributeNames(const QueueAttributeName& value) { m_attributeNamesHasBeenSet = true; m_attributeNames.push_back(value); return *this; }
+    inline ReceiveMessageRequest& AddAttributeNames(const Aws::String& value) { m_attributeNamesHasBeenSet = true; m_attributeNames.push_back(value); return *this; }
 
     /*
      <p>A list of attributes that need to be returned along with each message. </p> <p> The following lists the names and descriptions of the attributes that can be returned: </p> <ul> <li> <code>All</code> - returns all values.</li> <li> <code>ApproximateFirstReceiveTimestamp</code> - returns the time when the message was first received from the queue (epoch time in milliseconds).</li> <li> <code>ApproximateReceiveCount</code> - returns the number of times a message has been received from the queue but not deleted.</li> <li> <code>SenderId</code> - returns the AWS account number (or the IP address, if anonymous access is allowed) of the sender.</li> <li> <code>SentTimestamp</code> - returns the time when the message was sent to the queue (epoch time in milliseconds).</li> </ul>
     */
-    inline ReceiveMessageRequest& AddAttributeNames(QueueAttributeName&& value) { m_attributeNamesHasBeenSet = true; m_attributeNames.push_back(value); return *this; }
+    inline ReceiveMessageRequest& AddAttributeNames(Aws::String&& value) { m_attributeNamesHasBeenSet = true; m_attributeNames.push_back(value); return *this; }
 
     /*
      <p>The name of the message attribute, where <i>N</i> is the index. The message attribute name can contain the following characters: A-Z, a-z, 0-9, underscore (_), hyphen (-), and period (.). The name must not start or end with a period, and it should not have successive periods. The name is case sensitive and must be unique among all attribute names for the message. The name can be up to 256 characters long. The name cannot start with "AWS." or "Amazon." (or any variations in casing), because these prefixes are reserved for use by Amazon Web Services.</p> <p>When using <code>ReceiveMessage</code>, you can send a list of attribute names to receive, or you can return all of the attributes by specifying "All" or ".*" in your request. You can also use "foo.*" to return all message attributes starting with the "foo" prefix.</p>
@@ -193,7 +192,7 @@ namespace Model
   private:
     Aws::String m_queueUrl;
     bool m_queueUrlHasBeenSet;
-    Aws::Vector<QueueAttributeName> m_attributeNames;
+    Aws::Vector<Aws::String> m_attributeNames;
     bool m_attributeNamesHasBeenSet;
     Aws::Vector<Aws::String> m_messageAttributeNames;
     bool m_messageAttributeNamesHasBeenSet;

--- a/aws-cpp-sdk-sqs/source/model/Message.cpp
+++ b/aws-cpp-sdk-sqs/source/model/Message.cpp
@@ -84,8 +84,7 @@ Message& Message::operator =(const XmlNode& xmlNode)
       {
         XmlNode keyNode = attributeEntry.FirstChild("Name");
         XmlNode valueNode = attributeEntry.FirstChild("Value");
-        m_attributes[QueueAttributeNameMapper::GetQueueAttributeNameForName(StringUtils::Trim(keyNode.GetText().c_str()))] =
-            StringUtils::Trim(valueNode.GetText().c_str());
+        m_attributes[StringUtils::Trim(keyNode.GetText().c_str())] = StringUtils::Trim(valueNode.GetText().c_str());
         attributeEntry = attributeEntry.NextNode("Attribute");
       }
 

--- a/aws-cpp-sdk-sqs/source/model/ReceiveMessageRequest.cpp
+++ b/aws-cpp-sdk-sqs/source/model/ReceiveMessageRequest.cpp
@@ -46,7 +46,7 @@ Aws::String ReceiveMessageRequest::SerializePayload() const
     for(auto& item : m_attributeNames)
     {
       ss << "AttributeName." << attributeNamesCount << "="
-          << StringUtils::URLEncode(QueueAttributeNameMapper::GetNameForQueueAttributeName(item).c_str()) << "&";
+          << StringUtils::URLEncode(item.c_str()) << "&";
       attributeNamesCount++;
     }
   }


### PR DESCRIPTION
According to the AWS library of Java, SQS message's attributes should be String.
http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/sqs/model/Message.html
For example, I cant' get "ApproximateReceiveCount" by the current implementation.