### PR TITLE
Use AWS:: namespace for cmake targets

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -68,6 +68,7 @@ macro(do_packaging)
 
         export(EXPORT "${PROJECT_NAME}-targets"
             FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-targets.cmake"
+            NAMESPACE AWS::
         )
 
     if(${PROJECT_NAME} STREQUAL "aws-cpp-sdk-core")
@@ -85,6 +86,7 @@ macro(do_packaging)
         set(ConfigPackageLocation "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}")
         install(EXPORT "${PROJECT_NAME}-targets"
             FILE "${PROJECT_NAME}-targets.cmake"
+            NAMESPACE AWS::
             DESTINATION ${ConfigPackageLocation}
         )
 


### PR DESCRIPTION
Issue #1307  

*Description of changes:*

The namespace AWS was added to the installed target. This let the consumers use the targets prefixed with `AWS::` like so:

`target_link_libraries(my_lib PRIVATE AWS::aws-cpp-sdk-s3)`

However users who were using the version without namespace will not get the transitive properties of the target(it will however link the library):

`target_link_libraries(my_lib PRIVATE aws-cpp-sdk-s3)`

It seems that AWSSDK_LINK_LIBRARIES is not populated correctly either since it uses the non-namespaced version of the targets. I did not find where the variables such as `AWSSDK_PLATFORM_DEPS_LIBS` `AWSSDK_CRYPTO_LIBS` etc are populated, and hence was unable to fix this.

This was only tested with `find_package(AWSSDK REQUIRED COMPONENTS s3)` but should work correctly when multiple components are required, or none specified.

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change. **Yes, using non-namespaced target names might cause consumer builds to fail. Fix is to add `AWS::`**
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update. **This will be needed.**

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [X] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
