### PR TITLE
Fix potential out of bound read in CalculateBase64DecodedLength

### DIFF
--- a/aws-cpp-sdk-core/source/utils/base64/Base64.cpp
+++ b/aws-cpp-sdk-core/source/utils/base64/Base64.cpp
@@ -132,8 +132,8 @@ Aws::Utils::ByteBuffer Base64::Decode(const Aws::String& str) const
 
 size_t Base64::CalculateBase64DecodedLength(const Aws::String& b64input)
 {
-    size_t len = b64input.length();
-    if(len == 0)
+    const size_t len = b64input.length();
+    if(len < 2)
     {
         return 0;
     }


### PR DESCRIPTION
If the length of base64 input is only one character.
len - 2 would wrap to size_t::max - 1, causing an out of bound read.

Albeit being an invalid base64 string, this should not cause UB.