### PR TITLE
Ability to Specify Storage Class and Server Side Encryption in Transfer Client

### DIFF
--- a/aws-cpp-sdk-transfer/include/aws/transfer/TransferClient.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/TransferClient.h
@@ -64,10 +64,10 @@ class AWS_TRANSFER_API TransferClient
         // Entry point for attempting an upload - attempting to create an existing bucket won't hurt anything but will affect performance
         // unnecessarily as the request waits for S3 to propagate the bucket
         // All queries about the upload after this point can be found in UploadFileRequest's interface
-        std::shared_ptr<UploadFileRequest> UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, bool createBucket = false, bool doConsistencyChecks = false);
+        std::shared_ptr<UploadFileRequest> UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, bool createBucket = false, bool doConsistencyChecks = false, S3::Model::ServerSideEncryption serverSideEncryption = S3::Model::ServerSideEncryption::NOT_SET, S3::Model::StorageClass storageClass = S3::Model::StorageClass::NOT_SET);
         // Entry point similar to above but with metadata specified
-        std::shared_ptr<UploadFileRequest> UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, const Aws::Map<Aws::String, Aws::String>& metadata, bool createBucket = false, bool doConsistencyChecks = false);
-        std::shared_ptr<UploadFileRequest> UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, Aws::Map<Aws::String, Aws::String>&& metadata, bool createBucket = false, bool doConsistencyChecks = false);
+        std::shared_ptr<UploadFileRequest> UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, const Aws::Map<Aws::String, Aws::String>& metadata, bool createBucket = false, bool doConsistencyChecks = false, S3::Model::ServerSideEncryption serverSideEncryption = S3::Model::ServerSideEncryption::NOT_SET, S3::Model::StorageClass storageClass = S3::Model::StorageClass::NOT_SET);
+        std::shared_ptr<UploadFileRequest> UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, Aws::Map<Aws::String, Aws::String>&& metadata, bool createBucket = false, bool doConsistencyChecks = false, S3::Model::ServerSideEncryption serverSideEncryption = S3::Model::ServerSideEncryption::NOT_SET, S3::Model::StorageClass storageClass = S3::Model::StorageClass::NOT_SET);
 
         // User requested upload cancels should go through here
         void CancelUpload(std::shared_ptr<UploadFileRequest>& fileRequest) const;

--- a/aws-cpp-sdk-transfer/include/aws/transfer/UploadFileRequest.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/UploadFileRequest.h
@@ -83,14 +83,18 @@ public:
                       Aws::Map<Aws::String, Aws::String>&& metadata,
                       const std::shared_ptr<Aws::S3::S3Client>& s3Client,
                       bool createBucket,
-                      bool doConsistencyChecks);
+                      bool doConsistencyChecks,
+                      Aws::S3::Model::ServerSideEncryption serverSideEncryption,
+                      Aws::S3::Model::StorageClass storageClass);
     UploadFileRequest(const Aws::String& fileName, 
                       const Aws::String& bucketName, 
                       const Aws::String& keyName, 
                       const Aws::String& contentType, 
                       const std::shared_ptr<Aws::S3::S3Client>& s3Client, 
                       bool createBucket,
-                      bool doConsistencyChecks);
+                      bool doConsistencyChecks,
+                      Aws::S3::Model::ServerSideEncryption serverSideEncryption,
+                      Aws::S3::Model::StorageClass storageClass);
     UploadFileRequest(const Aws::String& fileName,
                       const Aws::String& bucketName,
                       const Aws::String& keyName,
@@ -98,7 +102,9 @@ public:
                       const Aws::Map<Aws::String, Aws::String>& metadata,
                       const std::shared_ptr<Aws::S3::S3Client>& s3Client,
                       bool createBucket,
-                      bool doConsistencyChecks);
+                      bool doConsistencyChecks,
+                      Aws::S3::Model::ServerSideEncryption serverSideEncryption,
+                      Aws::S3::Model::StorageClass storageClass);
     virtual ~UploadFileRequest();
 
     // How many parts have we at least begun to upload
@@ -272,6 +278,8 @@ private:
 
     Aws::String m_contentType;
     Aws::Map<Aws::String, Aws::String> m_metadata;
+    Aws::S3::Model::ServerSideEncryption m_serverSideEncryption;
+    Aws::S3::Model::StorageClass m_storageClass;
     Aws::String m_uploadId;
     uint32_t m_createMultipartRetries;
     uint32_t m_createBucketRetries;

--- a/aws-cpp-sdk-transfer/source/transfer/TransferClient.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferClient.cpp
@@ -65,27 +65,27 @@ TransferClient::~TransferClient()
 {
 }
 
-std::shared_ptr<UploadFileRequest> TransferClient::UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, bool createBucket, bool doConsistencyChecks)
+std::shared_ptr<UploadFileRequest> TransferClient::UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, bool createBucket, bool doConsistencyChecks, S3::Model::ServerSideEncryption serverSideEncryption, S3::Model::StorageClass storageClass)
 {
-    auto request = Aws::MakeShared<UploadFileRequest>(ALLOCATION_TAG, fileName, bucketName, keyName, contentType, m_s3Client, createBucket, doConsistencyChecks);
+    auto request = Aws::MakeShared<UploadFileRequest>(ALLOCATION_TAG, fileName, bucketName, keyName, contentType, m_s3Client, createBucket, doConsistencyChecks, serverSideEncryption, storageClass);
 
     UploadFileInternal(request);
 
     return request;
 }
 
-std::shared_ptr<UploadFileRequest> TransferClient::UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, const Aws::Map<Aws::String, Aws::String>& metadata, bool createBucket, bool doConsistencyChecks)
+std::shared_ptr<UploadFileRequest> TransferClient::UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, const Aws::Map<Aws::String, Aws::String>& metadata, bool createBucket, bool doConsistencyChecks, S3::Model::ServerSideEncryption serverSideEncryption, S3::Model::StorageClass storageClass)
 {
-    auto request = Aws::MakeShared<UploadFileRequest>(ALLOCATION_TAG, fileName, bucketName, keyName, contentType, metadata, m_s3Client, createBucket, doConsistencyChecks);
+    auto request = Aws::MakeShared<UploadFileRequest>(ALLOCATION_TAG, fileName, bucketName, keyName, contentType, metadata, m_s3Client, createBucket, doConsistencyChecks, serverSideEncryption, storageClass);
 
     UploadFileInternal(request);
 
     return request;
 }
 
-std::shared_ptr<UploadFileRequest> TransferClient::UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, Aws::Map<Aws::String, Aws::String>&& metadata, bool createBucket, bool doConsistencyChecks)
+std::shared_ptr<UploadFileRequest> TransferClient::UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, Aws::Map<Aws::String, Aws::String>&& metadata, bool createBucket, bool doConsistencyChecks, S3::Model::ServerSideEncryption serverSideEncryption, S3::Model::StorageClass storageClass)
 {
-    auto request = Aws::MakeShared<UploadFileRequest>(ALLOCATION_TAG, fileName, bucketName, keyName, contentType, std::move(metadata), m_s3Client, createBucket, doConsistencyChecks);
+    auto request = Aws::MakeShared<UploadFileRequest>(ALLOCATION_TAG, fileName, bucketName, keyName, contentType, std::move(metadata), m_s3Client, createBucket, doConsistencyChecks, serverSideEncryption, storageClass);
 
     UploadFileInternal(request);
 

--- a/aws-cpp-sdk-transfer/source/transfer/UploadFileRequest.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/UploadFileRequest.cpp
@@ -230,8 +230,16 @@ bool UploadFileRequest::CreateMultipartUpload()
     Aws::S3::Model::CreateMultipartUploadRequest createMultipartUploadRequest;
     createMultipartUploadRequest.SetBucket(GetBucketName());
     createMultipartUploadRequest.SetKey(GetKeyName());
-    createMultipartUploadRequest.SetServerSideEncryption(m_serverSideEncryption);
-    createMultipartUploadRequest.SetStorageClass(m_storageClass);
+    
+    if (m_serverSideEncryption != Aws::S3::Model::ServerSideEncryption::NOT_SET) 
+    {
+        createMultipartUploadRequest.SetServerSideEncryption(m_serverSideEncryption);
+    }
+    if (m_storageClass != Aws::S3::Model::StorageClass::NOT_SET) 
+    {
+        createMultipartUploadRequest.SetStorageClass(m_storageClass);    
+    } 
+
     // not mandatory - defaults to binary in S3
     if (m_contentType.length())
     {
@@ -820,8 +828,15 @@ bool UploadFileRequest::DoSingleObjectUpload(std::shared_ptr<Aws::IOStream>& str
         putObjectRequest.SetMetadata(m_metadata);
     }
     putObjectRequest.SetKey(GetKeyName());
-    putObjectRequest.SetServerSideEncryption(m_serverSideEncryption);
-    putObjectRequest.SetStorageClass(m_storageClass);
+    
+    if (m_serverSideEncryption != Aws::S3::Model::ServerSideEncryption::NOT_SET) 
+    {
+        putObjectRequest.SetServerSideEncryption(m_serverSideEncryption);
+    }
+    if (m_storageClass != Aws::S3::Model::StorageClass::NOT_SET) 
+    {
+        putObjectRequest.SetStorageClass(m_storageClass);    
+    } 
 
     putObjectRequest.SetDataSentEventHandler(std::bind(&UploadFileRequest::OnDataSent, this, std::placeholders::_1, std::placeholders::_2));
     

--- a/aws-cpp-sdk-transfer/source/transfer/UploadFileRequest.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/UploadFileRequest.cpp
@@ -58,7 +58,9 @@ UploadFileRequest::UploadFileRequest(const Aws::String& fileName,
                                      Aws::Map<Aws::String, Aws::String>&& metadata,
                                      const std::shared_ptr<Aws::S3::S3Client>& s3Client, 
                                      bool createBucket,
-                                     bool doConsistencyChecks) :
+                                     bool doConsistencyChecks,
+                                     Aws::S3::Model::ServerSideEncryption serverSideEncryption,
+                                     Aws::S3::Model::StorageClass storageClass) :
 S3FileRequest(fileName, bucketName, keyName, s3Client),
 m_bytesRemaining(0),
 m_partCount(0),
@@ -75,6 +77,8 @@ m_totalParts(0),
 m_fileStream(fileName.c_str(), std::ios::binary | std::ios::ate),
 m_contentType(contentType),
 m_metadata(std::move(metadata)),
+m_serverSideEncryption(serverSideEncryption),
+m_storageClass(storageClass),
 m_createMultipartRetries(0),
 m_createBucketRetries(0),
 m_completeRetries(0),
@@ -113,8 +117,10 @@ UploadFileRequest::UploadFileRequest(const Aws::String& fileName,
                                      const Aws::String& contentType,
                                      const std::shared_ptr<Aws::S3::S3Client>& s3Client,
                                      bool createBucket,
-                                     bool doConsistencyChecks) :
-UploadFileRequest(fileName, bucketName, keyName, contentType, Aws::Map<Aws::String, Aws::String>{}, s3Client, createBucket, doConsistencyChecks)
+                                     bool doConsistencyChecks,
+                                     Aws::S3::Model::ServerSideEncryption serverSideEncryption,
+                                     Aws::S3::Model::StorageClass storageClass) :
+UploadFileRequest(fileName, bucketName, keyName, contentType, Aws::Map<Aws::String, Aws::String>{}, s3Client, createBucket, doConsistencyChecks, serverSideEncryption, storageClass)
 {
 }
 
@@ -125,8 +131,10 @@ UploadFileRequest::UploadFileRequest(const Aws::String& fileName,
                                      const Aws::Map<Aws::String, Aws::String>& metadata,
                                      const std::shared_ptr<Aws::S3::S3Client>& s3Client,
                                      bool createBucket,
-                                     bool doConsistencyChecks) :
-UploadFileRequest(fileName, bucketName, keyName, contentType, Aws::Map<Aws::String, Aws::String>(metadata), s3Client, createBucket, doConsistencyChecks)
+                                     bool doConsistencyChecks,
+                                     Aws::S3::Model::ServerSideEncryption serverSideEncryption,
+                                     Aws::S3::Model::StorageClass storageClass) :
+UploadFileRequest(fileName, bucketName, keyName, contentType, Aws::Map<Aws::String, Aws::String>(metadata), s3Client, createBucket, doConsistencyChecks, serverSideEncryption, storageClass)
 {
 }
 
@@ -222,6 +230,8 @@ bool UploadFileRequest::CreateMultipartUpload()
     Aws::S3::Model::CreateMultipartUploadRequest createMultipartUploadRequest;
     createMultipartUploadRequest.SetBucket(GetBucketName());
     createMultipartUploadRequest.SetKey(GetKeyName());
+    createMultipartUploadRequest.SetServerSideEncryption(m_serverSideEncryption);
+    createMultipartUploadRequest.SetStorageClass(m_storageClass);
     // not mandatory - defaults to binary in S3
     if (m_contentType.length())
     {
@@ -810,6 +820,8 @@ bool UploadFileRequest::DoSingleObjectUpload(std::shared_ptr<Aws::IOStream>& str
         putObjectRequest.SetMetadata(m_metadata);
     }
     putObjectRequest.SetKey(GetKeyName());
+    putObjectRequest.SetServerSideEncryption(m_serverSideEncryption);
+    putObjectRequest.SetStorageClass(m_storageClass);
 
     putObjectRequest.SetDataSentEventHandler(std::bind(&UploadFileRequest::OnDataSent, this, std::placeholders::_1, std::placeholders::_2));
     


### PR DESCRIPTION
This allows the transfer client to be able to specify the storage class such as Standard Infrequent Access when uploading files to S3. It also adds the ability to specify Server Side Encryption such as AES 256 when uploading files. This should resolve issue #100. Both Server Side Encryption and Storage default to NOT_SET. 