### PR TITLE
Openssl 1.1

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h
@@ -191,7 +191,8 @@ namespace Aws
 
                 virtual size_t GetKeyLengthBits() const = 0;
 
-                EVP_CIPHER_CTX m_ctx;
+                EVP_CIPHER_CTX *m_ctx;
+                EVP_CIPHER_CTX _m_ctx;
 
                 void CheckInitEncryptor();
                 void CheckInitDecryptor();

--- a/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h
@@ -105,7 +105,9 @@ namespace Aws
 
             private:
                 HMAC_CTX *m_ctx;
+#if OPENSSL_VERSION_NUMBER < 0x10100003L
                 HMAC_CTX _m_ctx;
+#endif
             };
 
             /**
@@ -196,7 +198,9 @@ namespace Aws
                 virtual size_t GetKeyLengthBits() const = 0;
 
                 EVP_CIPHER_CTX *m_ctx;
+#if OPENSSL_VERSION_NUMBER < 0x10100003L
                 EVP_CIPHER_CTX _m_ctx;
+#endif
 
                 void CheckInitEncryptor();
                 void CheckInitDecryptor();

--- a/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h
@@ -21,6 +21,7 @@
 #include <aws/core/utils/GetTheLights.h>
 #include <openssl/ossl_typ.h>
 #include <openssl/evp.h>
+#include <openssl/hmac.h>
 #include <openssl/rand.h>
 #include <atomic>
 #include <mutex>
@@ -96,12 +97,15 @@ namespace Aws
             {
             public:
 
-                Sha256HMACOpenSSLImpl()
-                { }
+                Sha256HMACOpenSSLImpl();
 
-                virtual ~Sha256HMACOpenSSLImpl() = default;
+                virtual ~Sha256HMACOpenSSLImpl();
 
                 virtual HashResult Calculate(const ByteBuffer& toSign, const ByteBuffer& secret) override;
+
+            private:
+                HMAC_CTX *m_ctx;
+                HMAC_CTX _m_ctx;
             };
 
             /**

--- a/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h
@@ -26,6 +26,11 @@
 #include <atomic>
 #include <mutex>
 
+#if defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x20000000L)
+#undef OPENSSL_VERSION_NUMBER
+#define OPENSSL_VERSION_NUMBER 0x1000107fL
+#endif
+
 namespace Aws
 {
     namespace Utils

--- a/aws-cpp-sdk-core/source/utils/crypto/factory/Factories.cpp
+++ b/aws-cpp-sdk-core/source/utils/crypto/factory/Factories.cpp
@@ -146,7 +146,7 @@ public:
 class DefaultSHA256HmacFactory : public HMACFactory
 {
 public:
-    std::shared_ptr<HMAC> CreateImplementation() const override
+    std::shared_ptr<Aws::Utils::Crypto::HMAC> CreateImplementation() const override
     {
 #if ENABLE_BCRYPT_ENCRYPTION
         return Aws::MakeShared<Sha256HMACBcryptImpl>(s_allocationTag);
@@ -750,7 +750,7 @@ std::shared_ptr<Hash> Aws::Utils::Crypto::CreateSha256Implementation()
     return s_Sha256Factory->CreateImplementation();
 }
 
-std::shared_ptr<HMAC> Aws::Utils::Crypto::CreateSha256HMACImplementation()
+std::shared_ptr<Aws::Utils::Crypto::HMAC> Aws::Utils::Crypto::CreateSha256HMACImplementation()
 {
     return s_Sha256HMACFactory->CreateImplementation();
 }

--- a/aws-cpp-sdk-core/source/utils/crypto/openssl/CryptoImpl.cpp
+++ b/aws-cpp-sdk-core/source/utils/crypto/openssl/CryptoImpl.cpp
@@ -229,19 +229,17 @@ namespace Aws
 
 
             OpenSSLCipher::OpenSSLCipher(const CryptoBuffer& key, size_t blockSizeBytes, bool ctrMode) :
-                    SymmetricCipher(key, blockSizeBytes, ctrMode), m_encDecInitialized(false), m_encryptionMode(false),
-                    m_decryptionMode(false)
+                    SymmetricCipher(key, blockSizeBytes, ctrMode), m_ctx(nullptr),
+                    m_encDecInitialized(false), m_encryptionMode(false), m_decryptionMode(false)
             {
                 Init();
             }
 
             OpenSSLCipher::OpenSSLCipher(OpenSSLCipher&& toMove) : SymmetricCipher(std::move(toMove)),
-                                                                   m_encDecInitialized(false)
+                                                                   m_ctx(nullptr), m_encDecInitialized(false)
             {
-                m_ctx = toMove.m_ctx;
-                toMove.m_ctx.cipher = nullptr;
-                toMove.m_ctx.cipher_data = nullptr;
-                toMove.m_ctx.engine = nullptr;
+                Init();
+                EVP_CIPHER_CTX_copy (m_ctx, toMove.m_ctx);
 
                 m_encDecInitialized = toMove.m_encDecInitialized;
                 m_encryptionMode = toMove.m_encryptionMode;
@@ -250,16 +248,16 @@ namespace Aws
 
             OpenSSLCipher::OpenSSLCipher(CryptoBuffer&& key, CryptoBuffer&& initializationVector, CryptoBuffer&& tag) :
                     SymmetricCipher(std::move(key), std::move(initializationVector), std::move(tag)),
-                    m_encDecInitialized(false),
-                    m_encryptionMode(false), m_decryptionMode(false)
+                    m_ctx(nullptr),
+                    m_encDecInitialized(false), m_encryptionMode(false), m_decryptionMode(false)
             {
                 Init();
             }
 
             OpenSSLCipher::OpenSSLCipher(const CryptoBuffer& key, const CryptoBuffer& initializationVector,
                                          const CryptoBuffer& tag) :
-                    SymmetricCipher(key, initializationVector, tag), m_encDecInitialized(false),
-                    m_encryptionMode(false), m_decryptionMode(false)
+                    SymmetricCipher(key, initializationVector, tag), m_ctx(nullptr),
+                    m_encDecInitialized(false), m_encryptionMode(false), m_decryptionMode(false)
             {
                 Init();
             }
@@ -271,7 +269,8 @@ namespace Aws
 
             void OpenSSLCipher::Init()
             {
-                EVP_CIPHER_CTX_init(&m_ctx);
+                m_ctx = &_m_ctx;
+                EVP_CIPHER_CTX_init(m_ctx);
             }
 
             void OpenSSLCipher::CheckInitEncryptor()
@@ -312,7 +311,7 @@ namespace Aws
                 int lengthWritten = static_cast<int>(unEncryptedData.GetLength() + (GetBlockSizeBytes() - 1));
                 CryptoBuffer encryptedText(static_cast<size_t>( lengthWritten + (GetBlockSizeBytes() - 1)));
 
-                if (!EVP_EncryptUpdate(&m_ctx, encryptedText.GetUnderlyingData(), &lengthWritten,
+                if (!EVP_EncryptUpdate(m_ctx, encryptedText.GetUnderlyingData(), &lengthWritten,
                                        unEncryptedData.GetUnderlyingData(),
                                        static_cast<int>(unEncryptedData.GetLength())))
                 {
@@ -340,7 +339,7 @@ namespace Aws
 
                 CryptoBuffer finalBlock(GetBlockSizeBytes());
                 int writtenSize = 0;
-                if (!EVP_EncryptFinal_ex(&m_ctx, finalBlock.GetUnderlyingData(), &writtenSize))
+                if (!EVP_EncryptFinal_ex(m_ctx, finalBlock.GetUnderlyingData(), &writtenSize))
                 {
                     m_failure = true;
                     LogErrors();
@@ -361,7 +360,7 @@ namespace Aws
                 int lengthWritten = static_cast<int>(encryptedData.GetLength() + (GetBlockSizeBytes() - 1));
                 CryptoBuffer decryptedText(static_cast<size_t>(lengthWritten));
 
-                if (!EVP_DecryptUpdate(&m_ctx, decryptedText.GetUnderlyingData(), &lengthWritten,
+                if (!EVP_DecryptUpdate(m_ctx, decryptedText.GetUnderlyingData(), &lengthWritten,
                                        encryptedData.GetUnderlyingData(),
                                        static_cast<int>(encryptedData.GetLength())))
                 {
@@ -389,7 +388,7 @@ namespace Aws
 
                 CryptoBuffer finalBlock(GetBlockSizeBytes());
                 int writtenSize = static_cast<int>(finalBlock.GetLength());
-                if (!EVP_DecryptFinal_ex(&m_ctx, finalBlock.GetUnderlyingData(), &writtenSize))
+                if (!EVP_DecryptFinal_ex(m_ctx, finalBlock.GetUnderlyingData(), &writtenSize))
                 {
                     m_failure = true;
                     LogErrors();
@@ -411,14 +410,9 @@ namespace Aws
                 m_encryptionMode = false;
                 m_decryptionMode = false;
 
-                if (m_ctx.cipher || m_ctx.cipher_data || m_ctx.engine)
-                {
-                    EVP_CIPHER_CTX_cleanup(&m_ctx);
-                }
+                EVP_CIPHER_CTX_cleanup(m_ctx);
 
-                m_ctx.cipher = nullptr;
-                m_ctx.cipher_data = nullptr;
-                m_ctx.engine = nullptr;
+                m_ctx = nullptr;
             }
 
             size_t AES_CBC_Cipher_OpenSSL::BlockSizeBytes = 16;
@@ -439,7 +433,7 @@ namespace Aws
 
             void AES_CBC_Cipher_OpenSSL::InitEncryptor_Internal()
             {
-                if (!EVP_EncryptInit_ex(&m_ctx, EVP_aes_256_cbc(), nullptr, m_key.GetUnderlyingData(),
+                if (!EVP_EncryptInit_ex(m_ctx, EVP_aes_256_cbc(), nullptr, m_key.GetUnderlyingData(),
                                         m_initializationVector.GetUnderlyingData()))
                 {
                     m_failure = true;
@@ -449,7 +443,7 @@ namespace Aws
 
             void AES_CBC_Cipher_OpenSSL::InitDecryptor_Internal()
             {
-                if (!EVP_DecryptInit_ex(&m_ctx, EVP_aes_256_cbc(), nullptr, m_key.GetUnderlyingData(),
+                if (!EVP_DecryptInit_ex(m_ctx, EVP_aes_256_cbc(), nullptr, m_key.GetUnderlyingData(),
                                         m_initializationVector.GetUnderlyingData()))
                 {
                     m_failure = true;
@@ -486,9 +480,9 @@ namespace Aws
 
             void AES_CTR_Cipher_OpenSSL::InitEncryptor_Internal()
             {
-                if (!(EVP_EncryptInit_ex(&m_ctx, EVP_aes_256_ctr(), nullptr, m_key.GetUnderlyingData(),
+                if (!(EVP_EncryptInit_ex(m_ctx, EVP_aes_256_ctr(), nullptr, m_key.GetUnderlyingData(),
                                          m_initializationVector.GetUnderlyingData())
-                        && EVP_CIPHER_CTX_set_padding(&m_ctx, 0)))
+                        && EVP_CIPHER_CTX_set_padding(m_ctx, 0)))
                 {
                     m_failure = true;
                     LogErrors(CTR_LOG_TAG);
@@ -497,9 +491,9 @@ namespace Aws
 
             void AES_CTR_Cipher_OpenSSL::InitDecryptor_Internal()
             {
-                if (!(EVP_DecryptInit_ex(&m_ctx, EVP_aes_256_ctr(), nullptr, m_key.GetUnderlyingData(),
+                if (!(EVP_DecryptInit_ex(m_ctx, EVP_aes_256_ctr(), nullptr, m_key.GetUnderlyingData(),
                                          m_initializationVector.GetUnderlyingData())
-                        && EVP_CIPHER_CTX_set_padding(&m_ctx, 0)))
+                        && EVP_CIPHER_CTX_set_padding(m_ctx, 0)))
                 {
                     m_failure = true;
                     LogErrors(CTR_LOG_TAG);
@@ -541,7 +535,7 @@ namespace Aws
             {
                 CryptoBuffer&& finalBuffer = OpenSSLCipher::FinalizeEncryption();
                 m_tag = CryptoBuffer(TagLengthBytes);
-                if (!EVP_CIPHER_CTX_ctrl(&m_ctx, EVP_CTRL_CCM_GET_TAG, static_cast<int>(m_tag.GetLength()),
+                if (!EVP_CIPHER_CTX_ctrl(m_ctx, EVP_CTRL_CCM_GET_TAG, static_cast<int>(m_tag.GetLength()),
                                          m_tag.GetUnderlyingData()))
                 {
                     m_failure = true;
@@ -554,10 +548,10 @@ namespace Aws
 
             void AES_GCM_Cipher_OpenSSL::InitEncryptor_Internal()
             {
-                if (!(EVP_EncryptInit_ex(&m_ctx, EVP_aes_256_gcm(), nullptr, nullptr, nullptr) &&
-                        EVP_EncryptInit_ex(&m_ctx, nullptr, nullptr, m_key.GetUnderlyingData(),
+                if (!(EVP_EncryptInit_ex(m_ctx, EVP_aes_256_gcm(), nullptr, nullptr, nullptr) &&
+                        EVP_EncryptInit_ex(m_ctx, nullptr, nullptr, m_key.GetUnderlyingData(),
                                            m_initializationVector.GetUnderlyingData()) &&
-                        EVP_CIPHER_CTX_set_padding(&m_ctx, 0)))
+                        EVP_CIPHER_CTX_set_padding(m_ctx, 0)))
                 {
                     m_failure = true;
                     LogErrors(GCM_LOG_TAG);
@@ -566,10 +560,10 @@ namespace Aws
 
             void AES_GCM_Cipher_OpenSSL::InitDecryptor_Internal()
             {
-                if (!(EVP_DecryptInit_ex(&m_ctx, EVP_aes_256_gcm(), nullptr, nullptr, nullptr) &&
-                        EVP_DecryptInit_ex(&m_ctx, nullptr, nullptr, m_key.GetUnderlyingData(),
+                if (!(EVP_DecryptInit_ex(m_ctx, EVP_aes_256_gcm(), nullptr, nullptr, nullptr) &&
+                        EVP_DecryptInit_ex(m_ctx, nullptr, nullptr, m_key.GetUnderlyingData(),
                                            m_initializationVector.GetUnderlyingData()) &&
-                        EVP_CIPHER_CTX_set_padding(&m_ctx, 0)))
+                        EVP_CIPHER_CTX_set_padding(m_ctx, 0)))
                 {
                     m_failure = true;
                     LogErrors(GCM_LOG_TAG);
@@ -588,7 +582,7 @@ namespace Aws
                     return;
                 }
 
-                if (!EVP_CIPHER_CTX_ctrl(&m_ctx, EVP_CTRL_GCM_SET_TAG, static_cast<int>(m_tag.GetLength()),
+                if (!EVP_CIPHER_CTX_ctrl(m_ctx, EVP_CTRL_GCM_SET_TAG, static_cast<int>(m_tag.GetLength()),
                                          m_tag.GetUnderlyingData()))
                 {
                     m_failure = true;
@@ -672,7 +666,7 @@ namespace Aws
                         memcpy(tempInput.GetUnderlyingData() + BlockSizeBytes, r, BlockSizeBytes);
 
                         //encrypt the concatenated A and R[I] and store it in B
-                        if (!EVP_EncryptUpdate(&m_ctx, b.GetUnderlyingData(), &outLen,
+                        if (!EVP_EncryptUpdate(m_ctx, b.GetUnderlyingData(), &outLen,
                                                tempInput.GetUnderlyingData(), static_cast<int>(tempInput.GetLength())))
                         {
                             LogErrors(KEY_WRAP_TAG);
@@ -749,7 +743,7 @@ namespace Aws
                         memcpy(tempInput.GetUnderlyingData() + BlockSizeBytes, r, BlockSizeBytes);
 
                         //Decrypt the concatenated buffer
-                        if(!EVP_DecryptUpdate(&m_ctx, b.GetUnderlyingData(), &outLen,
+                        if(!EVP_DecryptUpdate(m_ctx, b.GetUnderlyingData(), &outLen,
                                               tempInput.GetUnderlyingData(), static_cast<int>(tempInput.GetLength())))
                         {
                             m_failure = true;
@@ -784,8 +778,8 @@ namespace Aws
 
             void AES_KeyWrap_Cipher_OpenSSL::InitEncryptor_Internal()
             {
-                if (!EVP_EncryptInit_ex(&m_ctx, EVP_aes_256_ecb(), nullptr, m_key.GetUnderlyingData(), nullptr) &&
-                        EVP_CIPHER_CTX_set_padding(&m_ctx, 0))
+                if (!EVP_EncryptInit_ex(m_ctx, EVP_aes_256_ecb(), nullptr, m_key.GetUnderlyingData(), nullptr) &&
+                        EVP_CIPHER_CTX_set_padding(m_ctx, 0))
                 {
                     m_failure = true;
                     LogErrors(KEY_WRAP_TAG);
@@ -794,8 +788,8 @@ namespace Aws
 
             void AES_KeyWrap_Cipher_OpenSSL::InitDecryptor_Internal()
             {
-                if (!(EVP_DecryptInit_ex(&m_ctx, EVP_aes_256_ecb(), nullptr, m_key.GetUnderlyingData(), nullptr) &&
-                        EVP_CIPHER_CTX_set_padding(&m_ctx, 0)))
+                if (!(EVP_DecryptInit_ex(m_ctx, EVP_aes_256_ecb(), nullptr, m_key.GetUnderlyingData(), nullptr) &&
+                        EVP_CIPHER_CTX_set_padding(m_ctx, 0)))
                 {
                     m_failure = true;
                     LogErrors(KEY_WRAP_TAG);


### PR DESCRIPTION
I can't push to #362, so this is an updated version.

Compared to #362, this fixes a few issues detected so far:
- code involving EVP_CIPHER_CTX_copy() has been fixed
- EVP_CIPHER_CTX_init() / EVP_CIPHER_CTX_reset() / OpenSSLCipher::Reset() usages have been simplified in the OpenSSL 1.1.x case
- class Sha256HMACOpenSSLImpl allocates OpenSSL objects in its constructor now as requested
- this supports LibreSSL again