### PR TITLE
Fixed ConfigFileProfileFSM to flush last profile correctly

### DIFF
--- a/aws-cpp-sdk-core/source/config/AWSProfileConfigLoader.cpp
+++ b/aws-cpp-sdk-core/source/config/AWSProfileConfigLoader.cpp
@@ -137,7 +137,7 @@ namespace Aws
                     }
                 }
 
-                FlushProfileAndReset(line, 0, 0);
+                FlushProfileAndReset(line, std::string::npos, std::string::npos);
             }
 
         private:


### PR DESCRIPTION
The code as-is works, but it's not technically correct.  When the end of file is reached, the last profile should be flushed by FlushProfileAndReset, and that's it.  Instead, FlushProfileAndReset will still try to extract another profile name (which doesn't exist) because of the following line:

if(!line.empty() && openPos != std::string::npos && closePos != std::string::npos)
