### PR TITLE
Move to tagged versions of C dependency libraries

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -41,11 +41,11 @@ set(AWS_DEPS_BUILD_DIR "${CMAKE_BINARY_DIR}/build" CACHE PATH "Dependencies buil
 set(AWS_DEPS_DOWNLOAD_DIR "${AWS_DEPS_BUILD_DIR}/downloads" CACHE PATH "Dependencies download directory.")
 
 set(AWS_C_COMMON_URL "https://github.com/awslabs/aws-c-common.git")
-set(AWS_C_COMMON_TAG "29a7375a")
+set(AWS_C_COMMON_TAG "v0.3.0")
 include(BuildAwsCCommon)
 
 set(AWS_CHECKSUMS_URL "https://github.com/awslabs/aws-checksums.git")
-set(AWS_CHECKSUMS_TAG "v0.1.1")
+set(AWS_CHECKSUMS_TAG "v0.1.2")
 include(BuildAwsChecksums)
 
 set(AWS_EVENT_STREAM_URL "https://github.com/awslabs/aws-c-event-stream.git")


### PR DESCRIPTION
Needed because we were previously pinning to old version
of aws-c-common before some breaking changes.