### PR TITLE
Fix multiconfig generators not working by forcing single build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,11 @@ option(ENABLE_VIRTUAL_OPERATIONS "This option usually works with REGENERATE_CLIE
 
 set(BUILD_ONLY "" CACHE STRING "A semi-colon delimited list of the projects to build")
 set(CPP_STANDARD "11" CACHE STRING "Flag to upgrade the C++ standard used. The default is 11. The minimum is 11.")
-set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Release build by default.")
+
+get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if (NOT ${_isMultiConfig})
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Release build by default.")
+endif()
 
 #From https://stackoverflow.com/questions/18968979/how-to-get-colorized-output-with-cmake
 if(NOT WIN32)


### PR DESCRIPTION
*Issue #1745

By setting the cache variable CMAKE_BUILD_TYPE multi config generators such as the Visual Studio Solution generator are unable to produce more than one build configuration, leading to unexpected build failures. Setting this CMAKE_ variable is a regression from the 1.8.x series.

Our build scripts just did a cmake and then used cmake --build x --config y to build the two configurations. Its not a huge problem to fix on our end, but it forces developers that uses Visual Studio generated solutions to have two solutions. 