### PR TITLE
Wrap local classes in namespace for internal linkage

### DIFF
--- a/aws-cpp-sdk-core/source/utils/DateTimeCommon.cpp
+++ b/aws-cpp-sdk-core/source/utils/DateTimeCommon.cpp
@@ -376,6 +376,8 @@ static int GetMonthNumberFromStr(const char* timeString, size_t startIndex, size
         return -1;
     }
 }
+// Ensure local classes with generic names have internal linkage
+namespace {
 
 class DateParser
 {
@@ -1103,6 +1105,8 @@ private:
 
     int m_state;
 };
+    
+} // namespace 
 
 DateTime::DateTime(const std::chrono::system_clock::time_point& timepointToAssign) : m_time(timepointToAssign), m_valid(true)
 {


### PR DESCRIPTION
When the SDK is built using static libraries, classes that are local to a `.cpp` file with generic names like `DateParser`, can conflict with other classes and their constructors in an upstream project or package. This has caused crashes in our project because since our `DateParser` also uses a virtual destructor, it ends up getting called from the AWS code. Wrapping these date parser classes in anonymous namespace will ensure they are internally linked, according to the ISO C++ standard.

Example stack trace from the crash log:

```
#0  0x00005555582993ef in std::_Rb_tree<Str, std::pair<Str const, Str>, std::_Select1st<std::pair<Str const, Str> >, std::less<Str>, std::allocator<std::pair<Str const, Str> > >::_S_right (__x=0x48e0758948e87d89)
    at /usr/include/c++/9/bits/stl_tree.h:798
#1  0x0000555558294c0f in std::_Rb_tree<Str, std::pair<Str const, Str>, std::_Select1st<std::pair<Str const, Str> >, std::less<Str>, std::allocator<std::pair<Str const, Str> > >::_M_erase (this=0x7fffee1fca40, __x=0x48e0758948e87d89)
    at /usr/include/c++/9/bits/stl_tree.h:1913
#2  0x0000555558294c21 in std::_Rb_tree<Str, std::pair<Str const, Str>, std::_Select1st<std::pair<Str const, Str> >, std::less<Str>, std::allocator<std::pair<Str const, Str> > >::_M_erase (this=0x7fffee1fca40, __x=
    0x55555a006574 <ScopedPointer<BundlesSetup>::~ScopedPointer()+48>) at /usr/include/c++/9/bits/stl_tree.h:1913
#3  0x0000555558294c21 in std::_Rb_tree<Str, std::pair<Str const, Str>, std::_Select1st<std::pair<Str const, Str> >, std::less<Str>, std::allocator<std::pair<Str const, Str> > >::_M_erase (this=0x7fffee1fca40, __x=0x7fffee1fcb80)
    at /usr/include/c++/9/bits/stl_tree.h:1913
#4  0x0000555558294c21 in std::_Rb_tree<Str, std::pair<Str const, Str>, std::_Select1st<std::pair<Str const, Str> >, std::less<Str>, std::allocator<std::pair<Str const, Str> > >::_M_erase (this=0x7fffee1fca40, __x=0x7fffee1fca70)
    at /usr/include/c++/9/bits/stl_tree.h:1913
#5  0x000055555828f48e in std::_Rb_tree<Str, std::pair<Str const, Str>, std::_Select1st<std::pair<Str const, Str> >, std::less<Str>, std::allocator<std::pair<Str const, Str> > >::~_Rb_tree (this=0x7fffee1fca40, 
    __in_chrg=<optimized out>) at /usr/include/c++/9/bits/stl_tree.h:995
#6  0x0000555558283142 in std::map<Str, Str, std::less<Str>, std::allocator<std::pair<Str const, Str> > >::~map (this=0x7fffee1fca40, __in_chrg=<optimized out>) at /usr/include/c++/9/bits/stl_map.h:300
#7  0x00005555595125e0 in DateParserGuesser::~DateParserGuesser (this=0x7fffee1fca10, __in_chrg=<optimized out>) at src/util/DateParser.h:197
#8  0x000055555950b7ac in DateParser::~DateParser (this=0x7fffee1fc8b0, __in_chrg=<optimized out>) at src/util/DateParser.cpp:324
#9  0x000055555ae17c8e in RFC822DateParser::~RFC822DateParser (this=0x7fffee1fc8b0, __in_chrg=<optimized out>) at /home/hyan/code/some/main/contrib/aws-sdk-cpp-1.8.8/aws-cpp-sdk-core/source/utils/DateTimeCommon.cpp:506
#10 0x000055555ae160a2 in Aws::Utils::DateTime::ConvertTimestampStringToTimePoint (this=0x7fffee1fcb70, timestamp=0x7fffedc8ed20 "Wed, 30 Sep 2020 00:07:00 GMT", format=Aws::Utils::DateFormat::AutoDetect)
    at /home/hyan/code/some/main/contrib/aws-sdk-cpp-1.8.8/aws-cpp-sdk-core/source/utils/DateTimeCommon.cpp:1328
#11 0x000055555ae14c15 in Aws::Utils::DateTime::DateTime (this=0x7fffee1fcb70, timestamp=0x7fffedc8ed20 "Wed, 30 Sep 2020 00:07:00 GMT", format=Aws::Utils::DateFormat::AutoDetect)
    at /home/hyan/code/some/main/contrib/aws-sdk-cpp-1.8.8/aws-cpp-sdk-core/source/utils/DateTimeCommon.cpp:1033
#12 0x000055555ad98a02 in GetServerTimeFromError (error=...) at /home/hyan/code/some/main/contrib/aws-sdk-cpp-1.8.8/aws-cpp-sdk-core/source/client/AWSClient.cpp:153
```

Note: the key part is here:

```
#8  0x000055555950b7ac in DateParser::~DateParser (this=0x7fffee1fc8b0, __in_chrg=<optimized out>) at src/util/DateParser.cpp:324
#9  0x000055555ae17c8e in RFC822DateParser::~RFC822DateParser (this=0x7fffee1fc8b0, __in_chrg=<optimized out>) at /home/hyan/code/some/main/contrib/aws-sdk-cpp-1.8.8/aws-cpp-sdk-core/source/utils/DateTimeCommon.cpp:506
```
I cannot show our code here, but the `DateParser` of our code has a constructor which takes a `bool`, but in C++ any pointer is treated as a boolean value on whether or not its `nullptr`. Either way, wrapping these classes in an anonymous namespace fixes the problem , and I believe it's the intention not to expose these classes externally anyways.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.) Not applicable, this is a leakage of symbols when using the sdk as static libs
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
