### PR TITLE
Sanitize BUILD_ONLY CMake variable

### DIFF
--- a/cmake/sdks.cmake
+++ b/cmake/sdks.cmake
@@ -18,6 +18,9 @@ endif()
 
 
 if(BUILD_ONLY)
+    # Sanitize input client list, for example removing empty elements
+    # that may be introduced by trailing semicolons
+    set(BUILD_ONLY ${BUILD_ONLY})
     set(SDK_BUILD_LIST ${BUILD_ONLY})
     foreach(TARGET IN LISTS BUILD_ONLY)
         message(STATUS "Considering ${TARGET}")


### PR DESCRIPTION
Sanitize BUILD_ONLY CMake variable to prevent empty elements in the input list from breaking the build script (e.g. extra or trailing semicolons)

Issue #: 648 (https://github.com/aws/aws-sdk-cpp/issues/648)

Description of changes:

The CMake build script currently errors if the BUILD_ONLY list isn't formatted as a canonical CMake list. For instance, adding a trailing semicolon at the end of the client list will cause the build script to fail. Example:

`cmake < rest of parameters> -DBUILD_ONLY="dynamodb;s3;kms;"
`
Error output:

```
-- Considering kms
-- Considering
CMake Error at cmake/sdks.cmake:25 (get_dependencies_for_sdk):
  get_dependencies_for_sdk Function invoked with incorrect arguments for
  function named: get_dependencies_for_sdk
Call Stack (most recent call first):
  CMakeLists.txt:209 (include)
```

My one liner change ensures the custom list of aws clients to build is sanitized before use, any empty elements are automatically removed from the list. For instance, the following will now build correctly:

`cmake < rest of parameters> -DBUILD_ONLY="dynamodb;s3;kms;"
`cmake < rest of parameters> -DBUILD_ONLY="dynamodb;s3;kms;;;"
`cmake < rest of parameters> -DBUILD_ONLY=";dynamodb;s3;;kms;;;"



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
