### PR TITLE
Don't require git to download external projects

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -14,15 +14,15 @@ set(AWS_DEPS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}" CACHE PATH "Dependencies inst
 set(AWS_DEPS_BUILD_DIR "${CMAKE_BINARY_DIR}/build" CACHE PATH "Dependencies build directory.")
 set(AWS_DEPS_DOWNLOAD_DIR "${AWS_DEPS_BUILD_DIR}/downloads" CACHE PATH "Dependencies download directory.")
 
-set(AWS_C_COMMON_URL "https://github.com/awslabs/aws-c-common.git")
+set(AWS_C_COMMON_URL "https://github.com/awslabs/aws-c-common")
 set(AWS_C_COMMON_TAG "v0.4.42")
 include(BuildAwsCCommon)
 
-set(AWS_CHECKSUMS_URL "https://github.com/awslabs/aws-checksums.git")
+set(AWS_CHECKSUMS_URL "https://github.com/awslabs/aws-checksums")
 set(AWS_CHECKSUMS_TAG "v0.1.5")
 include(BuildAwsChecksums)
 
-set(AWS_EVENT_STREAM_URL "https://github.com/awslabs/aws-c-event-stream.git")
+set(AWS_EVENT_STREAM_URL "https://github.com/awslabs/aws-c-event-stream")
 set(AWS_EVENT_STREAM_TAG "v0.1.5")
 include(BuildAwsEventStream)
 

--- a/third-party/cmake/BuildAwsCCommon.cmake
+++ b/third-party/cmake/BuildAwsCCommon.cmake
@@ -1,8 +1,7 @@
 if(TARGET_ARCH STREQUAL "ANDROID")
     ExternalProject_Add(AwsCCommon
         PREFIX ${AWS_DEPS_BUILD_DIR}
-        GIT_REPOSITORY ${AWS_C_COMMON_URL}
-        GIT_TAG ${AWS_C_COMMON_TAG}
+        URL "${AWS_C_COMMON_URL}/archive/${AWS_C_COMMON_TAG}.tar.gz"
         BUILD_IN_SOURCE 0
         UPDATE_COMMAND ""
         CMAKE_ARGS
@@ -21,8 +20,7 @@ elseif(TARGET_ARCH STREQUAL "APPLE" AND DEFINED CMAKE_OSX_ARCHITECTURES AND NOT 
     message("Cross compiling aws-c-common for architecture ${CMAKE_OSX_ARCHITECTURES}")
     ExternalProject_Add(AwsCCommon
         PREFIX ${AWS_DEPS_BUILD_DIR}
-        GIT_REPOSITORY ${AWS_C_COMMON_URL}
-        GIT_TAG ${AWS_C_COMMON_TAG}
+        URL "${AWS_C_COMMON_URL}/archive/${AWS_C_COMMON_TAG}.tar.gz"
         BUILD_IN_SOURCE 0
         UPDATE_COMMAND ""
         CMAKE_ARGS
@@ -38,8 +36,7 @@ elseif(TARGET_ARCH STREQUAL "APPLE" AND DEFINED CMAKE_OSX_ARCHITECTURES AND NOT 
 else()
     ExternalProject_Add(AwsCCommon
         PREFIX ${AWS_DEPS_BUILD_DIR}
-        GIT_REPOSITORY ${AWS_C_COMMON_URL}
-        GIT_TAG ${AWS_C_COMMON_TAG}
+        URL "${AWS_C_COMMON_URL}/archive/${AWS_C_COMMON_TAG}.tar.gz"
         BUILD_IN_SOURCE 0
         UPDATE_COMMAND ""
         CMAKE_ARGS

--- a/third-party/cmake/BuildAwsChecksums.cmake
+++ b/third-party/cmake/BuildAwsChecksums.cmake
@@ -1,8 +1,7 @@
 if(TARGET_ARCH STREQUAL "ANDROID")
     ExternalProject_Add(AwsChecksums
         PREFIX ${AWS_DEPS_BUILD_DIR}
-        GIT_REPOSITORY ${AWS_CHECKSUMS_URL}
-        GIT_TAG ${AWS_CHECKSUMS_TAG}
+        URL "${AWS_CHECKSUMS_URL}/archive/${AWS_CHECKSUMS_TAG}.tar.gz"
         BUILD_IN_SOURCE 0
         UPDATE_COMMAND ""
         CMAKE_ARGS
@@ -20,8 +19,7 @@ elseif(TARGET_ARCH STREQUAL "APPLE" AND DEFINED CMAKE_OSX_ARCHITECTURES AND NOT 
     message("Cross compiling aws-checksums for architecture ${CMAKE_OSX_ARCHITECTURES}")
     ExternalProject_Add(AwsChecksums
         PREFIX ${AWS_DEPS_BUILD_DIR}
-        GIT_REPOSITORY ${AWS_CHECKSUMS_URL}
-        GIT_TAG ${AWS_CHECKSUMS_TAG}
+        URL "${AWS_CHECKSUMS_URL}/archive/${AWS_CHECKSUMS_TAG}.tar.gz"
         BUILD_IN_SOURCE 0
         UPDATE_COMMAND ""
         CMAKE_ARGS
@@ -37,8 +35,7 @@ elseif(TARGET_ARCH STREQUAL "APPLE" AND DEFINED CMAKE_OSX_ARCHITECTURES AND NOT 
 else()
     ExternalProject_Add(AwsChecksums
         PREFIX ${AWS_DEPS_BUILD_DIR}
-        GIT_REPOSITORY ${AWS_CHECKSUMS_URL}
-        GIT_TAG ${AWS_CHECKSUMS_TAG}
+        URL "${AWS_CHECKSUMS_URL}/archive/${AWS_CHECKSUMS_TAG}.tar.gz"
         BUILD_IN_SOURCE 0
         UPDATE_COMMAND ""
         CMAKE_ARGS
@@ -50,5 +47,3 @@ else()
         -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
         )
 endif()
-
-

--- a/third-party/cmake/BuildAwsEventStream.cmake
+++ b/third-party/cmake/BuildAwsEventStream.cmake
@@ -4,8 +4,7 @@ set(DEPS_RPATH "$ORIGIN")
 if(TARGET_ARCH STREQUAL "ANDROID")
     ExternalProject_Add(AwsCEventStream
         PREFIX ${AWS_DEPS_BUILD_DIR}
-        GIT_REPOSITORY ${AWS_EVENT_STREAM_URL}
-        GIT_TAG ${AWS_EVENT_STREAM_TAG}
+        URL "${AWS_EVENT_STREAM_URL}/archive/${AWS_EVENT_STREAM_TAG}.tar.gz"
         BUILD_IN_SOURCE 0
         UPDATE_COMMAND ""
         CMAKE_ARGS
@@ -26,8 +25,7 @@ elseif(TARGET_ARCH STREQUAL "APPLE" AND DEFINED CMAKE_OSX_ARCHITECTURES AND NOT 
     message("Cross compiling aws-c-event-stream for architecture ${CMAKE_OSX_ARCHITECTURES}")
     ExternalProject_Add(AwsCEventStream
         PREFIX ${AWS_DEPS_BUILD_DIR}
-        GIT_REPOSITORY ${AWS_EVENT_STREAM_URL}
-        GIT_TAG ${AWS_EVENT_STREAM_TAG}
+        URL "${AWS_EVENT_STREAM_URL}/archive/${AWS_EVENT_STREAM_TAG}.tar.gz"
         BUILD_IN_SOURCE 0
         UPDATE_COMMAND ""
         CMAKE_ARGS
@@ -45,8 +43,7 @@ elseif(TARGET_ARCH STREQUAL "APPLE" AND DEFINED CMAKE_OSX_ARCHITECTURES AND NOT 
 else()
     ExternalProject_Add(AwsCEventStream
         PREFIX ${AWS_DEPS_BUILD_DIR}
-        GIT_REPOSITORY ${AWS_EVENT_STREAM_URL}
-        GIT_TAG ${AWS_EVENT_STREAM_TAG}
+        URL "${AWS_EVENT_STREAM_URL}/archive/${AWS_EVENT_STREAM_TAG}.tar.gz"
         BUILD_IN_SOURCE 0
         UPDATE_COMMAND ""
         CMAKE_ARGS


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Building `aws-sdk-cpp` with the default `BUILD_DEPS=ON` fails if `git` is not found on the system:

```
-- Configuring incomplete, errors occurred!

-- stderr output is:
CMake Error at /tmp/RtmpqRJAdR/file1835205980df/cmake-3.18.1-Linux-x86_64/share/cmake-3.18/Modules/ExternalProject.cmake:2350 (message):
  error: could not find git for clone of AwsCCommon
Call Stack (most recent call first):
  /tmp/RtmpqRJAdR/file1835205980df/cmake-3.18.1-Linux-x86_64/share/cmake-3.18/Modules/ExternalProject.cmake:3228 (_ep_add_download_command)
  cmake/BuildAwsCCommon.cmake:39 (ExternalProject_Add)
  CMakeLists.txt:19 (include)


CMake Error at CMakeLists.txt:218 (message):
  Failed to configure third-party libraries.
```

These `third-party` cmake files specify a git repository and tag for the source for each library, but we can download the source without `git` by constructing a URL.

On https://github.com/apache/arrow/pull/8304 I've tested that this works as expected by applying it in a `PATCH_COMMAND`.

*Check all that applies:*
- [ ] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.) *Any CI you have that tests these cmake files will cover the changes; there are no behavior changes*
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
