### PR TITLE
Update HttpClientMetrics.cpp, adding const to static fields

### DIFF
--- a/aws-cpp-sdk-core/source/monitoring/HttpClientMetrics.cpp
+++ b/aws-cpp-sdk-core/source/monitoring/HttpClientMetrics.cpp
@@ -33,7 +33,7 @@ namespace Aws
         using namespace Aws::Utils;
         HttpClientMetricsType GetHttpClientMetricTypeByName(const Aws::String& name)
         {
-            static std::map<int, HttpClientMetricsType> metricsNameHashToType =
+            static const std::map<int, HttpClientMetricsType> metricsNameHashToType =
             {
                 std::pair<int, HttpClientMetricsType>(HashingUtils::HashString(HTTP_CLIENT_METRICS_DESTINATION_IP), HttpClientMetricsType::DestinationIp),
                 std::pair<int, HttpClientMetricsType>(HashingUtils::HashString(HTTP_CLIENT_METRICS_ACQUIRE_CONNECTION_LATENCY), HttpClientMetricsType::AcquireConnectionLatency),
@@ -56,7 +56,7 @@ namespace Aws
 
         Aws::String GetHttpClientMetricNameByType(HttpClientMetricsType type)
         {
-            static std::map<int, std::string> metricsTypeToName =
+            static const std::map<int, std::string> metricsTypeToName =
             {
                 std::pair<int, std::string>(static_cast<int>(HttpClientMetricsType::DestinationIp), HTTP_CLIENT_METRICS_DESTINATION_IP),
                 std::pair<int, std::string>(static_cast<int>(HttpClientMetricsType::AcquireConnectionLatency), HTTP_CLIENT_METRICS_ACQUIRE_CONNECTION_LATENCY),


### PR DESCRIPTION
Looks like clang does some strange optimizations after which this code becomes invalid under multithreaded access.

Here what adders sanitizer says when trying to download a file:

```
=================================================================
==2219==ERROR: AddressSanitizer: heap-use-after-free on address 0x606000010ae0 at pc 0x000007cfac57 bp 0x7f4f0b4f4290 sp 0x7f4f0b4f4288
READ of size 4 at 0x606000010ae0 thread T6
    #0 0x7cfac56 in std::__y1::less<int>::operator()(int const&, int const&) const /contrib/libs/cxxsupp/libcxx/include/__functional_base:55:17
    #1 0x7cfac56 in std::__y1::__map_value_compare<int, std::__y1::__value_type<int, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, std::__y1::less<int>, true>::operator()(std::__y1::__value_type<int, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > > const&, int const&) const /contrib/libs/cxxsupp/libcxx/include/map:516
    #2 0x7cfac56 in std::__y1::__tree_iterator<std::__y1::__value_type<int, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, std::__y1::__tree_node<std::__y1::__value_type<int, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, void*>*, long> std::__y1::__tree<std::__y1::__value_type<int, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, std::__y1::__map_value_compare<int, std::__y1::__value_type<int, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, std::__y1::less<int>, true>, std::__y1::allocator<std::__y1::__value_type<int, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > > > >::__lower_bound<int>(int const&, std::__y1::__tree_node<std::__y1::__value_type<int, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, void*>*, std::__y1::__tree_end_node<std::__y1::__tree_node_base<void*>*>*) /contrib/libs/cxxsupp/libcxx/include/__tree:2676
    #3 0x7cfac56 in std::__y1::__tree_iterator<std::__y1::__value_type<int, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, std::__y1::__tree_node<std::__y1::__value_type<int, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, void*>*, long> std::__y1::__tree<std::__y1::__value_type<int, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, std::__y1::__map_value_compare<int, std::__y1::__value_type<int, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, std::__y1::less<int>, true>, std::__y1::allocator<std::__y1::__value_type<int, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > > > >::find<int>(int const&) /contrib/libs/cxxsupp/libcxx/include/__tree:2605
    #4 0x7cfac56 in std::__y1::map<int, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> >, std::__y1::less<int>, std::__y1::allocator<std::__y1::pair<int const, std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > > > >::find(int const&) /contrib/libs/cxxsupp/libcxx/include/map:1378
    #5 0x7cfac56 in Aws::Monitoring::GetHttpClientMetricNameByType(Aws::Monitoring::HttpClientMetricsType) /contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/source/monitoring/HttpClientMetrics.cpp:72
    #6 0x7cf33b0 in Aws::Http::CurlHttpClient::MakeRequestInternal(Aws::Http::HttpRequest&, std::__y1::shared_ptr<Aws::Http::Standard::StandardHttpResponse>&, Aws::Utils::RateLimits::RateLimiterInterface*, Aws::Utils::RateLimits::RateLimiterInterface*) const /contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp:495:38
    #7 0x7cf8792 in Aws::Http::CurlHttpClient::MakeRequest(std::__y1::shared_ptr<Aws::Http::HttpRequest> const&, Aws::Utils::RateLimits::RateLimiterInterface*, Aws::Utils::RateLimits::RateLimiterInterface*) const /contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp:545:5
    #8 0x7d61be2 in Aws::Client::AWSClient::AttemptOneRequest(std::__y1::shared_ptr<Aws::Http::HttpRequest> const&, Aws::AmazonWebServiceRequest const&, char const*) const /contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/source/client/AWSClient.cpp:304:23
    #9 0x7d5cf37 in Aws::Client::AWSClient::AttemptExhaustively(Aws::Http::URI const&, Aws::AmazonWebServiceRequest const&, Aws::Http::HttpMethod, char const*) const /contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/source/client/AWSClient.cpp:183:19
    #10 0x7d6b4c4 in Aws::Client::AWSClient::MakeRequestWithUnparsedResponse(Aws::Http::URI const&, Aws::AmazonWebServiceRequest const&, Aws::Http::HttpMethod, char const*) const /contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/source/client/AWSClient.cpp:360:47
    #11 0x797332b in Aws::S3::S3Client::GetObject(Aws::S3::Model::GetObjectRequest const&) const /contrib/libs/aws-sdk-cpp/aws-cpp-sdk-s3/source/S3Client.cpp:1820:27
    #12 0x7e6fc10 in Aws::Transfer::TransferManager::DoSinglePartDownload(std::__y1::shared_ptr<Aws::Transfer::TransferHandle> const&) /contrib/libs/aws-sdk-cpp/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp:668:64
    #13 0x7e7436c in Aws::Transfer::TransferManager::DoDownload(std::__y1::shared_ptr<Aws::Transfer::TransferHandle> const&) /contrib/libs/aws-sdk-cpp/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp:777:17
    #14 0x7d2ed80 in std::__y1::__function::__value_func<void ()>::operator()() const /contrib/libs/cxxsupp/libcxx/include/functional:1860:16
    #15 0x7d2ed80 in std::__y1::function<void ()>::operator()() const /contrib/libs/cxxsupp/libcxx/include/functional:2426
    #16 0x7d2ed80 in Aws::Utils::Threading::ThreadTask::MainTaskRunner() /contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/source/utils/threading/ThreadTask.cpp:41
    #17 0x7d2f287 in decltype(*(std::__y1::forward<Aws::Utils::Threading::ThreadTask*&>(fp0)).*fp()) std::__y1::__invoke<void (Aws::Utils::Threading::ThreadTask::*&)(), Aws::Utils::Threading::ThreadTask*&, void>(void (Aws::Utils::Threading::ThreadTask::*&)(), Aws::Utils::Threading::ThreadTask*&) /contrib/libs/cxxsupp/libcxx/include/type_traits:3559:1
    #18 0x7d2f287 in std::__y1::__bind_return<void (Aws::Utils::Threading::ThreadTask::*)(), std::__y1::tuple<Aws::Utils::Threading::ThreadTask*>, std::__y1::tuple<>, __is_valid_bind_return<void (Aws::Utils::Threading::ThreadTask::*)(), std::__y1::tuple<Aws::Utils::Threading::ThreadTask*>, std::__y1::tuple<> >::value>::type std::__y1::__apply_functor<void (Aws::Utils::Threading::ThreadTask::*)(), std::__y1::tuple<Aws::Utils::Threading::ThreadTask*>, 0ul, std::__y1::tuple<> >(void (Aws::Utils::Threading::ThreadTask::*&)(), std::__y1::tuple<Aws::Utils::Threading::ThreadTask*>&, std::__y1::__tuple_indices<0ul>, std::__y1::tuple<>&&) /contrib/libs/cxxsupp/libcxx/include/functional:2732
    #19 0x7d2f287 in std::__y1::__bind_return<void (Aws::Utils::Threading::ThreadTask::*)(), std::__y1::tuple<Aws::Utils::Threading::ThreadTask*>, std::__y1::tuple<>, __is_valid_bind_return<void (Aws::Utils::Threading::ThreadTask::*)(), std::__y1::tuple<Aws::Utils::Threading::ThreadTask*>, std::__y1::tuple<> >::value>::type std::__y1::__bind<void (Aws::Utils::Threading::ThreadTask::*)(), Aws::Utils::Threading::ThreadTask*>::operator()<>() /contrib/libs/cxxsupp/libcxx/include/functional:2770
    #20 0x7d2f287 in decltype(std::__y1::forward<std::__y1::__bind<void (Aws::Utils::Threading::ThreadTask::*)(), Aws::Utils::Threading::ThreadTask*> >(fp)()) std::__y1::__invoke<std::__y1::__bind<void (Aws::Utils::Threading::ThreadTask::*)(), Aws::Utils::Threading::ThreadTask*> >(std::__y1::__bind<void (Aws::Utils::Threading::ThreadTask::*)(), Aws::Utils::Threading::ThreadTask*>&&) /contrib/libs/cxxsupp/libcxx/include/type_traits:3618
    #21 0x7d2f287 in void std::__y1::__thread_execute<std::__y1::unique_ptr<std::__y1::__thread_struct, std::__y1::default_delete<std::__y1::__thread_struct> >, std::__y1::__bind<void (Aws::Utils::Threading::ThreadTask::*)(), Aws::Utils::Threading::ThreadTask*> >(std::__y1::tuple<std::__y1::unique_ptr<std::__y1::__thread_struct, std::__y1::default_delete<std::__y1::__thread_struct> >, std::__y1::__bind<void (Aws::Utils::Threading::ThreadTask::*)(), Aws::Utils::Threading::ThreadTask*> >&, std::__y1::__tuple_indices<>) /contrib/libs/cxxsupp/libcxx/include/thread:343
    #22 0x7d2f287 in void* std::__y1::__thread_proxy<std::__y1::tuple<std::__y1::unique_ptr<std::__y1::__thread_struct, std::__y1::default_delete<std::__y1::__thread_struct> >, std::__y1::__bind<void (Aws::Utils::Threading::ThreadTask::*)(), Aws::Utils::Threading::ThreadTask*> > >(void*) /contrib/libs/cxxsupp/libcxx/include/thread:353
    #23 0x7f4f117f4668 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x9668)
    #24 0x7f4f1171c322 in clone /build/glibc-4WA41p/glibc-2.30/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95
0x606000010ae0 is located 32 bytes inside of 64-byte region [0x606000010ac0,0x606000010b00)
freed by thread T0 here:
    #0 0x247bd32 in operator delete(void*) /place/sandbox-data/tasks/5/1/433792615/build/last/clang/src/projects/compiler-rt/lib/asan/asan_new_delete.cc:167:3
    #1 0x7f4f11643ba6 in __run_exit_handlers /build/glibc-4WA41p/glibc-2.30/stdlib/exit.c:108:8
previously allocated by th
...
cxx/include/functional:1860:16
    #21 0x28f9d72 in std::__y1::function<void ()>::operator()() const /contrib/libs/cxxsupp/libcxx/include/functional:2426
    #22 0x28f9d72 in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, TCharTraits<char> > const&, char const*, bool) /library/unittest/utmain.cpp:475
    #23 0x28c18ce in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, TCharTraits<char> >, char const*, bool) /library/unittest/registar.cpp:375:18
    #24 0x24bad72 in maps::factory::processing::tests::NTestSuitecloud_optimize_tasks_should::TCurrentTest::Execute() /maps/factory/processing/cloud_optimize/tests/tests.cpp:25:1
    #25 0x28c3747 in NUnitTest::TTestFactory::Execute() /library/unittest/registar.cpp:484:19
    #26 0x28f18ec in NUnitTest::RunMain(int, char**) /library/unittest/utmain.cpp:755:44
    #27 0x7f4f116211e2 in __libc_start_main /build/glibc-4WA41p/glibc-2.30/csu/../csu/libc-start.c:308:16
Thread T4 created by T0 here:
    #0 0x243478d in __interceptor_pthread_create /place/sandbox-data/tasks/5/1/433792615/build/last/clang/src/projects/compiler-rt/lib/asan/asan_interceptors.cc:210:3
    #1 0x7d2f0df in std::__y1::__libcpp_thread_create(unsigned long*, void* (*)(void*), void*) /contrib/libs/cxxsupp/libcxx/include/__threading_support:331:10
    #2 0x7d2f0df in std::__y1::thread::thread<std::__y1::__bind<void (Aws::Utils::Threading::ThreadTask::*)(), Aws::Utils::Threading::ThreadTask*>, void>(std::__y1::__bind<void (Aws::Utils::Threading::ThreadTask::*)(), Aws::Utils::Threading::ThreadTask*>&&) /contrib/libs/cxxsupp/libcxx/include/thread:369
    #3 0x7d2ebd6 in Aws::Utils::Threading::ThreadTask::ThreadTask(Aws::Utils::Threading::PooledThreadExecutor&) /contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/source/utils/threading/ThreadTask.cpp:22:98
    #4 0x7d292d3 in Aws::Utils::Threading::ThreadTask* Aws::New<Aws::Utils::Threading::ThreadTask, Aws::Utils::Threading::PooledThreadExecutor&>(char const*, Aws::Utils::Threading::PooledThreadExecutor&) /contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/include/aws/core/utils/memory/AWSMemory.h:72:48
    #5 0x7d292d3 in Aws::Utils::Threading::PooledThreadExecutor::PooledThreadExecutor(unsigned long, Aws::Utils::Threading::OverflowPolicy) /contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/source/utils/threading/Executor.cpp:91
    #6 0x7eaaf35 in std::__y1::__compressed_pair_elem<Aws::Utils::Threading::PooledThreadExecutor, 1, false>::__compressed_pair_elem<unsigned long&, 0ul>(std::__y1::piecewise_construct_t, std::__y1::tuple<unsigned long&>, std::__y1::__tuple_indices<0ul>) /contrib/libs/cxxsupp/libcxx/include/memory:2160:9
    #7 0x7eaaf35 in std::__y1::__compressed_pair<std::__y1::allocator<Aws::Utils::Threading::PooledThreadExecutor>, Aws::Utils::Threading::PooledThreadExecutor>::__compressed_pair<std::__y1::allocator<Aws::Utils::Threading::PooledThreadExecutor>&, unsigned long&>(std::__y1::piecewise_construct_t, std::__y1::tuple<std::__y1::allocator<Aws::Utils::Threading::PooledThreadExecutor>&>, std::__y1::tuple<unsigned long&>) /contrib/libs/cxxsupp/libcxx/include/memory:2264
    #8 0x7eaaf35 in std::__y1::__shared_ptr_emplace<Aws::Utils::Threading::PooledThreadExecutor, std::__y1::allocator<Aws::Utils::Threading::PooledThreadExecutor> >::__shared_ptr_emplace<unsigned long&>(std::__y1::allocator<Aws::Utils::Threading::PooledThreadExecutor>, unsigned long&) /contrib/libs/cxxsupp/libcxx/include/memory:3684
    #9 0x7eaaf35 in std::__y1::shared_ptr<Aws::Utils::Threading::PooledThreadExecutor> std::__y1::shared_ptr<Aws::Utils::Threading::PooledThreadExecutor>::make_shared<unsigned long&>(unsigned long&) /contrib/libs/cxxsupp/libcxx/include/memory:4343
    #10 0x7eaaf35 in std::__y1::enable_if<!(is_array<Aws::Utils::Threading::PooledThreadExecutor>::value), std::__y1::shared_ptr<Aws::Utils::Threading::PooledThreadExecutor> >::type std::__y1::make_shared<Aws::Utils::Threading::PooledThreadExecutor, unsigned long&>(unsigned long&) /contrib/libs/cxxsupp/libcxx/include/memory:4722
SUMMARY: AddressSanitizer: heap-use-after-free /contrib/libs/cxxsupp/libcxx/include/__functional_base:55:17 in std::__y1::less<int>::operator()(int const&, int const&) const
Shadow bytes around the buggy address:
  0x0c0c7fffa100: fa fa fa fa fd fd fd fd fd fd fd fd fa fa fa fa
  0x0c0c7fffa110: fd fd fd fd fd fd fd fd fa fa fa fa fd fd fd fd
  0x0c0c7fffa120: fd fd fd fd fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c0c7fffa130: fa fa fa fa fd fd fd fd fd fd fd fd fa fa fa fa
  0x0c0c7fffa140: fd fd fd fd fd fd fd fd fa fa fa fa fd fd fd fd
=>0x0c0c7fffa150: fd fd fd fd fa fa fa fa fd fd fd fd[fd]fd fd fd
  0x0c0c7fffa160: fa fa fa fa fd fd fd fd fd fd fd fd fa fa fa fa
  0x0c0c7fffa170: fd fd fd fd fd fd fd fd fa fa fa fa fd fd fd fd
  0x0c0c7fffa180: fd fd fd fd fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c0c7fffa190: fa fa fa fa fd fd fd fd fd fd fd fd fa fa fa fa
  0x0c0c7fffa1a0: fd fd fd fd fd fd fd fd fa fa fa fa fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
```

Seems like errors stopped after this fix, or at least moved somewhere else.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
