### PR TITLE
Prevent the SDK uninstall target to clash with a another uninstall target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,4 +174,6 @@ add_sdks()
 include(setup_cmake_find_module)
 
 # for generating make unstaill target
-ADD_CUSTOM_TARGET(uninstall "${CMAKE_COMMAND}" -P "${AWS_NATIVE_SDK_ROOT}/cmake/make_uninstall.cmake") 
+if (NOT TARGET uninstall)
+    ADD_CUSTOM_TARGET(uninstall "${CMAKE_COMMAND}" -P "${AWS_NATIVE_SDK_ROOT}/cmake/make_uninstall.cmake")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,4 @@ add_sdks()
 include(setup_cmake_find_module)
 
 # for generating make unstaill target
-if (NOT TARGET uninstall)
-    ADD_CUSTOM_TARGET(uninstall "${CMAKE_COMMAND}" -P "${AWS_NATIVE_SDK_ROOT}/cmake/make_uninstall.cmake")
-endif()
+ADD_CUSTOM_TARGET(uninstall-awssdk "${CMAKE_COMMAND}" -P "${AWS_NATIVE_SDK_ROOT}/cmake/make_uninstall.cmake")


### PR DESCRIPTION
This SDK is usually used as a sub-project and if this change is not applied, the user gets an error if she wants to add a custom "uninstall" target.