### PR TITLE
crash attempting finalize unitialized ciphers

### DIFF
--- a/aws-cpp-sdk-core-tests/utils/crypto/CryptoStreamsTest.cpp
+++ b/aws-cpp-sdk-core-tests/utils/crypto/CryptoStreamsTest.cpp
@@ -547,9 +547,10 @@ TEST(CryptoStreamsTest, TestLiveSymmetricCipher)
         stream.read((char*)buffer.GetUnderlyingData(), buffer.GetLength());
 
         ASSERT_STREQ(expected_raw.c_str(), HashingUtils::HexEncode(buffer).c_str());
-        stream.Finalize();       
+        stream.Finalize();
         ASSERT_STREQ(tag_raw.c_str(), HashingUtils::HexEncode(cipher->GetTag()).c_str());
-    }
+		stream.seekg(0, std::ios_base::beg); //must work for WinSyncHttpClient::StreamPayloadToRequest
+	}
 
     {
         cipher = Aws::Utils::Crypto::CreateAES_GCMImplementation(HashingUtils::HexDecode(key_raw),

--- a/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h
@@ -189,6 +189,7 @@ namespace Aws
                 virtual size_t GetKeyLengthBits() const = 0;
 
                 EVP_CIPHER_CTX* m_ctx;
+				bool m_encDecInitialized;
 
                 void CheckInitEncryptor();
                 void CheckInitDecryptor();
@@ -197,7 +198,6 @@ namespace Aws
                 void Init();
                 void Cleanup();
 
-                bool m_encDecInitialized;
                 bool m_encryptionMode;
                 bool m_decryptionMode;
             };

--- a/aws-cpp-sdk-core/source/utils/crypto/openssl/CryptoImpl.cpp
+++ b/aws-cpp-sdk-core/source/utils/crypto/openssl/CryptoImpl.cpp
@@ -425,7 +425,9 @@ namespace Aws
 
             CryptoBuffer OpenSSLCipher::FinalizeEncryption()
             {
-                if (m_failure)
+				if (!m_encDecInitialized) //don't finalize uninitialized cipher
+					return CryptoBuffer();
+				if (m_failure)
                 {
                     AWS_LOGSTREAM_FATAL(OPENSSL_LOG_TAG,
                                         "Cipher not properly initialized for encryption finalization. Aborting");
@@ -474,6 +476,8 @@ namespace Aws
 
             CryptoBuffer OpenSSLCipher::FinalizeDecryption()
             {
+				if (!m_encDecInitialized) //don't finalize uninitialized cipher
+					return CryptoBuffer(); 
                 if (m_failure)
                 {
                     AWS_LOGSTREAM_FATAL(OPENSSL_LOG_TAG,
@@ -626,7 +630,9 @@ namespace Aws
 
             CryptoBuffer AES_GCM_Cipher_OpenSSL::FinalizeEncryption()
             {
-                CryptoBuffer&& finalBuffer = OpenSSLCipher::FinalizeEncryption();
+				if (!m_encDecInitialized) //don't finalize uninitialized cipher
+					return CryptoBuffer();
+				CryptoBuffer&& finalBuffer = OpenSSLCipher::FinalizeEncryption();
                 m_tag = CryptoBuffer(TagLengthBytes);
                 if (!EVP_CIPHER_CTX_ctrl(m_ctx, EVP_CTRL_CCM_GET_TAG, static_cast<int>(m_tag.GetLength()),
                                          m_tag.GetUnderlyingData()))


### PR DESCRIPTION
CryptoCipherStream supports resetting m_cipher when seek goes back to the beginning of the file. If you do that and then don't read or write to re initialize the underlying openssl cipher it crashes when finalizing in the destructor. I altered the live cipher test in aws-cpp-sdk-core-tests to reproduce the crash and then fix it. This was discovered running the s3-encryption-integration tests when building against openssl on windows. Finalize is noop with bcrypt so it doesn't have this problem. 