### PR TITLE
Add AssumeRole functionality for credentials/config files

### DIFF
--- a/aws-cpp-sdk-core-tests/aws/config/AWSProfileConfigLoaderTest.cpp
+++ b/aws-cpp-sdk-core-tests/aws/config/AWSProfileConfigLoaderTest.cpp
@@ -41,6 +41,34 @@ static void WriteDefaultConfigFile(Aws::OStream& stream, bool useProfilePrefix =
     stream << "region = us-west-2" << std::endl;
 }
 
+TEST(AWSConfigFileProfileConfigLoaderTest, TestProfileMerge)
+{
+    Aws::Config::Profile profile1, profile2;
+
+    profile1.SetName("name1");
+    Aws::Auth::AWSCredentials credentials1;
+    credentials1.SetAWSAccessKeyId("accessKey1");
+    credentials1.SetAWSSecretKey("secretKey1");
+    credentials1.SetSessionToken("token1");
+    profile1.SetCredentials(credentials1);
+
+    profile2.SetName("name2");
+    profile2.SetRegion("region2");
+    profile2.SetRoleArn("role2");
+    profile2.SetSourceProfile("source2");
+
+    profile1.MergeWith(profile2);
+
+    ASSERT_STREQ("name1", profile1.GetName().c_str());
+    ASSERT_STREQ("region2", profile1.GetRegion().c_str());
+    ASSERT_STREQ("accessKey1", profile1.GetCredentials().GetAWSAccessKeyId().c_str());
+    ASSERT_STREQ("secretKey1", profile1.GetCredentials().GetAWSSecretKey().c_str());
+    ASSERT_STREQ("token1", profile1.GetCredentials().GetSessionToken().c_str());
+    ASSERT_STREQ("role2", profile1.GetRoleArn().c_str());
+    ASSERT_STREQ("", profile1.GetExternalId().c_str());
+    ASSERT_STREQ("source2", profile1.GetSourceProfile().c_str());
+}
+
 TEST(AWSConfigFileProfileConfigLoaderTest, TestCredentialsFileLoad)
 {
     TempFile configFile(std::ios_base::out | std::ios_base::trunc);

--- a/aws-cpp-sdk-core/include/aws/core/config/AWSProfileConfigLoader.h
+++ b/aws-cpp-sdk-core/include/aws/core/config/AWSProfileConfigLoader.h
@@ -54,6 +54,12 @@ namespace Aws
                 return iter->second;
             }
 
+            /**
+             * Merges 'source' profile fields into 'this', giving priority to the fields in 'this' (ie. if a field
+             * has been populated in 'this', it will not get overwritten).
+             */
+            void MergeWith(const Profile& source);
+
         private:
             Aws::String m_name;
             Aws::String m_region;

--- a/aws-cpp-sdk-core/source/config/AWSProfileConfigLoader.cpp
+++ b/aws-cpp-sdk-core/source/config/AWSProfileConfigLoader.cpp
@@ -29,6 +29,50 @@ namespace Aws
         using namespace Aws::Utils;
         using namespace Aws::Auth;
 
+        static const char* const REGION_KEY = "region";
+        static const char* const ACCESS_KEY_ID_KEY = "aws_access_key_id";
+        static const char* const SECRET_KEY_KEY = "aws_secret_access_key";
+        static const char* const SESSION_TOKEN_KEY = "aws_session_token";
+        static const char* const ROLE_ARN_KEY = "role_arn";
+        static const char* const EXTERNAL_ID_KEY = "external_id";
+        static const char* const SOURCE_PROFILE_KEY = "source_profile";
+
+        void Profile::MergeWith(const Profile& source)
+        {
+            if(this->GetName().empty()) { this->SetName(source.GetName()); }
+            if(this->GetRegion().empty())
+            {
+                this->SetRegion(source.GetRegion());
+                this->m_allKeyValPairs[REGION_KEY] = source.GetRegion();
+            }
+
+            if(this->GetCredentials().GetAWSAccessKeyId().empty())
+            {
+                this->SetCredentials(source.GetCredentials());
+                this->m_allKeyValPairs[ACCESS_KEY_ID_KEY] = source.GetCredentials().GetAWSSecretKey();
+                this->m_allKeyValPairs[SECRET_KEY_KEY] = source.GetCredentials().GetAWSSecretKey();
+                this->m_allKeyValPairs[SESSION_TOKEN_KEY] = source.GetCredentials().GetSessionToken();
+            }
+
+            if(this->GetRoleArn().empty())
+            {
+                this->SetRoleArn(source.GetRoleArn());
+                this->m_allKeyValPairs[ROLE_ARN_KEY] = source.GetRoleArn();
+            }
+
+            if(this->GetExternalId().empty())
+            {
+                this->SetExternalId(source.GetExternalId());
+                this->m_allKeyValPairs[EXTERNAL_ID_KEY] = source.GetExternalId();
+            }
+
+            if(this->GetSourceProfile().empty())
+            {
+                this->SetSourceProfile(source.GetSourceProfile());
+                this->m_allKeyValPairs[SOURCE_PROFILE_KEY] = source.GetSourceProfile();
+            }
+        }
+
         static const char* const CONFIG_LOADER_TAG = "Aws::Config::AWSProfileConfigLoader";
 
         bool AWSProfileConfigLoader::Load()
@@ -62,13 +106,6 @@ namespace Aws
             return false;
         }
 
-        static const char* const REGION_KEY = "region";
-        static const char* const ACCESS_KEY_ID_KEY = "aws_access_key_id";
-        static const char* const SECRET_KEY_KEY = "aws_secret_access_key";
-        static const char* const SESSION_TOKEN_KEY = "aws_session_token";
-        static const char* const ROLE_ARN_KEY = "role_arn";
-        static const char* const EXTERNAL_ID_KEY = "external_id";
-        static const char* const SOURCE_PROFILE_KEY = "source_profile";
         static const char* const PROFILE_PREFIX = "profile ";
         static const char EQ = '=';
         static const char LEFT_BRACKET = '[';

--- a/aws-cpp-sdk-identity-management/include/aws/identity-management/auth/STSAssumeRoleCredentialsProvider.h
+++ b/aws-cpp-sdk-identity-management/include/aws/identity-management/auth/STSAssumeRoleCredentialsProvider.h
@@ -17,6 +17,7 @@
 
 #include <aws/identity-management/IdentityManagment_EXPORTS.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/config/AWSProfileConfigLoader.h>
 
 #include <memory>
 #include <mutex>
@@ -35,6 +36,13 @@ namespace Aws
          * The default credential lifetime is 15 minutes
          */
         static const int DEFAULT_CREDS_LOAD_FREQ_SECONDS = 900;
+
+        /**
+         * A user who a) wants DefaultAWSCredentialsProviderChain to provide role credentials and b) is building static
+         * AWS libraries should call this function to ensure the linker includes STS.  If the user never uses any
+         * symbols in STS, the linker may optimize by excluding STS.
+         */
+        void ActivateRoleCredentialsProvider();
 
         /**
          * Credentials provider for STS Assume Role


### PR DESCRIPTION
The role_arn and source_profile fields within a credentials file have been
ignored up until now.  This fix adds support for assuming a role from a
credentials and/or config file.