### PR TITLE
Inspect profile config only if a default profile is set

### DIFF
--- a/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
+++ b/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
@@ -42,7 +42,7 @@ static const char SECRET_KEY_ENV_VAR[] = "AWS_SECRET_ACCESS_KEY";
 static const char SESSION_TOKEN_ENV_VAR[] = "AWS_SESSION_TOKEN";
 static const char DEFAULT_PROFILE[] = "default";
 static const char AWS_PROFILE_ENV_VAR[] = "AWS_PROFILE";
-static const char AWS_PROFILE_DEFAULT_ENV_VAR[] = "AWS_DEFAULT_PROFILE";
+extern const char AWS_PROFILE_DEFAULT_ENV_VAR[] = "AWS_DEFAULT_PROFILE";
 
 static const char AWS_CREDENTIAL_PROFILES_FILE[] = "AWS_SHARED_CREDENTIALS_FILE";
 


### PR DESCRIPTION
The monitoring system should only hit the disk looking for a profile
setting if-and-only-if a default profile environment variable is set.
Otherwise, it's unclear which settings to apply if multiple exist and they
contradict somehow.