### PR TITLE
Add memory ordering to default executor for better performance on aarch64, also change a cmpexchng in a loop to weak

### DIFF
--- a/aws-cpp-sdk-core-tests/utils/threading/DefaultExecutorTest.cpp
+++ b/aws-cpp-sdk-core-tests/utils/threading/DefaultExecutorTest.cpp
@@ -11,6 +11,20 @@
 
 using namespace Aws::Utils::Threading;
 
+TEST(DefaultExecutor, InOrderMemoryTest)
+{
+    std::atomic<unsigned> count(10);
+    {
+        DefaultExecutor exec;
+        auto first = [&] {
+            count.fetch_add(2, std::memory_order_relaxed);
+            count.fetch_sub(3, std::memory_order_relaxed);
+        };
+        exec.Submit(first);
+    }
+    ASSERT_EQ(count.load(std::memory_order_acquire), 9);
+}
+
 TEST(DefaultExecutor, ThreadsJoinOnDestructionTest)
 {
     std::atomic<int> i(1);


### PR DESCRIPTION
On weakly ordered platforms, such as aarch64, it is desirable to have the memory ordering of atomic operations as relaxed as possible for the best performance. By default, with no explicit annotation, memory ordering uses either sequentially consistent ordering or acquire - release ordering, when in most cases, it only need either acquire or releases ordering, or just even relaxed ordering.

In `DefaultExecutor::SubmitToThread(std::function<void()>&&  fx)` , the `compare_exchange_strong()`  on success, is not cache coherent and does not require synchronization, just atomicity, so it's fine to relax it, but the `store()` should be release ordering.

In either `SubmitToThread` or `Detach`, we want the failed compare exchange to be in synchronization with the `store()` that happens before the return on a successful  compare exchange. This way, at the end of the `do .. while()` loop, the loaded state is properly checked and not our of order.

Additionally, the shutdown compare - exchange loop in `DefaultExecutor::~DefaultExecutor()` can be `compare_exchange_weak` instead because it is run inside the clause of a `while` loop. allowing it to tolerate spurious failures.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [x] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
