### PR TITLE
core-http-uri: percent encode reserved characters in URL paths as sug…

### DIFF
--- a/aws-cpp-sdk-core-tests/http/URITest.cpp
+++ b/aws-cpp-sdk-core-tests/http/URITest.cpp
@@ -188,7 +188,7 @@ TEST(URITest, TestParseWithColon)
     EXPECT_STREQ("test.com", uri.GetAuthority().c_str());
     EXPECT_EQ(443, uri.GetPort());
     EXPECT_STREQ("/path/1234:_Some_Path", uri.GetPath().c_str());
-    EXPECT_STREQ(strUri, uri.GetURIString().c_str());
+    EXPECT_STREQ("https://test.com/path/1234%3A_Some_Path", uri.GetURIString().c_str());
 
     const char* strUriWithPort = "https://test.com:8080/path/1234:_Some_Path";
     URI uriWithPort(strUriWithPort);
@@ -197,7 +197,7 @@ TEST(URITest, TestParseWithColon)
     EXPECT_STREQ("test.com", uriWithPort.GetAuthority().c_str());
     EXPECT_EQ(8080, uriWithPort.GetPort());
     EXPECT_STREQ("/path/1234:_Some_Path", uriWithPort.GetPath().c_str());
-    EXPECT_STREQ(strUriWithPort, uriWithPort.GetURIString().c_str());
+    EXPECT_STREQ("https://test.com:8080/path/1234%3A_Some_Path", uriWithPort.GetURIString().c_str());
 
     const char* strComplexUri = "http://s3.us-east-1.amazonaws.com/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject:1234/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject:Key";
     URI complexUri(strComplexUri);
@@ -206,7 +206,7 @@ TEST(URITest, TestParseWithColon)
     EXPECT_STREQ("s3.us-east-1.amazonaws.com", complexUri.GetAuthority().c_str());
     EXPECT_EQ(80, complexUri.GetPort());
     EXPECT_STREQ("/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject:1234/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject:Key", complexUri.GetPath().c_str());
-    EXPECT_STREQ(strComplexUri, complexUri.GetURIString().c_str());
+    EXPECT_STREQ("http://s3.us-east-1.amazonaws.com/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject%3A1234/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject%3AKey", complexUri.GetURIString().c_str());
     
 }
 
@@ -216,10 +216,10 @@ TEST(URITest, TestGetRFC3986URLEncodedPath)
     EXPECT_STREQ("/path/1234/", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
 
     uri = "https://test.com/path/$omething";
-    EXPECT_STREQ("/path/$omething", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
+    EXPECT_STREQ("/path/%24omething", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
 
     uri = "https://test.com/path/$omethingel$e";
-    EXPECT_STREQ("/path/$omethingel$e", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
+    EXPECT_STREQ("/path/%24omethingel%24e", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
 
     uri = "https://test.com/path/~something.an0ther";
     EXPECT_STREQ("/path/~something.an0ther", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
@@ -231,5 +231,5 @@ TEST(URITest, TestGetRFC3986URLEncodedPath)
     EXPECT_STREQ("/%E1%88%B4", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
 
     uri = "https://test.com/segment+other/b;jsession=1";
-    EXPECT_STREQ("/segment%2Bother/b%3Bjsession=1", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
+    EXPECT_STREQ("/segment%2Bother/b%3Bjsession%3D1", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
 }

--- a/aws-cpp-sdk-core/source/http/URI.cpp
+++ b/aws-cpp-sdk-core/source/http/URI.cpp
@@ -137,14 +137,16 @@ Aws::String URI::URLEncodePathRFC3986(const Aws::String& path)
             {
                 // §2.3 unreserved characters
                 case '-': case '_': case '.': case '~':
-                // The path section of the URL allow reserved characters to appear unescaped
-                // RFC 3986 §2.2 Reserved characters
-                // NOTE: this implementation does not accurately implement the RFC on purpose to accommodate for
-                // discrepancies in the implementations of URL encoding between AWS services for legacy reasons.
-                case '$': case '&': case ',':
-                case ':': case '=': case '@':
                     ss << c;
                     break;
+                // NOTE: S3 guidelines, as an example, provide a list of characters in object key names that likely
+                // require URL encoding:
+                //
+                //          '&',  '$',  '@',  '=',  ';',  ':',  '+',  ' ',  ',',  and  '?'.
+                //
+                // REFS:
+                //     https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-key-guidelines-special-handling
+                //     https://tools.ietf.org/html/rfc3986#section-2.2
                 default:
                     ss << '%' << std::setfill('0') << std::setw(2) << (int)((unsigned char)c) << std::setw(0);
             }


### PR DESCRIPTION
…gested by S3 guidelines

*Issue #, if available:*

This PR addresses issue #1196 when using the S3 library with S3-compatible storage servers (e.g., SwiftStack) that require reserved characters in object key names (e.g., my@file.txt) to be percent encoded in order to prevent a signing mismatch.

It is worth noting that the AWS CLI (e.g., botocore) does percent encode S3 object key names that contain reserved characters.

*Description of changes:*

The percent encoding of URL paths algorithm was modified to be compliant with S3 guidelines which indicates that reserved characters, as defined in RFC 3986, probably require encoding. The algorithm currently prevents encoding of six reserved characters in URL paths (`$`, `&`, `,`, `:`, `=`, and `@`) for legacy reasons related to AWS services.   

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
