### PR TITLE
AWS_SECRET_KEY_ID -> AWS_SECRET_ACCESS_KEY

### DIFF
--- a/aws-cpp-sdk-core-tests/aws/auth/AWSCredentialsProviderTest.cpp
+++ b/aws-cpp-sdk-core-tests/aws/auth/AWSCredentialsProviderTest.cpp
@@ -229,10 +229,10 @@ TEST(ProfileConfigFileAWSCredentialsProviderTest, TestNotSetup)
     Aws::String oldProfileFile = GetEnv("AWS_CREDENTIAL_PROFILES_FILE");  
     Aws::String oldProfileValue = GetEnv("AWS_DEFAULT_PROFILE");
     Aws::String oldAWSAccessKeyValue = GetEnv("AWS_ACCESS_KEY_ID");
-    Aws::String oldSecretKeyValue = GetEnv("AWS_SECRET_KEY_ID");
+    Aws::String oldSecretKeyValue = GetEnv("AWS_SECRET_ACCESS_KEY");
 
     unsetenv("AWS_ACCESS_KEY_ID");
-    unsetenv("AWS_SECRET_KEY_ID");
+    unsetenv("AWS_SECRET_ACCESS_KEY");
     unsetenv("AWS_CREDENTIAL_PROFILES_FILE");
 
     ProfileConfigFileAWSCredentialsProvider provider;
@@ -243,7 +243,7 @@ TEST(ProfileConfigFileAWSCredentialsProviderTest, TestNotSetup)
     if (!oldAWSAccessKeyValue.empty())
         setenv("AWS_ACCESS_KEY_ID", oldAWSAccessKeyValue.c_str(), 1);
     if (!oldSecretKeyValue.empty())
-        setenv("AWS_SECRET_KEY_ID", oldSecretKeyValue.c_str(), 1);
+        setenv("AWS_SECRET_ACCESS_KEY", oldSecretKeyValue.c_str(), 1);
 
     ASSERT_STREQ("", provider.GetAWSCredentials().GetAWSAccessKeyId().c_str());
     ASSERT_STREQ("", provider.GetAWSCredentials().GetAWSSecretKey().c_str());
@@ -276,7 +276,7 @@ TEST(EnvironmentAWSCredentialsProviderTest, TestEnvironmentVariablesDoNotExist)
     AWS_BEGIN_MEMORY_TEST(16, 10)
 
     unsetenv("AWS_ACCESS_KEY_ID");
-    unsetenv("AWS_SECRET_KEY_ID");
+    unsetenv("AWS_SECRET_ACCESS_KEY");
 
     EnvironmentAWSCredentialsProvider provider;
     ASSERT_EQ("", provider.GetAWSCredentials().GetAWSAccessKeyId());

--- a/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProvider.h
+++ b/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProvider.h
@@ -153,7 +153,7 @@ namespace Aws
         };
 
 /**
-* Reads AWS credentials from the Environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_KEY_ID if they exist. If they
+* Reads AWS credentials from the Environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY if they exist. If they
 * are not found, empty credentials are returned.
 */
         class AWS_CORE_API EnvironmentAWSCredentialsProvider : public AWSCredentialsProvider


### PR DESCRIPTION
A comment in AWSCredentialsProvider.h and a few tests reference
$AWS_SECRET_KEY_ID, which should be $AWS_SECRET_ACCESS_KEY.