### PR TITLE
Fix GCC7 compilation by telling fall through in switches

### DIFF
--- a/aws-cpp-sdk-core/source/config/AWSProfileConfigLoader.cpp
+++ b/aws-cpp-sdk-core/source/config/AWSProfileConfigLoader.cpp
@@ -115,6 +115,7 @@ namespace Aws
                             FlushProfileAndReset(line, openPos, closePos);
                             break;
                         }
+                        // fall through
                     case PROFILE_FOUND:
                     {
                         auto keyValuePair = StringUtils::Split(line, EQ);

--- a/aws-cpp-sdk-core/source/external/tinyxml2/tinyxml2.cpp
+++ b/aws-cpp-sdk-core/source/external/tinyxml2/tinyxml2.cpp
@@ -337,14 +337,17 @@ namespace tinyxml2
       --output;
       *output = (char)((input | BYTE_MARK) & BYTE_MASK);
       input >>= 6;
+      // fall through
     case 3:
       --output;
       *output = (char)((input | BYTE_MARK) & BYTE_MASK);
       input >>= 6;
+      // fall through
     case 2:
       --output;
       *output = (char)((input | BYTE_MARK) & BYTE_MASK);
       input >>= 6;
+      // fall through
     case 1:
       --output;
       *output = (char)(input | FIRST_BYTE_MARK[*length]);

--- a/aws-cpp-sdk-core/source/http/HttpClientFactory.cpp
+++ b/aws-cpp-sdk-core/source/http/HttpClientFactory.cpp
@@ -53,6 +53,7 @@ namespace Aws
             {
                 case SIGPIPE:
                     AWS_LOGSTREAM_ERROR(HTTP_CLIENT_FACTORY_ALLOCATION_TAG, "Received a SIGPIPE error");
+                    break;
                 default:
                     AWS_LOGSTREAM_ERROR(HTTP_CLIENT_FACTORY_ALLOCATION_TAG, "Unhandled system SIGNAL error"  << signal);
             }


### PR DESCRIPTION
Make aws-cpp-sdk-core compile with GCC 7.