### PR TITLE
Mingw-w64 compilation support:

### DIFF
--- a/aws-cpp-sdk-core/CMakeLists.txt
+++ b/aws-cpp-sdk-core/CMakeLists.txt
@@ -147,7 +147,7 @@ elseif(ENABLE_WINDOWS_CLIENT)
         # https://docs.microsoft.com/en-us/windows/desktop/WinHttp/option-flags#WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL
         set(CMAKE_REQUIRED_LIBRARIES "WinHttp.lib")
         check_cxx_source_runs("
-        #include <Windows.h>
+        #include <windows.h>
         #include <winhttp.h>
         int main() {
 
@@ -167,7 +167,7 @@ elseif(ENABLE_WINDOWS_CLIENT)
 
         set(CMAKE_REQUIRED_LIBRARIES "Wininet.lib")
         check_cxx_source_runs("
-        #include <Windows.h>
+        #include <windows.h>
         #include <WinInet.h>
         int main() {
         auto handle = InternetOpenA(\"aws-cpp-sdk\"/*lpszAgent*/,

--- a/aws-cpp-sdk-core/include/aws/core/utils/Array.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/Array.h
@@ -14,11 +14,11 @@
 #include <cstring>
 #include <algorithm>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 
 #include <iterator>
 
-#endif // _WIN32
+#endif // _MSC_VER
 
 namespace Aws
 {
@@ -54,7 +54,7 @@ namespace Aws
                 {
                     m_data.reset(Aws::NewArray<T>(m_size, ARRAY_ALLOCATION_TAG));
 
-#ifdef _WIN32
+#ifdef _MSC_VER
                     std::copy(arrayToCopy, arrayToCopy + arraySize, stdext::checked_array_iterator< T * >(m_data.get(), m_size));
 #else
                     std::copy(arrayToCopy, arrayToCopy + arraySize, m_data.get());
@@ -82,7 +82,7 @@ namespace Aws
                     if(arr->m_size > 0 && arr->m_data)
                     {
                         size_t arraySize = arr->m_size;
-#ifdef _WIN32
+#ifdef _MSC_VER
                         std::copy(arr->m_data.get(), arr->m_data.get() + arraySize, stdext::checked_array_iterator< T * >(m_data.get() + location, m_size));
 #else
                         std::copy(arr->m_data.get(), arr->m_data.get() + arraySize, m_data.get() + location);
@@ -101,7 +101,7 @@ namespace Aws
                 {
                     m_data.reset(Aws::NewArray<T>(m_size, ARRAY_ALLOCATION_TAG));
 
-#ifdef _WIN32
+#ifdef _MSC_VER
                     std::copy(other.m_data.get(), other.m_data.get() + other.m_size, stdext::checked_array_iterator< T * >(m_data.get(), m_size));
 #else
                     std::copy(other.m_data.get(), other.m_data.get() + other.m_size, m_data.get());
@@ -134,7 +134,7 @@ namespace Aws
                 {
                     m_data.reset(Aws::NewArray<T>(m_size, ARRAY_ALLOCATION_TAG));
 
-#ifdef _WIN32
+#ifdef _MSC_VER
                     std::copy(other.m_data.get(), other.m_data.get() + other.m_size, stdext::checked_array_iterator< T * >(m_data.get(), m_size));
 #else
                     std::copy(other.m_data.get(), other.m_data.get() + other.m_size, m_data.get());

--- a/aws-cpp-sdk-core/include/aws/core/utils/json/JsonSerializer.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/json/JsonSerializer.h
@@ -15,6 +15,10 @@
 
 #include <utility>
 
+#ifdef GetObject
+#undef GetObject
+#endif
+
 namespace Aws
 {
     namespace Utils

--- a/aws-cpp-sdk-core/source/http/windows/WinConnectionPoolMgr.cpp
+++ b/aws-cpp-sdk-core/source/http/windows/WinConnectionPoolMgr.cpp
@@ -6,7 +6,7 @@
 #include <aws/core/http/windows/WinConnectionPoolMgr.h>
 #include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/memory/AWSMemory.h>
-#include <Windows.h>
+#include <windows.h>
 #include <algorithm>
 
 using namespace Aws::Utils::Logging;

--- a/aws-cpp-sdk-core/source/http/windows/WinHttpConnectionPoolMgr.cpp
+++ b/aws-cpp-sdk-core/source/http/windows/WinHttpConnectionPoolMgr.cpp
@@ -7,7 +7,7 @@
 
 #include <aws/core/utils/StringUtils.h>
 
-#include <Windows.h>
+#include <windows.h>
 #include <winhttp.h>
 
 using namespace Aws::Http;

--- a/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
+++ b/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
@@ -17,7 +17,7 @@
 #include <aws/core/utils/ratelimiter/RateLimiterInterface.h>
 #include <aws/core/utils/UnreferencedParam.h>
 
-#include <Windows.h>
+#include <windows.h>
 #include <winhttp.h>
 #include <sstream>
 #include <iostream>

--- a/aws-cpp-sdk-core/source/http/windows/WinINetConnectionPoolMgr.cpp
+++ b/aws-cpp-sdk-core/source/http/windows/WinINetConnectionPoolMgr.cpp
@@ -4,7 +4,7 @@
  */
 
 #include <aws/core/http/windows/WinINetConnectionPoolMgr.h>
-#include <Windows.h>
+#include <windows.h>
 #include <WinInet.h>
 
 using namespace Aws::Http;

--- a/aws-cpp-sdk-core/source/http/windows/WinINetSyncHttpClient.cpp
+++ b/aws-cpp-sdk-core/source/http/windows/WinINetSyncHttpClient.cpp
@@ -16,7 +16,7 @@
 #include <aws/core/utils/ratelimiter/RateLimiterInterface.h>
 #include <aws/core/utils/UnreferencedParam.h>
 
-#include <Windows.h>
+#include <windows.h>
 #include <WinInet.h>
 #include <sstream>
 #include <iostream>

--- a/aws-cpp-sdk-core/source/http/windows/WinSyncHttpClient.cpp
+++ b/aws-cpp-sdk-core/source/http/windows/WinSyncHttpClient.cpp
@@ -14,7 +14,7 @@
 #include <aws/core/utils/memory/stl/AWSStreamFwd.h>
 #include <aws/core/utils/ratelimiter/RateLimiterInterface.h>
 
-#include <Windows.h>
+#include <windows.h>
 #include <sstream>
 #include <iostream>
 

--- a/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
+++ b/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
@@ -37,6 +37,11 @@ static const char EC2_METADATA_CLIENT_LOG_TAG[] = "EC2MetadataClient";
 static const char ECS_CREDENTIALS_CLIENT_LOG_TAG[] = "ECSCredentialsClient";
 static const char SSO_GET_ROLE_RESOURCE[] = "/federation/credentials";
 
+//undef winapi
+#ifdef GetObject
+#undef GetObject
+#endif
+
 namespace Aws
 {
     namespace Client

--- a/aws-cpp-sdk-core/source/monitoring/MonitoringManager.cpp
+++ b/aws-cpp-sdk-core/source/monitoring/MonitoringManager.cpp
@@ -14,6 +14,10 @@
 #pragma warning(disable : 4592)
 #endif
 
+#ifdef interface
+#undef interface
+#endif
+
 namespace Aws
 {
     namespace Monitoring

--- a/aws-cpp-sdk-core/source/net/windows/Net.cpp
+++ b/aws-cpp-sdk-core/source/net/windows/Net.cpp
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-#include <WinSock2.h>
+#include <winsock2.h>
 #include <cassert>
 #include <aws/core/utils/logging/LogMacros.h>
 

--- a/aws-cpp-sdk-core/source/net/windows/SimpleUDP.cpp
+++ b/aws-cpp-sdk-core/source/net/windows/SimpleUDP.cpp
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-#include <WinSock2.h>
-#include <Ws2ipdef.h>
-#include <Ws2tcpip.h>
+#include <winsock2.h>
+#include <ws2ipdef.h>
+#include <ws2tcpip.h>
 #include <cassert>
 #include <aws/core/net/SimpleUDP.h>
 #include <aws/core/utils/logging/LogMacros.h>

--- a/aws-cpp-sdk-core/source/platform/windows/FileSystem.cpp
+++ b/aws-cpp-sdk-core/source/platform/windows/FileSystem.cpp
@@ -9,9 +9,11 @@
 #include <aws/core/utils/StringUtils.h>
 #include <cassert>
 #include <iostream>
-#include <Userenv.h>
+#include <userenv.h>
 
+#ifdef _MSC_VER
 #pragma warning( disable : 4996)
+#endif
 
 using namespace Aws::Utils;
 namespace Aws

--- a/aws-cpp-sdk-core/source/platform/windows/OSVersionInfo.cpp
+++ b/aws-cpp-sdk-core/source/platform/windows/OSVersionInfo.cpp
@@ -9,7 +9,9 @@
 
 #include <iomanip>
 
+#ifdef _MSC_VER
 #pragma warning(disable: 4996)
+#endif
 #include <windows.h>
 #include <stdio.h>
 namespace Aws

--- a/aws-cpp-sdk-core/source/utils/Document.cpp
+++ b/aws-cpp-sdk-core/source/utils/Document.cpp
@@ -11,6 +11,10 @@
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/json/JsonSerializer.h>
 
+#ifdef GetObject
+#undef GetObject
+#endif
+
 using namespace Aws::Utils;
 
 Document::Document() : m_wasParseSuccessful(true)

--- a/aws-cpp-sdk-core/source/utils/StringUtils.cpp
+++ b/aws-cpp-sdk-core/source/utils/StringUtils.cpp
@@ -14,7 +14,7 @@
 #include <functional>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 using namespace Aws::Utils;

--- a/aws-cpp-sdk-core/source/utils/crypto/factory/Factories.cpp
+++ b/aws-cpp-sdk-core/source/utils/crypto/factory/Factories.cpp
@@ -868,7 +868,7 @@ std::shared_ptr<Aws::Utils::Crypto::HMAC> Aws::Utils::Crypto::CreateSha256HMACIm
     return GetSha256HMACFactory()->CreateImplementation();
 }
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #pragma warning( push )
 #pragma warning( disable : 4702 )
 #endif
@@ -961,7 +961,7 @@ std::shared_ptr<SymmetricCipher> Aws::Utils::Crypto::CreateAES_KeyWrapImplementa
     return GetAES_KeyWrapFactory()->CreateImplementation(key);
 }
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 

--- a/aws-cpp-sdk-core/source/utils/json/JsonSerializer.cpp
+++ b/aws-cpp-sdk-core/source/utils/json/JsonSerializer.cpp
@@ -11,6 +11,10 @@
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/Document.h>
 
+#ifdef GetObject
+#undef GetObject
+#endif
+
 using namespace Aws::Utils;
 using namespace Aws::Utils::Json;
 

--- a/aws-cpp-sdk-text-to-speech/include/aws/text-to-speech/windows/WaveOutPCMOutputDriver.h
+++ b/aws-cpp-sdk-text-to-speech/include/aws/text-to-speech/windows/WaveOutPCMOutputDriver.h
@@ -10,7 +10,7 @@
 
 #include <mutex>
 
-#include <Windows.h>
+#include <windows.h>
 
 namespace Aws
 {

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -31,11 +31,12 @@ function(set_compiler_warnings target)
     endif()
 endfunction()
 
+check_c_compiler_flag(-fPIC HAS_FPIC_FLAG)
 
 macro(set_gcc_flags)
     list(APPEND AWS_COMPILER_FLAGS "-fno-exceptions" "-std=c++${CPP_STANDARD}")
 
-    if(NOT BUILD_SHARED_LIBS)
+    if(NOT BUILD_SHARED_LIBS AND HAS_FPIC_FLAG)
         list(APPEND AWS_COMPILER_FLAGS "-fPIC")
     endif()
 


### PR DESCRIPTION
Allow compile s3-crt on Mingw-w64 toolchain:

- Changed case of Windows headers to lower case
- Added undefine WinAPI defines for "interface", "GetObject", "ERROR"
- removed -fPIC compiler option for Windows
- Replaced _WIN32 to _MSC_VER or viceversa when needed
