### PR TITLE
Respect ${INCLUDE_DIRECTORY} when installing the s3-encryption headers

### DIFF
--- a/aws-cpp-sdk-s3-encryption/CMakeLists.txt
+++ b/aws-cpp-sdk-s3-encryption/CMakeLists.txt
@@ -69,9 +69,9 @@ target_link_libraries(${PROJECT_NAME} ${PROJECT_LIBS})
 
 setup_install()
 
-install (FILES ${S3ENCRYPTION_HEADERS} DESTINATION include/aws/s3-encryption)
-install (FILES ${S3ENCRYPTION_MATERIALS_HEADERS} DESTINATION include/aws/s3-encryption/materials)
-install (FILES ${S3ENCRYPTION_HANDLERS_HEADERS} DESTINATION include/aws/s3-encryption/handlers)
-install (FILES ${S3ENCRYPTION_MODULES_HEADERS} DESTINATION include/aws/s3-encryption/modules)
+install (FILES ${S3ENCRYPTION_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/s3-encryption)
+install (FILES ${S3ENCRYPTION_MATERIALS_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/s3-encryption/materials)
+install (FILES ${S3ENCRYPTION_HANDLERS_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/s3-encryption/handlers)
+install (FILES ${S3ENCRYPTION_MODULES_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/s3-encryption/modules)
 
 do_packaging()


### PR DESCRIPTION
`${INCLUDE_DIRECTORY}` is respected by all components of aws-sdk-cpp except `s3-encryption`. This causes problems in Nixpkgs which uses `${INCLUDE_DIRECTORY}` to install header files under a different prefix.