### PR TITLE
Remove (presumably) erroneous whitespace

### DIFF
--- a/code-generation/api-descriptions/storagegateway-2013-06-30.normal.json
+++ b/code-generation/api-descriptions/storagegateway-2013-06-30.normal.json
@@ -1876,7 +1876,7 @@
         "InvalidParameters",
         "InvalidSchedule",
         "LocalStorageLimitExceeded",
-        "LunAlreadyAllocated ",
+        "LunAlreadyAllocated",
         "LunInvalid",
         "MaximumContentLengthExceeded",
         "MaximumTapeCartridgeCountExceeded",


### PR DESCRIPTION
The space in question looks to be accidental to me.

I'm not sure of the side-effects, if any, of this change.  At the very least, I _assume_ [ErrorCode::LunAlreadyAllocated_HASH](https://github.com/aws/aws-sdk-cpp/blob/d8a7539da21392d019c63cdabe3108a4923c51ad/aws-cpp-sdk-storagegateway/source/model/ErrorCode.cpp#L61) will change upon regeneration... is that a good or bad thing?

Cheers.
