### PR TITLE
Fix #361 adding conditions to differentiate OpenSSL v1.0.2 and v1.1.x in CryptoImpl

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h
@@ -191,7 +191,8 @@ namespace Aws
 
                 virtual size_t GetKeyLengthBits() const = 0;
 
-                EVP_CIPHER_CTX m_ctx;
+                EVP_CIPHER_CTX *m_ctx;
+                EVP_CIPHER_CTX _m_ctx;
 
                 void CheckInitEncryptor();
                 void CheckInitDecryptor();

--- a/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h
@@ -192,7 +192,9 @@ namespace Aws
                 virtual size_t GetKeyLengthBits() const = 0;
 
                 EVP_CIPHER_CTX *m_ctx;
+#if OPENSSL_VERSION_NUMBER < 0x10100003L
                 EVP_CIPHER_CTX _m_ctx;
+#endif
 
                 void CheckInitEncryptor();
                 void CheckInitDecryptor();


### PR DESCRIPTION
OpenSSL v1.1 issue has been mentioned in both #361  