### PR TITLE
feat: added PooledThreadExecutor::WaitUntilStopped function

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/utils/threading/Executor.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/threading/Executor.h
@@ -93,6 +93,11 @@ namespace Aws
                 PooledThreadExecutor(PooledThreadExecutor&&) = delete;
                 PooledThreadExecutor& operator =(PooledThreadExecutor&&) = delete;
 
+                /**
+                * Call to ensure the threadpool can be safely destroyed. It blocks until all threads finished.
+                */
+                void WaitUntilStopped();
+
             protected:
                 bool SubmitToThread(std::function<void()>&&) override;
 
@@ -103,6 +108,7 @@ namespace Aws
                 Aws::Vector<ThreadTask*> m_threadTaskHandles;
                 size_t m_poolSize;
                 OverflowPolicy m_overflowPolicy;
+                bool m_stopped{false};
 
                 /**
                  * Once you call this, you are responsible for freeing the memory pointed to by task.

--- a/aws-cpp-sdk-core/source/utils/threading/Executor.cpp
+++ b/aws-cpp-sdk-core/source/utils/threading/Executor.cpp
@@ -84,6 +84,15 @@ PooledThreadExecutor::PooledThreadExecutor(size_t poolSize, OverflowPolicy overf
 
 PooledThreadExecutor::~PooledThreadExecutor()
 {
+    WaitUntilStopped();
+}
+
+void PooledThreadExecutor::WaitUntilStopped()
+{
+    {
+        std::lock_guard<std::mutex> locker(m_queueLock);
+        m_stopped = true;
+    }
     for(auto threadTask : m_threadTaskHandles)
     {
         threadTask->StopProcessingWork();
@@ -95,6 +104,7 @@ PooledThreadExecutor::~PooledThreadExecutor()
     {
         Aws::Delete(threadTask);
     }
+    m_threadTaskHandles.clear();
 
     while(m_tasks.size() > 0)
     {
@@ -106,7 +116,6 @@ PooledThreadExecutor::~PooledThreadExecutor()
             Aws::Delete(fn);
         }
     }
-
 }
 
 bool PooledThreadExecutor::SubmitToThread(std::function<void()>&& fn)
@@ -117,7 +126,7 @@ bool PooledThreadExecutor::SubmitToThread(std::function<void()>&& fn)
     {
         std::lock_guard<std::mutex> locker(m_queueLock);
 
-        if (m_overflowPolicy == OverflowPolicy::REJECT_IMMEDIATELY && m_tasks.size() >= m_poolSize)
+        if (m_stopped || (m_overflowPolicy == OverflowPolicy::REJECT_IMMEDIATELY && m_tasks.size() >= m_poolSize))
         {
             Aws::Delete(fnCpy);
             return false;


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-sdk-cpp/issues/1776

*Description of changes:*
 to able to wait to safe release shared_ptr for executor in a main thread

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.) - I didn't find any specific test for PooledThreadExecutor but it used in many other test, so it should be covered.
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Current 

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
