### PR TITLE
CPP-4885 fix URI::URLEncodePathRFC3986 to handle tabs

### DIFF
--- a/aws-cpp-sdk-core/source/http/URI.cpp
+++ b/aws-cpp-sdk-core/source/http/URI.cpp
@@ -145,7 +145,7 @@ Aws::String URI::URLEncodePathRFC3986(const Aws::String& path)
                     ss << c;
                     break;
                 default:
-                    ss << '%' << std::setw(2) << (int)((unsigned char)c) << std::setw(0);
+                    ss << '%' << std::setfill('0') << std::setw(2) << (int)((unsigned char)c) << std::setw(0);
             }
         }
     }


### PR DESCRIPTION
Aws::String URI::URLEncodePathRFC3986(const Aws::String& path) does not correctly encode elements of path when their code is under 0x10.

To reproduce:

```
Aws::Http::URI u("http://xxx.yyy.zzz/path/\tfilename.txt");
printf("%s\n", u.GetURIString().c_str());
```

will yield following:

```
http://xxx.yyy.zzz/path/% 9filename.txt
```

notice, the tab character is encoded as "% 9" instead of "%09". This causes issues when used in conjunction with S3 upload, for example:

CurlHttpClient: Making request to https://snapper-output.s3.us-west-2.amazonaws.com/% 9emfout/%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%25%2AO% F@%DD%B9.mp4?uploads

which ultimately fails with HTTP 505, HttpVersionNotSupported (because URI has a space).