### PR TITLE
Removed definition of JSON_USE_EXCEPTIONS

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/SDKConfig.h.in
+++ b/aws-cpp-sdk-core/include/aws/core/SDKConfig.h.in
@@ -15,5 +15,3 @@
 
 #cmakedefine USE_AWS_MEMORY_MANAGEMENT
 
-#define JSON_USE_EXCEPTION 0
-


### PR DESCRIPTION
*Issue* #982

*Description of changes:*

JSON_USE_EXCEPTIONS is exported to project which uses AWS SDK. If the project also uses JsonCpp
then JSON_USE_EXCEPTIONS may clash causing compilation error:

    /usr/include/aws/core/SDKConfig.h:18:0: error: "JSON_USE_EXCEPTION" redefined [-Werror]

According to issue #982, JsonCpp was replaced with another library cJSON. As a result JSON_USE_EXCEPTIONS
may be useless for AWS SDK.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
