### PR TITLE
Enabling SOCKS5 proxyScheme 

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/http/Scheme.h
+++ b/aws-cpp-sdk-core/include/aws/core/http/Scheme.h
@@ -29,7 +29,8 @@ namespace Aws
         enum class Scheme
         {
             HTTP,
-            HTTPS
+            HTTPS,
+            SOCKS5
         };
 
         namespace SchemeMapper

--- a/aws-cpp-sdk-core/source/http/Scheme.cpp
+++ b/aws-cpp-sdk-core/source/http/Scheme.cpp
@@ -35,6 +35,8 @@ namespace SchemeMapper
                 return "http";
             case Scheme::HTTPS:
                 return "https";
+            case Scheme::SOCKS5:
+                return "socks5";
             default:
                 return "http";
         }
@@ -55,6 +57,11 @@ namespace SchemeMapper
         {
             return Scheme::HTTPS;
         }
+        else if (loweredTrimmedString == "socks5")
+        {
+            return Scheme::SOCKS5;
+        }
+
 
         return Scheme::HTTPS;
     }


### PR DESCRIPTION
I have been experiencing some difficulties in connecting to S3 from enterprise networks configured with SOCKS5 proxies. I ended up with a couple of changes to Scheme which allows to setup SOCKS5 proxy in clientconfig:

Aws::Client::ClientConfiguration clientConfig;
clientConfig.proxyHost = ...;
clientConfig.proxyPort = ...;
clientConfig.proxyScheme = Aws::Http::Scheme::**SOCKS5**;