### PR TITLE
CMakeLists.txt: fix libdir ordering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,12 @@ endif()
 
 set(PYTHON_CMD "python")
 
+if (UNIX AND NOT APPLE)
+    include(GNUInstallDirs)
+elseif(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+    set(CMAKE_INSTALL_LIBDIR "lib")
+endif()
+
 # CMAKE_MODULE_PATH is a CMAKE variable. It contains a list of paths
 # which could be used to search CMAKE modules by "include()" or "find_package()", but the default value is empty.
 # Add ${CMAKE_INSTALL_LIBDIR}/cmake and ${CMAKE_PREFIX_PATH}/lib/cmake to search list
@@ -145,12 +151,6 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
 
 # build the sdk targets
 project("aws-cpp-sdk-all" VERSION "${PROJECT_VERSION}" LANGUAGES CXX)
-
-if (UNIX AND NOT APPLE)
-    include(GNUInstallDirs)
-elseif(NOT DEFINED CMAKE_INSTALL_LIBDIR)
-    set(CMAKE_INSTALL_LIBDIR "lib")
-endif()
 
 if (DEFINED CMAKE_PREFIX_PATH)
     file(TO_CMAKE_PATH "${CMAKE_PREFIX_PATH}" CMAKE_PREFIX_PATH)


### PR DESCRIPTION
*Description of changes:*

The logic which appends /lib to the CMAKE_INSTALL_LIBDIR variable is currently
set below `set(AWS_MODULE_DIR "/${CMAKE_INSTALL_LIBDIR}/cmake")` which breaks
cross-compiled environments such as buildroot when cmake attempts to find packages.

Move the logic above `set(AWS_MODULE_DIR "/${CMAKE_INSTALL_LIBDIR}/cmake")`
to fix the issue.


*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
  Not sure how I would add a test for this.
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
  APIs haven't changed.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms

I'm hoping there's an automated build for testing other platforms!