### PR TITLE
change cmake_minimum_required to 3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 # minimum version of cmake that 
 #   (1) supports ExternalProject_Add URL_HASH
 #   (2) correctly extracts OPENSSL's version number from openssl/opensslv.h in version 1.0.2d
-cmake_minimum_required (VERSION 2.8.1)
+cmake_minimum_required (VERSION 3.0.0)
 
 # git is required for Android builds and optional for all other platforms
 find_package(Git)


### PR DESCRIPTION
this lib require target_compile_options, which was added to cmake 3.0.0,
a older version cmake will report this error:
CMake Error at aws-cpp-sdk-core/CMakeLists.txt:342 (target_compile_options):
  Unknown CMake command "target_compile_options".