### PR TITLE
Fixing ClientConfiguration::verifySSL having no effect on Windows

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/http/windows/WinHttpSyncHttpClient.h
+++ b/aws-cpp-sdk-core/include/aws/core/http/windows/WinHttpSyncHttpClient.h
@@ -52,6 +52,8 @@ namespace Aws
             const char* GetLogTag() const override { return "WinHttpSyncHttpClient"; }
 
         private:
+            bool m_verifySSL;
+
             // WinHttp specific implementations
             void* OpenRequest(const Aws::Http::HttpRequest& request, void* connection, const Aws::StringStream& ss) const override;
             void DoAddHeaders(void* httpRequest, Aws::String& headerStr) const override;

--- a/aws-cpp-sdk-core/include/aws/core/http/windows/WinINetSyncHttpClient.h
+++ b/aws-cpp-sdk-core/include/aws/core/http/windows/WinINetSyncHttpClient.h
@@ -50,6 +50,7 @@ namespace Aws
              */
             const char* GetLogTag() const override { return "WinInetSyncHttpClient"; }
         private:
+            bool m_verifySSL;
 
             // WinHttp specific implementations
             void* OpenRequest(const Aws::Http::HttpRequest& request, void* connection, const Aws::StringStream& ss) const override;


### PR DESCRIPTION
ClientConfiguration.verifySSL value used to have no effect with clients WinHttpSyncHttpClient and WinINetSyncHttpClient since you cannot set INTERNET_OPTION_SECURITY_FLAGS on session handles. This pull request makes INTERNET_OPTION_SECURITY_FLAGS to be set on request handles.