### PR TITLE
Add outcome header in few client headers 

### DIFF
--- a/aws-cpp-sdk-cloudtrail/include/aws/cloudtrail/CloudTrailClient.h
+++ b/aws-cpp-sdk-cloudtrail/include/aws/cloudtrail/CloudTrailClient.h
@@ -14,6 +14,7 @@
 */
 
 #pragma once
+#include <aws/core/utils/Outcome.h>
 #include <aws/cloudtrail/CloudTrail_EXPORTS.h>
 #include <aws/cloudtrail/CloudTrailErrors.h>
 #include <aws/core/client/AWSError.h>

--- a/aws-cpp-sdk-codecommit/include/aws/codecommit/CodeCommitClient.h
+++ b/aws-cpp-sdk-codecommit/include/aws/codecommit/CodeCommitClient.h
@@ -14,6 +14,7 @@
 */
 
 #pragma once
+#include <aws/core/utils/Outcome.h>
 #include <aws/codecommit/CodeCommit_EXPORTS.h>
 #include <aws/codecommit/CodeCommitErrors.h>
 #include <aws/core/client/AWSError.h>

--- a/aws-cpp-sdk-elasticfilesystem/include/aws/elasticfilesystem/EFSClient.h
+++ b/aws-cpp-sdk-elasticfilesystem/include/aws/elasticfilesystem/EFSClient.h
@@ -14,6 +14,7 @@
 */
 
 #pragma once
+#include <aws/core/utils/Outcome.h>
 #include <aws/elasticfilesystem/EFS_EXPORTS.h>
 #include <aws/elasticfilesystem/EFSErrors.h>
 #include <aws/core/client/AWSError.h>

--- a/aws-cpp-sdk-glacier/include/aws/glacier/GlacierClient.h
+++ b/aws-cpp-sdk-glacier/include/aws/glacier/GlacierClient.h
@@ -14,6 +14,7 @@
 */
 
 #pragma once
+#include <aws/core/utils/Outcome.h>
 #include <aws/glacier/Glacier_EXPORTS.h>
 #include <aws/glacier/GlacierErrors.h>
 #include <aws/core/client/AWSError.h>

--- a/aws-cpp-sdk-neptune/include/aws/neptune/NeptuneClient.h
+++ b/aws-cpp-sdk-neptune/include/aws/neptune/NeptuneClient.h
@@ -14,6 +14,7 @@
 */
 
 #pragma once
+#include <aws/core/utils/Outcome.h>
 #include <aws/neptune/Neptune_EXPORTS.h>
 #include <aws/neptune/NeptuneErrors.h>
 #include <aws/core/client/AWSError.h>


### PR DESCRIPTION
In CPP SDK few of the SDKs have the forward declaration of object like [this](https://github.com/aws/aws-sdk-cpp/blob/master/aws-cpp-sdk-codecommit/include/aws/codecommit/CodeCommitClient.h#L71); for this the code need to include the header `#include <aws/core/utils/Outcome.h>` otherwise it would error as the outcome obj types are not defined in the typedef due to forward declarations. I ran a benchmark of compilation time with and without including this header and I think it would be better to include the header in client headers itself in the SDK as it doesn't seem to be costly on compilation time in terms of repetitive headers included. Another reason of opening this PR is I don't get this error in SES and few other SDKs as what I observed from grep and SDK code is client headers does not have the outcome header in includes directory with a forward declaration of outcome object so the SDKs like SES also should error; curious if I have missed something reading in the code, thanks for any pointers.

<details>

```cpp
error: invalid use of incomplete type ‘Aws::CodeCommit::Model::CreateRepositoryOutcome {aka class Aws::Utils::Outcome<Aws::CodeCommit::Model::CreateRepositoryResult, Aws::Client::AWSError<Aws::CodeCommit::CodeCommitErrors> >}’
     auto cr_out = codecommit.CreateRepository(cr_req);
                                                     ^
In file included from /home/tapasweni/aws-sdk-cpp/aws-cpp-sdk-core/include/aws/core/utils/crypto/Hash.h:19:0,
                 from /home/tapasweni/aws-sdk-cpp/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h:23,
                 from /home/tapasweni/aws-sdk-cpp/aws-cpp-sdk-codecommit/include/aws/codecommit/CodeCommitClient.h:22,
                 from /home/tapasweni/aws-doc-sdk-examples/cpp/example_code/codecommit/create_repository.cpp:14:
/home/tapasweni/aws-sdk-cpp/aws-cpp-sdk-core/include/aws/core/utils/crypto/HashResult.h:26:50: note: declaration of ‘Aws::CodeCommit::Model::CreateRepositoryOutcome {aka class Aws::Utils::Outcome<Aws::CodeCommit::Model::CreateRepositoryResult, Aws::Client::AWSError<Aws::CodeCommit::CodeCommitErrors> >}’
         template< typename R, typename E > class Outcome;
                                                  ^
```
</details>