### PR TITLE
Do not force to run a test when crosscompiling

### DIFF
--- a/aws-cpp-sdk-core/CMakeLists.txt
+++ b/aws-cpp-sdk-core/CMakeLists.txt
@@ -86,23 +86,30 @@ file(GLOB UTILS_CRYPTO_FACTORY_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/utils/
 include(CheckCXXSourceCompiles)
 include(CheckCSourceRuns)
 include(CheckCXXSourceRuns)
+include(CheckCSourceCompiles)
 
 # http client implementations
 if(ENABLE_CURL_CLIENT)
     file(GLOB HTTP_CURL_CLIENT_HEADERS "include/aws/core/http/curl/*.h")
     file(GLOB HTTP_CURL_CLIENT_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/http/curl/*.cpp")
     set(CMAKE_REQUIRED_LIBRARIES ${CURL_LIBRARIES})
-    check_c_source_runs("
-    #include <curl/curl.h>
+    set(CHECK_CURL_HTTP_VERSION_CODE "
+    include <curl/curl.h>
     int main() {
     CURL* handle = curl_easy_init();
-    return curl_easy_setopt(handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0); }" CURL_HAS_H2)
-    check_c_source_runs("
-    #include <curl/curl.h>
+    return curl_easy_setopt(handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0); }")
+    set(CHECK_CURL_CERT_CODE "
+    include <curl/curl.h>
     int main() {
     CURL* handle = curl_easy_init();
-    return curl_easy_setopt(handle, CURLOPT_PROXY_SSLCERT, \"client.pem\"); }" CURL_HAS_TLS_PROXY)
-    unset(CMAKE_REQUIRED_LIBRARIES)
+    return curl_easy_setopt(handle, CURLOPT_PROXY_SSLCERT, \"client.pem\"); }")
+    if (${CMAKE_CROSSCOMPILING})
+        check_c_source_compiles("${CHECK_CURL_HTTP_VERSION_CODE}" CURL_HAS_H2)
+        check_c_source_compiles("${CHECK_CURL_CERT_CODE}" CURL_HAS_TLS_PROXY)
+    else()
+        check_c_source_runs("${CHECK_CURL_HTTP_VERSION_CODE}" CURL_HAS_H2)
+        check_c_source_runs("${CHECK_CURL_CERT_CODE}" CURL_HAS_TLS_PROXY)
+    endif()
 elseif(ENABLE_WINDOWS_CLIENT)
     # NOTE: HTTP/2 is not supported when using IXML_HTTP_REQUEST_2
     if(USE_IXML_HTTP_REQUEST_2)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I'm using Amazon TranscribeStreaming in both PC64 and ARM64 machines.

When crosscompiling the SDK there is a check_c_source_runs CMake sentence that forces to run a CURL code in order to enable its functionality. Since the crosscompiled code is not runnable in the host machine, the checker fails when CURL is actually capable to work with both HTTP2 and TLS Proxy connections. This is affecting to the TranscribeStreaming service.
My proposal is that for SDK cross-compilations CMake should check weather CURL is compilable instead of runnable. Of course, both HTTP2 and TLS Proxy may not be enable, can be checked in the target machine, but at least the SDK does not discard this feature just because it is not runnable in the target machine at compile time.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
