### PR TITLE
fix URI being extra encoded when request retries

### DIFF
--- a/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -307,7 +307,7 @@ HttpResponseOutcome AWSClient::AttemptExhaustively(const Aws::Http::URI& uri,
             m_httpClient->RetryRequestSleep(std::chrono::milliseconds(sleepMillis));
         }
 
-        Aws::Http::URI newUri(uri.GetURIString());
+        Aws::Http::URI newUri = uri;
         Aws::String newEndpoint = GetErrorMarshaller()->ExtractEndpoint(outcome.GetError());
         if (!newEndpoint.empty())
         {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

URI paths, such as `/path with space`, are double encoded when request retry happens.
This PR fixes the problem.



*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
