### PR TITLE
Adds lock in CurlHandleContainer::AcquireCurlHandle

### DIFF
--- a/aws-cpp-sdk-core/source/http/curl/CurlHandleContainer.cpp
+++ b/aws-cpp-sdk-core/source/http/curl/CurlHandleContainer.cpp
@@ -44,6 +44,8 @@ CurlHandleContainer::~CurlHandleContainer()
 
 CURL* CurlHandleContainer::AcquireCurlHandle()
 {
+    static std::mutex m_acquireHandleLock;
+    std::lock_guard<std::mutex> locker(m_acquireHandleLock);
     AWS_LOGSTREAM_DEBUG(CURL_HANDLE_CONTAINER_TAG, "Attempting to acquire curl connection.");
 
     if(!m_handleContainer.HasResourcesAvailable())


### PR DESCRIPTION
*Issue #, if available:*

#1185 


*Description of changes:*

There is a race condition in checking and acquiring connection.

## The bug

When a program need to acquire a connection, 2 things are done:

1) check if there's available connection (`CurlHandleContainer::AcquireCurlHandle`)
2) if not, double the number of total connection (`CurlHandleContainer::CheckAndGrowPool`)

While 2) is guarded by a mutex, 1) is not. This results in a race condition that if 2 threads tries to acquire a connection at the same time when no connection is available, both threads will double the number (sequentially, because mutex).

The issue is significantly worsen when a large number of threads acquire connections at the very beginning, with each thread trying to double the number, the number of connections increases exponentially, much more than requested.

## The Fix

add a mutex for 1).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

@JonathanHenson 