### PR TITLE
AWSAuthSigner: PresignRequest also signs payload if m_signPayloads == true.

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/auth/AWSAuthSigner.h
+++ b/aws-cpp-sdk-core/include/aws/core/auth/AWSAuthSigner.h
@@ -125,6 +125,7 @@ namespace Aws
 
         private:
             Aws::String GenerateSignature(const Aws::Auth::AWSCredentials& credentials, const Aws::String& stringToSign, const Aws::String& simpleDate) const;
+            Aws::String GetPayloadHash(Aws::Http::HttpRequest&) const;
             Aws::String ComputePayloadHash(Aws::Http::HttpRequest&) const;
             Aws::String GenerateStringToSign(const Aws::String& dateValue, const Aws::String& simpleDate, const Aws::String& canonicalRequestHash) const;
 


### PR DESCRIPTION
IoT doesn't want "UNSIGNED-PAYLOAD" to be used in the canonical request string, like S3 does. Instead, you just hash the empty payload string (see http://docs.aws.amazon.com/iot/latest/developerguide/protocols.html). This change uses the same logic in PresignRequest() as that used in SignRequest() to conditionally sign the payload. The S3 client will have m_signPayloads == false so the behavior will not change there.
