### PR TITLE
Bug fix for "Avoid disabling speed checks when timeout is less than 1 second"

### DIFF
--- a/aws-cpp-sdk-core/source/http/curl/CurlHandleContainer.cpp
+++ b/aws-cpp-sdk-core/source/http/curl/CurlHandleContainer.cpp
@@ -118,7 +118,7 @@ void CurlHandleContainer::SetDefaultOptionsOnHandle(CURL* handle)
     curl_easy_setopt(handle, CURLOPT_TIMEOUT_MS, 0L);
     curl_easy_setopt(handle, CURLOPT_CONNECTTIMEOUT_MS, m_connectTimeout);
     curl_easy_setopt(handle, CURLOPT_LOW_SPEED_LIMIT, m_lowSpeedLimit);
-    curl_easy_setopt(handle, CURLOPT_LOW_SPEED_TIME, m_requestTimeout < 1000 ? 1 : m_requestTimeout / 1000);
+    curl_easy_setopt(handle, CURLOPT_LOW_SPEED_TIME, m_requestTimeout < 1000 ? m_requestTimeout == 0 ? 0 : 1 : m_requestTimeout / 1000);
     curl_easy_setopt(handle, CURLOPT_TCP_KEEPALIVE, m_enableTcpKeepAlive ? 1L : 0L);
     curl_easy_setopt(handle, CURLOPT_TCP_KEEPINTVL, m_tcpKeepAliveIntervalMs);
     curl_easy_setopt(handle, CURLOPT_TCP_KEEPIDLE, m_tcpKeepAliveIntervalMs);


### PR DESCRIPTION
*Description of changes:*
This makes the hack to avoid disabling speed checks take into account configurations that disable speed checks with a configured time of 0.
Examples:
1000 ms timeout -> 1 second
40 ms timeout -> 1 second
timeout disabled (0 ms) -> 0 second

Original commit: https://github.com/aws/aws-sdk-cpp/commit/9260512d52cdb686f707128d4696f384678abc74

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
