### PR TITLE
Added parenthesis around m_expiration

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentials.h
+++ b/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentials.h
@@ -33,7 +33,7 @@ namespace Aws
              * Empty credentials are not expired by default.
              * Credentials expire only if an expiration date is explicitly set on them.
              */
-            AWSCredentials() : m_expiration(std::chrono::time_point<std::chrono::system_clock>::max())
+            AWSCredentials() : m_expiration((std::chrono::time_point<std::chrono::system_clock>::max)())
             {
             }
 
@@ -43,7 +43,7 @@ namespace Aws
              * Expiration date is set to "never expire".
              */
             AWSCredentials(const Aws::String& accessKeyId, const Aws::String& secretKey) :
-                m_accessKeyId(accessKeyId), m_secretKey(secretKey), m_expiration(std::chrono::time_point<std::chrono::system_clock>::max())
+                m_accessKeyId(accessKeyId), m_secretKey(secretKey), m_expiration((std::chrono::time_point<std::chrono::system_clock>::max)())
             {
             }
 
@@ -52,7 +52,7 @@ namespace Aws
              * Expiration date is set to "never expire".
              */
             AWSCredentials(const Aws::String& accessKeyId, const Aws::String& secretKey, const Aws::String& sessionToken) :
-                m_accessKeyId(accessKeyId), m_secretKey(secretKey), m_sessionToken(sessionToken), m_expiration(std::chrono::time_point<std::chrono::system_clock>::max())
+                m_accessKeyId(accessKeyId), m_secretKey(secretKey), m_sessionToken(sessionToken), m_expiration((std::chrono::time_point<std::chrono::system_clock>::max)())
             {
             }
 


### PR DESCRIPTION
Definition of static constexpr _Rep (max) function in chrono is surrounded by parenthesis. If we don't do so instead of calling the max function from chrono it replaces it with the max preprocessor present in winmindef.h

*Issue #, if available:*

*Description of changes:*

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)

- Only manual tests are needed for this change. We were able to build it successfully because the function is prioritized over the macro expansion.

- [x] Checked if this PR is a breaking (APIs have been changed) change.

- Not a breaking change.

- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

- N/A

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
