### PR TITLE
Use the Credentials file instead of profile

### DIFF
--- a/aws-cpp-sdk-identity-management/source/auth/STSProfileCredentialsProvider.cpp
+++ b/aws-cpp-sdk-identity-management/source/auth/STSProfileCredentialsProvider.cpp
@@ -165,7 +165,7 @@ static ProfileState CheckProfile(const Aws::Config::Profile& profile, bool topLe
 void STSProfileCredentialsProvider::Reload()
 {
     // make a copy of the profiles map to be able to set credentials on the individual profiles when assuming role
-    auto loadedProfiles = Aws::Config::GetCachedConfigProfiles();
+    auto loadedProfiles = Aws::Config::GetCachedCredentialsProfiles();
     auto profileIt = loadedProfiles.find(m_profileName);
 
     if(profileIt == loadedProfiles.end())


### PR DESCRIPTION
*Issue #150 and #1330 *

*Description of changes:*
This one-liner changes the source of information when the STS Profile Credentials Provider looks for its profiles.
This is consistent with the default config file provider, which also looks only at the credentials file to get access keys.


*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change. not breaking
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.  consisten cross-platform
- [X] Checked if this PR would require a ReadMe/Wiki update.   This is a bug fix.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [X] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
