### PR TITLE
JsonValue : uninitialized member variable in copy process

### DIFF
--- a/aws-cpp-sdk-core-tests/utils/json/JsonSerializerTest.cpp
+++ b/aws-cpp-sdk-core-tests/utils/json/JsonSerializerTest.cpp
@@ -294,3 +294,14 @@ TEST(JsonSerializerTest, TestNullSanity)
     ASSERT_EQ("{\n}\n", emptyObjValue);
 }
 
+TEST(JsonSerializerTest, TestCopy)
+{
+    JsonValue value;
+    ASSERT_TRUE(value.WasParseSuccessful());
+    JsonValue copied_value(value);
+    ASSERT_TRUE(copied_value.WasParseSuccessful());
+    JsonValue copied_value2;
+    copied_value2 = value;
+    ASSERT_TRUE(copied_value2.WasParseSuccessful());
+}
+

--- a/aws-cpp-sdk-core/source/utils/json/JsonSerializer.cpp
+++ b/aws-cpp-sdk-core/source/utils/json/JsonSerializer.cpp
@@ -390,12 +390,16 @@ JsonValue& JsonValue::WithObject(const Aws::String& key, const JsonValue&& value
 JsonValue& JsonValue::AsObject(const JsonValue& value)
 {
     m_value = value.m_value;
+    m_wasParseSuccessful = value.m_wasParseSuccessful;
+    m_errorMessage = value.m_errorMessage;
     return *this;
 }
 
 JsonValue& JsonValue::AsObject(JsonValue && value)
 {
     m_value = std::move(value.m_value);
+    m_wasParseSuccessful = value.m_wasParseSuccessful;
+    m_errorMessage = value.m_errorMessage;
     return *this;
 }
 


### PR DESCRIPTION
Hi, I found bug. Please check this.

[Detail]
When JsonValue created from copy constructor, WasParseSuccessful method return false. Because,  copy constructor does not copy m_wasParseSuccessful.