### PR TITLE
[Transfer] Add a helper to get number of streamable bytes from start of a file

### DIFF
--- a/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
@@ -266,6 +266,14 @@ namespace Aws
             inline void SetBytesTotalSize(uint64_t value) { m_bytesTotalSize.store(value); }
 
             /**
+             * Gets the total size of contigious bytes from the file begining that is already transferred, and available to users.
+             * For multiple-part downloads, it's guaranteed that these bytes are commited to the underlying stream already.
+             * For single-part downloads, it's also true since we write() directly to the underlying stream.
+             * A potential use case is to poll and stream bytes to users as we are still doing multi-part downloading.
+             */
+            inline uint64_t GetBytesAvailableFromStart() const { return m_bytesAvailableFromStart.load(std::memory_order_relaxed); }
+
+            /**
              * Bucket portion of the object location in Amazon S3.
              */
             inline const Aws::String& GetBucketName() const { return m_bucket; }
@@ -378,6 +386,9 @@ namespace Aws
             std::atomic<uint64_t> m_bytesTransferred;
             std::atomic<bool> m_lastPart;
             std::atomic<uint64_t> m_bytesTotalSize;
+            std::atomic<uint64_t> m_bytesAvailableFromStart;
+            /* The next part number to watch, that is able to grow m_bytesAvailableFromStart. */
+            size_t m_nextPartToWatch;
             uint64_t m_offset;
             Aws::String m_bucket;
             Aws::String m_key;


### PR DESCRIPTION
Currently the transfer manager provides convenient ways to run callbacks, such
as during status and progress updates. This gives a way for users to poll if
files are ready. One use case is to "stream" files to users, without waiting
for the entire file to finish downloading. It is possible for users to query
all completed parts and calculate how many bytes are ready for streaming, from
the start of the file.

This patch performs calculations when a part is completed successfully, and is
written to the underlying stream. It also adds an API for querying number of
bytes available from the beginning of the file, which removes locking and
accounting code from users who wish to use TransferManager asynchronously.

*Issue #, if available:*
#1636
*Description of changes:*
This patch performs calculations when a part is completed successfully, and is
written to the underlying stream. It also adds an API for querying number of
bytes available from the beginning of the file, which removes locking and
accounting code from users who wish to use TransferManager asynchronously.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
