### PR TITLE
Prevent deadlock in CurlHandleContainer::AcquireCurlHandle()

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/http/curl/CurlHandleContainer.h
+++ b/aws-cpp-sdk-core/include/aws/core/http/curl/CurlHandleContainer.h
@@ -53,6 +53,7 @@ private:
     CurlHandleContainer(const CurlHandleContainer&&) = delete;
     const CurlHandleContainer& operator = (const CurlHandleContainer&&) = delete;
 
+    CURL* CreateCurlHandleInPool();
     bool CheckAndGrowPool();
     void SetDefaultOptionsOnHandle(CURL* handle);
 


### PR DESCRIPTION
*Issue #, if available:*

### Brief
When a heavily multi-threaded application creates a lot of S3Clients, a deadlock is observed in CurlHandleContainer::AcquireCurlHandle()

### Issue Description:
Consider this snippet from AcquireCurlHandle:

    if(!m_handleContainer.HasResourcesAvailable())   
    {  
        CheckAndGrowPool();  
    }  
    CURL* handle = m_handleContainer.Acquire();

If the pool has already reached max limit, it will not grow further and caller will block at `m_handleContainer.Acquire();`
However, if the thread that has acquired the handle, encounters an error, it calls DestroyCurlHandle() instead of ReleaseCurlHandle(), which does not release the handle back into the pool. If none of the threads are released back, then the waiting threads will never get the handle.
Added a unit test to reproduce the scenario.

### Fix details
I am assuming there was a good reason to call DestroyCurlHandle() instead of just resetting and release it back. As a proposed fix, I have created a new handle to replace the one being destroyed so that pool size remains the same.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
