### PR TITLE
Export part state class for windows dlls

### DIFF
--- a/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
@@ -44,7 +44,7 @@ namespace Aws
             // TBI: controls for in-memory parts vs. resumable file-based parts with state serialization to/from file
         };
 
-        class PartState
+        class AWS_TRANSFER_API PartState
         {
             public:
                 PartState();


### PR DESCRIPTION
Adding export target for part state class so that it can be reference outside of the transfer handle class on windows.

*Issue #, if available:*
Resolves [#1879](https://github.com/aws/aws-sdk-cpp/issues/1879)

*Description of changes:*

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
      No tests were added because it's only an added export.
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
