### PR TITLE
Improved correctness of VERSION_STRING inside git repo

### DIFF
--- a/cmake/initialize_project_version.cmake
+++ b/cmake/initialize_project_version.cmake
@@ -1,5 +1,5 @@
 if(GIT_FOUND)
-    execute_process(COMMAND ${GIT_EXECUTABLE} describe --abbrev=0 --tags
+    execute_process(COMMAND ${GIT_EXECUTABLE} --work-tree=${CMAKE_CURRENT_SOURCE_DIR} describe --abbrev=0 --tags
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     OUTPUT_VARIABLE VERSION_STRING
     OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
`VERSION_STRING` is now derived from a git repository if and only if that git repository is rooted at the source directory. This is to prevent behavior seen in aws#383 and elsewhere where the SDK repository is included as a tarball inside of another git repository but the `VERSION_STRING` is derived from the parent project instead of the SDK.