### PR TITLE
Add integrity verification function to TrasferManager

### DIFF
--- a/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
@@ -46,7 +46,7 @@ namespace Aws
          */
         struct TransferManagerConfiguration
         {
-            TransferManagerConfiguration(Aws::Utils::Threading::Executor* executor) : s3Client(nullptr), transferExecutor(executor), transferBufferMaxHeapSize(10 * MB5), bufferSize(MB5)
+            TransferManagerConfiguration(Aws::Utils::Threading::Executor* executor) : s3Client(nullptr), transferExecutor(executor), needsComputeContentMd5(false), transferBufferMaxHeapSize(10 * MB5), bufferSize(MB5)
             {
             }
 
@@ -60,6 +60,10 @@ namespace Aws
              * It is not a bug to use the same executor, but at least be aware that this is how the manager will be used.
              */
             Aws::Utils::Threading::Executor* transferExecutor;
+            /**
+             * If this is set to true, calculate content-md5 and set it to upload part request.
+             */
+            bool needsComputeContentMd5;
             /**
              * If you have special arguments you want passed to our put object calls, put them here. We will copy the template for each put object call
              * overriding the body stream, bucket, and key. If object metadata is passed through, we will override that as well.

--- a/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
@@ -46,7 +46,7 @@ namespace Aws
          */
         struct TransferManagerConfiguration
         {
-            TransferManagerConfiguration(Aws::Utils::Threading::Executor* executor) : s3Client(nullptr), transferExecutor(executor), needsComputeContentMd5(false), transferBufferMaxHeapSize(10 * MB5), bufferSize(MB5)
+            TransferManagerConfiguration(Aws::Utils::Threading::Executor* executor) : s3Client(nullptr), transferExecutor(executor), computeContentMD5(false), transferBufferMaxHeapSize(10 * MB5), bufferSize(MB5)
             {
             }
 
@@ -61,9 +61,11 @@ namespace Aws
              */
             Aws::Utils::Threading::Executor* transferExecutor;
             /**
-             * If this is set to true, calculate content-md5 and set it to upload part request.
+             * When true, TransferManager will calculate the MD5 digest of the content being uploaded.
+             * The digest is sent to S3 via an HTTP header enabling the service to perform integrity checks.
+             * This option is disabled by default.
              */
-            bool needsComputeContentMd5;
+            bool computeContentMD5;
             /**
              * If you have special arguments you want passed to our put object calls, put them here. We will copy the template for each put object call
              * overriding the body stream, bucket, and key. If object metadata is passed through, we will override that as well.

--- a/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -359,7 +359,7 @@ namespace Aws
 
                     uploadPartRequest.SetBody(preallocatedStreamReader);
                     uploadPartRequest.SetContentType(handle->GetContentType());
-                    if (m_transferConfig.needsComputeContentMd5) {
+                    if (m_transferConfig.computeContentMD5) {
                         uploadPartRequest.SetContentMD5(Aws::Utils::HashingUtils::Base64Encode(Aws::Utils::HashingUtils::CalculateMD5(*preallocatedStreamReader)));
                     }
                     auto asyncContext = Aws::MakeShared<TransferHandleAsyncContext>(CLASS_TAG);
@@ -435,7 +435,7 @@ namespace Aws
             auto preallocatedStreamReader = Aws::MakeShared<Aws::IOStream>(CLASS_TAG, streamBuf);
 
             putObjectRequest.SetBody(preallocatedStreamReader);
-            if (m_transferConfig.needsComputeContentMd5) {
+            if (m_transferConfig.computeContentMD5) {
                 putObjectRequest.SetContentMD5(Aws::Utils::HashingUtils::Base64Encode(Aws::Utils::HashingUtils::CalculateMD5(*preallocatedStreamReader)));
             }
 

--- a/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -359,6 +359,9 @@ namespace Aws
 
                     uploadPartRequest.SetBody(preallocatedStreamReader);
                     uploadPartRequest.SetContentType(handle->GetContentType());
+                    if (m_transferConfig.needsComputeContentMd5) {
+                        uploadPartRequest.SetContentMD5(Aws::Utils::HashingUtils::Base64Encode(Aws::Utils::HashingUtils::CalculateMD5(*preallocatedStreamReader)));
+                    }
                     auto asyncContext = Aws::MakeShared<TransferHandleAsyncContext>(CLASS_TAG);
                     asyncContext->handle = handle;
                     asyncContext->partState = partsIter->second;
@@ -432,6 +435,9 @@ namespace Aws
             auto preallocatedStreamReader = Aws::MakeShared<Aws::IOStream>(CLASS_TAG, streamBuf);
 
             putObjectRequest.SetBody(preallocatedStreamReader);
+            if (m_transferConfig.needsComputeContentMd5) {
+                putObjectRequest.SetContentMD5(Aws::Utils::HashingUtils::Base64Encode(Aws::Utils::HashingUtils::CalculateMD5(*preallocatedStreamReader)));
+            }
 
             auto self = shared_from_this(); // keep transfer manager alive until all callbacks are finished.
             auto uploadProgressCallback = [self, partState, handle](const Aws::Http::HttpRequest*, long long progress)


### PR DESCRIPTION
Add the function of integrity verification of upload using MD5 to TransferManager.

In order to perform integrity verification with multipart upload, it is necessary to calculate MD5 for each part and attach `Content-MD5` header, but currently it can not be realized in TransferManager.
For that reason, I implemented TransferManager with MD5 calculation and `Content-MD5` header attached.