### PR TITLE
Disabled MD5 depreciation errors

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/Core_EXPORTS.h
+++ b/aws-cpp-sdk-core/include/aws/core/Core_EXPORTS.h
@@ -1,12 +1,12 @@
 /*
   * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  * 
+  *
   * Licensed under the Apache License, Version 2.0 (the "License").
   * You may not use this file except in compliance with the License.
   * A copy of the License is located at
-  * 
+  *
   *  http://aws.amazon.com/apache2.0
-  * 
+  *
   * or in the "license" file accompanying this file. This file is distributed
   * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
   * express or implied. See the License for the specific language governing
@@ -51,17 +51,26 @@
     #elif defined (__GNUC__)
         #define DO_PRAGMA(x) _Pragma(#x)
         #define AWS_DEPRECATED(msg) __attribute__((deprecated(msg)))
-        /** 
-         * WRAP() is a useless macro to get around GCC quirks related to expanding macros which includes _Pragma
-         * see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=715271
-         * and https://stackoverflow.com/questions/49698645/how-to-use-pragma-operator-in-macro
-         */
-        #define WRAP(W) DO_PRAGMA(GCC diagnostic push) \
-                        DO_PRAGMA(GCC diagnostic ignored W)
-        #define AWS_SUPPRESS_WARNING_(W, ...) \
-            W \
-            __VA_ARGS__; \
-            DO_PRAGMA(GCC diagnostic pop)
+        #ifdef __clang__
+            #define WRAP(W) DO_PRAGMA(clang diagnostic push) \
+                            DO_PRAGMA(clang diagnostic ignored W)
+            #define AWS_SUPPRESS_WARNING_(W, ...) \
+                W \
+                __VA_ARGS__; \
+                DO_PRAGMA(clang diagnostic pop)
+        #else
+            /**
+             * WRAP() is a useless macro to get around GCC quirks related to expanding macros which includes _Pragma
+             * see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=715271
+             * and https://stackoverflow.com/questions/49698645/how-to-use-pragma-operator-in-macro
+             */
+            #define WRAP(W) DO_PRAGMA(GCC diagnostic push) \
+                            DO_PRAGMA(GCC diagnostic ignored W)
+            #define AWS_SUPPRESS_WARNING_(W, ...) \
+                W \
+                __VA_ARGS__; \
+                DO_PRAGMA(GCC diagnostic pop)
+        #endif
         #define AWS_SUPPRESS_WARNING(W, ...) AWS_SUPPRESS_WARNING_(WRAP(W), __VA_ARGS__)
         /**
          * Clang is the only compiler that does not emit warnings for deprecated functions used within deprecated functions.

--- a/aws-cpp-sdk-core/source/utils/crypto/commoncrypto/CryptoImpl.cpp
+++ b/aws-cpp-sdk-core/source/utils/crypto/commoncrypto/CryptoImpl.cpp
@@ -1,12 +1,12 @@
 /*
   * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  * 
+  *
   * Licensed under the Apache License, Version 2.0 (the "License").
   * You may not use this file except in compliance with the License.
   * A copy of the License is located at
-  * 
+  *
   *  http://aws.amazon.com/apache2.0
-  * 
+  *
   * or in the "license" file accompanying this file. This file is distributed
   * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
   * express or implied. See the License for the specific language governing
@@ -90,8 +90,12 @@ namespace Aws
 
             HashResult MD5CommonCryptoImpl::Calculate(Aws::IStream& stream)
             {
+#ifdef __APPLE__
+AWS_SUPPRESS_WARNING("-Wdeprecated-declarations",
                 CC_MD5_CTX md5;
                 CC_MD5_Init(&md5);
+                )
+#endif
 
                 auto currentPos = stream.tellg();
                 stream.seekg(0, stream.beg);
@@ -104,7 +108,11 @@ namespace Aws
 
                     if(bytesRead > 0)
                     {
+#ifdef __APPLE__
+AWS_SUPPRESS_WARNING("-Wdeprecated-declarations",
                         CC_MD5_Update(&md5, streamBuffer, static_cast<CC_LONG>(bytesRead));
+                        )
+#endif
                     }
                 }
 
@@ -112,7 +120,11 @@ namespace Aws
                 stream.seekg(currentPos, stream.beg);
 
                 ByteBuffer hash(CC_MD5_DIGEST_LENGTH);
+#ifdef __APPLE__
+AWS_SUPPRESS_WARNING("-Wdeprecated-declarations",
                 CC_MD5_Final(hash.GetUnderlyingData(), &md5);
+                )
+#endif
 
                 return HashResult(std::move(hash));
             }

--- a/aws-cpp-sdk-core/source/utils/crypto/commoncrypto/CryptoImpl.cpp
+++ b/aws-cpp-sdk-core/source/utils/crypto/commoncrypto/CryptoImpl.cpp
@@ -24,7 +24,6 @@
 
 // Fix for deprectation errors in OSX 10.15: https://github.com/aws/aws-sdk-cpp/issues/1259
 #if defined(__APPLE__) && defined(__clang__)
-#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 

--- a/aws-cpp-sdk-core/source/utils/crypto/commoncrypto/CryptoImpl.cpp
+++ b/aws-cpp-sdk-core/source/utils/crypto/commoncrypto/CryptoImpl.cpp
@@ -24,6 +24,7 @@
 
 // Fix for deprectation errors in OSX 10.15: https://github.com/aws/aws-sdk-cpp/issues/1259
 #if defined(__APPLE__) && defined(__clang__)
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
@@ -546,3 +547,7 @@ namespace Aws
         }
     }
 }
+
+#if defined(__APPLE__) && defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/aws-cpp-sdk-core/source/utils/crypto/commoncrypto/CryptoImpl.cpp
+++ b/aws-cpp-sdk-core/source/utils/crypto/commoncrypto/CryptoImpl.cpp
@@ -22,6 +22,12 @@
 #include <CommonCrypto/CommonCryptor.h>
 #include <CommonCrypto/CommonSymmetricKeywrap.h>
 
+// Fix for deprectation errors in OSX 10.15: https://github.com/aws/aws-sdk-cpp/issues/1259
+#if defined(__APPLE__) && defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 //for OSX < 10.10 compatibility
 typedef int32_t CCStatus;
 typedef int32_t CCCryptorStatus;


### PR DESCRIPTION
Fix issue #1259 

Disables errors related to MD5 Deprecation in MacOS 10.15 Catalina.

- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
