### PR TITLE
fix deadlock at TransferHandle::WaitUntilFinished 

### DIFF
--- a/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -501,9 +501,9 @@ namespace Aws
             }
             else
             {
-                transferContext->handle->UpdateStatus(DetermineIfFailedOrCanceled(*transferContext->handle));
                 transferContext->handle->ChangePartToFailed(transferContext->partState);
                 transferContext->handle->SetError(outcome.GetError());
+                transferContext->handle->UpdateStatus(DetermineIfFailedOrCanceled(*transferContext->handle));
                 TriggerErrorCallback(*transferContext->handle, outcome.GetError());
             }
 


### PR DESCRIPTION
Hi,

I encountered a deadlock when calling WaitUntilFinish, for transfer request which failed. i tried to upload to non existent bucket. from time to time, my process got deadlock. The reason is that transferContext->handle->UpdateStatus method shall be called last, after the part status was changed (and this is the fix).

The waiting thread is waiting on conditional variable and being notified when object status is changed to finished status. however the predicate it uses checks also it does not have pending parts.
A deadlock can occur if the transfer manager change the object status to failed and notify the waiting thread to be awaken, however it did not yet changed the part status, so it is regarded as pending part.
so waiting thread is awaken, checks the predicate and enter a sleep. now no one will awake it again, and this result with deadlock.

If you look at HandlePutObjectResponse you can see, it first change the part status and then the object status. the same behavior shall be done for failed case. I also put the SetError to be before the UpdateStatus call, as thread which is waiting may want to observe the error message on failure case.

