### PR TITLE
Add timeouts and retries configuration to metadata service clients (#923)

### DIFF
--- a/aws-cpp-sdk-core-tests/aws/auth/AWSHttpResourceClientTest.cpp
+++ b/aws-cpp-sdk-core-tests/aws/auth/AWSHttpResourceClientTest.cpp
@@ -68,7 +68,7 @@ namespace
         ASSERT_EQ("/path/to/res", mockRequest.GetUri().GetPath());
         ASSERT_EQ(Aws::Http::HttpMethod::HTTP_GET, mockRequest.GetMethod());
         ASSERT_EQ("", result);
-        // Retries should be done when request can't be made at all
+        // 1 initial request + 4 retries should be done when request can't be made at all
         ASSERT_EQ(5u, mockHttpClient->GetAllRequestsMade().size());
     }
 
@@ -140,7 +140,7 @@ namespace
         ASSERT_EQ("/path/to/res", mockRequest.GetUri().GetPath());
         ASSERT_EQ(Aws::Http::HttpMethod::HTTP_GET, mockRequest.GetMethod());
         ASSERT_EQ("", result);
-        // Retries should be done for status code >= 500
+        // 1 initial request + 4 retries should be done for status code >= 500
         ASSERT_EQ(5u, mockHttpClient->GetAllRequestsMade().size());
     }
 
@@ -168,7 +168,7 @@ namespace
         ASSERT_EQ(1u, mockHttpClient->GetAllRequestsMade().size());
     }
 
-    TEST_F(AWSHttpResourceClientTest, TestAWSHttpResourceClientWithTemporaryNullResponse)
+    TEST_F(AWSHttpResourceClientTest, TestAWSHttpResourceClientWithSuccessResponseAfterOneNullResponse)
     {
         mockHttpClient->AddResponseToReturn(nullptr);
 
@@ -190,11 +190,11 @@ namespace
         ASSERT_EQ("/path/to/res", mockRequest.GetUri().GetPath());
         ASSERT_EQ(Aws::Http::HttpMethod::HTTP_GET, mockRequest.GetMethod());
         ASSERT_EQ("{ \"Resource\": \"TestResource\" }", result);
-        // There should be one retry
+        // 1 initial request + 1 retry
         ASSERT_EQ(2u, mockHttpClient->GetAllRequestsMade().size());
     }
 
-    TEST_F(AWSHttpResourceClientTest, TestAWSHttpResourceClientWithTemporaryInternalServerError)
+    TEST_F(AWSHttpResourceClientTest, TestAWSHttpResourceClientWithSuccessResponseAfterOneInternalServerError)
     {
         // This mocked URI is used to initiate http response and has nothing to do with the requested URI actually sent out.
         std::shared_ptr<HttpRequest> request = CreateHttpRequest(URI("http://www.uri.com/path/to/res"),
@@ -219,7 +219,7 @@ namespace
         ASSERT_EQ("/path/to/res", mockRequest.GetUri().GetPath());
         ASSERT_EQ(Aws::Http::HttpMethod::HTTP_GET, mockRequest.GetMethod());
         ASSERT_EQ("{ \"Resource\": \"TestResource\" }", result);
-        // There should be one retry
+        // 1 initial request + 1 retry
         ASSERT_EQ(2u, mockHttpClient->GetAllRequestsMade().size());
     }
 

--- a/aws-cpp-sdk-core/include/aws/core/internal/AWSHttpResourceClient.h
+++ b/aws-cpp-sdk-core/include/aws/core/internal/AWSHttpResourceClient.h
@@ -18,6 +18,7 @@
 #include <aws/core/Core_EXPORTS.h>
 #include <aws/core/utils/memory/AWSMemory.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
+#include <aws/core/client/ClientConfiguration.h>
 #include <memory>
 
 namespace Aws
@@ -40,6 +41,7 @@ namespace Aws
              * Builds an AWSHttpResourceClient instance by using default http stack.
              */
             AWSHttpResourceClient(const char* logtag = "AWSHttpResourceClient");
+            AWSHttpResourceClient(const Client::ClientConfiguration& clientConfiguration, const char* logtag = "AWSHttpResourceClient");
 
             AWSHttpResourceClient& operator =(const AWSHttpResourceClient& rhs) = delete;
             AWSHttpResourceClient(const AWSHttpResourceClient& rhs) = delete;
@@ -63,6 +65,7 @@ namespace Aws
             Aws::String m_logtag;
 
         private:
+            std::shared_ptr<Client::RetryStrategy> m_retryStrategy;
             std::shared_ptr<Http::HttpClient> m_httpClient;
         };
 
@@ -76,6 +79,7 @@ namespace Aws
              * Build an instance with default EC2 Metadata service endpoint
              */
             EC2MetadataClient(const char* endpoint = "http://169.254.169.254");
+            EC2MetadataClient(const Client::ClientConfiguration& clientConfiguration, const char* endpoint = "http://169.254.169.254");
 
             EC2MetadataClient& operator =(const EC2MetadataClient& rhs) = delete;
             EC2MetadataClient(const EC2MetadataClient& rhs) = delete;
@@ -121,6 +125,10 @@ namespace Aws
              */
             ECSCredentialsClient(const char* resourcePath, const char* endpoint = "http://169.254.170.2",
                     const char* authToken = "");
+            ECSCredentialsClient(const Client::ClientConfiguration& clientConfiguration,
+                                 const char* resourcePath, const char* endpoint = "http://169.254.170.2",
+                                 const char* authToken = "");
+
             ECSCredentialsClient& operator =(ECSCredentialsClient& rhs) = delete;
             ECSCredentialsClient(const ECSCredentialsClient& rhs) = delete;
             ECSCredentialsClient& operator =(ECSCredentialsClient&& rhs) = delete;

--- a/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
+++ b/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
@@ -41,7 +41,7 @@ static const char* ECS_CREDENTIALS_CLIENT_LOG_TAG = "ECSCredentialsClient";
 
 
 namespace {
-    ClientConfiguration makeDefaultHttpResourceClientConfiguration(const char *logtag)
+    ClientConfiguration MakeDefaultHttpResourceClientConfiguration(const char *logtag)
     {
         ClientConfiguration res;
 
@@ -87,7 +87,7 @@ AWSHttpResourceClient::AWSHttpResourceClient(const Client::ClientConfiguration& 
 }
 
 AWSHttpResourceClient::AWSHttpResourceClient(const char* logtag)
-: AWSHttpResourceClient(makeDefaultHttpResourceClientConfiguration(logtag), logtag)
+: AWSHttpResourceClient(MakeDefaultHttpResourceClientConfiguration(logtag), logtag)
 {
 }
 

--- a/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
+++ b/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
@@ -14,13 +14,15 @@
   */
 
 #include <aws/core/internal/AWSHttpResourceClient.h>
-#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/client/DefaultRetryStrategy.h>
 #include <aws/core/http/HttpClient.h>
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/http/HttpResponse.h>
 #include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/platform/Environment.h>
+#include <aws/core/client/AWSError.h>
+#include <aws/core/client/CoreErrors.h>
 
 #include <sstream>
 
@@ -33,33 +35,60 @@ using namespace Aws::Internal;
 static const char* EC2_SECURITY_CREDENTIALS_RESOURCE = "/latest/meta-data/iam/security-credentials";
 static const char* EC2_REGION_RESOURCE = "/latest/meta-data/placement/availability-zone";
 
+static const char* RESOURCE_CLIENT_CONFIGURATION_ALLOCATION_TAG = "AWSHttpResourceClient";
 static const char* EC2_METADATA_CLIENT_LOG_TAG = "EC2MetadataClient";
 static const char* ECS_CREDENTIALS_CLIENT_LOG_TAG = "ECSCredentialsClient";
 
-AWSHttpResourceClient::AWSHttpResourceClient(const char* logtag)
-    : m_logtag(logtag), m_httpClient(nullptr)
+
+namespace {
+    ClientConfiguration makeDefaultHttpResourceClientConfiguration(const char *logtag)
+    {
+        ClientConfiguration res;
+
+        res.maxConnections = 2;
+        res.scheme = Scheme::HTTP;
+
+    #if defined(WIN32) && defined(BYPASS_DEFAULT_PROXY)
+        // For security reasons, we must bypass any proxy settings when fetching sensitive information, for example
+        // user credentials. On Windows, IXMLHttpRequest2 does not support bypasing proxy settings, therefore,
+        // we force using WinHTTP client. On POSIX systems, CURL is set to bypass proxy settings by default.
+        res.httpLibOverride = TransferLibType::WIN_HTTP_CLIENT;
+        AWS_LOGSTREAM_INFO(logtag, "Overriding the current HTTP client to WinHTTP to bypass proxy settings.");
+    #else
+        (void) logtag;  // To disable warning about unused variable
+    #endif
+        // Explicitly set the proxy settings to empty/zero to avoid relying on defaults that could potentially change
+        // in the future.
+        res.proxyHost = "";
+        res.proxyUserName = "";
+        res.proxyPassword = "";
+        res.proxyPort = 0;
+
+        // EC2MetatadaService throttles by delaying the response so the service client should set a large read timeout.
+        // EC2MetatadaService delay is in order of seconds so it only make sense to retry after a couple of seconds.
+        res.connectTimeoutMs = 1000;
+        res.requestTimeoutMs = 5000;
+        res.retryStrategy = Aws::MakeShared<DefaultRetryStrategy>(RESOURCE_CLIENT_CONFIGURATION_ALLOCATION_TAG, 4, 1000);
+
+        return res;
+    }
+}
+
+AWSHttpResourceClient::AWSHttpResourceClient(const Client::ClientConfiguration& clientConfiguration, const char* logtag)
+: m_logtag(logtag), m_retryStrategy(clientConfiguration.retryStrategy), m_httpClient(nullptr)
 {
     AWS_LOGSTREAM_INFO(m_logtag.c_str(),
-            "Creating HttpClient with max connections" << 2 << " and scheme " << "http");
-    ClientConfiguration clientConfiguration;
-    clientConfiguration.maxConnections = 2;
-    clientConfiguration.scheme = Scheme::HTTP;
-
-#if defined(WIN32) && defined(BYPASS_DEFAULT_PROXY)
-    // For security reasons, we must bypass any proxy settings when fetching sensitive information, for example
-    // user credentials. On Windows, IXMLHttpRequest2 does not support bypasing proxy settings, therefore,
-    // we force using WinHTTP client. On POSIX systems, CURL is set to bypass proxy settings by default.
-    clientConfiguration.httpLibOverride = TransferLibType::WIN_HTTP_CLIENT;
-    AWS_LOGSTREAM_INFO(logtag, "Overriding the current HTTP client to WinHTTP to bypass proxy settings.");
-#endif
-    // Explicitly set the proxy settings to empty/zero to avoid relying on defaults that could potentially change
-    // in the future.
-    clientConfiguration.proxyHost = "";
-    clientConfiguration.proxyUserName = "";
-    clientConfiguration.proxyPassword = "";
-    clientConfiguration.proxyPort = 0;
+                       "Creating AWSHttpResourceClient with max connections"
+                        << clientConfiguration.maxConnections
+                        << " and scheme "
+                        << SchemeMapper::ToString(clientConfiguration.scheme));
 
     m_httpClient = CreateHttpClient(clientConfiguration);
+}
+
+AWSHttpResourceClient::AWSHttpResourceClient(const char* logtag)
+: AWSHttpResourceClient(makeDefaultHttpResourceClientConfiguration(logtag), logtag)
+{
 }
 
 AWSHttpResourceClient::~AWSHttpResourceClient()
@@ -72,39 +101,66 @@ Aws::String AWSHttpResourceClient::GetResource(const char* endpoint, const char*
     ss << endpoint << resource;
     AWS_LOGSTREAM_TRACE(m_logtag.c_str(), "Retrieving credentials from " << ss.str().c_str());
 
-    std::shared_ptr<HttpRequest> request(CreateHttpRequest(ss.str(), HttpMethod::HTTP_GET,
-                Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
-
-    if(authToken)
+    for (long retries = 0;; retries++)
     {
-        request->SetHeaderValue(Aws::Http::AWS_AUTHORIZATION_HEADER, authToken);
-    }
+        std::shared_ptr<HttpRequest> request(CreateHttpRequest(ss.str(), HttpMethod::HTTP_GET,
+                    Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
 
-    std::shared_ptr<HttpResponse> response(m_httpClient->MakeRequest(request));
+        if (authToken)
+        {
+            request->SetHeaderValue(Aws::Http::AWS_AUTHORIZATION_HEADER, authToken);
+        }
 
-    if (response == nullptr)
-    {
-        AWS_LOGSTREAM_ERROR(m_logtag.c_str(), "Http request to retrieve credentials failed.");
-    }
-    else if (response->GetResponseCode() != HttpResponseCode::OK)
-    {
-        AWS_LOGSTREAM_ERROR(m_logtag.c_str(), "Http request to retrieve credentials failed with error code "
-                << static_cast<int>(response->GetResponseCode()));
-    }
-    else
-    {
-        Aws::IStreamBufIterator eos;
-        return Aws::String(Aws::IStreamBufIterator(response->GetResponseBody()), eos);
-    }
+        std::shared_ptr<HttpResponse> response(m_httpClient->MakeRequest(request));
 
-    return "";
+        const HttpResponseCode responseCode = response ? response->GetResponseCode() : HttpResponseCode::REQUEST_NOT_MADE;
+
+        if (responseCode == HttpResponseCode::OK)
+        {
+            Aws::IStreamBufIterator eos;
+            return Aws::String(Aws::IStreamBufIterator(response->GetResponseBody()), eos);
+        }
+        else if (responseCode == HttpResponseCode::REQUEST_NOT_MADE)
+        {
+            AWS_LOGSTREAM_ERROR(m_logtag.c_str(), "Http request to retrieve credentials failed.");
+        }
+        else if (response->GetResponseCode() >= HttpResponseCode::INTERNAL_SERVER_ERROR)
+        {
+            AWS_LOGSTREAM_ERROR(m_logtag.c_str(), "Http request to retrieve credentials failed with error code "
+                                << static_cast<int>(response->GetResponseCode()));
+        }
+        else
+        {
+            // Client error, retrying the same request will not help
+            AWS_LOGSTREAM_ERROR(m_logtag.c_str(), "Http request to retrieve credentials failed with non-retriable error code "
+                                << static_cast<int>(response->GetResponseCode()));
+            return {};
+        }
+
+        // Internal error that is retryable
+        Aws::Client::AWSError<Aws::Client::CoreErrors> error(Aws::Client::CoreErrors::INTERNAL_FAILURE, true);
+        if (!m_retryStrategy->ShouldRetry(error, retries))
+        {
+            AWS_LOGSTREAM_ERROR(m_logtag.c_str(), "Can not retrive resource " << resource);
+            return {};
+        }
+
+        auto sleepMillis = m_retryStrategy->CalculateDelayBeforeNextRetry(error, retries);
+        AWS_LOGSTREAM_WARN(m_logtag.c_str(), "Request failed, now waiting " << sleepMillis << " ms before attempting again.");
+        m_httpClient->RetryRequestSleep(std::chrono::milliseconds(sleepMillis));
+    }
 }
 
 EC2MetadataClient::EC2MetadataClient(const char* endpoint)
     : AWSHttpResourceClient(EC2_METADATA_CLIENT_LOG_TAG), m_endpoint(endpoint)
 {
-
 }
+
+EC2MetadataClient::EC2MetadataClient(const Client::ClientConfiguration& clientConfiguration, const char* endpoint)
+    : AWSHttpResourceClient(clientConfiguration, EC2_METADATA_CLIENT_LOG_TAG), m_endpoint(endpoint)
+{
+}
+
 
 EC2MetadataClient::~EC2MetadataClient()
 {
@@ -185,6 +241,12 @@ Aws::String EC2MetadataClient::GetCurrentRegion() const
 
 ECSCredentialsClient::ECSCredentialsClient(const char* resourcePath, const char* endpoint, const char* token)
     : AWSHttpResourceClient(ECS_CREDENTIALS_CLIENT_LOG_TAG),
+    m_resourcePath(resourcePath), m_endpoint(endpoint), m_token(token)
+{
+}
+
+ECSCredentialsClient::ECSCredentialsClient(const Client::ClientConfiguration& clientConfiguration, const char* resourcePath, const char* endpoint, const char* token)
+    : AWSHttpResourceClient(clientConfiguration, ECS_CREDENTIALS_CLIENT_LOG_TAG),
     m_resourcePath(resourcePath), m_endpoint(endpoint), m_token(token)
 {
 }


### PR DESCRIPTION
Fix for #923

The commit also makes the default configuration to be useful. Now it has 5s request timeout and does 4 retries with 1s exponential back-off.