### PR TITLE
Made S3Client::ComputeEndpointString() public for ease of endpoint de…

### DIFF
--- a/aws-cpp-sdk-s3/include/aws/s3/S3Client.h
+++ b/aws-cpp-sdk-s3/include/aws/s3/S3Client.h
@@ -9416,11 +9416,13 @@ namespace Aws
         virtual bool MultipartUploadSupported() const;
 
         void OverrideEndpoint(const Aws::String& endpoint);
+
+        ComputeEndpointOutcome ComputeEndpointString() const;
+        
     private:
         void init(const Client::ClientConfiguration& clientConfiguration);
         void LoadS3SpecificConfig(const Aws::String& profile);
         ComputeEndpointOutcome ComputeEndpointString(const Aws::String& bucket) const;
-        ComputeEndpointOutcome ComputeEndpointString() const;
 
         void AbortMultipartUploadAsyncHelper(const Model::AbortMultipartUploadRequest& request, const AbortMultipartUploadResponseReceivedHandler& handler, const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context) const;
         void CompleteMultipartUploadAsyncHelper(const Model::CompleteMultipartUploadRequest& request, const CompleteMultipartUploadResponseReceivedHandler& handler, const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context) const;


### PR DESCRIPTION
Would like to make S3Client::ComputeEndpointString() public for ease of client configuration / endpoint debugging on disconnected systems such as snowballs. This is a const method so it's a safe change.

*Issue #, if available:* N/A

*Description of changes:* Moved method from private to public in class declaration.

*Check all that applies:*
- [x ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x ] Linux
- [x ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
