### PR TITLE
Keep ANSI function and type usage consistent

### DIFF
--- a/aws-cpp-sdk-core/source/platform/windows/OSVersionInfo.cpp
+++ b/aws-cpp-sdk-core/source/platform/windows/OSVersionInfo.cpp
@@ -30,9 +30,9 @@ namespace Utils
 
 Aws::String ComputeOSVersionString() 
 {
-    OSVERSIONINFO versionInfo;
-    ZeroMemory(&versionInfo, sizeof(OSVERSIONINFO));
-    versionInfo.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+    OSVERSIONINFOA versionInfo;
+    ZeroMemory(&versionInfo, sizeof(OSVERSIONINFOA));
+    versionInfo.dwOSVersionInfoSize = sizeof(OSVERSIONINFOA);
     GetVersionExA(&versionInfo);
     Aws::StringStream ss;
     ss << "Windows/" << versionInfo.dwMajorVersion << "." << versionInfo.dwMinorVersion << "." << versionInfo.dwBuildNumber << "-" << versionInfo.szCSDVersion;


### PR DESCRIPTION
This code failed to build when using unicode on windows