### PR TITLE
aws-sdk-cpp/core: Fix proxy when using schemes other than HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ struct AWS_CORE_API ClientConfiguration
     long connectTimeoutMs;
     std::shared_ptr<RetryStrategy> retryStrategy;
     Aws::String endpointOverride;
+    Aws::Http::Scheme proxyScheme;
     Aws::String proxyHost;
     unsigned proxyPort;
     Aws::String proxyUserName;
@@ -433,7 +434,7 @@ The retry strategy defaults to exponential backoff. You can override this defaul
 ##### Endpoint Override
 Do not alter the endpoint.
 
-##### Proxy Host, Port, User Name, and Password
+##### Proxy Scheme, Host, Port, User Name, and Password
 These settings allow you to configure a proxy for all communication with AWS. Examples of when this functionality might be useful include debugging in conjunction with the Burp suite, or using a proxy to connect to the internet.
 
 ##### Executor

--- a/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -86,6 +86,10 @@ namespace Aws
              */
             Aws::String endpointOverride;
             /**
+             * If you have users going through a proxy, set the proxy scheme here. Default HTTPS
+             */
+            Aws::Http::Scheme proxyScheme;
+            /**
              * If you have users going through a proxy, set the host here.
              */
             Aws::String proxyHost;

--- a/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
+++ b/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
@@ -45,6 +45,7 @@ ClientConfiguration::ClientConfiguration() :
     requestTimeoutMs(3000), 
     connectTimeoutMs(1000),
     retryStrategy(Aws::MakeShared<DefaultRetryStrategy>(CLIENT_CONFIGURATION_ALLOCATION_TAG)),
+    proxyScheme(Aws::Http::Scheme::HTTPS),
     proxyPort(0),
     executor(Aws::MakeShared<Aws::Utils::Threading::DefaultExecutor>(CLIENT_CONFIGURATION_ALLOCATION_TAG)),
     verifySSL(true),

--- a/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
+++ b/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
@@ -58,14 +58,14 @@ WinHttpSyncHttpClient::WinHttpSyncHttpClient(const ClientConfiguration& config) 
 
     if (isUsingProxy)
     {
-        AWS_LOGSTREAM_INFO(GetLogTag(), "Http Client is using a proxy. Setting up proxy with settings host " << config.proxyHost
-             << ", port " << config.proxyPort << ", username " << config.proxyUserName);
-
+        const char *const proxySchemeString = Aws::Http::SchemeMapper::ToString(config.proxyScheme);
+        AWS_LOGSTREAM_INFO(GetLogTag(), "Http Client is using a proxy. Setting up proxy with settings scheme " << proxySchemeString
+             << ", host " << config.proxyHost << ", port " << config.proxyPort << ", username " << config.proxyUserName);
 
         winhttpFlags = WINHTTP_ACCESS_TYPE_NAMED_PROXY;
         Aws::StringStream ss;
         const char* schemeString = Aws::Http::SchemeMapper::ToString(config.scheme);
-        ss << StringUtils::ToUpper(schemeString) << "=" << schemeString << "://" << config.proxyHost << ":" << config.proxyPort;
+        ss << StringUtils::ToUpper(schemeString) << "=" << proxySchemeString << "://" << config.proxyHost << ":" << config.proxyPort;
         strProxyHosts.assign(ss.str());
         proxyHosts = strProxyHosts.c_str();
 


### PR DESCRIPTION
There was no way to tell which scheme to use for the proxy settings, so
the user set ClientConfiguration::scheme to HTTPS for making HTTPS
requests to S3, it also sets HTTPS for the proxy host -- which does not
make any sense. Given that, on some versions of Windows 10 (e.g. RS1),
by setting a proxy host with HTTPS when it *atually* works over HTTP,
the proxy fails.

This patch should fix issue #382
(https://github.com/aws/aws-sdk-cpp/issues/382)

Signed-off-by: Paulo Alcantara <paulo.alc.cavalcanti@hp.com>