### PR TITLE
Fix crashes in S3 CRT GetObjectAsync / PutObjectAsync

### DIFF
--- a/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
+++ b/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
@@ -11322,8 +11322,9 @@ namespace Aws
 
         struct CrtRequestCallbackUserData {
           const S3CrtClient *s3CrtClient;
-          const void *userCallback;
-          std::shared_ptr<const Aws::Client::AsyncCallerContext> userCallbackContext;
+          GetObjectResponseReceivedHandler getResponseHandler;
+          PutObjectResponseReceivedHandler putResponseHandler;
+          std::shared_ptr<const Aws::Client::AsyncCallerContext> asyncCallerContext;
           const Aws::AmazonWebServiceRequest *originalRequest;
           std::shared_ptr<Aws::Http::HttpRequest> request;
           std::shared_ptr<Aws::Http::HttpResponse> response;

--- a/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -458,8 +458,7 @@ static void GetObjectRequestShutdownCallback(void *user_data)
   auto *userData = static_cast<S3CrtClient::CrtRequestCallbackUserData*>(user_data);
   // call user callback and release user_data
   S3Crt::Model::GetObjectOutcome outcome(userData->s3CrtClient->GenerateStreamOutcome(userData->response));
-  auto handler = static_cast<const GetObjectResponseReceivedHandler*>(userData->userCallback);
-  (*handler)(userData->s3CrtClient, *(reinterpret_cast<const GetObjectRequest*>(userData->originalRequest)), std::move(outcome), userData->userCallbackContext);
+  userData->getResponseHandler(userData->s3CrtClient, *(reinterpret_cast<const GetObjectRequest*>(userData->originalRequest)), std::move(outcome), userData->asyncCallerContext);
 
   Aws::Delete(userData);
 }
@@ -489,8 +488,8 @@ void S3CrtClient::GetObjectAsync(const GetObjectRequest& request, const GetObjec
   aws_s3_meta_request_options options;
   AWS_ZERO_STRUCT(options);
 
-  userData->userCallback = static_cast<const void*>(&handler);
-  userData->userCallbackContext = context;
+  userData->getResponseHandler = handler;
+  userData->asyncCallerContext = context;
   InitCommonCrtRequestOption(userData, &options, &request, uri, Aws::Http::HttpMethod::HTTP_GET);
   options.shutdown_callback = GetObjectRequestShutdownCallback;
   options.type = AWS_S3_META_REQUEST_TYPE_GET_OBJECT;
@@ -526,8 +525,7 @@ static void PutObjectRequestShutdownCallback(void *user_data)
   auto *userData = static_cast<S3CrtClient::CrtRequestCallbackUserData*>(user_data);
   // call user callback and release user_data
   S3Crt::Model::PutObjectOutcome outcome(userData->s3CrtClient->GenerateXmlOutcome(userData->response));
-  auto handler = static_cast<const PutObjectResponseReceivedHandler*>(userData->userCallback);
-  (*handler)(userData->s3CrtClient, *(reinterpret_cast<const PutObjectRequest*>(userData->originalRequest)), std::move(outcome), userData->userCallbackContext);
+  userData->putResponseHandler(userData->s3CrtClient, *(reinterpret_cast<const PutObjectRequest*>(userData->originalRequest)), std::move(outcome), userData->asyncCallerContext);
 
   Aws::Delete(userData);
 }
@@ -557,8 +555,8 @@ void S3CrtClient::PutObjectAsync(const PutObjectRequest& request, const PutObjec
   aws_s3_meta_request_options options;
   AWS_ZERO_STRUCT(options);
 
-  userData->userCallback = static_cast<const void*>(&handler);
-  userData->userCallbackContext = context;
+  userData->putResponseHandler = handler;
+  userData->asyncCallerContext = context;
   InitCommonCrtRequestOption(userData, &options, &request, uri, Aws::Http::HttpMethod::HTTP_PUT);
   options.shutdown_callback = PutObjectRequestShutdownCallback;
   options.type = AWS_S3_META_REQUEST_TYPE_PUT_OBJECT;


### PR DESCRIPTION
_This fixes undefined behaviour in `Get/PutObjecAsync` which results in crashes and program termination._

*Issue #, if available:*
Resolves #1655.

*Description of changes:*

The `Get/PutObjectAsync` methods use const-references to `std::function` as callbacks:
```c++
typedef std::function<void(const S3CrtClient*, const Model::GetObjectRequest&, Model::GetObjectOutcome, const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) > GetObjectResponseReceivedHandler;
typedef std::function<void(const S3CrtClient*, const Model::PutObjectRequest&, const Model::PutObjectOutcome&, const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) > PutObjectResponseReceivedHandler;

void S3CrtClient::GetObjectAsync(const GetObjectRequest& request, const GetObjectResponseReceivedHandler& handler, const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context) const;
void S3CrtClient::PutObjectAsync(const PutObjectRequest& request, const PutObjectResponseReceivedHandler& handler, const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context) const;
```
The _address_ of these const references is taken and later dereferenced (the `PutObjectAsync` path is similar):
```c++
// S3Client.h:
        struct CrtRequestCallbackUserData {
          const S3CrtClient *s3CrtClient;
          const void *userCallback;  // <== HERE
          // ...
   };

// S3CrtClient.cpp:
  CrtRequestCallbackUserData *userData = Aws::New<CrtRequestCallbackUserData>(ALLOCATION_TAG);
  // ...
  userData->userCallback = static_cast<const void*>(&handler);
```
By the time the `userCallback` is executed within `GetObjectRequestShutdownCallback`, the `handler` object is out of scope, since the `GetObjectAsync` function returns quickly. The _address_ now points to a destructed `std::function` object.

### Fix
Rather than taking the address of a (temporary) object and risk its destruction, copy-construct the handlers within `CrtRequestCallbackUserData` to ensure that the required `std::function` objects are still alive when the shutdown callbacks get called.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
  Tested behaviour manually, using the code in #1655 and a similar local application. Please see below for more details.
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
