### PR TITLE
Mark DateTime comparison operators as 'const'

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/utils/DateTime.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/DateTime.h
@@ -94,12 +94,12 @@ namespace Aws
              */
             DateTime(const char* timestamp, DateFormat format);
 
-            bool operator == (const DateTime& other);
-            bool operator < (const DateTime& other);
-            bool operator > (const DateTime& other);
-            bool operator != (const DateTime& other);
-            bool operator <= (const DateTime& other);
-            bool operator >= (const DateTime& other);
+            bool operator == (const DateTime& other) const;
+            bool operator < (const DateTime& other) const;
+            bool operator > (const DateTime& other) const;
+            bool operator != (const DateTime& other) const;
+            bool operator <= (const DateTime& other) const;
+            bool operator >= (const DateTime& other) const;
 
             /**
              * Assign from seconds.millis since epoch.

--- a/aws-cpp-sdk-core/source/utils/DateTimeCommon.cpp
+++ b/aws-cpp-sdk-core/source/utils/DateTimeCommon.cpp
@@ -906,32 +906,32 @@ DateTime& DateTime::operator=(const std::chrono::system_clock::time_point& timep
     return *this;
 }
 
-bool DateTime::operator == (const DateTime& other)
+bool DateTime::operator == (const DateTime& other) const
 {
     return m_time == other.m_time;
 }
 
-bool DateTime::operator < (const DateTime& other)
+bool DateTime::operator < (const DateTime& other) const
 {
     return m_time < other.m_time;
 }
 
-bool DateTime::operator > (const DateTime& other)
+bool DateTime::operator > (const DateTime& other) const
 {
     return m_time > other.m_time;
 }
 
-bool DateTime::operator != (const DateTime& other)
+bool DateTime::operator != (const DateTime& other) const
 {
     return m_time != other.m_time;
 }
 
-bool DateTime::operator <= (const DateTime& other)
+bool DateTime::operator <= (const DateTime& other) const
 {
     return m_time <= other.m_time;
 }
 
-bool DateTime::operator >= (const DateTime& other)
+bool DateTime::operator >= (const DateTime& other) const
 {
     return m_time >= other.m_time;
 }


### PR DESCRIPTION
Currently, you have to access the 'Millis()' member function to compare DateTime members on an object marked as const.

For example when using the Async version of the requests, the lambda declares the 'Outcome' parameter as const, which makes all members of that operation's result const. Therefore, you can't do something like this: 
`outcome.GetResult().GetItem().CreatedOn() >= myOtherDateObject.`
