### PR TITLE
Added support for specifying the Polly Engine (standard or neural) when using the Aws::TextToSpeech::TextToSpeechManager object to generate speech.

### DIFF
--- a/aws-cpp-sdk-text-to-speech/include/aws/text-to-speech/TextToSpeechManager.h
+++ b/aws-cpp-sdk-text-to-speech/include/aws/text-to-speech/TextToSpeechManager.h
@@ -85,6 +85,11 @@ namespace Aws
             Aws::Vector<std::pair<Aws::String, Aws::String>> ListAvailableVoices() const;
 
             /**
+             * Sets the active engine for use with the Polly Service.
+             */
+            void SetActiveEngine(const Aws::String& engine);
+
+            /**
              * Sets the active voice for use with the Polly Service.
              */
             void SetActiveVoice(const Aws::String& voice);
@@ -99,6 +104,7 @@ namespace Aws
             Polly::PollyClient* m_pollyClient;
             std::shared_ptr<PCMOutputDriver> m_activeDriver;
             Aws::Vector<std::shared_ptr<PCMOutputDriver>> m_drivers;
+            std::atomic<Polly::Model::Engine> m_activeEngine;
             std::atomic<Polly::Model::VoiceId> m_activeVoice;
             CapabilityInfo m_selectedCaps;
             mutable std::mutex m_driverLock;

--- a/aws-cpp-sdk-text-to-speech/source/text-to-speech/TextToSpeechManager.cpp
+++ b/aws-cpp-sdk-text-to-speech/source/text-to-speech/TextToSpeechManager.cpp
@@ -41,7 +41,7 @@ namespace Aws
 
         TextToSpeechManager::TextToSpeechManager(const std::shared_ptr<Polly::PollyClient>& pollyClient, 
             const std::shared_ptr<PCMOutputDriverFactory>& driverFactory) 
-            : m_pollyClient(pollyClient.get()), m_activeVoice(VoiceId::Kimberly)
+            : m_pollyClient(pollyClient.get()), m_activeEngine(Engine::standard), m_activeVoice(VoiceId::Kimberly)
         {
             m_drivers = (driverFactory ? driverFactory : DefaultPCMOutputDriverFactoryInitFn())->LoadDrivers();
         }
@@ -66,6 +66,7 @@ namespace Aws
                 .WithSampleRate(StringUtils::to_string(m_selectedCaps.sampleRate))
                 .WithTextType(TextType::text)
                 .WithText(text)
+                .WithEngine(m_activeEngine)
                 .WithVoiceId(m_activeVoice);
 
             auto context = Aws::MakeShared<SendTextCompletionHandlerCallbackContext>(CLASS_TAG);
@@ -126,6 +127,12 @@ namespace Aws
             }
 
             return m_voices;
+        }
+
+        void TextToSpeechManager::SetActiveEngine(const Aws::String& engine)
+        {
+            AWS_LOGSTREAM_DEBUG(CLASS_TAG, "Setting active engine as: " << engine);
+            m_activeEngine = EngineMapper::GetEngineForName(engine);
         }
 
         void TextToSpeechManager::SetActiveVoice(const Aws::String& voice)


### PR DESCRIPTION
*Description of changes:*
Added support for specifying the Polly Engine (standard or neural) when using the Aws::TextToSpeech::TextToSpeechManager object to generate speech.

```
...
auto manager = Aws::TextToSpeech::TextToSpeechManager::Create(client, factory);

manager->SetActiveEngine("neural");
manager->SetActiveVoice("Olivia");
...
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
