### PR TITLE
Update opendjk 8 link for Debian

### DIFF
--- a/CI/docker-file/Debain/Dockerfile
+++ b/CI/docker-file/Debain/Dockerfile
@@ -10,14 +10,14 @@ RUN apt-get update && \
 RUN pip install awscli --upgrade
 
 # We can install openjdk by "apt install openjdk-8-jdk", but it has some issues during building code-generation, we have to install it manually.
-RUN wget --no-check-certificate -c --header "Cookie: oraclelicense=accept-securebackup-cookie" https://download.oracle.com/otn-pub/java/jdk/8u191-b12/2787e4a523244c269598db4e85c51e0c/jdk-8u191-linux-x64.tar.gz && \
-    tar zxvf jdk-8u191-linux-x64.tar.gz && \
+RUN wget --no-check-certificate -c --header "Cookie: oraclelicense=accept-securebackup-cookie" https://download.oracle.com/otn-pub/java/jdk/8u241-b07/1f5b5a70bf22433b84d0e960903adac8/jdk-8u241-linux-x64.tar.gz && \
+    tar zxvf jdk-8u241-linux-x64.tar.gz && \
     mkdir /usr/bin/java && \
-    mv jdk1.8.0_191 /usr/bin/java && \
-    rm jdk-8u191-linux-x64.tar.gz && \
-    ln -s /usr/bin/java/jdk1.8.0_191/bin/java /bin/java && \
-    ln -s /usr/bin/java/jdk1.8.0_191/bin/javac /bin/javac
-ENV JAVA_HOME /usr/bin/java/jdk1.8.0_191
+    mv jdk1.8.0_241 /usr/bin/java && \
+    rm jdk-8u241-linux-x64.tar.gz && \
+    ln -s /usr/bin/java/jdk1.8.0_241/bin/java /bin/java && \
+    ln -s /usr/bin/java/jdk1.8.0_241/bin/javac /bin/javac
+ENV JAVA_HOME /usr/bin/java/jdk1.8.0_241
 RUN apt-get install -y maven
 
 # Download and install Android NDK


### PR DESCRIPTION
*Description of changes:*
Remove old link in the Dockerfile. The old link returns a 404 response, so the current Dockerfile cannot successfully build. With the updated link, however, it successfully builds.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [X] MacOS
- [ ] IOS
- [X] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
