### PR TITLE
Added missing virtual destructors

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/platform/FileSystem.h
+++ b/aws-cpp-sdk-core/include/aws/core/platform/FileSystem.h
@@ -133,6 +133,8 @@ namespace FileSystem
          */
         Directory(const Aws::String& path, const Aws::String& relativePath);        
 
+        virtual ~Directory() = default;
+
         /**
          * If this directory is valid for use.
          */

--- a/aws-cpp-sdk-core/include/aws/core/utils/crypto/SecureRandom.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/crypto/SecureRandom.h
@@ -102,6 +102,8 @@ namespace Aws
             class SecureRandomFactory
             {
             public:
+                virtual ~SecureRandomFactory() = default;
+
                 /**
                  * Factory method. Returns SecureRandom implementation.
                  */


### PR DESCRIPTION
When building under Clang 6.0.0 (trunk 314768) the following warning (promoted to error) is caught when attempting to use derived classes from Directory and SecureRandomFactory:

`error: destructor called on non-final 'DefaultSecureRandFactory' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]`