### PR TITLE
missing cmath include

### DIFF
--- a/aws-cpp-sdk-core/source/external/json-cpp/jsoncpp.cpp
+++ b/aws-cpp-sdk-core/source/external/json-cpp/jsoncpp.cpp
@@ -100,6 +100,8 @@ This file has been modified from its original version by Amazon:
  * It is an internal header that must not be exposed.
  */
 
+#include <cmath>
+
 namespace Aws {
 namespace External {
 namespace Json {

--- a/aws-cpp-sdk-core/source/external/json-cpp/jsoncpp.cpp
+++ b/aws-cpp-sdk-core/source/external/json-cpp/jsoncpp.cpp
@@ -68,6 +68,7 @@ license you like.
 This file has been modified from its original version by Amazon:
   (1) Memory management operations use aws memory management api
   (2) #includes all use <>
+  (3) included <cmath> as std::isfinite is defined in <cmath>
 */
 
 // //////////////////////////////////////////////////////////////////////
@@ -99,8 +100,6 @@ This file has been modified from its original version by Amazon:
  *
  * It is an internal header that must not be exposed.
  */
-
-#include <cmath>
 
 namespace Aws {
 namespace External {
@@ -3090,6 +3089,7 @@ Value& Path::make(Value& root) const {
 #if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
 
 #include <float.h>
+
 #define IS_FINITE _finite
 #define snprintf _snprintf
 
@@ -3100,6 +3100,7 @@ Value& Path::make(Value& root) const {
 
 #else
 
+#include <cmath>
 #ifdef isfinite
 #define IS_FINITE isfinite
 #else


### PR DESCRIPTION
cmath include missing, failed to compile under Clang++ 3.9 with libc++ 

