### PR TITLE
Fix syntax in the generated pkgconfig .pc files

### DIFF
--- a/toolchains/pkg-config.pc.in
+++ b/toolchains/pkg-config.pc.in
@@ -7,4 +7,5 @@ Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 Cflags: -I${includedir}
-Libs: -L${libdir} @PROJECT_NAME@  @PROJECT_LIBS@
+Libs: -L${libdir} -l@PROJECT_NAME@
+Requires: @PROJECT_LIBS@


### PR DESCRIPTION
The 'Libs:' line should only include the package's own libraries as linker flags,
while dependent packages should be listed on a separate 'Requires:' line.