### PR TITLE
Aws::Ec2::model::Snapshot: m_startTime double -> Aws::String

### DIFF
--- a/aws-cpp-sdk-ec2/include/aws/ec2/model/Snapshot.h
+++ b/aws-cpp-sdk-ec2/include/aws/ec2/model/Snapshot.h
@@ -216,17 +216,17 @@ namespace Model
     /**
      * <p>The time stamp when the snapshot was initiated.</p>
      */
-    inline double GetStartTime() const{ return m_startTime; }
+    inline const Aws::String& GetStartTime() const{ return m_startTime; }
 
     /**
      * <p>The time stamp when the snapshot was initiated.</p>
      */
-    inline void SetStartTime(double value) { m_startTimeHasBeenSet = true; m_startTime = value; }
+    inline void SetStartTime(const Aws::String& value) { m_startTimeHasBeenSet = true; m_startTime = value; }
 
     /**
      * <p>The time stamp when the snapshot was initiated.</p>
      */
-    inline Snapshot& WithStartTime(double value) { SetStartTime(value); return *this;}
+    inline Snapshot& WithStartTime(const Aws::String& value) { SetStartTime(value); return *this;}
 
     /**
      * <p>The progress of the snapshot, as a percentage.</p>
@@ -590,7 +590,7 @@ namespace Model
     bool m_stateHasBeenSet;
     Aws::String m_stateMessage;
     bool m_stateMessageHasBeenSet;
-    double m_startTime;
+    Aws::String m_startTime;
     bool m_startTimeHasBeenSet;
     Aws::String m_progress;
     bool m_progressHasBeenSet;

--- a/aws-cpp-sdk-ec2/source/model/Snapshot.cpp
+++ b/aws-cpp-sdk-ec2/source/model/Snapshot.cpp
@@ -28,7 +28,6 @@ Snapshot::Snapshot() :
     m_volumeIdHasBeenSet(false),
     m_stateHasBeenSet(false),
     m_stateMessageHasBeenSet(false),
-    m_startTime(0.0),
     m_startTimeHasBeenSet(false),
     m_progressHasBeenSet(false),
     m_ownerIdHasBeenSet(false),
@@ -50,7 +49,6 @@ Snapshot::Snapshot(const XmlNode& xmlNode) :
     m_volumeIdHasBeenSet(false),
     m_stateHasBeenSet(false),
     m_stateMessageHasBeenSet(false),
-    m_startTime(0.0),
     m_startTimeHasBeenSet(false),
     m_progressHasBeenSet(false),
     m_ownerIdHasBeenSet(false),
@@ -101,7 +99,7 @@ Snapshot& Snapshot::operator =(const XmlNode& xmlNode)
     XmlNode startTimeNode = resultNode.FirstChild("startTime");
     if(!startTimeNode.IsNull())
     {
-      m_startTime = StringUtils::ConvertToDouble(StringUtils::Trim(startTimeNode.GetText().c_str()).c_str());
+      m_startTime = StringUtils::Trim(startTimeNode.GetText().c_str()).c_str();
       m_startTimeHasBeenSet = true;
     }
     XmlNode progressNode = resultNode.FirstChild("progress");
@@ -189,7 +187,7 @@ void Snapshot::OutputToStream(Aws::OStream& oStream, const char* location, unsig
   }
   if(m_startTimeHasBeenSet)
   {
-        oStream << location << index << locationValue << ".StartTime=" << StringUtils::URLEncode(m_startTime) << "&";
+        oStream << location << index << locationValue << ".StartTime=" << StringUtils::URLEncode(m_startTime.c_str()) << "&";
   }
   if(m_progressHasBeenSet)
   {
@@ -261,7 +259,7 @@ void Snapshot::OutputToStream(Aws::OStream& oStream, const char* location) const
   }
   if(m_startTimeHasBeenSet)
   {
-        oStream << location << ".StartTime=" << StringUtils::URLEncode(m_startTime) << "&";
+        oStream << location << ".StartTime=" << StringUtils::URLEncode(m_startTime.c_str()) << "&";
   }
   if(m_progressHasBeenSet)
   {


### PR DESCRIPTION
Hi!

Regarding #135, I patched Snapshot handling startTime as string instead of double.

I think, there is a general bug in handling timestamps within the sdk.

The string conversion to double produces wrong results.

I see three possible solutions for timestamp attributes:

1. Work with the raw string data instead of doubles (an example is this pull request)
2. Convert them to a correct double representation.
3. Convert them to std::time_t or a custom Aws::TimeStamp type 

BR, max