### PR TITLE
only set proxy username and password options when specified for curl

### DIFF
--- a/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -422,8 +422,11 @@ void CurlHttpClient::MakeRequestInternal(HttpRequest& request,
             ss << m_proxyScheme << "://" << m_proxyHost;
             curl_easy_setopt(connectionHandle, CURLOPT_PROXY, ss.str().c_str());
             curl_easy_setopt(connectionHandle, CURLOPT_PROXYPORT, (long) m_proxyPort);
-            curl_easy_setopt(connectionHandle, CURLOPT_PROXYUSERNAME, m_proxyUserName.c_str());
-            curl_easy_setopt(connectionHandle, CURLOPT_PROXYPASSWORD, m_proxyPassword.c_str());
+            if (!m_proxyUserName.empty() || !m_proxyPassword.empty())
+            {
+                curl_easy_setopt(connectionHandle, CURLOPT_PROXYUSERNAME, m_proxyUserName.c_str());
+                curl_easy_setopt(connectionHandle, CURLOPT_PROXYPASSWORD, m_proxyPassword.c_str());
+            }
         }
         else
         {


### PR DESCRIPTION
If the proxy username and password are blank then sending them to curl causes curl to generate a
```Proxy-Authorization: Basic Og==``` header. This causes problems with proxies that don't require authentication (e.g. CNTLM) as they reject this incorrect username and password.