### PR TITLE
Fix build break in cmake 3.22.0-rc2

### DIFF
--- a/cmake/AWSSDKConfig.cmake
+++ b/cmake/AWSSDKConfig.cmake
@@ -129,7 +129,7 @@ endif()
 get_filename_component(TEMP_PATH "${AWSSDK_CORE_LIB_FILE}" PATH)
 get_filename_component(TEMP_NAME "${TEMP_PATH}" NAME)
 
-while (NOT TEMP_NAME STREQUAL ${LIB_SEARCH_PREFIX})
+while (NOT TEMP_NAME STREQUAL "${LIB_SEARCH_PREFIX}")
     set(TEMP_PLATFORM_PREFIX "${TEMP_NAME}/${TEMP_PLATFORM_PREFIX}")
     get_filename_component(TEMP_PATH "${TEMP_PATH}" PATH)
     get_filename_component(TEMP_NAME "${TEMP_PATH}" NAME)


### PR DESCRIPTION
The build fails in cmake 3.22.0-rc2 when LIB_SEARCH_PATH is empty. Adding quotes ensures there is always a string to compare to. 

Questions about process:
* This is not a code change just a build fix so I'm not sure tests are relevant (please let me know if that's isn't the case)
* I've made sure it fixes the issue I was seeing on windows I don't think this will have any effect on building the library so I haven't built the SDK on any platform (I've included it in another project in windows though which is probably sufficient windows testing)
* I'm not sure what doing a review by myself involves for this PR

- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
