### PR TITLE
Avoid warning as error for always true comparison on g++ 4.9.3

### DIFF
--- a/aws-cpp-sdk-core/source/utils/StringUtils.cpp
+++ b/aws-cpp-sdk-core/source/utils/StringUtils.cpp
@@ -122,12 +122,12 @@ Aws::String StringUtils::URLEncode(const char* unsafe)
     size_t unsafeLength = strlen(unsafe);
     for (auto i = unsafe, n = unsafe + unsafeLength; i != n; ++i)
     {
-        char c = *i;
+        int c = *i;
 		//MSVC 2015 has an assertion that c is positive in isalnum(). This breaks unicode support.
 		//bypass that with the first check.
         if (c >= 0 && (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~'))
         {
-            escaped << c;
+            escaped << (char)c;
         }
         else
         {


### PR DESCRIPTION
On platforms where char is unsigned, the expression (c >= 0)
will always be true and will fail to compile when -Werror
is specified.

Signed-off-by: Clark Rawlins <clark@bit63.org>