### PR TITLE
Moving generated libraries to generated directory

### DIFF
--- a/cmake_legacy/dependencies.cmake
+++ b/cmake_legacy/dependencies.cmake
@@ -50,7 +50,7 @@ endfunction()
 #
 # Uses selection sort (stable).
 function(sort_links targets_list)
-    # Special case of empty input list. Futher code assumes list to be non-empty.
+    # Special case of empty input list. Further code assumes list to be non-empty.
     if(NOT ${targets_list})
         return()
     endif()

--- a/cmake_legacy/legacy_main.cmake
+++ b/cmake_legacy/legacy_main.cmake
@@ -98,7 +98,7 @@ set(PYTHON_CMD "python")
 # CMAKE_MODULE_PATH is a CMAKE variable. It contains a list of paths
 # which could be used to search CMAKE modules by "include()" or "find_package()", but the default value is empty.
 # Add ${CMAKE_INSTALL_LIBDIR}/cmake and ${CMAKE_PREFIX_PATH}/lib/cmake to search list
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake_legacy")
 set(AWS_MODULE_DIR "/${CMAKE_INSTALL_LIBDIR}/cmake")
 string(REPLACE ";" "${AWS_MODULE_DIR};" AWS_MODULE_PATH "${CMAKE_PREFIX_PATH}${AWS_MODULE_DIR}")
 list(APPEND CMAKE_MODULE_PATH ${AWS_MODULE_PATH})

--- a/cmake_legacy/setup_cmake_find_module.cmake
+++ b/cmake_legacy/setup_cmake_find_module.cmake
@@ -59,7 +59,7 @@ install(
 
 # copy all cmake files to destination, these files include useful macros, functions and variables for users.
 # useful macros and variables will be included in this cmake file for user to use
-install(DIRECTORY "${AWS_NATIVE_SDK_ROOT}/cmake/" DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}")
+install(DIRECTORY "${AWS_NATIVE_SDK_ROOT}/cmake_legacy/" DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}")
 
 # following two files are vital for cmake to find correct package, but since we copied all files from above
 # we left the code here to give you bettern understanding


### PR DESCRIPTION
*Issue #, if available:* 1888

*Description of changes:*
- Moved generated code to generated directory
- modified legacy codebase to generate, build, and install using the new location for generated code

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
Manually tested by running configuration, build, unit test, and install from clean environment with and without BUILD_ONLY parameter.
- [x] Checked if this PR is a breaking (APIs have been changed) change.
No an API breaking changing, but forces upgrade of CMAKE for those having older than 3.12 in their toolchain. We were warning in every build about it since a year ago, and we are going to hold this from reaching main branch until version 1.10 is released.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
