### PR TITLE
cmake: GNUInstallDirs must be included after project()

### DIFF
--- a/cmake/platform/linux.cmake
+++ b/cmake/platform/linux.cmake
@@ -2,8 +2,6 @@
 message(STATUS "Generating linux build config")
 set(SDK_INSTALL_BINARY_PREFIX "linux")
 
-include(GNUInstallDirs)
-
 if(SIMPLE_INSTALL)
     include(CMakePackageConfigHelpers)
 
@@ -19,6 +17,8 @@ if(SIMPLE_INSTALL)
 endif()
 
 macro(apply_post_project_platform_settings)
+    include(GNUInstallDirs)
+
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
         set(SDK_INSTALL_BINARY_PREFIX "${SDK_INSTALL_BINARY_PREFIX}/intel64")
     else()


### PR DESCRIPTION
GNUInstallDirs uses CMAKE_SYSTEM_NAME, which is defined only
after project()

It works in Ubuntu, because they add a local hack which ends
up bypassing the relevant bits of GNUInstallDirs.cmake, but
when using CMake from source, or when using any other
distribution, the way GNUInstallDirs is used in the AWS C++
SDK doesn't work.

By moving the call to GNUInstallDirs into the
apply_post_project_platform_settings() macro, things seem to
work OK.

Tested on Debian Jessie/Stretch/Sid as well as
Ubuntu Trusty/Xenial.

See #527

Signed-off-by: André Draszik <git@andred.net>