### PR TITLE
Support for transfer manager to download only part of file

### DIFF
--- a/aws-cpp-sdk-transfer-tests/TransferTests.cpp
+++ b/aws-cpp-sdk-transfer-tests/TransferTests.cpp
@@ -52,11 +52,11 @@ using namespace Aws::Client;
 using namespace Aws::Http;
 using namespace Aws::Utils;
 
-static const char* MULTI_PART_CONTENT_KEY = "MultiContentKey";
-static const char* MULTI_PART_CONTENT_TEXT = "This is a test..##";
+//static const char* MULTI_PART_CONTENT_KEY = "MultiContentKey";
+//static const char* MULTI_PART_CONTENT_TEXT = "This is a test..##";
 
 static const char* CONTENT_TEST_FILE_TEXT = "This is a test..";
-static const char* CONTENT_TEST_FILE_NAME = "ContentTransferTestFile.txt";
+//static const char* CONTENT_TEST_FILE_NAME = "ContentTransferTestFile.txt";
 static const char* CONTENT_FILE_KEY = "ContentFileKey";
 
 static const char* BIG_FILE_KEY = "BigFileKey";
@@ -66,7 +66,7 @@ static const wchar_t* UNICODE_TEST_FILE_NAME = L"测试文件.txt";
 static const char* UNICODE_FILE_KEY = "UnicodeFileKey";
 #endif
 
-static const char* CANCEL_FILE_KEY = "CancelFileKey";
+//static const char* CANCEL_FILE_KEY = "CancelFileKey";
 
 static const char* TEST_BUCKET_NAME_BASE = "transfertests";
 static const unsigned SMALL_TEST_SIZE = MB5 / 2;
@@ -78,8 +78,8 @@ static const unsigned PARTS_IN_MEDIUM_TEST = 2;
 
 static const unsigned PARTS_IN_BIG_TEST = 15;
 static const unsigned BIG_TEST_SIZE = MB5 * PARTS_IN_BIG_TEST;
-static const char* testString = "S3 MultiPart upload Test File ";
-static const uint32_t testStrLen = static_cast<uint32_t>(strlen(testString));
+//static const char* testString = "S3 MultiPart upload Test File ";
+//static const uint32_t testStrLen = static_cast<uint32_t>(strlen(testString));
 static const std::chrono::seconds TEST_WAIT_TIMEOUT = std::chrono::seconds(10);
 static const unsigned WAIT_MAX_RETRIES = 10;
 
@@ -616,7 +616,7 @@ protected:
 };
 
 std::shared_ptr<MockS3Client> TransferTests::m_s3Client(nullptr);
-
+/*
 TEST_F(TransferTests, TransferManager_ThreadExecutorJoinsAsyncOperations)
 {
     const Aws::String RandomFileName = Aws::Utils::UUID::RandomUUID();
@@ -771,6 +771,7 @@ TEST_F(TransferTests, TransferManager_ContentTest)
                        "text/plain",
                        Aws::Map<Aws::String, Aws::String>());
 }
+*/
 
 TEST_F(TransferTests, TransferManager_RangeContentTest)
 {
@@ -810,7 +811,7 @@ TEST_F(TransferTests, TransferManager_RangeContentTest)
                                       "text/plain",
                                       Aws::Map<Aws::String, Aws::String>());
 }
-
+/*
 TEST_F(TransferTests, TransferManager_DirectoryUploadAndDownloadTest)
 {
     const Aws::String RandomFileName = Aws::Utils::UUID::RandomUUID();
@@ -1648,4 +1649,7 @@ TEST_F(TransferTests, MultipartUploadWithComputeContentMd5Test)
                        "text/plain",
                        Aws::Map<Aws::String, Aws::String>());
 }
+*/
 }
+
+

--- a/aws-cpp-sdk-transfer-tests/TransferTests.cpp
+++ b/aws-cpp-sdk-transfer-tests/TransferTests.cpp
@@ -377,14 +377,11 @@ protected:
             for (size_t i = 0; i < part_count; i++) {
 
                 size_t part_size;
-                if (part_count == 1) {
-                    part_size = sourceLength;
-                } else if (i == part_count - 1) {
-                    part_size = sourceLength - (buffer_size * (i-1));
+                if (i == part_count - 1) {
+                    part_size = sourceLength - (buffer_size *i);
                 } else {
                     part_size = buffer_size;
                 }
-
                 auto downloadPartFileName = MakeDownloadFileName(sourceFileName) + Aws::String(std::to_string(i).c_str());
                 auto create_stream_fn = [=](){
 #ifdef _MSC_VER

--- a/aws-cpp-sdk-transfer-tests/TransferTests.cpp
+++ b/aws-cpp-sdk-transfer-tests/TransferTests.cpp
@@ -52,11 +52,11 @@ using namespace Aws::Client;
 using namespace Aws::Http;
 using namespace Aws::Utils;
 
-//static const char* MULTI_PART_CONTENT_KEY = "MultiContentKey";
-//static const char* MULTI_PART_CONTENT_TEXT = "This is a test..##";
+static const char* MULTI_PART_CONTENT_KEY = "MultiContentKey";
+static const char* MULTI_PART_CONTENT_TEXT = "This is a test..##";
 
 static const char* CONTENT_TEST_FILE_TEXT = "This is a test..";
-//static const char* CONTENT_TEST_FILE_NAME = "ContentTransferTestFile.txt";
+static const char* CONTENT_TEST_FILE_NAME = "ContentTransferTestFile.txt";
 static const char* CONTENT_FILE_KEY = "ContentFileKey";
 
 static const char* BIG_FILE_KEY = "BigFileKey";
@@ -66,7 +66,7 @@ static const wchar_t* UNICODE_TEST_FILE_NAME = L"测试文件.txt";
 static const char* UNICODE_FILE_KEY = "UnicodeFileKey";
 #endif
 
-//static const char* CANCEL_FILE_KEY = "CancelFileKey";
+static const char* CANCEL_FILE_KEY = "CancelFileKey";
 
 static const char* TEST_BUCKET_NAME_BASE = "transfertests";
 static const unsigned SMALL_TEST_SIZE = MB5 / 2;
@@ -78,8 +78,8 @@ static const unsigned PARTS_IN_MEDIUM_TEST = 2;
 
 static const unsigned PARTS_IN_BIG_TEST = 15;
 static const unsigned BIG_TEST_SIZE = MB5 * PARTS_IN_BIG_TEST;
-//static const char* testString = "S3 MultiPart upload Test File ";
-//static const uint32_t testStrLen = static_cast<uint32_t>(strlen(testString));
+static const char* testString = "S3 MultiPart upload Test File ";
+static const uint32_t testStrLen = static_cast<uint32_t>(strlen(testString));
 static const std::chrono::seconds TEST_WAIT_TIMEOUT = std::chrono::seconds(10);
 static const unsigned WAIT_MAX_RETRIES = 10;
 
@@ -132,7 +132,7 @@ class ScopedTestFile
 
         ~ScopedTestFile()
         {
-            Aws::FileSystem::RemoveFileIfExists(m_fileName.c_str());
+           Aws::FileSystem::RemoveFileIfExists(m_fileName.c_str());
         }
 
     private:
@@ -229,9 +229,9 @@ protected:
         if (!sourceFile.good()) return false;
 
 #ifdef _MSC_VER
-        Aws::FStream concatenatedFile(Aws::Utils::StringUtils::ToWString(MakeDownloadFileName(sourceFileName).c_str()).c_str(), std::ios::binary | std::ios::in | std::ios::out);
+        Aws::FStream concatenatedFile(Aws::Utils::StringUtils::ToWString(MakeDownloadFileName(sourceFileName).c_str()).c_str(), std::ios::binary | std::ios::out);
 #else
-        Aws::FStream concatenatedFile(MakeDownloadFileName(sourceFileName).c_str(), std::ios::binary | std::ios::in | std::ios::out);
+        Aws::FStream concatenatedFile(MakeDownloadFileName(sourceFileName).c_str(), std::ios::binary | std::ios::out);
 #endif
 
         for (int i=0; i<numParts; i++) {
@@ -246,10 +246,14 @@ protected:
             concatenatedFile << inFile.rdbuf();
         }
 
-        // seek concatenatedFile to beginning
-        concatenatedFile.seekg(0, std::ios_base::beg);
-
-        return HashingUtils::CalculateSHA256(sourceFile) == HashingUtils::CalculateSHA256(concatenatedFile);
+        concatenatedFile.close();
+      
+#ifdef _MSC_VER
+        Aws::FStream concatenatedFileRead(Aws::Utils::StringUtils::ToWString(MakeDownloadFileName(sourceFileName).c_str()).c_str(), std::ios::binary | std::ios::in);
+#else
+        Aws::FStream concatenatedFileRead(MakeDownloadFileName(sourceFileName).c_str(), std::ios::binary | std::ios::in);
+#endif
+        return HashingUtils::CalculateSHA256(sourceFile) == HashingUtils::CalculateSHA256(concatenatedFileRead);
     }
 
     static Aws::String GetTestFilesDirectory()
@@ -422,7 +426,6 @@ protected:
 
             ASSERT_TRUE(SourceFileSameAsConcatenatedPartFiles(sourceFileName, part_count));
        
-        
             for (size_t i=0; i< part_count; i++) {
                 auto filename = MakeDownloadFileName(sourceFileName) + Aws::String(std::to_string(i).c_str());
                 Aws::FileSystem::RemoveFileIfExists(filename.c_str());
@@ -616,7 +619,7 @@ protected:
 };
 
 std::shared_ptr<MockS3Client> TransferTests::m_s3Client(nullptr);
-/*
+
 TEST_F(TransferTests, TransferManager_ThreadExecutorJoinsAsyncOperations)
 {
     const Aws::String RandomFileName = Aws::Utils::UUID::RandomUUID();
@@ -771,7 +774,6 @@ TEST_F(TransferTests, TransferManager_ContentTest)
                        "text/plain",
                        Aws::Map<Aws::String, Aws::String>());
 }
-*/
 
 TEST_F(TransferTests, TransferManager_RangeContentTest)
 {
@@ -811,7 +813,7 @@ TEST_F(TransferTests, TransferManager_RangeContentTest)
                                       "text/plain",
                                       Aws::Map<Aws::String, Aws::String>());
 }
-/*
+
 TEST_F(TransferTests, TransferManager_DirectoryUploadAndDownloadTest)
 {
     const Aws::String RandomFileName = Aws::Utils::UUID::RandomUUID();
@@ -1649,7 +1651,7 @@ TEST_F(TransferTests, MultipartUploadWithComputeContentMd5Test)
                        "text/plain",
                        Aws::Map<Aws::String, Aws::String>());
 }
-*/
+
 }
 
 

--- a/aws-cpp-sdk-transfer-tests/TransferTests.cpp
+++ b/aws-cpp-sdk-transfer-tests/TransferTests.cpp
@@ -689,6 +689,13 @@ TEST_F(TransferTests, TransferManager_EmptyFileTest)
         RandomFileName,
         "text/plain",
         Aws::Map<Aws::String, Aws::String>());
+
+    VerifyUploadedFileDownloadInParts(*transferManager,
+                                      emptyTestFileName,
+                                      GetTestBucketName(),
+                                      RandomFileName,
+                                      "text/plain",
+                                      Aws::Map<Aws::String, Aws::String>());
 }
 
 TEST_F(TransferTests, TransferManager_SmallTest)
@@ -773,38 +780,6 @@ TEST_F(TransferTests, TransferManager_ContentTest)
                        CONTENT_FILE_KEY,
                        "text/plain",
                        Aws::Map<Aws::String, Aws::String>());
-}
-
-TEST_F(TransferTests, TransferManager_RangeContentTest)
-{
-    const Aws::String RandomFileName = Aws::Utils::UUID::RandomUUID();
-    Aws::String contentTestFileName = MakeFilePath(RandomFileName.c_str());
-    ScopedTestFile testFile(contentTestFileName, CONTENT_TEST_FILE_TEXT);
-
-    TransferManagerConfiguration transferManagerConfig(m_executor.get());
-    transferManagerConfig.s3Client = m_s3Client;
-    auto transferManager = TransferManager::Create(transferManagerConfig);
-
-    std::shared_ptr<TransferHandle> requestPtr =
-            transferManager->UploadFile(contentTestFileName, GetTestBucketName(), CONTENT_FILE_KEY, "text/plain", Aws::Map<Aws::String, Aws::String>());
-
-    ASSERT_EQ(true, requestPtr->ShouldContinue());
-    ASSERT_EQ(TransferDirection::UPLOAD, requestPtr->GetTransferDirection());
-    ASSERT_STREQ(contentTestFileName.c_str(), requestPtr->GetTargetFilePath().c_str());
-    requestPtr->WaitUntilFinished();
-    ASSERT_EQ(TransferStatus::COMPLETED, requestPtr->GetStatus());
-    ASSERT_EQ(1u, requestPtr->GetCompletedParts().size()); // Should be tiny
-    ASSERT_EQ(0u, requestPtr->GetFailedParts().size());
-    ASSERT_EQ(0u, requestPtr->GetPendingParts().size());
-    ASSERT_EQ(0u, requestPtr->GetQueuedParts().size());
-
-    ASSERT_STREQ("text/plain", requestPtr->GetContentType().c_str());
-
-    uint64_t fileSize = requestPtr->GetBytesTotalSize();
-    ASSERT_EQ(fileSize, strlen(CONTENT_TEST_FILE_TEXT));
-    ASSERT_EQ(fileSize, requestPtr->GetBytesTransferred());
-
-    ASSERT_TRUE(WaitForObjectToPropagate(GetTestBucketName(), CONTENT_FILE_KEY));
 
     VerifyUploadedFileDownloadInParts(*transferManager,
                                       contentTestFileName,
@@ -813,6 +788,7 @@ TEST_F(TransferTests, TransferManager_RangeContentTest)
                                       "text/plain",
                                       Aws::Map<Aws::String, Aws::String>());
 }
+
 
 TEST_F(TransferTests, TransferManager_DirectoryUploadAndDownloadTest)
 {
@@ -1023,7 +999,15 @@ TEST_F(TransferTests, TransferManager_BigTest)
                        BIG_FILE_KEY,
                        "text/plain",
                        Aws::Map<Aws::String, Aws::String>());
+
+    VerifyUploadedFileDownloadInParts(*transferManager,
+                                      bigTestFileName,
+                                      GetTestBucketName(),
+                                      BIG_FILE_KEY,
+                                      "text/plain",
+                                      Aws::Map<Aws::String, Aws::String>());
 }
+
 
 #ifdef _MSC_VER
 TEST_F(TransferTests, TransferManager_UnicodeFileNameTest)
@@ -1316,6 +1300,13 @@ TEST_F(TransferTests, TransferManager_MultiPartContentTest)
                        MULTI_PART_CONTENT_KEY,
                        "text/plain",
                        Aws::Map<Aws::String, Aws::String>());
+
+    VerifyUploadedFileDownloadInParts(*transferManager,
+                                      multiPartContentFileName,
+                                      GetTestBucketName(),
+                                      MULTI_PART_CONTENT_KEY,
+                                      "text/plain",
+                                      Aws::Map<Aws::String, Aws::String>());
 }
 
 // Single part upload with metadata specified

--- a/aws-cpp-sdk-transfer-tests/TransferTests.cpp
+++ b/aws-cpp-sdk-transfer-tests/TransferTests.cpp
@@ -399,11 +399,14 @@ protected:
                 ASSERT_EQ(0u, downloadPtr->GetPendingParts().size());
 
                 size_t part_size;
-                if (i == part_count - 1) {
-                    part_size = sourceLength - (buffer_size * (i - 1));
+                if (part_count == 1) {
+                    part_size = sourceLength;
+                } else if (i == part_count - 1) {
+                    part_size = sourceLength - (buffer_size * (i-1));
                 } else {
                     part_size = buffer_size;
                 }
+
                 ASSERT_EQ(downloadPtr->GetBytesTotalSize(), part_size);
                 ASSERT_EQ(downloadPtr->GetBytesTransferred(), part_size);
 

--- a/aws-cpp-sdk-transfer-tests/TransferTests.cpp
+++ b/aws-cpp-sdk-transfer-tests/TransferTests.cpp
@@ -132,7 +132,7 @@ class ScopedTestFile
 
         ~ScopedTestFile()
         {
-           Aws::FileSystem::RemoveFileIfExists(m_fileName.c_str());
+            Aws::FileSystem::RemoveFileIfExists(m_fileName.c_str());
         }
 
     private:
@@ -339,6 +339,7 @@ protected:
             copyMetadata["ETag"] = downloadPtr->GetMetadata().find("ETag")->second;
             ASSERT_EQ(copyMetadata, downloadPtr->GetMetadata());
         }
+
         Aws::FileSystem::RemoveFileIfExists(downloadFileName.c_str());
     }
 
@@ -428,6 +429,7 @@ protected:
                 Aws::FileSystem::RemoveFileIfExists(filename.c_str());
             }
         }
+
         Aws::FileSystem::RemoveFileIfExists(MakeDownloadFileName(sourceFileName).c_str());
     }
 
@@ -1004,7 +1006,6 @@ TEST_F(TransferTests, TransferManager_BigTest)
                                       "text/plain",
                                       Aws::Map<Aws::String, Aws::String>());
 }
-
 
 #ifdef _MSC_VER
 TEST_F(TransferTests, TransferManager_UnicodeFileNameTest)
@@ -1639,7 +1640,4 @@ TEST_F(TransferTests, MultipartUploadWithComputeContentMd5Test)
                        "text/plain",
                        Aws::Map<Aws::String, Aws::String>());
 }
-
 }
-
-

--- a/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
@@ -158,7 +158,7 @@ namespace Aws
              * Alternate DOWNLOAD constructor
              */
             TransferHandle(const Aws::String& bucketName, const Aws::String& keyName, 
-                const uint64_t offset, const uint64_t totalBytes, 
+                const uint64_t fileOffset, const uint64_t downloadBytes, 
                 CreateDownloadStreamCallback createDownloadStreamFn, const Aws::String& targetFilePath = "");
 
 

--- a/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
@@ -154,6 +154,14 @@ namespace Aws
              */
             TransferHandle(const Aws::String& bucketName, const Aws::String& keyName, CreateDownloadStreamCallback createDownloadStreamFn, const Aws::String& targetFilePath = "");
 
+            /**
+             * Alternate DOWNLOAD constructor
+             */
+            TransferHandle(const Aws::String& bucketName, const Aws::String& keyName, 
+                const uint64_t offset, const uint64_t totalBytes, 
+                CreateDownloadStreamCallback createDownloadStreamFn, const Aws::String& targetFilePath = "");
+
+
             ~TransferHandle();
 
             /**
@@ -254,6 +262,10 @@ namespace Aws
             */
             void UpdateBytesTransferred(uint64_t amount) { m_bytesTransferred.fetch_add(amount); }
 
+            /**
+             * The offset from which to start downloading
+             */
+            inline uint64_t GetBytesOffset() const { return m_offset; }
             /**
              * The calculated total size of the object being transferred.
              */
@@ -376,6 +388,7 @@ namespace Aws
             std::atomic<uint64_t> m_bytesTransferred;
             std::atomic<bool> m_lastPart;
             std::atomic<uint64_t> m_bytesTotalSize;
+            uint64_t m_offset;
             Aws::String m_bucket;
             Aws::String m_key;
             Aws::String m_fileName;

--- a/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
@@ -182,13 +182,13 @@ namespace Aws
              * Downloads the contents of bucketName/keyName in S3 and writes it to writeToStream. This will perform a GetObject operation for the given range.
              */
             std::shared_ptr<TransferHandle> DownloadFile(const Aws::String& bucketName, 
-                                                             const Aws::String& keyName, 
-                                                             uint64_t offset,
-                                                             uint64_t numBytes,
-                                                             CreateDownloadStreamCallback writeToStreamfn, 
-                                                             const DownloadConfiguration& downloadConfig = DownloadConfiguration(),
-                                                             const Aws::String& writeToFile = "",
-                                                             const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context = nullptr);
+                                                         const Aws::String& keyName, 
+                                                         uint64_t fileOffset,
+                                                         uint64_t downloadBytes,
+                                                         CreateDownloadStreamCallback writeToStreamfn, 
+                                                         const DownloadConfiguration& downloadConfig = DownloadConfiguration(),
+                                                         const Aws::String& writeToFile = "",
+                                                         const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context = nullptr);
 
             /**
              * Retry an download that failed from a previous DownloadFile operation. If a multi-part download was used, only the failed parts will be re-fetched.

--- a/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
@@ -179,6 +179,18 @@ namespace Aws
                                                          const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context = nullptr);
 
             /**
+             * Downloads the contents of bucketName/keyName in S3 and writes it to writeToStream. This will perform a GetObject operation for the given range.
+             */
+            std::shared_ptr<TransferHandle> DownloadFile(const Aws::String& bucketName, 
+                                                             const Aws::String& keyName, 
+                                                             uint64_t offset,
+                                                             uint64_t numBytes,
+                                                             CreateDownloadStreamCallback writeToStreamfn, 
+                                                             const DownloadConfiguration& downloadConfig = DownloadConfiguration(),
+                                                             const Aws::String& writeToFile = "",
+                                                             const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context = nullptr);
+
+            /**
              * Retry an download that failed from a previous DownloadFile operation. If a multi-part download was used, only the failed parts will be re-fetched.
              */
             std::shared_ptr<TransferHandle> RetryDownload(const std::shared_ptr<TransferHandle>& retryHandle);

--- a/aws-cpp-sdk-transfer/source/transfer/TransferHandle.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferHandle.cpp
@@ -77,6 +77,7 @@ namespace Aws
             m_bytesTransferred(0), 
             m_lastPart(false),
             m_bytesTotalSize(totalSize),
+            m_offset(0),
             m_bucket(bucketName), 
             m_key(keyName), 
             m_fileName(targetFilePath),
@@ -94,6 +95,7 @@ namespace Aws
             m_bytesTransferred(0), 
             m_lastPart(false),
             m_bytesTotalSize(0),
+            m_offset(0),
             m_bucket(bucketName), 
             m_key(keyName), 
             m_fileName(targetFilePath),
@@ -111,6 +113,26 @@ namespace Aws
             m_bytesTransferred(0), 
             m_lastPart(false),
             m_bytesTotalSize(0),
+            m_offset(0),
+            m_bucket(bucketName), 
+            m_key(keyName), 
+            m_fileName(targetFilePath),
+            m_versionId(""),
+            m_status(TransferStatus::NOT_STARTED), 
+            m_cancel(false),
+            m_handleId(Utils::UUID::RandomUUID()),
+            m_createDownloadStreamFn(createDownloadStreamFn), 
+            m_downloadStream(nullptr)
+        {}
+
+        
+        TransferHandle::TransferHandle(const Aws::String& bucketName, const Aws::String& keyName, const uint64_t offset, const uint64_t totalSize,CreateDownloadStreamCallback createDownloadStreamFn, const Aws::String& targetFilePath) :
+            m_isMultipart(false), 
+            m_direction(TransferDirection::DOWNLOAD), 
+            m_bytesTransferred(0), 
+            m_lastPart(false),
+            m_bytesTotalSize(totalSize),
+            m_offset(offset),
             m_bucket(bucketName), 
             m_key(keyName), 
             m_fileName(targetFilePath),

--- a/aws-cpp-sdk-transfer/source/transfer/TransferHandle.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferHandle.cpp
@@ -126,14 +126,16 @@ namespace Aws
         {}
 
         
-        TransferHandle::TransferHandle(const Aws::String& bucketName, const Aws::String& keyName, const uint64_t offset, const uint64_t totalSize,CreateDownloadStreamCallback createDownloadStreamFn, const Aws::String& targetFilePath) :
+        TransferHandle::TransferHandle(const Aws::String& bucketName, const Aws::String& keyName, 
+            const uint64_t fileOffset, const uint64_t downloadBytes,
+            CreateDownloadStreamCallback createDownloadStreamFn, const Aws::String& targetFilePath) :
             m_isMultipart(false), 
             m_direction(TransferDirection::DOWNLOAD), 
             m_bytesTransferred(0), 
             m_lastPart(false),
-            m_bytesTotalSize(totalSize),
-            m_offset(offset),
-            m_bucket(bucketName), 
+            m_bytesTotalSize(downloadBytes),
+            m_offset(fileOffset),
+            m_bucket(bucketName),
             m_key(keyName), 
             m_fileName(targetFilePath),
             m_versionId(""),

--- a/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -754,16 +754,16 @@ namespace Aws
                 if (!headObjectOutcome.IsSuccess())
                 {
                     AWS_LOGSTREAM_ERROR(CLASS_TAG, "Transfer handle [" << handle->GetId()
-                        << "] Failed to get download parts information for object in Bucket: ["
-                        << handle->GetBucketName() << "] with Key: [" << handle->GetKey()
-                        << "] " << headObjectOutcome.GetError());
+                            << "] Failed to get download parts information for object in Bucket: ["
+                            << handle->GetBucketName() << "] with Key: [" << handle->GetKey()
+                            << "] " << headObjectOutcome.GetError());
                     handle->UpdateStatus(TransferStatus::FAILED);
                     handle->SetError(headObjectOutcome.GetError());
                     TriggerErrorCallback(handle, headObjectOutcome.GetError());
                     TriggerTransferStatusUpdatedCallback(handle);
                     return false;
                 }
-                
+
                 std::size_t downloadSize = static_cast<size_t>(headObjectOutcome.GetResult().GetContentLength());
                 handle->SetBytesTotalSize(downloadSize);
                 handle->SetContentType(headObjectOutcome.GetResult().GetContentType());
@@ -847,7 +847,6 @@ namespace Aws
                     getObjectRangeRequest.SetContinueRequestHandler([handle](const Aws::Http::HttpRequest*) { return handle->ShouldContinue(); });
                     getObjectRangeRequest.SetBucket(handle->GetBucketName());
                     getObjectRangeRequest.WithKey(handle->GetKey());
-
                     getObjectRangeRequest.SetRange(FormatRangeSpecifier(rangeStart, rangeEnd));
                     getObjectRangeRequest.SetResponseStreamFactory(responseStreamFunction);
                     if(handle->GetVersionId().size() > 0)

--- a/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -120,14 +120,14 @@ namespace Aws
 
         std::shared_ptr<TransferHandle> TransferManager::DownloadFile(const Aws::String& bucketName, 
                                                                       const Aws::String& keyName, 
-                                                                      uint64_t offset, 
-                                                                      uint64_t numBytes,
+                                                                      uint64_t fileOffset, 
+                                                                      uint64_t downloadBytes,
                                                                       CreateDownloadStreamCallback writeToStreamfn, 
                                                                       const DownloadConfiguration& downloadConfig,
                                                                       const Aws::String& writeToFile,
                                                                       const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context)
         {
-            auto handle = Aws::MakeShared<TransferHandle>(CLASS_TAG, bucketName, keyName, offset, numBytes, writeToStreamfn, writeToFile);
+            auto handle = Aws::MakeShared<TransferHandle>(CLASS_TAG, bucketName, keyName, fileOffset, downloadBytes, writeToStreamfn, writeToFile);
             handle->ApplyDownloadConfiguration(downloadConfig);
             handle->SetContext(context);
 


### PR DESCRIPTION
*Description of changes:*
This feature arises from our use of the SDK in the open source project Tensorflow. We would like to use transfer manager to download a file specified by an offset and given number of bytes. 

I thought this feature makes less sense when downloading to a file, hence I only added support when downloading to a stream.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
