### PR TITLE
cmake: fix libatomic check with GCC 8

### DIFF
--- a/cmake/platform/linux.cmake
+++ b/cmake/platform/linux.cmake
@@ -15,6 +15,12 @@ int main() {
     return x + y;
 }")
 
+set(LIBATOMIC_TEST_CXX_SOURCE "
+int main() {
+    __atomic_load_8(nullptr, 0);
+    return 0;
+}")
+
 macro(apply_post_project_platform_settings)
     include(GNUInstallDirs)
 
@@ -32,12 +38,9 @@ macro(apply_post_project_platform_settings)
     list(APPEND CMAKE_REQUIRED_FLAGS "-std=c++${CPP_STANDARD}")
     check_cxx_source_compiles("${ATOMIC_TEST_CXX_SOURCE}" HAVE_ATOMICS_WITHOUT_LIBATOMIC)
     if(NOT HAVE_ATOMICS_WITHOUT_LIBATOMIC)
-        if("${CMAKE_VERSION}" VERSION_LESS "3.4.0")
-            enable_language(C)
-        endif()
-        check_library_exists(atomic __atomic_load_8 "" LIBATOMIC_EXISTS)
+        set(CMAKE_REQUIRED_LIBRARIES atomic)
+        check_cxx_source_compiles("${LIBATOMIC_TEST_CXX_SOURCE}" LIBATOMIC_EXISTS)
         if(LIBATOMIC_EXISTS)
-            set(CMAKE_REQUIRED_LIBRARIES atomic)
             check_cxx_source_compiles("${ATOMIC_TEST_CXX_SOURCE}" HAVE_ATOMICS_WITH_LIBATOMIC)
         endif()
         if(HAVE_ATOMICS_WITH_LIBATOMIC)


### PR DESCRIPTION
*Issue #, if available:*
#1199 

*Description of changes:*

Fixes detection of libatomic with GCC 8. This solution is based on https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=907277#25, which describes why the error occurs (in that case with autotools).

Some of the possible solutions are:
1. Unconditionally call `enable_language(C)` so that the check runs in C mode (untested)
2. Run a compile test that calls `__atomic_load_8` with the right number of arguments
3. Drop the explicit `libatomic` test altogether and just check whether C++ atomics work when linked to `libatomic`

I chose option 2 because it maintained the existing semantics and seemed cleaner than using the C compiler to work around this issue.

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
