### PR TITLE
Closes #1095 add ability to disable multipart upload with env. variable

### DIFF
--- a/aws-cpp-sdk-s3/include/aws/s3/S3Client.h
+++ b/aws-cpp-sdk-s3/include/aws/s3/S3Client.h
@@ -3055,6 +3055,7 @@ namespace Aws
         Aws::String m_configScheme;
         std::shared_ptr<Utils::Threading::Executor> m_executor;
         bool m_useVirtualAdressing;
+        bool m_multipartUploadSupported;
     };
 
   } // namespace S3

--- a/aws-cpp-sdk-s3/source/S3Client.cpp
+++ b/aws-cpp-sdk-s3/source/S3Client.cpp
@@ -21,6 +21,7 @@
 #include <aws/core/http/HttpResponse.h>
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/platform/Environment.h>
 #include <aws/core/utils/xml/XmlSerializer.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 #include <aws/core/utils/threading/Executor.h>
@@ -126,7 +127,7 @@ using namespace Aws::Utils::Xml;
 
 static const char* SERVICE_NAME = "s3";
 static const char* ALLOCATION_TAG = "S3Client";
-
+static const char* DISABLE_MULTIPART_SUPPORT_ENV_VAR = "AWS_DISABLE_MULTIPART";
 
 S3Client::S3Client(const Client::ClientConfiguration& clientConfiguration, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy signPayloads, bool useVirtualAdressing) :
   BASECLASS(clientConfiguration,
@@ -175,6 +176,7 @@ void S3Client::init(const ClientConfiguration& config)
   {
       OverrideEndpoint(config.endpointOverride);
   }
+  m_multipartUploadSupported = Aws::Environment::GetEnv(DISABLE_MULTIPART_SUPPORT_ENV_VAR).empty();
 }
 
 void S3Client::OverrideEndpoint(const Aws::String& endpoint)
@@ -3916,5 +3918,5 @@ Aws::String S3Client::ComputeEndpointString() const
 
 bool S3Client::MultipartUploadSupported() const
 {
-    return true;
+    return m_multipartUploadSupported;
 }


### PR DESCRIPTION
*Issue #, if available:*
1095

*Description of changes:*
Simply check if env variable to disable multipart upload is set. 
I didn't see any tests for S3Client. Please point me to them, if they exist, and I will add the test for this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
