### PR TITLE
*fixed AWSMemory.cpp for including SDKConfig.h

### DIFF
--- a/aws-cpp-sdk-core/source/utils/memory/AWSMemory.cpp
+++ b/aws-cpp-sdk-core/source/utils/memory/AWSMemory.cpp
@@ -14,7 +14,7 @@
   */
 
 #include <aws/core/utils/memory/AWSMemory.h>
-
+#include <aws/core/SDKConfig.h>
 #include <aws/core/utils/memory/MemorySystemInterface.h>
 
 #include <atomic>


### PR DESCRIPTION
Added one include line to apply USE_AWS_MEMORY_MANAGEMENT 
The reason is that both AWSMemory.h and MemorySystemInterface.h don't include the header file, SDKConfig.h