### PR TITLE
fix compute_links on cmake 3.18.4

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -31,14 +31,16 @@ function(compute_links lib)
     while(links)
         list(POP_FRONT links link)
         if(TARGET ${link}) # Collect only target links
-              get_target_property(target_type ${link} TYPE)
-              if (target_type STREQUAL "INTERFACE_LIBRARY")
+            if (${CMAKE_VERSION} VERSION_LESS_EQUAL "3.18.4")
                 # workaround needed for CMake 3.18.4 (Debian sid and bullseye): attempting to get/set property `LINK_LIBRARIES_ALL`
                 # on a `INTERFACE_LIBRARY` target (https://github.com/Kitware/CMake/blob/v3.18.4/Source/cmTargetPropertyComputer.cxx#L102-L103)
                 # fails due to property whitelist: https://github.com/Kitware/CMake/blob/v3.18.4/Source/cmTargetPropertyComputer.cxx#L51-L95
-                get_target_property(interface_links ${link} INTERFACE_LINK_LIBRARIES)
-                list(PREPEND links ${interface_links})
-                continue()
+                get_target_property(target_type ${link} TYPE)
+                if (target_type STREQUAL "INTERFACE_LIBRARY")
+                    get_target_property(interface_links ${link} INTERFACE_LINK_LIBRARIES)
+                    list(PREPEND links ${interface_links})
+                    continue()
+                endif()
             endif()
 
             compute_links(${link})

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -28,8 +28,19 @@ function(compute_links lib)
     endif()
 
     # For each direct link append it and its links
-    foreach(link ${links})
+    while(links)
+        list(POP_FRONT links link)
         if(TARGET ${link}) # Collect only target links
+              get_target_property(target_type ${link} TYPE)
+              if (target_type STREQUAL "INTERFACE_LIBRARY")
+                # workaround needed for CMake 3.18.4 (Debian sid and bullseye): attempting to get/set property `LINK_LIBRARIES_ALL`
+                # on a `INTERFACE_LIBRARY` target (https://github.com/Kitware/CMake/blob/v3.18.4/Source/cmTargetPropertyComputer.cxx#L102-L103)
+                # fails due to property whitelist: https://github.com/Kitware/CMake/blob/v3.18.4/Source/cmTargetPropertyComputer.cxx#L51-L95
+                get_target_property(interface_links ${link} INTERFACE_LINK_LIBRARIES)
+                list(PREPEND links ${interface_links})
+                continue()
+            endif()
+
             compute_links(${link})
             get_target_property(link_links_all ${link} LINK_LIBRARIES_ALL)
             set_property(TARGET ${lib} APPEND PROPERTY
@@ -39,7 +50,7 @@ function(compute_links lib)
             message(STATUS "Library '${lib}' uses link '${link}'.")
             message(FATAL_ERROR "Algorithm doesn't work with generator expressions.")
         endif()
-    endforeach(link ${links})
+    endwhile()
     # Remove duplicates
     get_target_property(links_all ${lib} LINK_LIBRARIES_ALL)
     list(REMOVE_DUPLICATES links_all)


### PR DESCRIPTION
*Description of changes:*
The cmake function `compute_links` fails on CMake 3.18.4 (the version on Debian sid and bullseye).
When the function attempts to get or set the property `LINK_LIBRARIES_ALL` on a `INTERFACE_LIBRARY` target, it fails due to a property whitelist check.

The problem can be easily visualized in CMake's source code for version 3.18.4:
- special case for `INTERFACE_LIBRARY`: https://github.com/Kitware/CMake/blob/v3.18.4/Source/cmTargetPropertyComputer.cxx#L102-L103
- property whitelist: https://github.com/Kitware/CMake/blob/v3.18.4/Source/cmTargetPropertyComputer.cxx#L51-L95

This fix works around CMake's whitelist by special casing `INTERFACE_LIBRARY`: instead of recursing and using an implicitly blacklisted property (`LINK_LIBRARIES_ALL`) for recursion control, the interface library's dependencies (`INTERFACE_LINK_LIBRARIES` property) take its place in the `links` list and iterative processing of dependencies proceeds normally. Only interface libraries are special cased. The behavior is preserved for all other targets.

Below is the error output of CMake without the patch:
```
CMake Error at cmake/dependencies.cmake:15 (get_property):
  INTERFACE_LIBRARY targets may only have whitelisted properties.  The
  property "LINK_LIBRARIES_ALL" is not allowed.
Call Stack (most recent call first):
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:59 (compute_links)
  cmake/sdks.cmake:239 (sort_links)
  CMakeLists.txt:275 (add_sdks)


CMake Error at cmake/dependencies.cmake:20 (set_property):
  INTERFACE_LIBRARY targets may only have whitelisted properties.  The
  property "LINK_LIBRARIES_ALL" is not allowed.
Call Stack (most recent call first):
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:59 (compute_links)
  cmake/sdks.cmake:239 (sort_links)
  CMakeLists.txt:275 (add_sdks)


CMake Error at cmake/dependencies.cmake:24 (get_target_property):
  INTERFACE_LIBRARY targets may only have whitelisted properties.  The
  property "LINK_LIBRARIES" is not allowed.
Call Stack (most recent call first):
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:59 (compute_links)
  cmake/sdks.cmake:239 (sort_links)
  CMakeLists.txt:275 (add_sdks)


CMake Error at cmake/dependencies.cmake:34 (get_target_property):
  INTERFACE_LIBRARY targets may only have whitelisted properties.  The
  property "LINK_LIBRARIES_ALL" is not allowed.
Call Stack (most recent call first):
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:59 (compute_links)
  cmake/sdks.cmake:239 (sort_links)
  CMakeLists.txt:275 (add_sdks)


CMake Error at cmake/dependencies.cmake:15 (get_property):
  INTERFACE_LIBRARY targets may only have whitelisted properties.  The
  property "LINK_LIBRARIES_ALL" is not allowed.
Call Stack (most recent call first):
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:59 (compute_links)
  cmake/sdks.cmake:239 (sort_links)
  CMakeLists.txt:275 (add_sdks)


CMake Error at cmake/dependencies.cmake:20 (set_property):
  INTERFACE_LIBRARY targets may only have whitelisted properties.  The
  property "LINK_LIBRARIES_ALL" is not allowed.
Call Stack (most recent call first):
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:59 (compute_links)
  cmake/sdks.cmake:239 (sort_links)
  CMakeLists.txt:275 (add_sdks)


CMake Error at cmake/dependencies.cmake:24 (get_target_property):
  INTERFACE_LIBRARY targets may only have whitelisted properties.  The
  property "LINK_LIBRARIES" is not allowed.
Call Stack (most recent call first):
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:59 (compute_links)
  cmake/sdks.cmake:239 (sort_links)
  CMakeLists.txt:275 (add_sdks)


CMake Error at cmake/dependencies.cmake:34 (get_target_property):
  INTERFACE_LIBRARY targets may only have whitelisted properties.  The
  property "LINK_LIBRARIES_ALL" is not allowed.
Call Stack (most recent call first):
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:33 (compute_links)
  cmake/dependencies.cmake:59 (compute_links)
  cmake/sdks.cmake:239 (sort_links)
  CMakeLists.txt:275 (add_sdks)
```

Unit tests have not been added due to the change being on the build system. Issue should be self evident upon build on CI.

*Issue #, if available:*
No issue filed.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.