### PR TITLE
RetryStrategy.h: include <memory> for shared_ptr

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/client/RetryStrategy.h
+++ b/aws-cpp-sdk-core/include/aws/core/client/RetryStrategy.h
@@ -17,6 +17,7 @@
 
 #include <aws/core/Core_EXPORTS.h>
 #include <aws/core/utils/threading/ReaderWriterLock.h>
+#include <memory>
 
 namespace Aws
 {


### PR DESCRIPTION
On RHEL/CentOS 7, the default compiler is GCC 4.8.5, which results in
this compile error:

    In file included from /builddir/build/BUILD/aws-sdk-cpp-1.7.328/aws-cpp-sdk-core/include/aws/core/client/DefaultRetryStrategy.h:19:0,
                     from /builddir/build/BUILD/aws-sdk-cpp-1.7.328/aws-cpp-sdk-core/source/client/DefaultRetryStrategy.cpp:16:
    /builddir/build/BUILD/aws-sdk-cpp-1.7.328/aws-cpp-sdk-core/include/aws/core/client/RetryStrategy.h:40:32: error: 'shared_ptr' is not a member of 'std'
             typedef Utils::Outcome<std::shared_ptr<Aws::Http::HttpResponse>, AWSError<CoreErrors>> HttpResponseOutcome;

Include `<memory>` so that std::shared_ptr is available in the header
file.

The above error does not occur on other platforms (e.g. Fedora 31 with
GCC 9.3.1).

*Issue #, if available:*

*Description of changes:*

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
