### PR TITLE
Make Transfer::TransferHandle::GetAllPartsTransactional() const

### DIFF
--- a/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
@@ -218,7 +218,7 @@ namespace Aws
              * Get the parts transactionally, mostly for internal purposes.
              */
             void GetAllPartsTransactional(PartStateMap& queuedParts, PartStateMap& pendingParts,
-                    PartStateMap& failedParts, PartStateMap& completedParts);
+                    PartStateMap& failedParts, PartStateMap& completedParts) const;
             /**
              * Returns true or false if any parts have been created for this transfer
              */

--- a/aws-cpp-sdk-transfer/source/transfer/TransferHandle.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferHandle.cpp
@@ -225,7 +225,7 @@ namespace Aws
         }
 
         void TransferHandle::GetAllPartsTransactional(PartStateMap& queuedParts, PartStateMap& pendingParts,
-            PartStateMap& failedParts, PartStateMap& completedParts)
+            PartStateMap& failedParts, PartStateMap& completedParts) const
         {
             std::lock_guard<std::mutex> locker(m_partsLock);
             queuedParts = m_queuedParts;


### PR DESCRIPTION
*Issue #, if available:*

I just make `const` a method in the transfer sdk. (#1605)

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [x] IOS
- [x] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
