### PR TITLE
Fix warnings with old gcc compilers

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/client/AWSError.h
+++ b/aws-cpp-sdk-core/include/aws/core/client/AWSError.h
@@ -92,7 +92,7 @@ namespace Aws
             /**
              * Move assignment operator
              */
-            AWSError& operator=(AWSError<ERROR_TYPE>&& other) = default;
+            AWSError& operator=(AWSError<ERROR_TYPE>&&) = default;
 
             /**
              * Gets underlying errorType.


### PR DESCRIPTION
*Description of changes:*
Fix warnings with old gcc compiler(s)
```
/usr/bin/g++ --version
g++ (GCC) 4.8.5 20150623 (Red Hat 4.8.5-28)


[ 88%] Building CXX object aws-cpp-sdk-core/CMakeFiles/aws-cpp-sdk-core.dir/ub_core.cpp.o
cd /ws/skamath/del/dd/ccl/ccl/deps/aws-sdk-cpp/build/aws-cpp-sdk-core && /usr/bin/c++ -DAWS_MQTT_WITH_WEBSOCKETS -DAWS_SDK_VERSION_MAJOR=1 -DAWS_SDK_VERSION_MINOR=9 -DAWS_SDK_VERSION_PATCH=166 -DAWS_USE_EPOLL -DENABLE_CURL_CLIENT -DENABLE_CURL_LOGGING -DENABLE_OPENSSL_ENCRYPTION -DHAS_PATHCONF -DHAS_UMASK -DPLATFORM_LINUX -Daws_cpp_sdk_core_EXPORTS @CMakeFiles/aws-cpp-sdk-core.dir/includes_CXX.rsp -O3 -DNDEBUG -fPIC -fno-exceptions -std=c++11 -Wall -Werror -pedantic -Wextra -DS2N_SIKE_P434_R3_ASM -DS2N_BIKE_R3_AVX2 -DS2N_BIKE_R3_PCLMUL -DS2N_KYBER512R3_AVX2_BMI2 -DS2N_ADX -DS2N_HAVE_EXECINFO -DS2N_CPUID_AVAILABLE -fPIC -DS2N___RESTRICT__SUPPORTED -pthread -o CMakeFiles/aws-cpp-sdk-core.dir/ub_core.cpp.o -c /ws/skamath/del/dd/ccl/ccl/deps/aws-sdk-cpp/build/aws-cpp-sdk-core/ub_core.cpp
In file included from /ws/skamath/del/dd/ccl/ccl/deps/aws-sdk-cpp/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp:17:0,
                 from /ws/skamath/del/dd/ccl/ccl/deps/aws-sdk-cpp/build/aws-cpp-sdk-core/ub_core.cpp:4:
/ws/skamath/del/dd/ccl/ccl/deps/aws-sdk-cpp/aws-cpp-sdk-core/include/aws/core/client/AWSError.h:41:15: error: unused parameter ‘other’ [-Werror=unused-parameter]
         class AWSError
               ^
In file included from /ws/skamath/del/dd/ccl/ccl/deps/aws-sdk-cpp/build/aws-cpp-sdk-core/ub_core.cpp:8:0:
/ws/skamath/del/dd/ccl/ccl/deps/aws-sdk-cpp/aws-cpp-sdk-core/source/client/AWSClient.cpp: In member function ‘virtual Aws::Client::AWSError<Aws::Client::CoreErrors> Aws::Client::AWSJsonClient::BuildAWSError(const std::shared_ptr<Aws::Http::HttpResponse>&) const’:
/ws/skamath/del/dd/ccl/ccl/deps/aws-sdk-cpp/aws-cpp-sdk-core/source/client/AWSClient.cpp:1010:15: note: synthesized method ‘Aws::Client::AWSError<ERROR_TYPE>& Aws::Client::AWSError<ERROR_TYPE>::operator=(Aws::Client::AWSError<ERROR_TYPE>&&) [with ERROR_TYPE = Aws::Client::CoreErrors]’ first required here
         error = AWSError<CoreErrors>(httpResponse->GetClientErrorType(), "", httpResponse->GetClientErrorMessage(), retryable);
               ^
cc1plus: all warnings being treated as errors
```
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
