### PR TITLE
Honor client's stream seek position when multipart downloading with o…

### DIFF
--- a/aws-cpp-sdk-transfer/source/transfer/TransferHandle.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferHandle.cpp
@@ -370,9 +370,11 @@ namespace Aws
             }
 
             partStream->seekg(0);
-            m_downloadStream->seekp(writeOffset);
+            std::size_t pos = m_downloadStream->tellg();
+            m_downloadStream->seekp(pos + writeOffset);
             (*m_downloadStream) << partStream->rdbuf();
             m_downloadStream->flush();
+            m_downloadStream->seekg(pos);
         }
 
         void TransferHandle::ApplyDownloadConfiguration(const DownloadConfiguration& downloadConfig)


### PR DESCRIPTION
*Issue #, if available:*
 #1495 

*Description of changes:*
Read client stream seek position when calculating multipart chunk offset write when Downloading from S3 in multipart

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
