### PR TITLE
Fix segfault on error response with empty xml body

### DIFF
--- a/aws-cpp-sdk-core/source/client/AWSErrorMarshaller.cpp
+++ b/aws-cpp-sdk-core/source/client/AWSErrorMarshaller.cpp
@@ -68,7 +68,7 @@ AWSError<CoreErrors> XmlErrorMarshaller::Marshall(const Aws::Http::HttpResponse&
     AWS_LOGSTREAM_TRACE(AWS_ERROR_MARSHALLER_LOG_TAG, "Error response is " << doc.ConvertToString());
     bool errorParsed = false;
     AWSError<CoreErrors> error;
-    if (doc.WasParseSuccessful())
+    if (doc.WasParseSuccessful() && !doc.GetRootElement().IsNull())
     {
         XmlNode errorNode = doc.GetRootElement();
         if (errorNode.GetName() != "Error")


### PR DESCRIPTION
*Issue #, if available:* 

https://github.com/aws/aws-sdk-cpp/issues/660

*Description of changes:*

Check xml document has root node before accessing its name. 
In case of response with body like ```<? xml ... ?>``` the root element will be null which will cause segfault. Such xml response can be produced by various rate-limiters, for example.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
