### PR TITLE
Adding a patch to fix a data race in the AWS Client

### DIFF
--- a/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -116,6 +116,11 @@ AWSClient::AWSClient(const Aws::Client::ClientConfiguration& configuration,
     m_requestTimeoutMs(configuration.requestTimeoutMs),
     m_enableClockSkewAdjustment(configuration.enableClockSkewAdjustment)
 {
+    // user doesn't override user agent string
+    if (m_userAgent.empty())
+    {
+        m_userAgent = ComputeUserAgent(GetServiceClientName());
+    }
 }
 
 AWSClient::AWSClient(const Aws::Client::ClientConfiguration& configuration,
@@ -133,6 +138,11 @@ AWSClient::AWSClient(const Aws::Client::ClientConfiguration& configuration,
     m_requestTimeoutMs(configuration.requestTimeoutMs),
     m_enableClockSkewAdjustment(configuration.enableClockSkewAdjustment)
 {
+    // user doesn't override user agent string
+    if (m_userAgent.empty())
+    {
+        m_userAgent = ComputeUserAgent(GetServiceClientName());
+    }
 }
 
 void AWSClient::DisableRequestProcessing()
@@ -686,11 +696,6 @@ void AWSClient::BuildHttpRequest(const Aws::AmazonWebServiceRequest& request,
 
 void AWSClient::AddCommonHeaders(HttpRequest& httpRequest) const
 {
-    // user doesn't override user agent string
-    if (m_userAgent.empty())
-    {
-        m_userAgent = ComputeUserAgent(GetServiceClientName());
-    }
     httpRequest.SetUserAgent(m_userAgent);
 }
 


### PR DESCRIPTION
*Issue #, if available:*
We were seeing the following errors while running the code through thread sanitizers? 
```
#0 Aws::Client::AWSClient::AddCommonHeaders(Aws::Http::HttpRequest&) const ??:? (libexternal_Saws_Slibaws.so+0xe2e6e)
    #1 Aws::Client::AWSClient::BuildHttpRequest(Aws::AmazonWebServiceRequest const&, std::shared_ptr<Aws::Http::HttpRequest> const&) const ??:? (libexternal_Saws_Slibaws.so+0xe64b8)
    #2 Aws::Client::AWSClient::AttemptOneRequest(std::shared_ptr<Aws::Http::HttpRequest> const&, Aws::AmazonWebServiceRequest const&, char const*, char const*) const ??:? (libexternal_Saws_Slibaws.so+0xdcbef)
    #3 Aws::Client::AWSClient::AttemptExhaustively(Aws::Http::URI const&, Aws::AmazonWebServiceRequest const&, Aws::Http::HttpMethod, char const*, char const*) const ??:? (libexternal_Saws_Slibaws.so+0xd85a4)
    #4 Aws::Client::AWSClient::MakeRequestWithUnparsedResponse(Aws::Http::URI const&, Aws::AmazonWebServiceRequest const&, Aws::Http::HttpMethod, char const*, char const*) const ??:? (libexternal_Saws_Slibaws.so+0xe3662)
    #5 Aws::S3::S3Client::GetObject(Aws::S3::Model::GetObjectRequest const&) const ??:? (libexternal_Saws_Slibaws-s3.so+0x212890)
```

*Description of changes:*
The way the code is written right now results in a race condition. 
Moving the code the constructor alleviates the race condition as it is not required to call the code with every invocation of `AddCommonHeaders` 

*Check all that applies:*
- [ X] Did a review by yourself.
- [ X] Added proper tests to cover this PR. (If tests are not applicable, explain.) - NO TESTS WERE ADDED AS THIS IS A THREADING ISSUE AND IT IS HARD TO REPRODUCE USING A UNIT TEST. WE WERE ABLE TO REPRODUCE THIS EVERY SINGLE TIME BY JUST RUNNING THE CODE THROUGH A THREAD SANITIZER

- [ X] Checked if this PR is a breaking (APIs have been changed) change.
- [ X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
