### PR TITLE
Fixed dereferencing a nullptr (#1750)

### DIFF
--- a/aws-cpp-sdk-core/source/utils/event/EventStreamDecoder.cpp
+++ b/aws-cpp-sdk-core/source/utils/event/EventStreamDecoder.cpp
@@ -72,9 +72,7 @@ namespace Aws
                 assert(handler);
                 if (!handler)
                 {
-                    AWS_LOGSTREAM_ERROR(EVENT_STREAM_DECODER_CLASS_TAG, "Payload received, but decoder encountered internal errors before."
-                        "ErrorCode: " << EventStreamErrorsMapper::GetNameForError(handler->GetInternalError()) << ", "
-                        "ErrorMessage: " << handler->GetEventPayloadAsString());
+                    AWS_LOGSTREAM_ERROR(EVENT_STREAM_DECODER_CLASS_TAG, "Payload received, but decoder encountered internal errors before.");
                     return;
                 }
                 handler->WriteMessageEventPayload(static_cast<unsigned char*>(payload->buffer), payload->len);
@@ -129,9 +127,7 @@ namespace Aws
                 assert(handler);
                 if (!handler)
                 {
-                    AWS_LOGSTREAM_ERROR(EVENT_STREAM_DECODER_CLASS_TAG, "Payload received, but decoder encountered internal errors before."
-                        "ErrorCode: " << EventStreamErrorsMapper::GetNameForError(handler->GetInternalError()) << ", "
-                        "ErrorMessage: " << handler->GetEventPayloadAsString());
+                    AWS_LOGSTREAM_ERROR(EVENT_STREAM_DECODER_CLASS_TAG, "Payload received, but decoder encountered internal errors before.");
                     return;
                 }
 


### PR DESCRIPTION
#1750

Fixed dereferencing a nullptr in aws-cpp-sdk-core/source/utils/event/EventStreamDecoder.cpp
