### PR TITLE
Add header for implementation *Outcome*.

### DIFF
--- a/aws-cpp-sdk-rekognition/include/aws/rekognition/RekognitionClient.h
+++ b/aws-cpp-sdk-rekognition/include/aws/rekognition/RekognitionClient.h
@@ -21,6 +21,7 @@
 #include <aws/core/client/AWSClient.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/utils/json/JsonSerializer.h>
+#include <aws/core/utils/Outcome.h>
 #include <aws/rekognition/model/CompareFacesResult.h>
 #include <aws/rekognition/model/CreateCollectionResult.h>
 #include <aws/rekognition/model/CreateProjectResult.h>


### PR DESCRIPTION
I have build aws c++ sdk for rekognition service on Linux MInt x64. When I've run my native code, I have error message:

` invalid use of incomplete type ‘Aws::Rekognition::Model::CompareFacesOutcome {aka class Aws::Utils::Outcome<Aws::Rekognition::Model::CompareFacesResult, Aws::Client::AWSError<Aws::Rekognition::RekognitionErrors> >}`

There wasn't class implementation so I've added header which have one.

Check all that applies:

- [x]  Did a review by yourself.
- [ ]  Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ]  Checked if this PR is a breaking (APIs have been changed) change.
- [ ]  Checked if this PR will not introduce cross-platform inconsistent behavior.
- [ ]  Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x]  Linux
- [ ]  Windows
- [ ]  Android
- [ ]  MacOS
- [ ]  IOS
- [ ]  Other Platforms

