### PR TITLE
TransferManager: Allow setting a content-encoding for S3 uploads

### DIFF
--- a/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
@@ -296,6 +296,14 @@ namespace Aws
              */
             inline void SetContentType(const Aws::String& value) { std::lock_guard<std::mutex> locker(m_getterSetterLock); m_contentType = value; } 
             /**
+             * Content encoding of the object being transferred
+             */
+            inline const Aws::String GetContentEncoding() const { std::lock_guard<std::mutex> locker(m_getterSetterLock); return m_contentEncoding; }
+            /**
+             * Content type of the object being transferred
+             */
+            inline void SetContentEncoding(const Aws::String& value) { std::lock_guard<std::mutex> locker(m_getterSetterLock); m_contentEncoding = value; }
+            /**
              * In case of an upload, this is the metadata that was placed on the object when it was uploaded.
              * In the case of a download, this is the object metadata from the GetObject operation.
              */
@@ -380,6 +388,7 @@ namespace Aws
             Aws::String m_key;
             Aws::String m_fileName;
             Aws::String m_contentType;
+            Aws::String m_contentEncoding;
             Aws::String m_versionId;
             Aws::Map<Aws::String, Aws::String> m_metadata;
             TransferStatus m_status;

--- a/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
@@ -152,7 +152,8 @@ namespace Aws
                                                        const Aws::String& keyName,
                                                        const Aws::String& contentType, 
                                                        const Aws::Map<Aws::String, Aws::String>& metadata,
-                                                       const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context = nullptr);
+                                                       const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context = nullptr,
+                                                       const Aws::String& contentEncoding = "");
 
             /**
              * Downloads the contents of bucketName/keyName in S3 to the file specified by writeToFile. This will perform a GetObject operation.
@@ -232,7 +233,8 @@ namespace Aws
                                                                    const Aws::Map<Aws::String,
                                                                    Aws::String>& metadata,
                                                                    const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context,
-                                                                   const Aws::String& fileName = "");
+                                                                   const Aws::String& fileName = "",
+                                                                   const Aws::String& contentEncoding = "");
 
             /**
              * Submits the actual task to task schecduler
@@ -248,7 +250,8 @@ namespace Aws
                                                          const Aws::String& keyName,
                                                          const Aws::String& contentType,
                                                          const Aws::Map<Aws::String, Aws::String>& metadata,
-                                                         const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context);
+                                                         const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context,
+                                                         const Aws::String& contentEncoding);
 
             /**
              * Uploads the contents of file, to bucketName/keyName in S3. contentType and metadata will be added to the object. If the object is larger than the configured bufferSize,


### PR DESCRIPTION
This adds an argument to `Aws::Transfer::TransferManager::UploadFile()` to allow the `Content-Encoding` of the object to be set. We needed this in https://github.com/NixOS/nix to allow files to be uploaded to an S3 bucket with a `brotli` Content-Encoding.

(An alternative to adding yet another positional argument to `UploadFile()` might be to allow the caller to create a `TransferHandle` and pass it to `TransferManager`.)
