### PR TITLE
Use explicit Aws::Map constructor in UploadFileRequest constructor

### DIFF
--- a/aws-cpp-sdk-transfer/source/transfer/UploadFileRequest.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/UploadFileRequest.cpp
@@ -114,7 +114,7 @@ UploadFileRequest::UploadFileRequest(const Aws::String& fileName,
                                      const std::shared_ptr<Aws::S3::S3Client>& s3Client,
                                      bool createBucket,
                                      bool doConsistencyChecks) :
-UploadFileRequest(fileName, bucketName, keyName, contentType, {}, s3Client, createBucket, doConsistencyChecks)
+UploadFileRequest(fileName, bucketName, keyName, contentType, Aws::Map<Aws::String, Aws::String>{}, s3Client, createBucket, doConsistencyChecks)
 {
 }
 


### PR DESCRIPTION
Fixes the following error when building on Mac <= 10.10, Clang <= 6.0 (issue #141)
```
[ 90%] Building CXX object aws-cpp-sdk-transfer/CMakeFiles/aws-cpp-sdk-transfer.dir/source/transfer/UploadFileRequest.cpp.o
/Users/zwass/aws-sdk-cpp/aws-cpp-sdk-transfer/source/transfer/UploadFileRequest.cpp:117:63: error: 
      chosen constructor is explicit in copy-initialization
UploadFileRequest(fileName, bucketName, keyName, contentType, {}, s3Client, cr...
                                                              ^~
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/map:838:14: note: 
      constructor declared here
    explicit map(const key_compare& __comp = key_compare())
             ^
/Users/zwass/aws-sdk-cpp/aws-cpp-sdk-transfer/source/transfer/UploadFileRequest.cpp:58:75: note: 
      passing argument to parameter 'metadata' here
                                     Aws::Map<Aws::String, Aws::String>&& metadata,
                                                                          ^
1 error generated.
```