### PR TITLE
fix: check for minimal supported macos version

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/utils/crypto/commoncrypto/CryptoImpl.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/crypto/commoncrypto/CryptoImpl.h
@@ -13,7 +13,8 @@
 #if defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
 #if defined(__MAC_10_13) && (__MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_13)
 #define MAC_13_AVAILABLE  1
-#elif defined(__MAC_10_14_4) && (__MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_14_4)
+#endif
+#if defined(__MAC_10_14_4) && (__MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_14_4)
 #define MAC_14_4_AVAILABLE  1
 #endif
 #endif


### PR DESCRIPTION
Before this change the only the version of the macOS SDK
was checked, to find out if the modern function declarations
are available at all.

But the code does not take the minimal supported macos version
into account. Even on macos 11.0 you could set
`-mmacosx-version-min=10.8`. Before ths change this led to the
following error:

```
error: 'CCCryptorGCMSetIV' is only available on macOS 10.13 or newer
```

The code is now using the compiler built-in runtime check to
dynamically switch between versions. This also plays along nicely
with the Apple availability macros.

If a newer macOS SDK than 10.13 SDK is detected it could also be newer
than 10.14.4 at the same time.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
