### PR TITLE
fix aws/aws-sdk-cpp#702 expose tts buffer size

### DIFF
--- a/aws-cpp-sdk-text-to-speech/include/aws/text-to-speech/TextToSpeechManager.h
+++ b/aws-cpp-sdk-text-to-speech/include/aws/text-to-speech/TextToSpeechManager.h
@@ -38,6 +38,12 @@ namespace Aws
 		typedef Aws::Vector<OutputDevicePair> OutputDeviceList;
 
         /**
+         * Maximum bytes size of audio to be sent to PCM drivers by TextToSpeechManager in one operation
+         * with PCMOutputDriver::WriteBufferToDevice()
+         */
+        constexpr size_t BUFF_SIZE = 8192;
+
+        /**
          * Manager for rendering text to the Polly service and then sending directly to an audio driver.
          * By default this uses our best guess at the correct drivers for you operating system.
          * On windows, this is the WaveOut API.

--- a/aws-cpp-sdk-text-to-speech/source/text-to-speech/TextToSpeechManager.cpp
+++ b/aws-cpp-sdk-text-to-speech/source/text-to-speech/TextToSpeechManager.cpp
@@ -27,7 +27,6 @@ namespace Aws
 {
     namespace TextToSpeech
     {
-        static const size_t BUFF_SIZE = 8192;
         static const char* CLASS_TAG = "TextToSpeechManager";
 
         struct SendTextCompletionHandlerCallbackContext : public Aws::Client::AsyncCallerContext


### PR DESCRIPTION
I used a simple constexpr as that is supported in C++11 compilers *and* most importantly the value can be used as a template argument. Making it a `static const` in a header file would have restricted it to only runtime usage. I need compile time. `constexpr` provides it also at compile-time for C++11 template goodness.