### PR TITLE
fixes truncation of file size

### DIFF
--- a/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -916,7 +916,7 @@ namespace Aws
                 const Aws::String& contentType, const Aws::Map<Aws::String, Aws::String>& metadata, const Aws::String& fileName)
         {
             fileStream->seekg(0, std::ios_base::end);
-            size_t length = static_cast<size_t>(fileStream->tellg());
+            auto length = fileStream->tellg();
             fileStream->seekg(0, std::ios_base::beg);
             auto handle = Aws::MakeShared<TransferHandle>(CLASS_TAG, bucketName, keyName, length, fileName);
             handle->SetContentType(contentType);


### PR DESCRIPTION
Found that issue doing code review(trying to implement similar things for my needs, so was looking here as an example)
On vs2015x86 tellg() result holds 64bit long long which is truncated to 32bit size_t and then passed to TransferHandle which needs uint64_t. I've removed redundant cast.

Warning: while the fix looks correct, but I actually did not try to compile that.