### PR TITLE
Fix race condition in ComputeLongLivedHash

### DIFF
--- a/aws-cpp-sdk-core/source/auth/AWSAuthSigner.cpp
+++ b/aws-cpp-sdk-core/source/auth/AWSAuthSigner.cpp
@@ -115,7 +115,7 @@ static Http::HeaderValueCollection CanonicalizeHeaders(Http::HeaderValueCollecti
         );
         headerValue.erase(new_end, headerValue.end());
 
-        canonicalHeaders[trimmedHeaderName] = headerValue;       
+        canonicalHeaders[trimmedHeaderName] = headerValue;
     }
 
     return canonicalHeaders;
@@ -139,7 +139,7 @@ AWSAuthV4Signer::AWSAuthV4Signer(const std::shared_ptr<Auth::AWSCredentialsProvi
 
 AWSAuthV4Signer::~AWSAuthV4Signer()
 {
-    // empty destructor in .cpp file to keep from needing the implementation of (AWSCredentialsProvider, Sha256, Sha256HMAC) in the header file 
+    // empty destructor in .cpp file to keep from needing the implementation of (AWSCredentialsProvider, Sha256, Sha256HMAC) in the header file
 }
 
 
@@ -328,7 +328,7 @@ bool AWSAuthV4Signer::PresignRequest(Aws::Http::HttpRequest& request, const char
         return false;
     }
 
-    //add that the signature to the query string    
+    //add that the signature to the query string
     request.AddQueryStringParameter(X_AMZ_SIGNATURE, finalSigningHash);
 
     return true;
@@ -341,7 +341,7 @@ Aws::String AWSAuthV4Signer::GenerateSignature(const AWSCredentials& credentials
     Aws::StringStream ss;
 
     auto& partialSignature = ComputeLongLivedHash(credentials.GetAWSSecretKey(), simpleDate);
-        
+
     auto hashResult = m_HMAC->Calculate(ByteBuffer((unsigned char*)stringToSign.c_str(), stringToSign.length()), partialSignature);
     if (!hashResult.IsSuccess())
     {
@@ -412,7 +412,7 @@ const Aws::Utils::Array<unsigned char>& AWSAuthV4Signer::ComputeLongLivedHash(co
 
             //now we do the complicated part of deriving a signing key.
             Aws::String signingKey(SIGNING_KEY);
-            
+
             signingKey.append(m_currentSecretKey);
 
             //we use digest only for the derivation process.


### PR DESCRIPTION
This change fixes a race condition in AWSAuthV4Signer::ComputeLongLivedHash, where the following happens:

1. Thread A sees that the secret key and date arguments don't match the cached values. It locks m_partialSignatureLock and sets m_currentSecretKey and m_currentDateStr, but it does not yet modify m_partialSignature.
2. Thread B, running ComputeLongLiveHash with the same args as thread A, sees that m_currentSecretKey and m_currentDateStr match the args, and assumes that it can use m_partialSignature even though thread A hasn't updated m_partialSignature yet.

The old code was trying to avoid taking the lock, and this fix always takes the lock, which may have some perf costs, but I think that any correct solution is going to require an unavoidable interlocked operation somewhere.