### PR TITLE
text-to-speech: Adds missing virtual destructor to PCMOutputDriverFac…

### DIFF
--- a/aws-cpp-sdk-text-to-speech/include/aws/text-to-speech/PCMOutputDriver.h
+++ b/aws-cpp-sdk-text-to-speech/include/aws/text-to-speech/PCMOutputDriver.h
@@ -96,6 +96,8 @@ namespace Aws
         class AWS_TEXT_TO_SPEECH_API PCMOutputDriverFactory
         {
         public:
+            virtual ~PCMOutputDriverFactory() = default;
+
             /**
              * Return a list of drivers that you want supported for the application.
              */


### PR DESCRIPTION
…tory

This addresses the same issue as described in #825 and addressed
in PR #828.

This adds a defaulted virtual destructor to PCMOutputDriverFactory.