### PR TITLE
Add support for compiling Android using Clang up to API-9

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -72,8 +72,20 @@ elseif(USE_GCC_FLAGS)
 
     if(COMPILER_CLANG)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-private-field")
-        if(PLATFORM_ANDROID AND ANDROID_ABI MATCHES "mips*")
-            string(REGEX REPLACE "-finline-functions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+        if(PLATFORM_ANDROID)
+            if(ANDROID_ABI MATCHES "mips*")
+                string(REGEX REPLACE "-finline-functions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+            endif()
+
+            # when using clang with libc and API lower than 21 we need to include Android support headers and ignore the gnu-include-next warning.
+            if(ANDROID_STL MATCHES "libc" AND ANDROID_NATIVE_API_LEVEL_NUM LESS "21")
+                # NDK lower than 12 doesn't support ignoring the gnu-include-next warning so we need to disable pedantic mode.
+                if(NDK_RELEASE_NUMBER LESS "12000")
+                    string(REGEX REPLACE "-pedantic" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+                else()
+                    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-gnu-include-next")
+                endif()
+            endif()
         endif()
     endif()
 endif()

--- a/cmake/platform/android.cmake
+++ b/cmake/platform/android.cmake
@@ -20,11 +20,15 @@ macro(determine_stdlib_and_api)
             SET(ANDROID_STL "libc++_static" CACHE STRING "" FORCE)
         endif()
 
-        # API levels below 21 will not build with libc++
+        if(NOT ANDROID_NATIVE_API_LEVEL)
+            set(ANDROID_NATIVE_API_LEVEL "android-19")
+        endif()
+
+        # API levels below 9 will not build with libc++
         string(REGEX REPLACE "android-(..?)" "\\1" EXTRACTED_API_LEVEL "${ANDROID_NATIVE_API_LEVEL}")
-        if(NOT ANDROID_NATIVE_API_LEVEL OR EXTRACTED_API_LEVEL LESS "21")
-            message(STATUS "Libc++ requires setting API level to at least 21")
-            set(ANDROID_NATIVE_API_LEVEL "android-21" CACHE STRING "" FORCE)
+        if(EXTRACTED_API_LEVEL LESS "9")
+            message(STATUS "Libc++ requires setting API level to at least 9")
+            set(ANDROID_NATIVE_API_LEVEL "android-9" CACHE STRING "" FORCE)
         endif()
 
         set(STANDALONE_TOOLCHAIN_STL "libc++")
@@ -239,5 +243,9 @@ macro(apply_post_project_platform_settings)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -isystem ${ANDROID_STANDALONE_TOOLCHAIN}/include/c++/4.9.x")
         endif()
     endif()
+    if(ANDROID_STL MATCHES "libc" AND ANDROID_NATIVE_API_LEVEL_NUM LESS "21")
+        include_directories("${NDK_DIR}/sources/android/support/include")
+    endif()
+
 endmacro()
 


### PR DESCRIPTION
Hi all,

I added support for compiling Android with Clang up to API-9. There was some NDK support headers missing that were causing compiling errors. Unfortunately the new headers use  "include_next" that generates a warning because of the "pedantic" mode. For NDK >= 12 there's a way to ignore the warning, but for lower versions I had to remove the "pedantic" mode.