### PR TITLE
Avoid closing HTTP handle twice

### DIFF
--- a/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
+++ b/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
@@ -105,6 +105,7 @@ WinHttpSyncHttpClient::WinHttpSyncHttpClient(const ClientConfiguration& config) 
 WinHttpSyncHttpClient::~WinHttpSyncHttpClient()
 {
     WinHttpCloseHandle(GetOpenHandle());
+    SetOpenHandle(nullptr);  // the handle is already closed, annul it to avoid double-closing the handle (in the base class' destructor)
 }
 
 void* WinHttpSyncHttpClient::OpenRequest(const Aws::Http::HttpRequest& request, void* connection, const Aws::StringStream& ss) const

--- a/aws-cpp-sdk-core/source/http/windows/WinINetSyncHttpClient.cpp
+++ b/aws-cpp-sdk-core/source/http/windows/WinINetSyncHttpClient.cpp
@@ -93,7 +93,8 @@ WinINetSyncHttpClient::WinINetSyncHttpClient(const ClientConfiguration& config) 
 
 WinINetSyncHttpClient::~WinINetSyncHttpClient()
 {
-    InternetCloseHandle(GetOpenHandle());   
+    InternetCloseHandle(GetOpenHandle());
+    SetOpenHandle(nullptr);  // the handle is already closed, annul it to avoid double-closing the handle (in the base class' destructor)
 }
 
 void* WinINetSyncHttpClient::OpenRequest(const Aws::Http::HttpRequest& request, void* connection, const Aws::StringStream& ss) const


### PR DESCRIPTION
`WinHttpSyncHttpClient::~WinHttpSyncHttpClient()` closes the handle, so does its base class' destructor. Annul the handle's pointer to avoid the second closing.

This also fixes the AWS core and S3 unit tests (when ran through `AppVerifier` or `gflags`, they crash).