### PR TITLE
Silent warning about mangled name changing in C++17

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -49,7 +49,7 @@ macro(set_gcc_flags)
 endmacro()
 
 macro(set_gcc_warnings)
-    list(APPEND AWS_COMPILER_WARNINGS "-Wall" "-Werror" "-pedantic" "-Wextra")
+    list(APPEND AWS_COMPILER_WARNINGS "-Wall" "-Werror" "-pedantic" "-Wextra" "-Wno-noexcept-type")
     if(COMPILER_CLANG)
         if(PLATFORM_ANDROID)
             # when using clang with libc and API lower than 21 we need to include Android support headers and ignore the gnu-include-next warning.


### PR DESCRIPTION
When compiling with a recent gcc (for example, 7.2.0), the compiler
warns about mangled name to change in C++17 because the exception
specification is part of the function type:

```
/home/…/aws-sdk-cpp/aws-cpp-sdk-core/include/aws/core/utils/memory/stl/AWSFunction.h:57:3: error: mangled name for ‘F Aws::BuildFunction(F) [with F = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > > (*)() noexcept]’ will change in C++17 because the exception specification is part of a function type [-Werror=noexcept-type]
 F BuildFunction(F f)
   ^~~~~~~~~~~~~
```

As per #620, this warning is considered as harmless as people are
unlikely to build the library with one compiler and use it from a
different one. However, as warnings trigger errors by default, we just
silent this warning.