### PR TITLE
Add SOCKS5 and SOCKS5H schemes

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/http/Scheme.h
+++ b/aws-cpp-sdk-core/include/aws/core/http/Scheme.h
@@ -19,7 +19,9 @@ namespace Aws
         enum class Scheme
         {
             HTTP,
-            HTTPS
+            HTTPS,
+            SOCKS5,
+            SOCKS5H
         };
 
         namespace SchemeMapper

--- a/aws-cpp-sdk-core/source/http/Scheme.cpp
+++ b/aws-cpp-sdk-core/source/http/Scheme.cpp
@@ -25,6 +25,10 @@ namespace SchemeMapper
                 return "http";
             case Scheme::HTTPS:
                 return "https";
+            case Scheme::SOCKS5:
+                return "socks5";
+            case Scheme::SOCKS5H:
+                return "socks5h";
             default:
                 return "http";
         }
@@ -44,6 +48,14 @@ namespace SchemeMapper
         else if (loweredTrimmedString == "https")
         {
             return Scheme::HTTPS;
+        }
+        else if (loweredTrimmedString == "socks5")
+        {
+            return Scheme::SOCKS5;
+        }
+        else if (loweredTrimmedString == "socks5h")
+        {
+            return Scheme::SOCKS5H;
         }
 
         return Scheme::HTTPS;


### PR DESCRIPTION
*Description of changes:*
Added schemes required for proxying connections to socks5 and socks5h (with host resolution) with CURL library.
Proxifying your connections to AWS is a very common requirement when using AWS SDK. unfortunately, since the default client only accepts http and https schemas, we cannot use socks5 and socks5h proxies that are already supported by curl. socks5h is especially useful in my case since I'm running my WebAssembly application on Google Chrome, and the only way to connect to AWS servers with WebAssembly is by proxifying the requests to a SOCKS proxy AND doing the DNS resolution on the proxy itself.
I could create a new client and use the overriding function but I found it too much of a hassle to create a new client and implement the overriding method and then setting as a default client configuration just so that I can add the schema.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
Not applicable: it doesn't add anything functional. It just enables prepending socks5 and socks5h to the host name
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [X] Windows
- [X] Android
- [X] MacOS
- [X] IOS
- [X] Other Platforms
WebAssembly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
