### PR TITLE
Update CMakeLists.txt replace find_package with aws_use_package for aws-c-event-stream

### DIFF
--- a/aws-cpp-sdk-core/CMakeLists.txt
+++ b/aws-cpp-sdk-core/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_project(aws-cpp-sdk-core "Core http and utility library for the AWS C++ SDK")
 
+include(AwsFindPackage)
+
 if(VERSION_STRING)
     set(AWSSDK_VERSION_STRING ${VERSION_STRING})
     message(STATUS "Updating version info to ${VERSION_STRING}")
@@ -493,9 +495,9 @@ endif()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PLATFORM_DEP_LIBS} ${CLIENT_LIBS} ${CRYPTO_LIBS} ${AWS_SDK_ADDITIONAL_LIBRARIES})
 
-find_package(aws-c-event-stream REQUIRED)
+aws_use_package(aws-c-event-stream)
 
-target_link_libraries(${PROJECT_NAME} PUBLIC AWS::aws-c-event-stream)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_AWS_LIBS})
 
 
 if(USE_WINDOWS_DLL_SEMANTICS)

--- a/cmake/AwsFindPackage.cmake
+++ b/cmake/AwsFindPackage.cmake
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+option(IN_SOURCE_BUILD "If the CRT libs are being built from your source tree (add_subdirectory), set this to ON" OFF)
+
+# This function handles dependency list building based on if traditional CMAKE modules via. find_package should be
+# used, vs if this is an in source build via. something like git submodules and add_subdirectory.
+# This is largely because CMake was not well planned out, and as a result, in-source and modules don't play well
+# together. Only use this on CRT libraries (including S2N), libcrypto will stay as an assumed external dependency.
+#
+# package_name: is the name of the package to find
+# DEP_CRT_LIBS: output variable will be appended after each call to this function. You don't have to use it,
+#    but it can be passed directly target_link_libraries and it will be the properly qualified library
+#    name and namespace based on configuration.
+function(aws_use_package package_name)
+    if (IN_SOURCE_BUILD)
+        set(DEP_AWS_LIBS ${DEP_AWS_LIBS} ${package_name} PARENT_SCOPE)
+    else()
+        find_package(${package_name} REQUIRED)
+        set(DEP_AWS_LIBS ${DEP_AWS_LIBS} AWS::${package_name} PARENT_SCOPE)
+    endif()
+endfunction()

--- a/cmake/AwsFindPackage.cmake
+++ b/cmake/AwsFindPackage.cmake
@@ -9,7 +9,7 @@ option(IN_SOURCE_BUILD "If the CRT libs are being built from your source tree (a
 # together. Only use this on CRT libraries (including S2N), libcrypto will stay as an assumed external dependency.
 #
 # package_name: is the name of the package to find
-# DEP_CRT_LIBS: output variable will be appended after each call to this function. You don't have to use it,
+# DEP_AWS_LIBS: output variable will be appended after each call to this function. You don't have to use it,
 #    but it can be passed directly target_link_libraries and it will be the properly qualified library
 #    name and namespace based on configuration.
 function(aws_use_package package_name)


### PR DESCRIPTION
*Issue #, if available:*
When building alongside aws-c-event-stream find_package pulls in the system library instead of the in source target. 

*Description of changes:*
This change brings over the concept of `aws_use_package` from aws-c-common to aws-cpp-sdk-core. I did not add any testing because with `IN_SOURCE_BUILD=OFF` the same fine_package behaviour is maintained.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
