### PR TITLE
cmake: don't set PACKAGE_VERSION in Config.cmake

### DIFF
--- a/cmake/AWSSDKConfig.cmake
+++ b/cmake/AWSSDKConfig.cmake
@@ -35,7 +35,6 @@ if(AWSSDK_FOUND)
     return()
 endif()
 
-include(${CMAKE_CURRENT_LIST_DIR}/AWSSDKConfigVersion.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/sdksCommon.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/platformDeps.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/compiler_settings.cmake)
@@ -158,7 +157,7 @@ if (AWSSDK_ADDITIONAL_LIBS)
 	set(AWSSDK_PLATFORM_DEPS "${AWSSDK_PLATFORM_DEPS}" "${AWSSDK_ADDITIONAL_LIBS}")
 endif()
 
-message(STATUS "Found AWS SDK for C++, Version: ${PACKAGE_VERSION}, Install Root:${AWSSDK_ROOT_DIR}, Platform Prefix:${AWSSDK_PLATFORM_PREFIX}, Platform Dependent Libraries: ${AWSSDK_PLATFORM_DEPS}")
+message(STATUS "Found AWS SDK for C++, Version: ${AWSSDK_VERSION}, Install Root:${AWSSDK_ROOT_DIR}, Platform Prefix:${AWSSDK_PLATFORM_PREFIX}, Platform Dependent Libraries: ${AWSSDK_PLATFORM_DEPS}")
 
 
 # copy libs of services in SERVICE_LIST and all there dependent libs to DEST_DIR


### PR DESCRIPTION
don't include the ConfigVersion.cmake in Config.cmake
as this sets e.g. PACKAGE_VERSION in other projects find_package-ing
AWSSDK.

Use AWSDK_VERSION for printing the found version instead it is supposed
to be.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
