### PR TITLE
TransferManager: If directory does not exist, create it when downloading

### DIFF
--- a/aws-cpp-sdk-core-tests/utils/FileSystemUtilsTest.cpp
+++ b/aws-cpp-sdk-core-tests/utils/FileSystemUtilsTest.cpp
@@ -63,6 +63,80 @@ TEST(FileTest, TempFile)
     ASSERT_FALSE(testIn.good());
 }
 
+TEST(FileTest, TestGetDirectoryName)
+{
+#ifdef _WIN32
+    const char* test1 = "d\\f";
+    EXPECT_STREQ("d", Aws::FileSystem::GetDirectoryName(test1).c_str());
+
+    const char* test2 = "C:\\d\\f";
+    EXPECT_STREQ("C:\\d", Aws::FileSystem::GetDirectoryName(test2).c_str());
+
+    const char* test3 = "d\\f\\";
+    EXPECT_STREQ("d", Aws::FileSystem::GetDirectoryName(test3).c_str());
+
+    const char* test4 = "C:\\d\\f\\";
+    EXPECT_STREQ("C:\\d", Aws::FileSystem::GetDirectoryName(test4).c_str());
+
+    const char* test5 = "f";
+    EXPECT_STREQ(".", Aws::FileSystem::GetDirectoryName(test5).c_str());
+
+    const char* test6 = "C:\\";
+    EXPECT_STREQ("C:", Aws::FileSystem::GetDirectoryName(test6).c_str());
+
+    const char* test7 = "C:\\\\";
+    EXPECT_STREQ("C:", Aws::FileSystem::GetDirectoryName(test7).c_str());
+
+    const char* test8 = "C:\\d";
+    EXPECT_STREQ("C:", Aws::FileSystem::GetDirectoryName(test8).c_str());
+
+    const char* test9 = "C:\\\\\\";
+    EXPECT_STREQ("C:", Aws::FileSystem::GetDirectoryName(test9).c_str());
+
+    const char* test10 = "C:\\\\\\d\\\\\\";
+    EXPECT_STREQ("C:", Aws::FileSystem::GetDirectoryName(test10).c_str());
+#else
+    const char* test1 = "d/f";
+    EXPECT_STREQ("d", Aws::FileSystem::GetDirectoryName(test1).c_str());
+
+    const char* test2 = "/d/f";
+    EXPECT_STREQ("/d", Aws::FileSystem::GetDirectoryName(test2).c_str());
+
+    const char* test3 = "d/f/";
+    EXPECT_STREQ("d", Aws::FileSystem::GetDirectoryName(test3).c_str());
+
+    const char* test4 = "/d/f/";
+    EXPECT_STREQ("/d", Aws::FileSystem::GetDirectoryName(test4).c_str());
+
+    const char* test5 = "f";
+    EXPECT_STREQ(".", Aws::FileSystem::GetDirectoryName(test5).c_str());
+
+    const char* test6 = "/";
+    EXPECT_STREQ("/", Aws::FileSystem::GetDirectoryName(test6).c_str());
+
+    const char* test7 = "//";
+    EXPECT_STREQ("/", Aws::FileSystem::GetDirectoryName(test7).c_str());
+
+    const char* test8 = "//d";
+    EXPECT_STREQ("/", Aws::FileSystem::GetDirectoryName(test8).c_str());
+
+    const char* test9 = "///";
+    EXPECT_STREQ("/", Aws::FileSystem::GetDirectoryName(test9).c_str());
+
+    const char* test10 = "///d///";
+    EXPECT_STREQ("/", Aws::FileSystem::GetDirectoryName(test10).c_str());
+#endif
+
+    const char* test11 = "";
+    EXPECT_STREQ(".", Aws::FileSystem::GetDirectoryName(test11).c_str());
+
+    const char* test12 = ".";
+    EXPECT_STREQ(".", Aws::FileSystem::GetDirectoryName(test12).c_str());
+
+    const char* test13 = "..";
+    EXPECT_STREQ(".", Aws::FileSystem::GetDirectoryName(test13).c_str());
+}
+
 class DirectoryTreeTest : public ::testing::Test
 {
 public:

--- a/aws-cpp-sdk-core/include/aws/core/platform/FileSystem.h
+++ b/aws-cpp-sdk-core/include/aws/core/platform/FileSystem.h
@@ -45,6 +45,12 @@ namespace FileSystem
     AWS_CORE_API Aws::String GetExecutableDirectory();
 
     /**
+     * Returns the directory part of a filename. If filename is empty string or if no path delimiters found
+     * then the "." is returned.
+     */
+    AWS_CORE_API Aws::String GetDirectoryName(const char* fileName);
+
+    /**
     * Creates directory if it doesn't exist. Returns true if the directory was created
     * or already exists. False for failure.
     */

--- a/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -100,6 +100,8 @@ namespace Aws
                                                                       const DownloadConfiguration& downloadConfig)
         {
 
+            Aws::FileSystem::CreateDirectoryIfNotExists(Aws::FileSystem::GetDirectoryName(writeToFile.c_str()).c_str());
+
             auto createFileFn = [=]() { return Aws::New<Aws::FStream>(CLASS_TAG, writeToFile.c_str(),
                                                                      std::ios_base::out | std::ios_base::in | std::ios_base::binary | std::ios_base::trunc);};
 


### PR DESCRIPTION
When downloading to a filename which has a non-existent directory,
create first this directory before start downloading.

https://github.com/aws/aws-sdk-cpp/issues/578