### PR TITLE
Possible fix for crashing EC2 requests

### DIFF
--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/queryxml/QueryXmlResultSource.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/queryxml/QueryXmlResultSource.vm
@@ -34,7 +34,7 @@ ${typeInfo.className}& ${typeInfo.className}::operator =(const AmazonWebServiceR
   const XmlDocument& xmlDocument = result.GetPayload();
   XmlNode rootNode = xmlDocument.GetRootElement();
   XmlNode resultNode = rootNode;
-  if (rootNode.GetName() != "${typeInfo.shape.name}")
+  if (!rootNode.IsNull() && (rootNode.GetName() != "${typeInfo.shape.name}"))
   {
     resultNode = rootNode.FirstChild("${typeInfo.shape.name}");
   }
@@ -45,10 +45,11 @@ ${typeInfo.className}& ${typeInfo.className}::operator =(const AmazonWebServiceR
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/ModelClassMembersDeserializeXml.vm")
   }
 
-  XmlNode responseMetadataNode = rootNode.FirstChild("ResponseMetadata");
-  m_responseMetadata = responseMetadataNode;
-  AWS_LOGSTREAM_DEBUG("Aws::${metadata.namespace}::Model::${typeInfo.className}", "x-amzn-request-id: " << m_responseMetadata.GetRequestId() );
-
+  if (!rootNode.IsNull()) {
+    XmlNode responseMetadataNode = rootNode.FirstChild("ResponseMetadata");
+    m_responseMetadata = responseMetadataNode;
+    AWS_LOGSTREAM_DEBUG("Aws::${metadata.namespace}::Model::${typeInfo.className}", "x-amzn-request-id: " << m_responseMetadata.GetRequestId() );
+  }
 #if($shape.hasHeaderMembers())
   const auto& headers = result.GetHeaderValueCollection();
 #foreach($memberEntry in $shape.members.entrySet())

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/rest/RestXmlServiceClientOperations.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/rest/RestXmlServiceClientOperations.vm
@@ -66,7 +66,12 @@ ${operation.name}Outcome ${className}::${operation.name}(const ${operation.reque
 #if($operation.result.shape.hasStreamMembers())
     return ${operation.name}Outcome(${operation.result.shape.name}(outcome.GetResultWithOwnership()));
 #else
-    return ${operation.name}Outcome(${operation.result.shape.name}(outcome.GetResult()));
+    if(!outcome.GetResult().GetPayload().GetRootElement().IsNull())
+    {
+      return ${operation.name}Outcome(${operation.result.shape.name}(outcome.GetResult()));
+    } else {
+      return ${operation.name}Outcome(AWSError<CoreErrors>(CoreErrors::UNKNOWN, "", "Failed with an empty payload.", false));
+    }
 #end
 #else
     return ${operation.name}Outcome(NoResult());
@@ -116,7 +121,12 @@ ${operation.name}Outcome ${className}::${operation.name}() const
 #if($operation.result.shape.hasStreamMembers())
     return ${operation.name}Outcome(${operation.result.shape.name}(outcome.GetResultWithOwnership()));
 #else
-    return ${operation.name}Outcome(${operation.result.shape.name}(outcome.GetResult()));
+    if(!outcome.GetResult().GetPayload().GetRootElement().IsNull())
+    {
+      return ${operation.name}Outcome(${operation.result.shape.name}(outcome.GetResult()));
+    } else {
+      return ${operation.name}Outcome(AWSError<CoreErrors>(CoreErrors::UNKNOWN, "", "Failed with an empty payload.", false));
+    }
 #end
 #else
     return ${operation.name}Outcome(NoResult());


### PR DESCRIPTION
My colleague had two crashes in version 1.0.98 on Windows and sent me the minidumps.

I was unable to determine exactly what happened in EC2Client::MakeRequest but the request was reported as successful and included headers. The XmlDocument payload in the result did not have a root element and this caused the crashes when calling GetName(). 

Stack traces:

>  	Aws::External::tinyxml2::StrPair::GetStr() Line 201	
>  	Aws::Utils::Xml::XmlNode::GetName() Line 59
>  	Aws::EC2::Model::DescribeInstancesResponse::operator=(const Aws::AmazonWebServiceResult<Aws::Utils::Xml::XmlDocument> & result) Line 43
>  	Aws::EC2::EC2Client::DescribeInstances(const Aws::EC2::Model::DescribeInstancesRequest & request) Line 3860
>      ...

>  	Aws::External::tinyxml2::StrPair::GetStr() Line 201
>  	Aws::Utils::Xml::XmlNode::GetName() Line 59
>  	Aws::EC2::Model::DescribeRegionsResponse::operator=(const Aws::AmazonWebServiceResult<Aws::Utils::Xml::XmlDocument> & result) Line 43
>  	Aws::EC2::EC2Client::DescribeRegions(const Aws::EC2::Model::DescribeRegionsRequest & request) Line 4190
>      ...

I added an IsNull() check for the root element to avoid the crash. However, since returning an empty result is wrong for many operations I have also made a change to cause an empty payload to be treated as an error when the result is not ignored and not being streamed. 

