### PR TITLE
Implementation of probe collection for every operation.

### DIFF
--- a/aws-cpp-sdk-core-tests/RunTests.cpp
+++ b/aws-cpp-sdk-core-tests/RunTests.cpp
@@ -17,6 +17,7 @@
 #include <aws/core/utils/crypto/Factories.h>
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/Aws.h>
+#include <aws/core/probes/SimpleProbeLogHandler.h>
 #include <aws/testing/TestingEnvironment.h>
 #include <aws/testing/platform/PlatformTesting.h>
 #include <aws/testing/MemoryTesting.h>
@@ -44,6 +45,7 @@ int main(int argc, char** argv)
 
     options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Trace;
     options.httpOptions.installSigPipeHandler = true;
+    options.probeOptions.probeHandlers.push_back(Aws::MakeShared<Aws::Probes::SimpleProbeLogHandler>("Aws_probes"));
 
     Aws::InitAPI(options);
     ::testing::InitGoogleTest(&argc, argv);

--- a/aws-cpp-sdk-core/CMakeLists.txt
+++ b/aws-cpp-sdk-core/CMakeLists.txt
@@ -25,6 +25,14 @@ else()
     message(STATUS "Custom memory management disabled")
 endif()
 
+if(("${ENABLE_PROBES}" STREQUAL "1"))
+    set(USE_AWS_PROBES ON)
+    message(STATUS "Probes generation enabled;")
+else()
+    set(USE_AWS_PROBES OFF)
+    message(STATUS "Probes generation disabled")
+endif()
+
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/include/aws/core/SDKConfig.h.in" 
                "${CMAKE_CURRENT_SOURCE_DIR}/include/aws/core/SDKConfig.h")
 
@@ -38,6 +46,7 @@ file(GLOB HTTP_HEADERS "include/aws/core/http/*.h")
 file(GLOB HTTP_STANDARD_HEADERS "include/aws/core/http/standard/*.h")
 file(GLOB CONFIG_HEADERS "include/aws/core/config/*.h")
 file(GLOB PLATFORM_HEADERS "include/aws/core/platform/*.h")
+file(GLOB PROBES_HEADERS "include/aws/core/probes/*.h")
 file(GLOB UTILS_HEADERS "include/aws/core/utils/*.h")
 file(GLOB UTILS_EVENT_HEADERS "include/aws/core/utils/event/*.h")
 file(GLOB UTILS_BASE64_HEADERS "include/aws/core/utils/base64/*.h")
@@ -62,6 +71,7 @@ file(GLOB AWS_INTERNAL_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/internal/*.cpp
 file(GLOB AWS_MODEL_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/aws/model/*.cpp")
 file(GLOB HTTP_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/http/*.cpp")
 file(GLOB HTTP_STANDARD_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/http/standard/*.cpp")
+file(GLOB PROBES_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/probes/*.cpp")
 file(GLOB CONFIG_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/config/*.cpp")
 file(GLOB UTILS_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/utils/*.cpp")
 file(GLOB UTILS_EVENT_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/utils/event/*.cpp")
@@ -111,6 +121,7 @@ file(GLOB AWS_NATIVE_SDK_COMMON_SRC
     ${AWS_INTERNAL_SOURCE}
     ${HTTP_STANDARD_SOURCE}
     ${HTTP_CLIENT_SOURCE}
+    ${PROBES_SOURCE}
     ${CONFIG_SOURCE}
     ${UTILS_EVENT_SOURCE}
     ${UTILS_BASE64_SOURCE}
@@ -135,6 +146,7 @@ file(GLOB AWS_NATIVE_SDK_COMMON_HEADERS
   ${HTTP_HEADERS}
   ${HTTP_STANDARD_HEADERS}
   ${CONFIG_HEADERS}
+  ${PROBES_HEADERS}
   ${HTTP_CLIENT_HEADERS}
   ${PLATFORM_HEADERS}
   ${UTILS_HEADERS}
@@ -199,6 +211,7 @@ file(GLOB AWS_NATIVE_SDK_NON_UNITY_SRC
     ${UTILS_CRYPTO_FACTORY_SOURCE}
     ${UTILS_SOURCE}
     ${HTTP_SOURCE}
+    ${PROBES_SOURCE}
     ${AWS_JSONCPP_SOURCE}
     ${AWS_NATIVE_SDK_CUSTOM_SRC}
 )
@@ -234,6 +247,7 @@ if(MSVC)
     source_group("Header Files\\aws\\core\\internal" FILES ${AWS_INTERNAL_HEADERS})
     source_group("Header Files\\aws\\core\\http" FILES ${HTTP_HEADERS})
     source_group("Header Files\\aws\\core\\http\\standard" FILES ${HTTP_STANDARD_HEADERS})
+    source_group("Header Files\\aws\\core\\probes" FILES ${PROBES_HEADERS})
     source_group("Header Files\\aws\\core\\config" FILES ${CONFIG_HEADERS})
     source_group("Header Files\\aws\\core\\platform" FILES ${PLATFORM_HEADERS})
     source_group("Header Files\\aws\\core\\utils" FILES ${UTILS_HEADERS})
@@ -275,6 +289,7 @@ if(MSVC)
     source_group("Source Files\\internal" FILES ${AWS_INTERNAL_SOURCE})
     source_group("Source Files\\http" FILES ${HTTP_SOURCE})
     source_group("Source Files\\http\\standard" FILES ${HTTP_STANDARD_SOURCE})
+    source_group("Source Files\\probes" FILES ${PROBES_SOURCE})
     source_group("Source Files\\config" FILES ${CONFIG_SOURCE})
     source_group("Source Files\\platform\\windows" FILES ${PLATFORM_WINDOWS_SOURCE})
     source_group("Source Files\\utils" FILES ${UTILS_SOURCE})
@@ -410,6 +425,7 @@ install (FILES ${AWS_CLIENT_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/core/c
 install (FILES ${AWS_INTERNAL_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/core/internal)
 install (FILES ${HTTP_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/core/http)
 install (FILES ${HTTP_STANDARD_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/core/http/standard)
+install (FILES ${PROBES_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/core/probes/)
 install (FILES ${CONFIG_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/core/config/)
 install (FILES ${PLATFORM_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/core/platform)
 install (FILES ${UTILS_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/core/utils)

--- a/aws-cpp-sdk-core/include/aws/core/Aws.h
+++ b/aws-cpp-sdk-core/include/aws/core/Aws.h
@@ -20,10 +20,24 @@
 #include <aws/core/utils/crypto/Factories.h>
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/Core_EXPORTS.h>
+#include <aws/core/utils/memory/stl/AWSVector.h>
+#include <aws/core/probes/ProbeHandlerInterface.h>
 
 namespace Aws
 {
     static const char* DEFAULT_LOG_PREFIX = "aws_sdk_";
+
+    /**
+     * SDK wide options for probes collection
+     */
+    struct ProbeOptions
+    {
+        /**
+         * Defaults to empty.
+         * If set, then the probe handlers will be used to compute every operation probe.
+         */
+        Aws::Vector<std::shared_ptr<Aws::Probes::ProbeHandlerInterface>> probeHandlers;
+    };
 
     /**
      * SDK wide options for logging
@@ -199,6 +213,10 @@ namespace Aws
          * SDK wide options for crypto
          */
         CryptoOptions cryptoOptions;
+        /**
+         * SDK wide options for probe collection
+         */
+        ProbeOptions probeOptions;
     };
 
     /*

--- a/aws-cpp-sdk-core/include/aws/core/SDKConfig.h.in
+++ b/aws-cpp-sdk-core/include/aws/core/SDKConfig.h.in
@@ -14,6 +14,7 @@
   */
 
 #cmakedefine USE_AWS_MEMORY_MANAGEMENT
+#cmakedefine USE_AWS_PROBES
 
 #define JSON_USE_EXCEPTION 0
 

--- a/aws-cpp-sdk-core/include/aws/core/probes/Probe.h
+++ b/aws-cpp-sdk-core/include/aws/core/probes/Probe.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <aws/core/Core_EXPORTS.h>
+
+#include <aws/core/utils/memory/stl/AWSString.h>
+#include <aws/core/utils/memory/stl/AWSVector.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/core/client/AWSError.h>
+#include <chrono>
+
+namespace Aws
+{
+    namespace Client
+    {
+        enum class CoreErrors;
+    }
+
+    namespace Http
+    {
+        class HttpResponse;
+    }
+
+    namespace Probes
+    {
+
+        typedef Utils::Outcome<std::shared_ptr<Http::HttpResponse>, Client::AWSError<Client::CoreErrors>> HttpResponseOutcome;
+
+        /**
+         * Struct that contains information about each attempt
+         */
+        struct AWS_CORE_API Attempt
+        {
+            /**
+             * The cumulativeLatency refers to the latency since the start of the first attempt for the request until the end of this particular attempt.
+             * The cumulativeLatency of the last attempt thus represents the overall latency of the request.
+             * The latency of a single attempt is obtained by substracting the cumulativeLatency of the previous attempt.
+             */
+            std::chrono::microseconds cumulativeLatency;
+            HttpResponseOutcome outcome;
+        };
+
+        /**
+         * Class that collects information for a given operation
+         */
+        class AWS_CORE_API Probe
+        {
+        public:
+            /**
+             * Initialize the probe with the given request information and with the current system time system.
+             */
+            Probe(const char* requestName);
+            /**
+             * Call the probe handlers on this current probe.
+             */
+            ~Probe();
+            /**
+             * Get the request name.
+             */
+            const char* GetServiceRequestName() const;
+            /**
+             * Get the global operation latency.
+             * If AddAttempt is not called, the method returns 0.
+             */
+            std::chrono::microseconds GetGlobalLatency() const;
+            /**
+             * Get a reference to a vector of attempts. The attempts are sorted in chronological order.
+             */
+            const Aws::Vector<Attempt>& GetAttemptVector() const;
+            /**
+             * Add a new attempt.
+             */
+            void AddAttempt(HttpResponseOutcome outcome);
+
+        private:
+            std::chrono::steady_clock::time_point start;
+
+            const char* serviceRequestName;
+            Aws::Vector<Attempt> attempts;
+
+        };
+
+    } // namespace Probes
+} // namespace Aws
+

--- a/aws-cpp-sdk-core/include/aws/core/probes/ProbeHandlerInterface.h
+++ b/aws-cpp-sdk-core/include/aws/core/probes/ProbeHandlerInterface.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <aws/core/Core_EXPORTS.h>
+
+#include <aws/core/probes/Probe.h>
+#include <aws/core/utils/memory/stl/AWSVector.h>
+#include <memory>
+
+namespace Aws
+{
+    namespace Probes
+    {
+
+        /**
+         * Interface for probe handling implementations.
+         */
+        class AWS_CORE_API ProbeHandlerInterface
+        {
+        public:
+            virtual ~ProbeHandlerInterface() = default;
+
+            /**
+             * Process the input probe upon its reception.
+             */
+            virtual void OnReceive(const Probe& probe) = 0;
+        };
+
+        /**
+         * Return a reference to the probe handlers vector. Used only internally.
+         */
+        Aws::Vector<std::shared_ptr<ProbeHandlerInterface>>& GetProbeHandlers();
+
+        /**
+         * Set the probe handlers vector. Used only internally.
+         */
+        void SetProbeHandlers(const Aws::Vector<std::shared_ptr<ProbeHandlerInterface>>& probeHandlers);
+
+    } // namespace Probes
+} // namespace Aws

--- a/aws-cpp-sdk-core/include/aws/core/probes/SimpleProbeLogHandler.h
+++ b/aws-cpp-sdk-core/include/aws/core/probes/SimpleProbeLogHandler.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <aws/core/Core_EXPORTS.h>
+
+#include <aws/core/probes/ProbeHandlerInterface.h>
+#include <aws/core/probes/Probe.h>
+#include <ostream>
+
+namespace Aws
+{
+    namespace Probes
+    {
+        /**
+         * Probe handler implementation that formats the probe and logs it using the aws logging system.
+         * This is a simplistic example of a possible probe handler implementation.
+         */
+        class SimpleProbeLogHandler : public ProbeHandlerInterface
+        {
+        public:
+            virtual void OnReceive(const Probe& probe);
+
+        };
+
+    } // namespace Probes
+} // namespace Aws

--- a/aws-cpp-sdk-core/source/Aws.cpp
+++ b/aws-cpp-sdk-core/source/Aws.cpp
@@ -97,10 +97,18 @@ namespace Aws
         Aws::Http::SetInitCleanupCurlFlag(options.httpOptions.initAndCleanupCurl);
         Aws::Http::SetInstallSigPipeHandlerFlag(options.httpOptions.installSigPipeHandler);
         Aws::Http::InitHttp();
+
+#ifdef USE_AWS_PROBES
+        Aws::Probes::SetProbeHandlers(options.probeOptions.probeHandlers);
+#endif // USE_AWS_PROBES
     }
 
     void ShutdownAPI(const SDKOptions& options)
     {
+#ifdef USE_AWS_PROBES
+        Aws::Probes::GetProbeHandlers().clear();
+#endif // USE_AWS_PROBES
+
         Aws::Http::CleanupHttp();
         Aws::Utils::Crypto::CleanupCrypto();
 

--- a/aws-cpp-sdk-core/source/probes/Probe.cpp
+++ b/aws-cpp-sdk-core/source/probes/Probe.cpp
@@ -1,0 +1,50 @@
+#include <aws/core/probes/Probe.h>
+#include <aws/core/probes/ProbeHandlerInterface.h>
+
+using namespace Aws;
+using namespace Aws::Probes;
+
+Probe::Probe(const char* s) :
+    start(std::chrono::steady_clock::now()),
+    serviceRequestName(s)
+{
+}
+
+Probe::~Probe()
+{
+    // Trigger the probe handlers to process the current probe before its destruction.
+    for(auto& sH: GetProbeHandlers())
+    {
+        sH->OnReceive(*this);
+    }
+}
+
+void Probe::AddAttempt(HttpResponseOutcome outcome)
+{
+    // Compute the cumulative latency and insert a new attempt to the attempts vector
+    auto now = std::chrono::steady_clock::now();
+    auto latency = std::chrono::duration_cast<std::chrono::microseconds>(now - start);
+    attempts.push_back(Attempt{latency, outcome});
+}
+
+const char* Probe::GetServiceRequestName() const
+{
+    return serviceRequestName;
+}
+
+std::chrono::microseconds Probe::GetGlobalLatency() const
+{
+    if(attempts.empty())
+    {
+        return std::chrono::microseconds(0);
+    }
+    else
+    {
+        return attempts.back().cumulativeLatency;
+    }
+}
+
+const Aws::Vector<Attempt>& Probe::GetAttemptVector() const
+{
+    return attempts;
+}

--- a/aws-cpp-sdk-core/source/probes/ProbeHandlerInterface.cpp
+++ b/aws-cpp-sdk-core/source/probes/ProbeHandlerInterface.cpp
@@ -1,0 +1,21 @@
+#include <aws/core/probes/ProbeHandlerInterface.h>
+#include <aws/core/utils/logging/LogMacros.h>
+
+static const char* TAG = "Aws_probes";
+
+using namespace Aws;
+using namespace Aws::Probes;
+
+// Global vector containing one or multiple stats handlers
+static Aws::Vector<std::shared_ptr<ProbeHandlerInterface>> ProbeHandlers;
+
+Aws::Vector<std::shared_ptr<ProbeHandlerInterface>>& Aws::Probes::GetProbeHandlers()
+{
+    return ProbeHandlers;
+}
+
+void Aws::Probes::SetProbeHandlers(const Aws::Vector<std::shared_ptr<ProbeHandlerInterface>>& probeHandlers)
+{
+    AWS_LOGSTREAM_DEBUG(TAG, probeHandlers.size() << " probe Handlers have been set");
+    ProbeHandlers = probeHandlers;
+}

--- a/aws-cpp-sdk-core/source/probes/SimpleProbeLogHandler.cpp
+++ b/aws-cpp-sdk-core/source/probes/SimpleProbeLogHandler.cpp
@@ -1,0 +1,34 @@
+#include <aws/core/probes/SimpleProbeLogHandler.h>
+#include <aws/core/utils/logging/LogMacros.h>
+#include <aws/core/utils/DateTime.h>
+
+#include <sstream>
+
+using namespace Aws;
+using namespace Aws::Probes;
+
+static const char* ALLOCATION_TAG = "Aws_probes";
+
+/*
+ * Logs basic information from every probe received: Global latency, number of attempts and the final return code.
+ */
+void SimpleProbeLogHandler::OnReceive(const Probe& aProbe)
+{
+    const char* requestName(aProbe.GetServiceRequestName());
+
+    uint32_t latency_microseconds = aProbe.GetGlobalLatency().count();
+    uint32_t nbAttempts = aProbe.GetAttemptVector().size();
+    uint32_t rc = 0;
+    if (!aProbe.GetAttemptVector().empty())
+    {
+        auto outcome = aProbe.GetAttemptVector().back().outcome;
+        if (outcome.IsSuccess())
+        {
+            rc = static_cast<uint32_t>(outcome.GetResult()->GetResponseCode());
+        }
+    }
+
+    AWS_LOGSTREAM_INFO(ALLOCATION_TAG, "[" << requestName << "] latency: " << latency_microseconds << " us");
+    AWS_LOGSTREAM_INFO(ALLOCATION_TAG, "[" << requestName << "] attempts: " << nbAttempts);
+    AWS_LOGSTREAM_INFO(ALLOCATION_TAG, "[" << requestName << "] return code: " << rc);
+}

--- a/aws-cpp-sdk-s3-integration-tests/RunTests.cpp
+++ b/aws-cpp-sdk-s3-integration-tests/RunTests.cpp
@@ -15,6 +15,7 @@
 
 #include <aws/external/gtest.h>
 #include <aws/core/Aws.h>
+#include <aws/core/probes/SimpleProbeLogHandler.h>
 #include <aws/testing/platform/PlatformTesting.h>
 #include <aws/testing/TestingEnvironment.h>
 #include <aws/testing/MemoryTesting.h>
@@ -23,6 +24,7 @@ int main(int argc, char** argv)
 {
     Aws::SDKOptions options;
     options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Trace;
+    options.probeOptions.probeHandlers.push_back(Aws::MakeShared<Aws::Probes::SimpleProbeLogHandler>("Aws_probes"));
     AWS_BEGIN_MEMORY_TEST_EX(options, 1024, 128);
     Aws::Testing::InitPlatformTest(options);
     Aws::Testing::ParseArgs(argc, argv);


### PR DESCRIPTION
@jwustrack-amadeus and I opened a [ticket ](https://github.com/aws/aws-sdk-cpp/issues/618) for requesting the feature of client side monitoring in the cpp sdk.
We propose to add a probe collection mechanism to AWSClient where all the operations are processed. The collection can be disabled with a compiler variable.
The user can then initialize the sdk with one or more probe handlers that will process a given probe.
We proposed a very simplistic implementation of the probe handler interface and we will propose later a gist of what we will do internally with the sdk.
For aggregation purposes, we prefered to add an abstract method to AmazonWebServiceRequest instead of using typeid.