### PR TITLE
fix ExpiredObjectDeleteMarker xml

### DIFF
--- a/aws-cpp-sdk-s3/source/model/LifecycleExpiration.cpp
+++ b/aws-cpp-sdk-s3/source/model/LifecycleExpiration.cpp
@@ -98,7 +98,7 @@ void LifecycleExpiration::AddToNode(XmlNode& parentNode) const
   if(m_expiredObjectDeleteMarkerHasBeenSet)
   {
    XmlNode expiredObjectDeleteMarkerNode = parentNode.CreateChildElement("ExpiredObjectDeleteMarker");
-  ss << m_expiredObjectDeleteMarker;
+  ss << std::boolalpha << m_expiredObjectDeleteMarker;
    expiredObjectDeleteMarkerNode.SetText(ss.str());
   ss.str("");
   }


### PR DESCRIPTION
Hi, I was receiving an invalid XML document error when trying to use WithExpiredObjectDeleteMarker on a PutBucketLifecycleConfiguration call. It would appear that the XML validation is expecting true or false instead of 1 or 0.