### PR TITLE
Parse INI-style file more like botocore (Python).

### DIFF
--- a/aws-cpp-sdk-core-tests/aws/config/AWSProfileConfigLoaderTest.cpp
+++ b/aws-cpp-sdk-core-tests/aws/config/AWSProfileConfigLoaderTest.cpp
@@ -28,7 +28,7 @@ static void WriteDefaultConfigFile(Aws::OStream& stream, bool useProfilePrefix =
     stream << "[" << profilePrefix << "default ]" << std::endl;
     stream << "aws_access_key_id=AKIAKEY" << std::endl;
     stream << "aws_secret_access_key=foobarbarfoo  " << std::endl;
-    stream << "  aws_session_token=tokentokentoken" << std::endl;
+    stream << "  aws_session_token= \"tokentokentoken==\"" << std::endl;
     stream << "region=us-east-1" << std::endl << std::endl;
     stream << "s3=" << std::endl;
     stream << "    max_concurrent_requests=10;" << std::endl;
@@ -57,7 +57,7 @@ TEST(AWSConfigFileProfileConfigLoaderTest, TestCredentialsFileLoad)
 
     ASSERT_STREQ("AKIAKEY", profiles["default"].GetCredentials().GetAWSAccessKeyId().c_str());
     ASSERT_STREQ("foobarbarfoo", profiles["default"].GetCredentials().GetAWSSecretKey().c_str());
-    ASSERT_STREQ("tokentokentoken", profiles["default"].GetCredentials().GetSessionToken().c_str());
+    ASSERT_STREQ("\"tokentokentoken==\"", profiles["default"].GetCredentials().GetSessionToken().c_str());
     ASSERT_STREQ("us-east-1", profiles["default"].GetRegion().c_str());
     ASSERT_TRUE(profiles["default"].GetRoleArn().empty());
     ASSERT_TRUE(profiles["default"].GetSourceProfile().empty());
@@ -86,7 +86,7 @@ TEST(AWSConfigFileProfileConfigLoaderTest, TestConfigFileLoad)
 
     ASSERT_STREQ("AKIAKEY", profiles["default"].GetCredentials().GetAWSAccessKeyId().c_str());
     ASSERT_STREQ("foobarbarfoo", profiles["default"].GetCredentials().GetAWSSecretKey().c_str());
-    ASSERT_STREQ("tokentokentoken", profiles["default"].GetCredentials().GetSessionToken().c_str());
+    ASSERT_STREQ("\"tokentokentoken==\"", profiles["default"].GetCredentials().GetSessionToken().c_str());
     ASSERT_STREQ("us-east-1", profiles["default"].GetRegion().c_str());
     ASSERT_TRUE(profiles["default"].GetRoleArn().empty());
     ASSERT_TRUE(profiles["default"].GetSourceProfile().empty());

--- a/aws-cpp-sdk-core/source/config/AWSProfileConfigLoader.cpp
+++ b/aws-cpp-sdk-core/source/config/AWSProfileConfigLoader.cpp
@@ -118,11 +118,13 @@ namespace Aws
                         // fall through
                     case PROFILE_FOUND:
                     {
-                        auto keyValuePair = StringUtils::Split(line, EQ);
-                        if (keyValuePair.size() == 2)
+                        auto equalsPos = line.find(EQ);
+                        if (equalsPos != std::string::npos)
                         {
-                            m_profileKeyValuePairs[StringUtils::Trim(keyValuePair[0].c_str())] =
-                                    StringUtils::Trim(keyValuePair[1].c_str());
+                            auto key = line.substr(0, equalsPos);
+                            auto value = line.substr(equalsPos + 1);
+                            m_profileKeyValuePairs[StringUtils::Trim(key.c_str())] =
+                                    StringUtils::Trim(value.c_str());
                             m_parserState = PROFILE_KEY_VALUE_FOUND;
                         }
 


### PR DESCRIPTION
This splits on the first equals, regardless of the presence of additional equals.

Note that the basic parsing implementation in botocore is based on [RawConfigParser](https://docs.python.org/2/library/configparser.html#ConfigParser.RawConfigParser), which retains quotes in values.

Fixes #765 .