### PR TITLE
Add space between consecutive right angle brackets

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/auth/AWSAuthSignerProvider.h
+++ b/aws-cpp-sdk-core/include/aws/core/auth/AWSAuthSignerProvider.h
@@ -57,7 +57,7 @@ namespace Aws
             void AddSigner(std::shared_ptr<Aws::Client::AWSAuthSigner>& signer) override;
             std::shared_ptr<Aws::Client::AWSAuthSigner> GetSigner(const Aws::String& signerName) const override;
         private:
-            Aws::Vector<std::shared_ptr<Aws::Client::AWSAuthSigner>> m_signers;
+            Aws::Vector<std::shared_ptr<Aws::Client::AWSAuthSigner> > m_signers;
         };
     }
 }

--- a/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
+++ b/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
@@ -86,8 +86,8 @@ namespace Aws
         struct ClientConfiguration;
         class RetryStrategy;
 
-        typedef Utils::Outcome<std::shared_ptr<Aws::Http::HttpResponse>, AWSError<CoreErrors>> HttpResponseOutcome;
-        typedef Utils::Outcome<AmazonWebServiceResult<Utils::Stream::ResponseStream>, AWSError<CoreErrors>> StreamOutcome;
+        typedef Utils::Outcome<std::shared_ptr<Aws::Http::HttpResponse>, AWSError<CoreErrors> > HttpResponseOutcome;
+        typedef Utils::Outcome<AmazonWebServiceResult<Utils::Stream::ResponseStream>, AWSError<CoreErrors> > StreamOutcome;
 
         /**
          * Abstract AWS Client. Contains most of the functionality necessary to build an http request, get it signed, and send it accross the wire.
@@ -279,7 +279,7 @@ namespace Aws
             bool m_enableClockSkewAdjustment;
         };
 
-        typedef Utils::Outcome<AmazonWebServiceResult<Utils::Json::JsonValue>, AWSError<CoreErrors>> JsonOutcome;
+        typedef Utils::Outcome<AmazonWebServiceResult<Utils::Json::JsonValue>, AWSError<CoreErrors> > JsonOutcome;
         AWS_CORE_API Aws::String GetAuthorizationHeader(const Aws::Http::HttpRequest& httpRequest);
 
         /**
@@ -338,7 +338,7 @@ namespace Aws
             JsonOutcome MakeEventStreamRequest(std::shared_ptr<Aws::Http::HttpRequest>& request) const;
         };
 
-        typedef Utils::Outcome<AmazonWebServiceResult<Utils::Xml::XmlDocument>, AWSError<CoreErrors>> XmlOutcome;
+        typedef Utils::Outcome<AmazonWebServiceResult<Utils::Xml::XmlDocument>, AWSError<CoreErrors> > XmlOutcome;
 
         /**
         *  AWSClient that handles marshalling xml response bodies. You would inherit from this class

--- a/aws-cpp-sdk-core/include/aws/core/utils/memory/stl/AWSAllocator.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/memory/stl/AWSAllocator.h
@@ -103,7 +103,7 @@ namespace Aws
     {
         AWS_UNREFERENCED_PARAM(allocationTag);
 
-        return std::allocate_shared<T, Aws::Allocator<T>>(Aws::Allocator<T>(), std::forward<ArgTypes>(args)...);
+        return std::allocate_shared<T, Aws::Allocator<T> >(Aws::Allocator<T>(), std::forward<ArgTypes>(args)...);
     }
 
 


### PR DESCRIPTION
*Description of changes:*
This PR fixes the following compiler errors:
```
In file included from /Users/yute/homebrew/include/aws/s3/S3Client.h:21:
/Users/yute/homebrew/include/aws/core/client/AWSClient.h:89:93: error: a space is required between consecutive right angle brackets (use '> >')
        typedef Utils::Outcome<std::shared_ptr<Aws::Http::HttpResponse>, AWSError<CoreErrors>> HttpResponseOutcome;

/Users/yute/homebrew/include/aws/core/auth/AWSAuthSignerProvider.h:60:67: error: a space is required between consecutive right angle brackets (use '> >')
            Aws::Vector<std::shared_ptr<Aws::Client::AWSAuthSigner>> m_signers;
                                                                  ^~
                                                                  > >
In file included from /Users/yute/homebrew/include/aws/s3/S3Client.h:21:
/Users/yute/homebrew/include/aws/core/client/AWSClient.h:90:106: error: a space is required between consecutive right angle brackets (use '> >')
        typedef Utils::Outcome<AmazonWebServiceResult<Utils::Stream::ResponseStream>, AWSError<CoreErrors>> StreamOutcome;

/Users/yute/homebrew/include/aws/core/client/AWSClient.h:282:99: error: a space is required between consecutive right angle brackets (use '> >')
        typedef Utils::Outcome<AmazonWebServiceResult<Utils::Json::JsonValue>, AWSError<CoreErrors>> JsonOutcome;
                                                                                                  ^~
/Users/yute/homebrew/include/aws/core/client/AWSClient.h:341:100: error: a space is required between consecutive right angle brackets (use '> >')
        typedef Utils::Outcome<AmazonWebServiceResult<Utils::Xml::XmlDocument>, AWSError<CoreErrors>> XmlOutcome;
                                                                                                   ^~
```
Here is the gcc version I use:
```
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 10.0.0 (clang-1000.11.45.5)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
