### PR TITLE
Build fixes for GCC9

### DIFF
--- a/aws-cpp-sdk-core-tests/aws/client/AWSErrorMashallerTest.cpp
+++ b/aws-cpp-sdk-core-tests/aws/client/AWSErrorMashallerTest.cpp
@@ -74,7 +74,7 @@ static Aws::UniquePtr<Aws::Http::HttpResponse> BuildHttpResponse(const Aws::Stri
         response->AddHeader(ERROR_TYPE_HEADER, exception);
     }
 
-    return std::move(response);
+    return response;
 }
 
 static Aws::UniquePtr<Aws::Http::HttpResponse> BuildHttpXmlResponse(const Aws::String& exception, const Aws::String& message, int style = SingularErrorNode)
@@ -113,7 +113,7 @@ static Aws::UniquePtr<Aws::Http::HttpResponse> BuildHttpXmlResponse(const Aws::S
     {
         *ss << "</Errors> </OtherRoot>";
     }
-    return std::move(response);
+    return response;
 }
 
 TEST(XmlErrorMarshallerTest, TestXmlErrorPayload)

--- a/aws-cpp-sdk-core/include/aws/core/client/AWSError.h
+++ b/aws-cpp-sdk-core/include/aws/core/client/AWSError.h
@@ -55,6 +55,11 @@ namespace Aws
             {}
 
             /**
+             * Copy assignment operator
+             */
+            AWSError& operator=(const AWSError<ERROR_TYPE>&) = default;
+
+            /**
              * Gets underlying errorType.
              */
             inline const ERROR_TYPE GetErrorType() const { return m_errorType; }


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/1136

*Description of changes:*

Build fixes for GCC9, one explicit copy assignment operator and removing 2 pessimizing moves.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
