### PR TITLE
Including functional header to use std::function

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/utils/ratelimiter/DefaultRateLimiter.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/ratelimiter/DefaultRateLimiter.h
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <mutex>
 #include <thread>
+#include <functional>
 
 namespace Aws
 {


### PR DESCRIPTION
Fixing build error function in namespace std does not name a template type