### PR TITLE
Fix Android crash in OpenSSL init/cleanup logic

### DIFF
--- a/aws-cpp-sdk-core/source/utils/crypto/openssl/CryptoImpl.cpp
+++ b/aws-cpp-sdk-core/source/utils/crypto/openssl/CryptoImpl.cpp
@@ -64,7 +64,7 @@ namespace Aws
                 {
                     if (CRYPTO_get_locking_callback() == &locking_fn)
                     {
-                        CRYPTO_set_id_callback(nullptr);
+                        CRYPTO_set_locking_callback(nullptr);
                         assert(locks);
                         Aws::DeleteArray(locks);
                         locks = nullptr;
@@ -72,7 +72,7 @@ namespace Aws
 
                     if (CRYPTO_get_id_callback() == &id_fn)
                     {
-                        CRYPTO_set_locking_callback(nullptr);
+                        CRYPTO_set_id_callback(nullptr);
                     }
                 }
 


### PR DESCRIPTION
Android crashes when initializing the sdk after a prior shutdown.
The cleanup logic of OpenSSL global state has two statements swapped. That results in the crash or at best, a memory leak if the SDK is not initialized again after the shutdown.

