### PR TITLE
Fix race condition in TransferHandle::WaitUntilFinished() deadlocking

### DIFF
--- a/aws-cpp-sdk-transfer/source/transfer/TransferHandle.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferHandle.cpp
@@ -229,6 +229,7 @@ namespace Aws
 
             if(IsTransitionAllowed(currentStatus, value))
             {
+                std::unique_lock<std::mutex> semaphoreLock(m_statusLock);
                 m_status.store(static_cast<long>(value));
 
                 if (IsFinishedStatus(value))
@@ -238,7 +239,6 @@ namespace Aws
                         CleanupDownloadStream();
                     }
 
-                    std::unique_lock<std::mutex> semaphoreLock(m_statusLock);
                     m_waitUntilFinishedSignal.notify_all();
                 }
             }

--- a/aws-cpp-sdk-transfer/source/transfer/TransferHandle.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferHandle.cpp
@@ -246,9 +246,9 @@ namespace Aws
 
         void TransferHandle::WaitUntilFinished() const
         {
+            std::unique_lock<std::mutex> semaphoreLock(m_statusLock);
             if (!IsFinishedStatus(static_cast<TransferStatus>(m_status.load())) || HasPendingParts())
             {
-                std::unique_lock<std::mutex> semaphoreLock(m_statusLock);
                 m_waitUntilFinishedSignal.wait(semaphoreLock, [this]()
                     { return IsFinishedStatus(static_cast<TransferStatus>(m_status.load())) && !HasPendingParts(); });
                 semaphoreLock.unlock();


### PR DESCRIPTION
I was debugging a rare deadlock condition we would observe on long running jobs processing data from s3. When I attached to the process it appears `TransferHandle::WaitUntilFinished()` would wait indefinitely.

From reading the code, it appears possible that `m_waitUntilFinishedSignal.notify_all();` may be called before `m_waitUntilFinishedSignal.wait(...);` if the `WaitUntilFinished` thread loses context after the conditional check on `m_status.load()`.

The fix (I think) is to broaden the scope of the lock to encompass setting the new status.

I'm not sure if the lock in `UpdateStatus` should actually be placed in a block to ensure `m_statusLock` is immediate available when `notify_all()` is called?