### PR TITLE
Queue: Do not wait to complete poll period if there are messages waiting

### DIFF
--- a/aws-cpp-sdk-queues/include/aws/queues/Queue.h
+++ b/aws-cpp-sdk-queues/include/aws/queues/Queue.h
@@ -117,18 +117,22 @@ namespace Aws
                 while(m_continue)
                 {
                     auto start = std::chrono::system_clock::now();
-                    MESSAGE_TYPE topMessage = Top();
-                    bool deleteMessage = false;
-                    
                     auto& receivedHandler = GetMessageReceivedEventHandler();
-                    if (receivedHandler)
-                    {
-                        receivedHandler(this, topMessage, deleteMessage);
-                    }
 
-                    if (deleteMessage)
+                    while(m_continue)
                     {
-                        Delete(topMessage);
+                        MESSAGE_TYPE topMessage = Top();
+                        bool deleteMessage = false;
+
+                        if (receivedHandler)
+                        {
+                            receivedHandler(this, topMessage, deleteMessage);
+                        }
+
+                        if (deleteMessage)
+                        {
+                            Delete(topMessage);
+                        }
                     }
 
                     if(m_continue)


### PR DESCRIPTION
After trying to receive an element from the queue the loop sleeps until poll period gets expired even though the queue is not empty.
In other words, if there are more than one element in the queue, it should continue receiving messages without waiting the poll period.