### PR TITLE
Dependency version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ cmake <path-to-root-of-this-source-code> -G "Visual Studio 15 Win64" -DCMAKE_BUI
 msbuild INSTALL.vcxproj /p:Configuration=Release
 ```
 
+* For macOS (Xcode):
+```sh
+cmake -G Xcode -DTARGET_ARCH="APPLE" -DCMAKE_BUILD_TYPE=Debug  <path-to-root-of-this-source-code>
+xcodebuild -target ALL_BUILD 
+```
+
 #### To build and install third party dependencies:
 Starting from version 1.7.0, we added several third party dependencies, including [`aws-c-common`](https://github.com/awslabs/aws-c-common), [`aws-checksums`](https://github.com/awslabs/aws-checksums) and [`aws-c-event-stream`](https://github.com/awslabs/aws-c-event-stream). By default, they will be built and installed in `<BUILD_DIR>/.deps/install`, and copied to default system directory during SDK installation. You can change the location by specifying `CMAKE_INSTALL_PREFIX`.
 

--- a/README.md
+++ b/README.md
@@ -74,12 +74,6 @@ cmake <path-to-root-of-this-source-code> -G "Visual Studio 15 Win64" -DCMAKE_BUI
 msbuild INSTALL.vcxproj /p:Configuration=Release
 ```
 
-* For macOS (Xcode):
-```sh
-cmake -G Xcode -DTARGET_ARCH="APPLE" -DCMAKE_BUILD_TYPE=Debug  <path-to-root-of-this-source-code>
-xcodebuild -target ALL_BUILD 
-```
-
 #### To build and install third party dependencies:
 Starting from version 1.7.0, we added several third party dependencies, including [`aws-c-common`](https://github.com/awslabs/aws-c-common), [`aws-checksums`](https://github.com/awslabs/aws-checksums) and [`aws-c-event-stream`](https://github.com/awslabs/aws-c-event-stream). By default, they will be built and installed in `<BUILD_DIR>/.deps/install`, and copied to default system directory during SDK installation. You can change the location by specifying `CMAKE_INSTALL_PREFIX`.
 

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -19,11 +19,11 @@ set(AWS_C_COMMON_TAG "v0.4.13")
 include(BuildAwsCCommon)
 
 set(AWS_CHECKSUMS_URL "https://github.com/awslabs/aws-checksums.git")
-set(AWS_CHECKSUMS_TAG "41dc36d")
+set(AWS_CHECKSUMS_TAG "v0.1.3")
 include(BuildAwsChecksums)
 
 set(AWS_EVENT_STREAM_URL "https://github.com/awslabs/aws-c-event-stream.git")
-set(AWS_EVENT_STREAM_TAG "ceb9f9b")
+set(AWS_EVENT_STREAM_TAG "v0.1.3")
 include(BuildAwsEventStream)
 
 add_dependencies(AwsCEventStream AwsCCommon AwsChecksums)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -15,7 +15,7 @@ set(AWS_DEPS_BUILD_DIR "${CMAKE_BINARY_DIR}/build" CACHE PATH "Dependencies buil
 set(AWS_DEPS_DOWNLOAD_DIR "${AWS_DEPS_BUILD_DIR}/downloads" CACHE PATH "Dependencies download directory.")
 
 set(AWS_C_COMMON_URL "https://github.com/awslabs/aws-c-common.git")
-set(AWS_C_COMMON_TAG "v0.3.15")
+set(AWS_C_COMMON_TAG "v0.4.13")
 include(BuildAwsCCommon)
 
 set(AWS_CHECKSUMS_URL "https://github.com/awslabs/aws-checksums.git")


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-encryption-sdk-c/issues/450

*Description of changes:*
- bump aws-c-common to v0.4.13
- bump aws-checksums to v0.1.3
- bump aws-c-event-stream to v0.1.3
- README snippet about macOS

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [X] MacOS
- [ ] IOS
- [ ] Other Platforms


```
cmake -G Xcode -DTARGET_ARCH="APPLE" -DCMAKE_BUILD_TYPE=Debug ~/gitrepos/github.com/aws-sdk-cpp/
xcodebuild -target ALL_BUILD

...snip...

=== BUILD AGGREGATE TARGET ALL_BUILD OF PROJECT AWSSDK WITH THE DEFAULT CONFIGURATION (Debug) ===

Check dependencies

Write auxiliary files
write-file /var/tmp/build-cpp/AWSSDK.build/Debug/ALL_BUILD.build/Script-E413315A813640D7AD27CD47.sh
chmod 0755 /var/tmp/build-cpp/AWSSDK.build/Debug/ALL_BUILD.build/Script-E413315A813640D7AD27CD47.sh

PhaseScriptExecution CMake\ Rules /var/tmp/build-cpp/AWSSDK.build/Debug/ALL_BUILD.build/Script-E413315A813640D7AD27CD47.sh
    cd /Users/dougch/gitrepos/github.com/aws-sdk-cpp
    /bin/sh -c /var/tmp/build-cpp/AWSSDK.build/Debug/ALL_BUILD.build/Script-E413315A813640D7AD27CD47.sh
echo ""

echo Build\ all\ projects
Build all projects

** BUILD SUCCEEDED **

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
