### PR TITLE
Fix #358 by properly reserving an empty vector

### DIFF
--- a/aws-cpp-sdk-dynamodb/source/model/BatchWriteItemResult.cpp
+++ b/aws-cpp-sdk-dynamodb/source/model/BatchWriteItemResult.cpp
@@ -42,7 +42,8 @@ BatchWriteItemResult& BatchWriteItemResult::operator =(const AmazonWebServiceRes
     for(auto& unprocessedItemsItem : unprocessedItemsJsonMap)
     {
       Array<JsonValue> writeRequestsJsonList = unprocessedItemsItem.second.AsArray();
-      Aws::Vector<WriteRequest> writeRequestsList((size_t)writeRequestsJsonList.GetLength());
+      Aws::Vector<WriteRequest> writeRequestsList;
+      writeRequestsList.reserve((size_t)writeRequestsJsonList.GetLength());
       for(unsigned writeRequestsIndex = 0; writeRequestsIndex < writeRequestsJsonList.GetLength(); ++writeRequestsIndex)
       {
         writeRequestsList.push_back(writeRequestsJsonList[writeRequestsIndex].AsObject());


### PR DESCRIPTION
Details can be found here: https://github.com/aws/aws-sdk-cpp/issues/358