### PR TITLE
Fix compile error when building core package independently with Clang

### DIFF
--- a/aws-cpp-sdk-core/source/utils/crypto/factory/Factories.cpp
+++ b/aws-cpp-sdk-core/source/utils/crypto/factory/Factories.cpp
@@ -15,6 +15,8 @@
 
 
 #include <aws/core/utils/crypto/Factories.h>
+#include <aws/core/utils/crypto/Hash.h>
+#include <aws/core/utils/crypto/HMAC.h>
 
 #if ENABLE_BCRYPT_ENCRYPTION
     #include <aws/core/utils/crypto/bcrypt/CryptoImpl.h>


### PR DESCRIPTION
Building the core package on OS X using stock Clang reports 3 errors because of missing class definition.
error: member access into incomplete type 'element_type' (aka 'Aws::Utils::Crypto::HashFactory') 
error: member access into incomplete type 'element_type' (aka 'Aws::Utils::Crypto::HMACFactory')

Adding the necessary header files fixes the problem.