### PR TITLE
Retry S3 InternalError and RequestTimeout errors

### DIFF
--- a/aws-cpp-sdk-core-tests/aws/client/AWSErrorMashallerTest.cpp
+++ b/aws-cpp-sdk-core-tests/aws/client/AWSErrorMashallerTest.cpp
@@ -194,6 +194,12 @@ TEST(JsonErrorMashallerTest, TestErrorsWithPrefixParse)
     ASSERT_EQ(message, error.GetMessage());
     ASSERT_TRUE(error.ShouldRetry());
 
+    error = awsErrorMarshaller.Marshall(*BuildHttpResponse(exceptionPrefix + "InternalError", message));
+    ASSERT_EQ(CoreErrors::INTERNAL_FAILURE, error.GetErrorType());
+    ASSERT_EQ("InternalError", error.GetExceptionName());
+    ASSERT_EQ(message, error.GetMessage());
+    ASSERT_TRUE(error.ShouldRetry());
+
     error = awsErrorMarshaller.Marshall(*BuildHttpResponse(exceptionPrefix + "InvalidAction", message));
     ASSERT_EQ(CoreErrors::INVALID_ACTION, error.GetErrorType());
     ASSERT_EQ("InvalidAction", error.GetExceptionName());
@@ -389,6 +395,12 @@ TEST(AWSErrorMashallerTest, TestErrorsWithoutPrefixParse)
     error = awsErrorMarshaller.Marshall(*BuildHttpResponse(exceptionPrefix + "InternalServerError", message));
     ASSERT_EQ(CoreErrors::INTERNAL_FAILURE, error.GetErrorType());
     ASSERT_EQ("InternalServerError", error.GetExceptionName());
+    ASSERT_EQ(message, error.GetMessage());
+    ASSERT_TRUE(error.ShouldRetry());
+
+    error = awsErrorMarshaller.Marshall(*BuildHttpResponse(exceptionPrefix + "InternalError", message));
+    ASSERT_EQ(CoreErrors::INTERNAL_FAILURE, error.GetErrorType());
+    ASSERT_EQ("InternalError", error.GetExceptionName());
     ASSERT_EQ(message, error.GetMessage());
     ASSERT_TRUE(error.ShouldRetry());
 

--- a/aws-cpp-sdk-core-tests/aws/client/AWSErrorMashallerTest.cpp
+++ b/aws-cpp-sdk-core-tests/aws/client/AWSErrorMashallerTest.cpp
@@ -362,6 +362,12 @@ TEST(JsonErrorMashallerTest, TestErrorsWithPrefixParse)
     ASSERT_EQ(message, error.GetMessage());
     ASSERT_FALSE(error.ShouldRetry());
 
+    error = awsErrorMarshaller.Marshall(*BuildHttpResponse(exceptionPrefix + "RequestTimeout", message));
+    ASSERT_EQ(CoreErrors::REQUEST_TIMEOUT, error.GetErrorType());
+    ASSERT_EQ("RequestTimeout", error.GetExceptionName());
+    ASSERT_EQ(message, error.GetMessage());
+    ASSERT_TRUE(error.ShouldRetry());
+
     error = awsErrorMarshaller.Marshall(*BuildHttpResponse(exceptionPrefix + "IDon'tExist", "JunkMessage"));
     ASSERT_EQ(CoreErrors::UNKNOWN, error.GetErrorType());
     ASSERT_EQ(exceptionPrefix + "IDon'tExist", error.GetExceptionName());
@@ -565,6 +571,12 @@ TEST(AWSErrorMashallerTest, TestErrorsWithoutPrefixParse)
     ASSERT_EQ("UnrecognizedClientException", error.GetExceptionName());
     ASSERT_EQ(message, error.GetMessage());
     ASSERT_FALSE(error.ShouldRetry());
+
+    error = awsErrorMarshaller.Marshall(*BuildHttpResponse(exceptionPrefix + "RequestTimeout", message));
+    ASSERT_EQ(CoreErrors::REQUEST_TIMEOUT, error.GetErrorType());
+    ASSERT_EQ("RequestTimeout", error.GetExceptionName());
+    ASSERT_EQ(message, error.GetMessage());
+    ASSERT_TRUE(error.ShouldRetry());
 
     error = awsErrorMarshaller.Marshall(*BuildHttpResponse(exceptionPrefix + "IDon'tExist", "JunkMessage"));
     ASSERT_EQ(CoreErrors::UNKNOWN, error.GetErrorType());

--- a/aws-cpp-sdk-core/include/aws/core/client/CoreErrors.h
+++ b/aws-cpp-sdk-core/include/aws/core/client/CoreErrors.h
@@ -53,6 +53,8 @@ namespace Aws
             INVALID_SIGNATURE = 21,
             SIGNATURE_DOES_NOT_MATCH = 22,
             INVALID_ACCESS_KEY_ID = 23,
+            REQUEST_TIMEOUT = 24,
+
             NETWORK_CONNECTION = 99, // General failure to send message to service 
 
             // These are needed for logical reasons

--- a/aws-cpp-sdk-core/source/client/CoreErrors.cpp
+++ b/aws-cpp-sdk-core/source/client/CoreErrors.cpp
@@ -29,6 +29,7 @@ static const int INVALID_SIGNATURE_EXCEPTION_HASH = HashingUtils::HashString("In
 static const int INVALID_SIGNATURE_HASH = HashingUtils::HashString("InvalidSignature");
 static const int INTERNAL_FAILURE_HASH = HashingUtils::HashString("InternalFailure");
 static const int INTERNAL_SERVER_ERROR_HASH = HashingUtils::HashString("InternalServerError");
+static const int INTERNAL_ERROR_HASH = HashingUtils::HashString("InternalError");
 static const int INVALID_ACTION_HASH = HashingUtils::HashString("InvalidAction");
 static const int INVALID_CLIENT_TOKEN_ID_HASH = HashingUtils::HashString("InvalidClientTokenId");
 static const int INVALID_CLIENT_TOKEN_ID_EXCEPTION_HASH = HashingUtils::HashString("InvalidClientTokenIdException");
@@ -80,7 +81,7 @@ AWSError<CoreErrors> CoreErrorsMapper::GetErrorForName(const char* errorName)
   {
       return AWSError<CoreErrors>(CoreErrors::INVALID_SIGNATURE, false);
   }
-  else if (errorHash == INTERNAL_FAILURE_HASH || errorHash == INTERNAL_SERVER_ERROR_HASH)
+  else if (errorHash == INTERNAL_FAILURE_HASH || errorHash == INTERNAL_SERVER_ERROR_HASH || errorHash == INTERNAL_ERROR_HASH)
   {
     return AWSError<CoreErrors>(CoreErrors::INTERNAL_FAILURE, true);
   }

--- a/aws-cpp-sdk-core/source/client/CoreErrors.cpp
+++ b/aws-cpp-sdk-core/source/client/CoreErrors.cpp
@@ -68,6 +68,7 @@ static const int INVALID_ACCESS_KEY_ID_HASH = HashingUtils::HashString("InvalidA
 static const int INVALID_ACCESS_KEY_ID_EXCEPTION_HASH = HashingUtils::HashString("InvalidAccessKeyIdException");
 static const int REQUEST_TIME_TOO_SKEWED_HASH = HashingUtils::HashString("RequestTimeTooSkewed");
 static const int REQUEST_TIME_TOO_SKEWED_EXCEPTION_HASH = HashingUtils::HashString("RequestTimeTooSkewedException");
+static const int REQUEST_TIMEOUT_HASH = HashingUtils::HashString("RequestTimeout");
 
 AWSError<CoreErrors> CoreErrorsMapper::GetErrorForName(const char* errorName)
 {
@@ -164,6 +165,10 @@ AWSError<CoreErrors> CoreErrorsMapper::GetErrorForName(const char* errorName)
   else if (errorHash == REQUEST_TIME_TOO_SKEWED_HASH || errorHash == REQUEST_TIME_TOO_SKEWED_EXCEPTION_HASH)
   {
     return AWSError<CoreErrors>(CoreErrors::REQUEST_TIME_TOO_SKEWED, true);
+  }
+  else if (errorHash == REQUEST_TIMEOUT_HASH)
+  {
+    return AWSError<CoreErrors>(CoreErrors::REQUEST_TIMEOUT, true);
   }
 
   return AWSError<CoreErrors>(CoreErrors::UNKNOWN, false);

--- a/aws-cpp-sdk-core/source/client/CoreErrors.cpp
+++ b/aws-cpp-sdk-core/source/client/CoreErrors.cpp
@@ -192,6 +192,8 @@ AWS_CORE_API AWSError<CoreErrors> CoreErrorsMapper::GetErrorForHttpResponseCode(
             return AWSError<CoreErrors>(CoreErrors::THROTTLING, true/*retry*/);
         case HttpResponseCode::SERVICE_UNAVAILABLE:
             return AWSError<CoreErrors>(CoreErrors::SERVICE_UNAVAILABLE, true/*retry*/);
+        case HttpResponseCode::REQUEST_TIMEOUT:
+            return AWSError<CoreErrors>(CoreErrors::REQUEST_TIMEOUT, true/*retry*/);
         default:
             int codeValue = static_cast<int>(code);
             return AWSError<CoreErrors>(CoreErrors::UNKNOWN, codeValue >= 500 && codeValue < 600);


### PR DESCRIPTION
This is an updated version of https://github.com/aws/aws-sdk-cpp/pull/167, which added support for the S3 InternalError, RequestTimeout and SlowDown exceptions. @JonathanHenson's comment at https://github.com/aws/aws-sdk-cpp/pull/167#issuecomment-269376107 suggested that this had been merged in some way, but in fact, only support for the SlowDown exception was added (in 56385be06b).

I haven't seen RequestTimeout from S3 lately, but I see InternalError all the time, so the library should definitely recognize it and retry requests.