### PR TITLE
Get rid of unused variable compiler warning

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/NoResult.h
+++ b/aws-cpp-sdk-core/include/aws/core/NoResult.h
@@ -22,9 +22,8 @@ namespace Aws
 
 class AWS_CORE_API NoResult
 {
-private:
-    //TODO: Remove this once we figure out how to make an empty class compile in a move on gcc.
-    int m_giveSomeSize;
+public:
+    virtual ~NoResult() {};
 };
 
 } // namespace Aws


### PR DESCRIPTION
I don't know if this is the most elegant way to accomplish this, but this approach successfully prevents the unused variable compiler warning for m_giveSomeSize.