### PR TITLE
Added check in AWSHttpResourceClient if authToken is actually set.

### DIFF
--- a/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
+++ b/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
@@ -172,7 +172,7 @@ EC2MetadataClient::~EC2MetadataClient()
 
 Aws::String EC2MetadataClient::GetResource(const char* resourcePath) const
 {
-    return GetResource(m_endpoint.c_str(), resourcePath, ""/*authToken*/);
+    return GetResource(m_endpoint.c_str(), resourcePath, nullptr/*authToken*/);
 }
 
 Aws::String EC2MetadataClient::GetDefaultCredentials() const


### PR DESCRIPTION
*If you set Authorization header with custom HttpClientFactory, AWSHttpResourceClient will overwrite it again because authToken check always passes. We should check for the actual content of the authToken passed.*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
