### PR TITLE
Adding support to set CURLOPT_CAINFO

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -116,6 +116,11 @@ namespace Aws
              */
             Aws::String caPath;
             /**
+             * If your Certificate Authority file is different from the default, you can tell
+             * curl where to find your CA file.
+             */
+            Aws::String caFile;
+            /**
              * Rate Limiter implementation for outgoing bandwidth. Default is wide-open.
              */
             std::shared_ptr<Aws::Utils::RateLimits::RateLimiterInterface> writeRateLimiter;

--- a/aws-cpp-sdk-core/include/aws/core/http/curl/CurlHttpClient.h
+++ b/aws-cpp-sdk-core/include/aws/core/http/curl/CurlHttpClient.h
@@ -54,6 +54,7 @@ private:
     unsigned m_proxyPort;
     bool m_verifySSL;
     Aws::String m_caPath;
+    Aws::String m_caCert;
     bool m_allowRedirects;
 
     static std::atomic<bool> isInit;

--- a/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -282,7 +282,7 @@ CurlHttpClient::CurlHttpClient(const ClientConfiguration& clientConfig) :
     m_curlHandleContainer(clientConfig.maxConnections, clientConfig.requestTimeoutMs, clientConfig.connectTimeoutMs),
     m_isUsingProxy(!clientConfig.proxyHost.empty()), m_proxyUserName(clientConfig.proxyUserName),
     m_proxyPassword(clientConfig.proxyPassword), m_proxyHost(clientConfig.proxyHost),
-    m_proxyPort(clientConfig.proxyPort), m_verifySSL(clientConfig.verifySSL), m_caPath(clientConfig.caPath), m_allowRedirects(clientConfig.followRedirects)
+    m_proxyPort(clientConfig.proxyPort), m_verifySSL(clientConfig.verifySSL), m_caPath(clientConfig.caPath), m_caCert(clientConfig.caFile), m_allowRedirects(clientConfig.followRedirects)
 {
 }
 
@@ -355,6 +355,10 @@ std::shared_ptr<HttpResponse> CurlHttpClient::MakeRequest(HttpRequest& request, 
         if(!m_caPath.empty())
         {
             curl_easy_setopt(connectionHandle, CURLOPT_CAPATH, m_caPath.c_str());
+        }
+        if(!m_caCert.empty())
+        {
+            curl_easy_setopt(connectionHandle, CURLOPT_CAINFO, m_caCert.c_str());
         }
 
 	// only set by android test builds because the emulator is missing a cert needed for aws services


### PR DESCRIPTION
Support for libcurl --cacert option. See https://github.com/aws/aws-sdk-cpp/issues/251 for more details.

Usage example:

```
    Aws::Client::ClientConfiguration s3Config;
    s3Config.region = Aws::Region::US_EAST_1;
    s3Config.scheme = Aws::Http::Scheme::HTTPS;
    s3Config.connectTimeoutMs = 60000;
    s3Config.requestTimeoutMs = 60000;
    s3Config.caFile = FileUtils::getInstance()->fullPathForFilename("certs/aws/cacert.pem");
```
