### PR TITLE
Update Default Provider Chain to include ProcessCredentialsProvider

### DIFF
--- a/aws-cpp-sdk-core/source/auth/AWSCredentialsProviderChain.cpp
+++ b/aws-cpp-sdk-core/source/auth/AWSCredentialsProviderChain.cpp
@@ -46,6 +46,7 @@ DefaultAWSCredentialsProviderChain::DefaultAWSCredentialsProviderChain() : AWSCr
 {
     AddProvider(Aws::MakeShared<EnvironmentAWSCredentialsProvider>(DefaultCredentialsProviderChainTag));
     AddProvider(Aws::MakeShared<ProfileConfigFileAWSCredentialsProvider>(DefaultCredentialsProviderChainTag));
+    AddProvider(Aws::MakeShared<ProcessCredentialsProvider>(DefaultCredentialsProviderChainTag));
     AddProvider(Aws::MakeShared<STSAssumeRoleWebIdentityCredentialsProvider>(DefaultCredentialsProviderChainTag));
     
     //ECS TaskRole Credentials only available when ENVIRONMENT VARIABLE is set


### PR DESCRIPTION
*Issue #, if available:*
#1388
*Description of changes:*
Add the ProcessCredentialsProvider to the default chain. At least Boto and Go SDKs appear to include it in their default chains.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
