### PR TITLE
Fixed missing PATH_MAX definition

### DIFF
--- a/aws-cpp-sdk-core/source/platform/linux-shared/FileSystem.cpp
+++ b/aws-cpp-sdk-core/source/platform/linux-shared/FileSystem.cpp
@@ -25,6 +25,7 @@
 #include <sys/stat.h>
 #include <dirent.h>
 #include <errno.h>
+#include <climits>
 
 #include <cassert>
 


### PR DESCRIPTION
Build on alpine linux failed with:
```
aws-sdk-cpp/aws-cpp-sdk-core/source/platform/linux-shared/FileSystem.cpp: In function 'Aws::String Aws::FileSystem::GetExecutableDirectory()':
aws-sdk-cpp/aws-cpp-sdk-core/source/platform/linux-shared/FileSystem.cpp:253:15: error: 'PATH_MAX' was not declared in this scope
     char dest[PATH_MAX];
               ^~~~~~~~
aws-sdk-cpp/aws-cpp-sdk-core/source/platform/linux-shared/FileSystem.cpp:254:30: error: 'dest' was not declared in this scope
     size_t destSize = sizeof(dest);
```