### PR TITLE
Add missing #include <cassert>

### DIFF
--- a/aws-cpp-sdk-core/source/http/standard/StandardHttpRequest.cpp
+++ b/aws-cpp-sdk-core/source/http/standard/StandardHttpRequest.cpp
@@ -19,6 +19,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <cassert>
 
 using namespace Aws::Http;
 using namespace Aws::Http::Standard;


### PR DESCRIPTION
This fixes

```
/build/source/aws-cpp-sdk-core/source/http/standard/StandardHttpRequest.cpp: In member function 'virtual const String& Aws::Http::Standard::Stand>
/build/source/aws-cpp-sdk-core/source/http/standard/StandardHttpRequest.cpp:72:5: error: 'assert' was not declared in this scope
     assert (iter != headerMap.end());
     ^~~~~~
```