### PR TITLE
Provide role session name in STSProfileCredentialsProvider::GetCredentialsFromSTSInternal()

### DIFF
--- a/aws-cpp-sdk-identity-management/source/auth/STSProfileCredentialsProvider.cpp
+++ b/aws-cpp-sdk-identity-management/source/auth/STSProfileCredentialsProvider.cpp
@@ -18,6 +18,7 @@
 #include <aws/sts/STSClient.h>
 #include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/Outcome.h>
+#include <aws/core/utils/UUID.h>
 
 #include <utility>
 
@@ -326,6 +327,7 @@ AWSCredentials STSProfileCredentialsProvider::GetCredentialsFromSTSInternal(cons
     AssumeRoleRequest assumeRoleRequest;
     assumeRoleRequest
         .WithRoleArn(roleArn)
+        .WithRoleSessionName(Aws::Utils::UUID::RandomUUID())
         .WithDurationSeconds(static_cast<int>(std::chrono::seconds(m_duration).count()));
     auto outcome = client->AssumeRole(assumeRoleRequest);
     if (outcome.IsSuccess())


### PR DESCRIPTION
*Issue #150*

*Description of changes:*

Add missing role session name when building the `AssumeRoleRequest` object in `STSProfileCredentialsProvider::GetCredentialsFromSTSInternal`. Without it, I am getting this error in the outcome:

> 1 validation error detected: Value null at 'roleSessionName' failed to satisfy constraint: Member must not be null with address : 54.239.24.200

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
