### PR TITLE
Do not make networking calls in AWSClient's constructor.

### DIFF
--- a/aws-cpp-sdk-core/source/auth/AWSAuthSigner.cpp
+++ b/aws-cpp-sdk-core/source/auth/AWSAuthSigner.cpp
@@ -132,8 +132,6 @@ AWSAuthV4Signer::AWSAuthV4Signer(const std::shared_ptr<Auth::AWSCredentialsProvi
     m_signPayloads(signPayloads),
     m_urlEscapePath(urlEscapePath)
 {
-    //go ahead and warm up the signing cache.
-    ComputeLongLivedHash(credentialsProvider->GetAWSCredentials().GetAWSSecretKey(), DateTime::CalculateGmtTimestampAsString(SIMPLE_DATE_FORMAT_STR));
 }
 
 AWSAuthV4Signer::~AWSAuthV4Signer()

--- a/aws-cpp-sdk-core/source/auth/AWSAuthSigner.cpp
+++ b/aws-cpp-sdk-core/source/auth/AWSAuthSigner.cpp
@@ -115,7 +115,7 @@ static Http::HeaderValueCollection CanonicalizeHeaders(Http::HeaderValueCollecti
         );
         headerValue.erase(new_end, headerValue.end());
 
-        canonicalHeaders[trimmedHeaderName] = headerValue;       
+        canonicalHeaders[trimmedHeaderName] = headerValue;
     }
 
     return canonicalHeaders;
@@ -138,7 +138,7 @@ AWSAuthV4Signer::AWSAuthV4Signer(const std::shared_ptr<Auth::AWSCredentialsProvi
 
 AWSAuthV4Signer::~AWSAuthV4Signer()
 {
-    // empty destructor in .cpp file to keep from needing the implementation of (AWSCredentialsProvider, Sha256, Sha256HMAC) in the header file 
+    // empty destructor in .cpp file to keep from needing the implementation of (AWSCredentialsProvider, Sha256, Sha256HMAC) in the header file
 }
 
 bool AWSAuthV4Signer::SignRequest(Aws::Http::HttpRequest& request) const
@@ -250,11 +250,11 @@ bool AWSAuthV4Signer::PresignRequest(Aws::Http::HttpRequest& request, long long 
 
     Aws::StringStream intConversionStream;
     intConversionStream << expirationTimeInSeconds;
-    request.AddQueryStringParameter(Http::X_AMZ_EXPIRES_HEADER, intConversionStream.str());   
+    request.AddQueryStringParameter(Http::X_AMZ_EXPIRES_HEADER, intConversionStream.str());
 
     if (!credentials.GetSessionToken().empty())
     {
-        request.AddQueryStringParameter(Http::AWS_SECURITY_TOKEN, credentials.GetSessionToken());       
+        request.AddQueryStringParameter(Http::AWS_SECURITY_TOKEN, credentials.GetSessionToken());
     }
 
     //calculate date header to use in internal signature (this also goes into date header).
@@ -272,7 +272,7 @@ bool AWSAuthV4Signer::PresignRequest(Aws::Http::HttpRequest& request, long long 
     //calculate signed headers parameter
     Aws::String signedHeadersValue(Http::HOST_HEADER);
     request.AddQueryStringParameter(X_AMZ_SIGNED_HEADERS, signedHeadersValue);
-    
+
     AWS_LOGSTREAM_DEBUG(v4LogTag, "Signed Headers value: " << signedHeadersValue);
 
     Aws::String simpleDate = now.ToGmtString(SIMPLE_DATE_FORMAT_STR);
@@ -303,7 +303,7 @@ bool AWSAuthV4Signer::PresignRequest(Aws::Http::HttpRequest& request, long long 
     }
 
     auto sha256Digest = hashResult.GetResult();
-    auto cannonicalRequestHash = HashingUtils::HexEncode(sha256Digest);   
+    auto cannonicalRequestHash = HashingUtils::HexEncode(sha256Digest);
 
     auto stringToSign = GenerateStringToSign(dateQueryValue, simpleDate, cannonicalRequestHash);
 
@@ -313,7 +313,7 @@ bool AWSAuthV4Signer::PresignRequest(Aws::Http::HttpRequest& request, long long 
         return false;
     }
 
-    //add that the signature to the query string    
+    //add that the signature to the query string
     request.AddQueryStringParameter(X_AMZ_SIGNATURE, finalSigningHash);
 
     return true;
@@ -326,7 +326,7 @@ Aws::String AWSAuthV4Signer::GenerateSignature(const AWSCredentials& credentials
     Aws::StringStream ss;
 
     auto& partialSignature = ComputeLongLivedHash(credentials.GetAWSSecretKey(), simpleDate);
-        
+
     auto hashResult = m_HMAC->Calculate(ByteBuffer((unsigned char*)stringToSign.c_str(), stringToSign.length()), partialSignature);
     if (!hashResult.IsSuccess())
     {
@@ -397,7 +397,7 @@ const Aws::Utils::Array<unsigned char>& AWSAuthV4Signer::ComputeLongLivedHash(co
 
             //now we do the complicated part of deriving a signing key.
             Aws::String signingKey(SIGNING_KEY);
-            
+
             signingKey.append(m_currentSecretKey);
 
             //we use digest only for the derivation process.


### PR DESCRIPTION
Before this change, the AWSAuthV4Signer constructor "warms up" the signer's cache. Warming up the cache requires getting credentials from the credentials provider, and getting credentials can require a networking operation if the credentials provider is a Cognito provider. This behavior is problematic for Android apps because it results in networking on the main thread when, during the app's initialization, the app tries to construct an AWSClient with a Cognito credentials provider.

This change removes the line of code that warms up the signer's cache in the signer's constructor. The warm-up will simply happen later, when the signer is used.