### PR TITLE
add aliases for cmake exported variables

### DIFF
--- a/cmake/AWSSDKConfig.cmake
+++ b/cmake/AWSSDKConfig.cmake
@@ -288,3 +288,6 @@ if (AWSSDK_FIND_COMPONENTS)
         message(STATUS "Found ${TARGET}")
     endforeach()
 endif()
+
+set(AWSSDK_INCLUDE_DIRS ${AWSSDK_INCLUDE_DIR})
+set(AWSSDK_LIBRARIES ${AWSSDK_LINK_LIBRARIES})


### PR DESCRIPTION
*Issue #, if available:*
#1208

*Description of changes:*
The current exported cmake names AWSSDK_LINK_LIBRARIES and AWSSDK_INCLUDE_DIR are not well-known for the cmake users.
Add aliases so that the names are more familiar for user.

```
set(AWSSDK_LIBRARIES ${AWSSDK_LINK_LIBRARIES})
set(AWSSDK_INCLUDE_DIRS ${AWSSDK_INCLUDE_DIR})
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
