### PR TITLE
Added const for DynamoDB::Model::AttributeValue::GetM()

### DIFF
--- a/aws-cpp-sdk-dynamodb/include/aws/dynamodb/model/AttributeValue.h
+++ b/aws-cpp-sdk-dynamodb/include/aws/dynamodb/model/AttributeValue.h
@@ -111,7 +111,7 @@ public:
     AttributeValue& AddBItem(const unsigned char* bItem, size_t size);
 
     /// returns the Attribute Map if the value is specialized to this type, otherwise an empty Map
-    const Aws::Map<Aws::String, const std::shared_ptr<AttributeValue>>& GetM();
+    const Aws::Map<Aws::String, const std::shared_ptr<AttributeValue>>& GetM() const;
     /// if already specialized to an Attribute Map, sets to these values
     /// if uninitialized, specializes the type to an Attribute Map with specified values
     /// if already specialized to another type then the behavior is undefined

--- a/aws-cpp-sdk-dynamodb/source/model/AttributeValue.cpp
+++ b/aws-cpp-sdk-dynamodb/source/model/AttributeValue.cpp
@@ -179,7 +179,7 @@ AttributeValue& AttributeValue::AddBItem(const unsigned char* bItem, size_t size
     return AddBItem(ByteBuffer(bItem, size));
 }
 
-const Aws::Map<Aws::String, const std::shared_ptr<AttributeValue>>& AttributeValue::GetM()
+const Aws::Map<Aws::String, const std::shared_ptr<AttributeValue>>& AttributeValue::GetM() const
 {
     if (m_value)
     {


### PR DESCRIPTION
Hello,
I found all of `DynamoDB::Model::AttributeValue::GetX()` are `const` member function,
and `AttributeValueValue::GetM()` is `const` too.
But `AttributeValue::GetM()` is non-const.
This helps users who just want to get entry inside M without letting parameter be non-const.