### PR TITLE
Convert 2 log messages WARN->INFO

### DIFF
--- a/aws-cpp-sdk-core/source/auth/STSCredentialsProvider.cpp
+++ b/aws-cpp-sdk-core/source/auth/STSCredentialsProvider.cpp
@@ -59,7 +59,7 @@ STSAssumeRoleWebIdentityCredentialsProvider::STSAssumeRoleWebIdentityCredentials
 
     if (m_tokenFile.empty())
     {
-        AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Token file must be specified to use STS AssumeRole web identity creds provider.");
+        AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Token file must be specified to use STS AssumeRole web identity creds provider.");
         return; // No need to do further constructing
     }
     else
@@ -69,7 +69,7 @@ STSAssumeRoleWebIdentityCredentialsProvider::STSAssumeRoleWebIdentityCredentials
 
     if (m_roleArn.empty())
     {
-        AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "RoleArn must be specified to use STS AssumeRole web identity creds provider.");
+        AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "RoleArn must be specified to use STS AssumeRole web identity creds provider.");
         return; // No need to do further constructing
     }
     else


### PR DESCRIPTION
As far as I can tell `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` are optional, so I don't think it's appropriate to log those as WARN, as that implies something has gone wrong.

My motivation at creating this PR is that my logs are getting filled with warning messages like:
`WARNING: Token file must be specified to use STS AssumeRole web identity creds provider.`

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
