### PR TITLE
S3 Crt ClientConfiguration: expose Aws::Client::ClientConfiguration

### DIFF
--- a/aws-cpp-sdk-s3-crt/include/aws/s3-crt/ClientConfiguration.h
+++ b/aws-cpp-sdk-s3-crt/include/aws/s3-crt/ClientConfiguration.h
@@ -19,16 +19,9 @@ namespace Aws
     {
         struct AWS_S3CRT_API ClientConfiguration : Aws::Client::ClientConfiguration
         {
-            ClientConfiguration() :
+            ClientConfiguration() : Aws::Client::ClientConfiguration(),
                 partSize(5 * 1024 * 1024),
-                throughputTargetGbps(2.0)
-            {
-                /* Parent configuration settings: */
-                region = Aws::Region::US_EAST_1;
-                useDualStack = false;
-                enableHostPrefixInjection = true;
-                scheme = Aws::Http::Scheme::HTTPS;
-            }
+                throughputTargetGbps(2.0) {}
 
             /** Client bootstrap used for common staples such as event loop group, host resolver, etc..
              *  If this is nullptr, SDK will create a default one for you.

--- a/aws-cpp-sdk-s3-crt/include/aws/s3-crt/ClientConfiguration.h
+++ b/aws-cpp-sdk-s3-crt/include/aws/s3-crt/ClientConfiguration.h
@@ -17,42 +17,18 @@ namespace Aws
 {
     namespace S3Crt
     {
-        class AWS_S3CRT_API ClientConfiguration
+        struct AWS_S3CRT_API ClientConfiguration : Aws::Client::ClientConfiguration
         {
-        public:
             ClientConfiguration() :
-                region(Aws::Region::US_EAST_1),
-                useDualStack(false),
-                enableHostPrefixInjection(true),
                 partSize(5 * 1024 * 1024),
-                scheme(Aws::Http::Scheme::HTTPS),
-                throughputTargetGbps(2.0),
-                shutdownCallbackUserData(nullptr)
-            {};
-
-            /* Region that the S3 bucket lives in. */
-            Aws::String region;
-
-            /* Config Profile Name for Service specific config*/
-            Aws::String profileName;
-
-            /* Customized endpoint. */
-            Aws::String endpointOverride;
-
-            /* Use dual stack*/
-            bool useDualStack;
-
-            /**
-            * Threading Executor implementation. Default uses std::thread::detach()
-            */
-            std::shared_ptr<Aws::Utils::Threading::Executor> executor;
-
-            /**
-             * Enable host prefix injection.
-             * For services whose endpoint is injectable. e.g. servicediscovery, you can modify the http host's prefix so as to add "data-" prefix for DiscoverInstances request.
-             * Default to true, enabled. You can disable it for testing purpose.
-             */
-            bool enableHostPrefixInjection;
+                throughputTargetGbps(2.0)
+            {
+                /* Parent configuration settings: */
+                region = Aws::Region::US_EAST_1;
+                useDualStack = false;
+                enableHostPrefixInjection = true;
+                scheme = Aws::Http::Scheme::HTTPS;
+            }
 
             /** Client bootstrap used for common staples such as event loop group, host resolver, etc..
              *  If this is nullptr, SDK will create a default one for you.
@@ -67,7 +43,6 @@ namespace Aws
             /** TLS Options to be used for each connection.
              *  If scheme is Https and tlsConnectionOptions is null, SDK will create a default one for you.
              */
-            Aws::Http::Scheme scheme;
             std::shared_ptr<Aws::Crt::Io::TlsConnectionOptions> tlsConnectionOptions;
 
             /* Throughput target in Gbps that we are trying to reach. Normally it's the NIC's throughput */
@@ -75,20 +50,7 @@ namespace Aws
 
             /* Callback and associated user data for when the client has completed its shutdown process. */
             std::function<void(void*)> clientShutdownCallback;
-            void *shutdownCallbackUserData;
-
-            operator Aws::Client::ClientConfiguration() const
-            {
-                Aws::Client::ClientConfiguration config;
-                config.region = region;
-                config.profileName = profileName;
-                config.endpointOverride = endpointOverride;
-                config.useDualStack = useDualStack;
-                config.executor = executor;
-                config.enableHostPrefixInjection = enableHostPrefixInjection;
-                config.scheme = scheme;
-                return config;
-            }
+            void *shutdownCallbackUserData = nullptr;
         };
     }
 }


### PR DESCRIPTION
Since the S3CrtClient is a sub-class of the AwsClient, expose the
configuration needed by the parent class.

Many API calls use the parent class, so preserving user configurations is important. 

This now uses slicing instead of a conversion operator, so that the
parent struct only sees the value relevant to it.

Since it initializes the base struct first, this also addresses #1768.

*Issue #, if available:*
Fixes #1882, #1768 and #1654.

*Description of changes:*

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
       Tested with large application in our repo
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
