### PR TITLE
[core/retry-strategy]: fix bitshift overflow and wrap-around

### DIFF
--- a/aws-cpp-sdk-core/source/client/RetryStrategy.cpp
+++ b/aws-cpp-sdk-core/source/client/RetryStrategy.cpp
@@ -61,7 +61,7 @@ namespace Aws
         {
             AWS_UNREFERENCED_PARAM(error);
             // Maximum left shift factor is capped by ceil(log2(max_delay)), to avoid wrap-around and overflow into negative values:
-            return std::min(rand() % 1000 * (1 << std::max(attemptedRetries, 15L)), 20000);
+            return std::min(rand() % 1000 * (1 << std::min(attemptedRetries, 15L)), 20000);
         }
 
         DefaultRetryQuotaContainer::DefaultRetryQuotaContainer() : m_retryQuota(INITIAL_RETRY_TOKENS)

--- a/aws-cpp-sdk-core/source/client/RetryStrategy.cpp
+++ b/aws-cpp-sdk-core/source/client/RetryStrategy.cpp
@@ -60,7 +60,8 @@ namespace Aws
         long StandardRetryStrategy::CalculateDelayBeforeNextRetry(const AWSError<CoreErrors>& error, long attemptedRetries) const
         {
             AWS_UNREFERENCED_PARAM(error);
-            return (std::min)(rand() % 1000 * (1 << attemptedRetries), 20000);
+            // Maximum left shift factor is capped by ceil(log2(max_delay)), to avoid wrap-around and overflow into negative values:
+            return std::min(rand() % 1000 * (1 << std::max(attemptedRetries, 15L)), 20000);
         }
 
         DefaultRetryQuotaContainer::DefaultRetryQuotaContainer() : m_retryQuota(INITIAL_RETRY_TOKENS)


### PR DESCRIPTION
When using the 'standard' retry strategy with max_attemts > 31,
negative delay values and wrap-around result, due to overflow
of the bitshift expression.

Avoid this problem by capping the maximum exponent at the
minimum value required by the maximum delay value of 20000ms.

Resolves #1713.


*Description of changes:*

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Did not add proper tests to cover this PR. (Tests depend on the max delay value of 20000, which is hard-coded).
        I did test this with my application and logging turned on to ensure it is now capping at 20,000 as expected.
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
