### PR TITLE
Copy only the newly read bytes fromn the buffer

### DIFF
--- a/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/main.java
+++ b/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/main.java
@@ -67,8 +67,9 @@ public class main {
                 StringBuilder stringBuilder = new StringBuilder();
 
                 byte[] buffer = new byte[1024];
-                while (stream.read(buffer) > 0) {
-                    stringBuilder.append(new String(buffer, StandardCharsets.UTF_8));
+                int bytes;
+                while ((bytes = stream.read(buffer)) > 0) {
+                    stringBuilder.append(new String(buffer, 0, bytes, StandardCharsets.UTF_8));
                 }
 
                 arbitraryJson = stringBuilder.toString();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

 With the current behaviour the last iteration appends both newly read bytes and bytes from the previous read. This results in a string which contains the json file and some fragments. Because the generator uses a very old version of gson in the pom.xml it will happily work with broken json but newer versions will refuse to load that string and throw an invalid json exception. This change ensures that only the new bytes are appended to the string. 



*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
