### PR TITLE
Fix CurlHandleContainer/StlAllocator crash on shutdown

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/utils/ResourceManager.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/ResourceManager.h
@@ -96,7 +96,6 @@ namespace Aws
              */
             Aws::Vector<RESOURCE_TYPE> ShutdownAndWait(size_t resourceCount)
             {
-                Aws::Vector<RESOURCE_TYPE> resources;
                 std::unique_lock<std::mutex> locker(m_queueLock);
                 m_shutdown = true;
 
@@ -106,9 +105,7 @@ namespace Aws
                     m_semaphore.wait(locker, [&]() { return m_resources.size() == resourceCount; });
                 }
 
-                resources = m_resources;
-                m_resources.clear();
-
+                Aws::Vector<RESOURCE_TYPE> resources{std::move(m_resources)};
                 return resources;
             }
 


### PR DESCRIPTION
This fixes #1833 (as per details in the issue).

*Description of changes:*
Use `move` construction rather than copy-assignment, since the allocator of `resources` may be `NULL` at shutdown.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
  Verified with my existing setup that this fixes the race condition on shutdown.
  A unit test specifically for this condition would be complex, since problem depends on sequence of events (see #1833).
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.