### PR TITLE
Update to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,31 +61,40 @@ You may also find the following link helpful for including the build in your pro
 https://aws.amazon.com/blogs/developer/using-cmake-exports-with-the-aws-sdk-for-c/
 
 ####Building for Android
-To build for Android, add -DTARGET_ARCH=ANDROID to your cmake command line.  We've included a cmake toolchain file that should cover what's needed, assuming you have the appropriate environment variables (ANDROID_NDK) set.
+To build for Android, add `-DTARGET_ARCH=ANDROID` to your cmake command line.  We've included a cmake toolchain file that should cover what's needed, assuming you have the appropriate environment variables (ANDROID_NDK) set.
 
 #####Android on Windows
 Building for Android on Windows requires some additional setup.  In particular, you will need to run cmake from a Visual Studio developer command prompt (2013 or higher).  Additionally, you will need 'git' and 'patch' in your path.  If you have git installed on a Windows system, then patch is likely found in a sibling directory (.../Git/usr/bin/).  Once you've verified these requirements, your cmake command line will change slightly to use nmake:
 
+```
 cmake -G "NMake Makefiles" -DTARGET_ARCH=ANDROID <other options> ..
+```
 
 Nmake builds targets in a serial fashion.  To make things quicker, we recommend installing JOM as an alternative to nmake and then changing the cmake invocation to:
 
+```
 cmake -G "NMake Makefiles JOM" -DTARGET_ARCH=ANDROID <other options> ..
+```
 
 ####CMake Variables
 
 #####BUILD_ONLY
-Allows you to only build the clients you want to use. This will resolve low level client dependencies if you set this to a high-level sdk such as aws-cpp-sdk-transfer. This will also build integration and unit tests related to the projects you select if they exist. aws-cpp-sdk-core always builds regardless of the value of this argument. This is a list argument. Example: -DBUILD_ONLY="aws-cpp-sdk-s3;aws-cpp-sdk-dynamodb;aws-cpp-sdk-cognito-identity"
+Allows you to only build the clients you want to use. This will resolve low level client dependencies if you set this to a high-level sdk such as aws-cpp-sdk-transfer. This will also build integration and unit tests related to the projects you select if they exist. aws-cpp-sdk-core always builds regardless of the value of this argument. This is a list argument. Example: 
+```
+cmake -DBUILD_ONLY="aws-cpp-sdk-s3;aws-cpp-sdk-dynamodb;aws-cpp-sdk-cognito-identity"
+```
 
 #####ADD_CUSTOM_CLIENTS
-Allows you to build any arbitrary clients based on the api definition. Simply place your definition in the code-generation/api-definitions folder. Then pass this arg to cmake. The cmake configure step will generate your client and include it as a subdirectory in your build. This is particularly useful if you want to generate a C++ client for using one of your API Gateway services. To use this feature you need to have python 2.7, java, jdk1.8, and maven installed and in your executable path. Example: -DADD_CUSTOM_CLIENTS="serviceName=myCustomService; version=2015-12-21;serviceName=someOtherService; version=2015-08-15"
+Allows you to build any arbitrary clients based on the api definition. Simply place your definition in the code-generation/api-definitions folder. Then pass this arg to cmake. The cmake configure step will generate your client and include it as a subdirectory in your build. This is particularly useful if you want to generate a C++ client for using one of your API Gateway services. To use this feature you need to have python 2.7, java, jdk1.8, and maven installed and in your executable path. Example: 
+```
+cmake -DADD_CUSTOM_CLIENTS="serviceName=myCustomService; version=2015-12-21;serviceName=someOtherService; version=2015-08-15"
+```
 
 #####REGENERATE_CLIENTS
-This argument will wipe out all generated code and generate the client directories from the code-generation/api-definitions folder. To use this argument, you need to have python 2.7, java, jdk1.8, and maven installed in your executable path. Example: -DREGENERATE_CLIENTS=1
+This argument will wipe out all generated code and generate the client directories from the code-generation/api-definitions folder. To use this argument, you need to have python 2.7, java, jdk1.8, and maven installed in your executable path. Example: `-DREGENERATE_CLIENTS=1`
 
 #####CUSTOM_MEMORY_MANAGEMENT  
 To use a custom memory manager, set the value to 1. You can install a custom allocator, and all STL types will use the custom allocation interface. If the value is set to 0, you still might want to use the STL template types to help with DLL safety on Windows. 
-
 If static linking is enabled, custom memory management defaults to off. If dynamic linking is enabled, custom memory management defaults to on and avoids cross-DLL allocation and deallocation. 
 
 Note: To prevent linker mismatch errors, you must use the same value (0 or 1) throughout your build system.
@@ -101,7 +110,7 @@ Options: WINDOWS | LINUX | APPLE | ANDROID
 Use this variable to generate build artifacts, such as Visual Studio solutions and Xcode projects. 
 
 Windows example:
--G "Visual Studio 12 Win64"
+`-G "Visual Studio 12 Win64"`
 
 For more information, see the CMake documentation for your platform.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cmake -G "NMake Makefiles JOM" -DTARGET_ARCH=ANDROID <other options> ..
 #####BUILD_ONLY
 Allows you to only build the clients you want to use. This will resolve low level client dependencies if you set this to a high-level sdk such as aws-cpp-sdk-transfer. This will also build integration and unit tests related to the projects you select if they exist. aws-cpp-sdk-core always builds regardless of the value of this argument. This is a list argument. Example: 
 ```
-cmake -DBUILD_ONLY="aws-cpp-sdk-s3;aws-cpp-sdk-dynamodb;aws-cpp-sdk-cognito-identity"
+cmake -DBUILD_ONLY="s3;dynamodb;cognito-identity"
 ```
 
 #####ADD_CUSTOM_CLIENTS


### PR DESCRIPTION
"Building the SDK" section is very hard to read especially the various cmake build options. I've just made it more clear to read by adding source code tags which makes typography "monospaced" and easier to read.