### PR TITLE
fixes #1010

### DIFF
--- a/aws-cpp-sdk-core-tests/utils/FileSystemUtilsTest.cpp
+++ b/aws-cpp-sdk-core-tests/utils/FileSystemUtilsTest.cpp
@@ -18,6 +18,10 @@
 #include <aws/core/utils/memory/stl/AWSSet.h>
 #include <aws/external/gtest.h>
 #include <fstream>
+#ifndef _WIN32
+# include <unistd.h>
+# include <limits.h>
+#endif
 
 using namespace Aws;
 using namespace Aws::Utils;
@@ -270,10 +274,20 @@ TEST_F(DirectoryTreeTest, TestPathUtilsGetFileNameWithoutExt)
 
 TEST_F(DirectoryTreeTest, CreateDirectoryIfNotExistedTest)
 {
+    long longNameLength;
+#ifdef _WIN32
     // Path compoments on Windows can't exceed 255(_MAX_FNAME) chars.
     // To cover the Windows case where the path with length over 260(MAX_PATH) chars,
     // set one path part to be 255 characters, so dir1/dir2/dir3/[longDirName] is over 260 chars.
-    Aws::String longDirName(255, 'a');
+    longNameLength = 255;
+#else
+    errno = 0;
+    longNameLength = pathconf(".", _PC_NAME_MAX);
+    ASSERT_TRUE(longNameLength >= 0 || errno == 0);
+    if (longNameLength <= 0)
+      longNameLength = NAME_MAX;
+#endif
+    Aws::String longDirName(longNameLength, 'a');
     // The directory is created under root directory "dir1", "dir1" will be deleted during TearDown().
     ASSERT_TRUE(FileSystem::CreateDirectoryIfNotExists(FileSystem::Join(FileSystem::Join(dir2, "dir3"), longDirName).c_str(), true/*create all intermediate directories on the path*/));
 }


### PR DESCRIPTION
On non-Windows systems, uses pathconf(3) to get the maximum
file name length in the current directory.

This prevents the test from failing when run on file systems
with different limitations (e.g. aufs)