### PR TITLE
Add missing destructor in abstract classes: fixes compilation with latest clang

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/platform/FileSystem.h
+++ b/aws-cpp-sdk-core/include/aws/core/platform/FileSystem.h
@@ -128,6 +128,8 @@ namespace FileSystem
     class AWS_CORE_API Directory
     {
     public:
+        virtual ~Directory() = default;
+
         /**
          * Initialize a directory with it's absolute path. If the path is invalid, the bool operator will return false.
          */

--- a/aws-cpp-sdk-core/include/aws/core/utils/crypto/SecureRandom.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/crypto/SecureRandom.h
@@ -102,6 +102,8 @@ namespace Aws
             class SecureRandomFactory
             {
             public:
+                virtual ~SecureRandomFactory() = default;
+
                 /**
                  * Factory method. Returns SecureRandom implementation.
                  */


### PR DESCRIPTION
The new clang released last week apparently introduced a new warning `delete-non-virtual-dtor`. Since this project is compiled with `-Werror` it caused the compilation to fail.

I do not have a FreeBSD, but this should fix #825 too.