### PR TITLE
Modeling SQS message default attributes

### DIFF
--- a/aws-cpp-sdk-sqs/include/aws/sqs/model/AttributeName.h
+++ b/aws-cpp-sdk-sqs/include/aws/sqs/model/AttributeName.h
@@ -1,0 +1,42 @@
+/*
+* Copyright 2010-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+#pragma once
+#include <aws/sqs/SQS_EXPORTS.h>
+#include <aws/core/utils/memory/stl/AWSString.h>
+
+namespace Aws
+{
+namespace SQS
+{
+namespace Model
+{
+  enum class AttributeName
+  {
+    NOT_SET,
+    ApproximateFirstReceiveTimestamp,
+    ApproximateReceiveCount,
+    SenderId,
+    SentTimestamp
+  };
+
+namespace AttributeNameMapper
+{
+AWS_SQS_API AttributeName GetAttributeNameForName(const Aws::String& name);
+
+AWS_SQS_API Aws::String GetNameForAttributeName(AttributeName value);
+} // namespace AttributeNameMapper
+} // namespace Model
+} // namespace SQS
+} // namespace Aws

--- a/aws-cpp-sdk-sqs/include/aws/sqs/model/Message.h
+++ b/aws-cpp-sdk-sqs/include/aws/sqs/model/Message.h
@@ -17,7 +17,7 @@
 #include <aws/core/utils/memory/stl/AWSStreamFwd.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/utils/memory/stl/AWSMap.h>
-#include <aws/sqs/model/QueueAttributeName.h>
+#include <aws/sqs/model/AttributeName.h>
 #include <aws/sqs/model/MessageAttributeValue.h>
 
 namespace Aws
@@ -216,7 +216,7 @@ namespace Model
      * representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a>
      * in milliseconds.</p>
      */
-    inline const Aws::Map<QueueAttributeName, Aws::String>& GetAttributes() const{ return m_attributes; }
+    inline const Aws::Map<AttributeName, Aws::String>& GetAttributes() const{ return m_attributes; }
 
     /**
      * <p><code>SenderId</code>, <code>SentTimestamp</code>,
@@ -226,7 +226,7 @@ namespace Model
      * representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a>
      * in milliseconds.</p>
      */
-    inline void SetAttributes(const Aws::Map<QueueAttributeName, Aws::String>& value) { m_attributesHasBeenSet = true; m_attributes = value; }
+    inline void SetAttributes(const Aws::Map<AttributeName, Aws::String>& value) { m_attributesHasBeenSet = true; m_attributes = value; }
 
     /**
      * <p><code>SenderId</code>, <code>SentTimestamp</code>,
@@ -236,7 +236,7 @@ namespace Model
      * representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a>
      * in milliseconds.</p>
      */
-    inline void SetAttributes(Aws::Map<QueueAttributeName, Aws::String>&& value) { m_attributesHasBeenSet = true; m_attributes = value; }
+    inline void SetAttributes(Aws::Map<AttributeName, Aws::String>&& value) { m_attributesHasBeenSet = true; m_attributes = value; }
 
     /**
      * <p><code>SenderId</code>, <code>SentTimestamp</code>,
@@ -246,7 +246,7 @@ namespace Model
      * representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a>
      * in milliseconds.</p>
      */
-    inline Message& WithAttributes(const Aws::Map<QueueAttributeName, Aws::String>& value) { SetAttributes(value); return *this;}
+    inline Message& WithAttributes(const Aws::Map<AttributeName, Aws::String>& value) { SetAttributes(value); return *this;}
 
     /**
      * <p><code>SenderId</code>, <code>SentTimestamp</code>,
@@ -256,7 +256,7 @@ namespace Model
      * representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a>
      * in milliseconds.</p>
      */
-    inline Message& WithAttributes(Aws::Map<QueueAttributeName, Aws::String>&& value) { SetAttributes(value); return *this;}
+    inline Message& WithAttributes(Aws::Map<AttributeName, Aws::String>&& value) { SetAttributes(value); return *this;}
 
     /**
      * <p><code>SenderId</code>, <code>SentTimestamp</code>,
@@ -266,7 +266,7 @@ namespace Model
      * representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a>
      * in milliseconds.</p>
      */
-    inline Message& AddAttributes(const QueueAttributeName& key, const Aws::String& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
+    inline Message& AddAttributes(const AttributeName& key, const Aws::String& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
 
     /**
      * <p><code>SenderId</code>, <code>SentTimestamp</code>,
@@ -276,7 +276,7 @@ namespace Model
      * representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a>
      * in milliseconds.</p>
      */
-    inline Message& AddAttributes(QueueAttributeName&& key, const Aws::String& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
+    inline Message& AddAttributes(AttributeName&& key, const Aws::String& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
 
     /**
      * <p><code>SenderId</code>, <code>SentTimestamp</code>,
@@ -286,7 +286,7 @@ namespace Model
      * representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a>
      * in milliseconds.</p>
      */
-    inline Message& AddAttributes(const QueueAttributeName& key, Aws::String&& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
+    inline Message& AddAttributes(const AttributeName& key, Aws::String&& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
 
     /**
      * <p><code>SenderId</code>, <code>SentTimestamp</code>,
@@ -296,7 +296,7 @@ namespace Model
      * representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a>
      * in milliseconds.</p>
      */
-    inline Message& AddAttributes(QueueAttributeName&& key, Aws::String&& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
+    inline Message& AddAttributes(AttributeName&& key, Aws::String&& value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
 
     /**
      * <p><code>SenderId</code>, <code>SentTimestamp</code>,
@@ -306,7 +306,7 @@ namespace Model
      * representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a>
      * in milliseconds.</p>
      */
-    inline Message& AddAttributes(QueueAttributeName&& key, const char* value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
+    inline Message& AddAttributes(AttributeName&& key, const char* value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
 
     /**
      * <p><code>SenderId</code>, <code>SentTimestamp</code>,
@@ -316,7 +316,7 @@ namespace Model
      * representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a>
      * in milliseconds.</p>
      */
-    inline Message& AddAttributes(const QueueAttributeName& key, const char* value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
+    inline Message& AddAttributes(const AttributeName& key, const char* value) { m_attributesHasBeenSet = true; m_attributes[key] = value; return *this; }
 
     /**
      * <p>An MD5 digest of the non-URL-encoded message attribute string. This can be
@@ -478,7 +478,7 @@ namespace Model
     bool m_mD5OfBodyHasBeenSet;
     Aws::String m_body;
     bool m_bodyHasBeenSet;
-    Aws::Map<QueueAttributeName, Aws::String> m_attributes;
+    Aws::Map<AttributeName, Aws::String> m_attributes;
     bool m_attributesHasBeenSet;
     Aws::String m_mD5OfMessageAttributes;
     bool m_mD5OfMessageAttributesHasBeenSet;

--- a/aws-cpp-sdk-sqs/include/aws/sqs/model/ReceiveMessageRequest.h
+++ b/aws-cpp-sdk-sqs/include/aws/sqs/model/ReceiveMessageRequest.h
@@ -17,7 +17,7 @@
 #include <aws/sqs/SQSRequest.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/utils/memory/stl/AWSVector.h>
-#include <aws/sqs/model/QueueAttributeName.h>
+#include <aws/sqs/model/AttributeName.h>
 
 namespace Aws
 {
@@ -82,7 +82,7 @@ namespace Model
      * - returns the time when the message was sent to the queue (epoch time in
      * milliseconds).</li> </ul>
      */
-    inline const Aws::Vector<QueueAttributeName>& GetAttributeNames() const{ return m_attributeNames; }
+    inline const Aws::Vector<AttributeName>& GetAttributeNames() const{ return m_attributeNames; }
 
     /**
      * <p>A list of attributes that need to be returned along with each message. </p>
@@ -97,7 +97,7 @@ namespace Model
      * - returns the time when the message was sent to the queue (epoch time in
      * milliseconds).</li> </ul>
      */
-    inline void SetAttributeNames(const Aws::Vector<QueueAttributeName>& value) { m_attributeNamesHasBeenSet = true; m_attributeNames = value; }
+    inline void SetAttributeNames(const Aws::Vector<AttributeName>& value) { m_attributeNamesHasBeenSet = true; m_attributeNames = value; }
 
     /**
      * <p>A list of attributes that need to be returned along with each message. </p>
@@ -112,7 +112,7 @@ namespace Model
      * - returns the time when the message was sent to the queue (epoch time in
      * milliseconds).</li> </ul>
      */
-    inline void SetAttributeNames(Aws::Vector<QueueAttributeName>&& value) { m_attributeNamesHasBeenSet = true; m_attributeNames = value; }
+    inline void SetAttributeNames(Aws::Vector<AttributeName>&& value) { m_attributeNamesHasBeenSet = true; m_attributeNames = value; }
 
     /**
      * <p>A list of attributes that need to be returned along with each message. </p>
@@ -127,7 +127,7 @@ namespace Model
      * - returns the time when the message was sent to the queue (epoch time in
      * milliseconds).</li> </ul>
      */
-    inline ReceiveMessageRequest& WithAttributeNames(const Aws::Vector<QueueAttributeName>& value) { SetAttributeNames(value); return *this;}
+    inline ReceiveMessageRequest& WithAttributeNames(const Aws::Vector<AttributeName>& value) { SetAttributeNames(value); return *this;}
 
     /**
      * <p>A list of attributes that need to be returned along with each message. </p>
@@ -142,7 +142,7 @@ namespace Model
      * - returns the time when the message was sent to the queue (epoch time in
      * milliseconds).</li> </ul>
      */
-    inline ReceiveMessageRequest& WithAttributeNames(Aws::Vector<QueueAttributeName>&& value) { SetAttributeNames(value); return *this;}
+    inline ReceiveMessageRequest& WithAttributeNames(Aws::Vector<AttributeName>&& value) { SetAttributeNames(value); return *this;}
 
     /**
      * <p>A list of attributes that need to be returned along with each message. </p>
@@ -157,7 +157,7 @@ namespace Model
      * - returns the time when the message was sent to the queue (epoch time in
      * milliseconds).</li> </ul>
      */
-    inline ReceiveMessageRequest& AddAttributeNames(const QueueAttributeName& value) { m_attributeNamesHasBeenSet = true; m_attributeNames.push_back(value); return *this; }
+    inline ReceiveMessageRequest& AddAttributeNames(const AttributeName& value) { m_attributeNamesHasBeenSet = true; m_attributeNames.push_back(value); return *this; }
 
     /**
      * <p>A list of attributes that need to be returned along with each message. </p>
@@ -172,7 +172,7 @@ namespace Model
      * - returns the time when the message was sent to the queue (epoch time in
      * milliseconds).</li> </ul>
      */
-    inline ReceiveMessageRequest& AddAttributeNames(QueueAttributeName&& value) { m_attributeNamesHasBeenSet = true; m_attributeNames.push_back(value); return *this; }
+    inline ReceiveMessageRequest& AddAttributeNames(AttributeName&& value) { m_attributeNamesHasBeenSet = true; m_attributeNames.push_back(value); return *this; }
 
     /**
      * <p>The name of the message attribute, where <i>N</i> is the index. The message
@@ -360,7 +360,7 @@ namespace Model
   private:
     Aws::String m_queueUrl;
     bool m_queueUrlHasBeenSet;
-    Aws::Vector<QueueAttributeName> m_attributeNames;
+    Aws::Vector<AttributeName> m_attributeNames;
     bool m_attributeNamesHasBeenSet;
     Aws::Vector<Aws::String> m_messageAttributeNames;
     bool m_messageAttributeNamesHasBeenSet;

--- a/aws-cpp-sdk-sqs/source/model/AttributeName.cpp
+++ b/aws-cpp-sdk-sqs/source/model/AttributeName.cpp
@@ -1,0 +1,91 @@
+/*
+* Copyright 2010-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+#include <aws/sqs/model/AttributeName.h>
+#include <aws/core/utils/HashingUtils.h>
+#include <aws/core/Globals.h>
+#include <aws/core/utils/EnumParseOverflowContainer.h>
+
+using namespace Aws::Utils;
+
+static const int ApproximateFirstReceiveTimestamp_HASH = HashingUtils::HashString("ApproximateFirstReceiveTimestamp");
+static const int ApproximateReceiveCount_HASH = HashingUtils::HashString("ApproximateReceiveCount");
+static const int SenderId_HASH = HashingUtils::HashString("SenderId");
+static const int SentTimestamp_HASH = HashingUtils::HashString("SentTimestamp");
+
+namespace Aws
+{
+  namespace SQS
+  {
+    namespace Model
+    {
+      namespace AttributeNameMapper
+      {
+
+        AttributeName GetAttributeNameForName(const Aws::String& name)
+        {
+          int hashCode = HashingUtils::HashString(name.c_str());
+          if (hashCode == ApproximateFirstReceiveTimestamp_HASH)
+          {
+            return AttributeName::ApproximateFirstReceiveTimestamp;
+          }
+          else if (hashCode == ApproximateReceiveCount_HASH)
+          {
+            return AttributeName::ApproximateReceiveCount;
+          }
+          else if (hashCode == SenderId_HASH)
+          {
+            return AttributeName::SenderId;
+          }
+          else if (hashCode == SentTimestamp_HASH)
+          {
+            return AttributeName::SentTimestamp;
+          }
+          EnumParseOverflowContainer* overflowContainer = Aws::GetEnumOverflowContainer();
+          if(overflowContainer)
+          {
+            overflowContainer->StoreOverflow(hashCode, name);
+            return static_cast<AttributeName>(hashCode);
+          }
+
+          return AttributeName::NOT_SET;
+        }
+
+        Aws::String GetNameForAttributeName(AttributeName enumValue)
+        {
+          switch(enumValue)
+          {
+          case AttributeName::ApproximateFirstReceiveTimestamp:
+            return "ApproximateFirstReceiveTimestamp";
+          case AttributeName::ApproximateReceiveCount:
+            return "ApproximateReceiveCount";
+          case AttributeName::SenderId:
+            return "SenderId";
+          case AttributeName::SentTimestamp:
+            return "SentTimestamp";
+          default:
+            EnumParseOverflowContainer* overflowContainer = Aws::GetEnumOverflowContainer();
+            if(overflowContainer)
+            {
+              return overflowContainer->RetrieveOverflow(static_cast<int>(enumValue));
+            }
+
+            return "";
+          }
+        }
+
+      } // namespace AttributeNameMapper
+    } // namespace Model
+  } // namespace SQS
+} // namespace Aws

--- a/aws-cpp-sdk-sqs/source/model/Message.cpp
+++ b/aws-cpp-sdk-sqs/source/model/Message.cpp
@@ -90,7 +90,7 @@ Message& Message::operator =(const XmlNode& xmlNode)
       {
         XmlNode keyNode = attributeEntry.FirstChild("Name");
         XmlNode valueNode = attributeEntry.FirstChild("Value");
-        m_attributes[QueueAttributeNameMapper::GetQueueAttributeNameForName(StringUtils::Trim(keyNode.GetText().c_str()))] =
+        m_attributes[AttributeNameMapper::GetAttributeNameForName(StringUtils::Trim(keyNode.GetText().c_str()))] =
             StringUtils::Trim(valueNode.GetText().c_str());
         attributeEntry = attributeEntry.NextNode("Attribute");
       }

--- a/aws-cpp-sdk-sqs/source/model/ReceiveMessageRequest.cpp
+++ b/aws-cpp-sdk-sqs/source/model/ReceiveMessageRequest.cpp
@@ -46,7 +46,7 @@ Aws::String ReceiveMessageRequest::SerializePayload() const
     for(auto& item : m_attributeNames)
     {
       ss << "AttributeName." << attributeNamesCount << "="
-          << StringUtils::URLEncode(QueueAttributeNameMapper::GetNameForQueueAttributeName(item).c_str()) << "&";
+          << StringUtils::URLEncode(AttributeNameMapper::GetNameForAttributeName(item).c_str()) << "&";
       attributeNamesCount++;
     }
   }


### PR DESCRIPTION
Modeled it very similar to Java SDK. 

Java SDK ReceiveMessageRequest has 2 methods
1. setMessageAttributeNames() - > For custom attributes 
2. setAttributeNames() - > For built-in message attributes

Attributes cannot be a union of both the built-in message attributes as well as custom attributes since:
1. built-in message attributes are attached with AttributeName.N={Value} to the request 
2. custom attributes are attached with MessageAttributeName.N={Value} to the request

Towards #83