### PR TITLE
Remove extraneous std::cout print statements in request path

### DIFF
--- a/aws-cpp-sdk-core/source/AmazonSerializableWebServiceRequest.cpp
+++ b/aws-cpp-sdk-core/source/AmazonSerializableWebServiceRequest.cpp
@@ -21,7 +21,6 @@ using namespace Aws;
 std::shared_ptr<Aws::IOStream> AmazonSerializableWebServiceRequest::GetBody() const
 {
     Aws::String&& payload = SerializePayload();
-    std::cout <<"\n\n\nRequest:\n" << payload << "\n\n\n";
     std::shared_ptr<Aws::IOStream> payloadBody;
 
     if (!payload.empty())

--- a/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -717,7 +717,6 @@ XmlOutcome AWSXMLClient::MakeRequest(const Aws::Http::URI& uri,
     if (httpOutcome.GetResult()->GetResponseBody().tellp() > 0)
     {
         XmlDocument xmlDoc = XmlDocument::CreateFromXmlStream(httpOutcome.GetResult()->GetResponseBody());
-        std::cout << "\n\n\nReponse:\n" << xmlDoc.ConvertToString() << "\n\n\n";
 
         if (!xmlDoc.WasParseSuccessful())
         {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This removes request+response debugging statements to stdout, introduced with commit 57752f1281c18bf03d7f441349add01b507a1e99