### PR TITLE
Queue: Do not wait to complete poll period if there are messages waiting

### DIFF
--- a/aws-cpp-sdk-queues/include/aws/queues/Queue.h
+++ b/aws-cpp-sdk-queues/include/aws/queues/Queue.h
@@ -56,7 +56,7 @@ namespace Aws
                 StopPolling();
             }
 
-            virtual MESSAGE_TYPE Top() const = 0;
+            virtual bool Top(MESSAGE_TYPE&) const = 0;
             virtual void Delete(const MESSAGE_TYPE&) = 0;
             virtual void Push(const MESSAGE_TYPE&) = 0;
 
@@ -121,15 +121,21 @@ namespace Aws
 
                     while(m_continue)
                     {
-                        MESSAGE_TYPE topMessage = Top();
+                        MESSAGE_TYPE topMessage;
+                        bool messageReceived = Top(topMessage);
                         bool deleteMessage = false;
 
-                        if (receivedHandler)
+                        if(!messageReceived)
+                        {
+                            break;
+                        }
+
+                        if(receivedHandler)
                         {
                             receivedHandler(this, topMessage, deleteMessage);
                         }
 
-                        if (deleteMessage)
+                        if(deleteMessage)
                         {
                             Delete(topMessage);
                         }

--- a/aws-cpp-sdk-queues/include/aws/queues/Queue.h
+++ b/aws-cpp-sdk-queues/include/aws/queues/Queue.h
@@ -117,18 +117,22 @@ namespace Aws
                 while(m_continue)
                 {
                     auto start = std::chrono::system_clock::now();
-                    MESSAGE_TYPE topMessage = Top();
-                    bool deleteMessage = false;
-                    
                     auto& receivedHandler = GetMessageReceivedEventHandler();
-                    if (receivedHandler)
-                    {
-                        receivedHandler(this, topMessage, deleteMessage);
-                    }
 
-                    if (deleteMessage)
+                    while(m_continue)
                     {
-                        Delete(topMessage);
+                        MESSAGE_TYPE topMessage = Top();
+                        bool deleteMessage = false;
+
+                        if (receivedHandler)
+                        {
+                            receivedHandler(this, topMessage, deleteMessage);
+                        }
+
+                        if (deleteMessage)
+                        {
+                            Delete(topMessage);
+                        }
                     }
 
                     if(m_continue)

--- a/aws-cpp-sdk-queues/include/aws/queues/sqs/SQSQueue.h
+++ b/aws-cpp-sdk-queues/include/aws/queues/sqs/SQSQueue.h
@@ -89,7 +89,7 @@ namespace Aws
                 /**
                  * Will continue polling until a message is received or StopPolling is called.
                  */
-                Aws::SQS::Model::Message Top() const override;
+                bool Top(Aws::SQS::Model::Message&) const override;
 
                 /**
                  * Does not block. Register for notifications of success or failure with the appropriate handlers.

--- a/aws-cpp-sdk-queues/source/sqs/SQSQueue.cpp
+++ b/aws-cpp-sdk-queues/source/sqs/SQSQueue.cpp
@@ -54,7 +54,7 @@ SQSQueue::SQSQueue(const std::shared_ptr<SQSClient>& client, const char* queueNa
 {
 }
 
-Message SQSQueue::Top() const
+bool SQSQueue::Top(Message& message) const
 {
     if(IsInitialized())
     {
@@ -71,7 +71,8 @@ Message SQSQueue::Top() const
             if (receiveMessageOutcome.IsSuccess() && receiveMessageOutcome.GetResult().GetMessages().size() > 0)
             {
                 AWS_LOGSTREAM_DEBUG(CLASS_TAG, "Message found, returning");
-                return receiveMessageOutcome.GetResult().GetMessages()[0];
+                message = receiveMessageOutcome.GetResult().GetMessages()[0];
+                return true;
             }
             else if (!receiveMessageOutcome.IsSuccess())
             {
@@ -87,7 +88,7 @@ Message SQSQueue::Top() const
         AWS_LOGSTREAM_ERROR(CLASS_TAG, "Queue is not initialized, not polling. Call EnsureQueueIsInitialized before calling this method.");
     }
 
-    return Message();
+    return false;
 }
 
 void SQSQueue::Delete(const Message& message)


### PR DESCRIPTION
After trying to receive an element from the queue the loop sleeps until poll period gets expired even though the queue is not empty.
In other words, if there are more than one element in the queue, it should continue receiving messages without waiting the poll period.