### PR TITLE
Do not use regex in DNS utils

### DIFF
--- a/aws-cpp-sdk-core/source/utils/DNS.cpp
+++ b/aws-cpp-sdk-core/source/utils/DNS.cpp
@@ -13,11 +13,8 @@
 * permissions and limitations under the License.
 */
 
-
-
-
 #include <aws/core/utils/DNS.h>
-#include <regex>
+#include <ctype.h>
 
 namespace Aws
 {
@@ -31,9 +28,23 @@ namespace Aws
             // 2- Cannot start or end with a dash
             // 3- Have a maximum length of 63 characters (the entirety of the domain name should be less than 255 bytes)
 
-            //TODO: consider making this regex static and passing std::regex_constants::optimize flag
-            const std::regex dnsLabel("^[[:alnum:]](?:[[:alnum:]-]{0,61}[[:alnum:]])?$");
-            return regex_search(label, dnsLabel);
+            if (label.empty())
+                return false;
+            if (label.size() > 63)
+                return false;
+
+            if (!isalnum(label.front()))
+                return false; // '-' is not acceptable as the first character
+            if (!isalnum(label.back()))
+                return false; // '-' is not acceptable as the last  character
+
+            for (int i = 1, e = label.size() - 1; i < e; ++i) {
+                auto c = label[i];
+                if (c != '-' && !isalnum(c))
+                    return false;
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
std::regex is broken in libstdc++ 4.8, it throws regex_errors.
Instead do the job by hand. This was taken from:
https://github.com/aws/aws-sdk-cpp/issues/571