### PR TITLE
Add missing includes

### DIFF
--- a/aws-cpp-sdk-cognitoidentity-integration-tests/IdentityPoolOperationTest.cpp
+++ b/aws-cpp-sdk-cognitoidentity-integration-tests/IdentityPoolOperationTest.cpp
@@ -6,6 +6,7 @@
 #include <aws/external/gtest.h>
 #include <aws/testing/MemoryTesting.h>
 #include <algorithm>
+#include <thread>
 
 #include <aws/cognito-identity/CognitoIdentityClient.h>
 #include <aws/cognito-identity/CognitoIdentityErrors.h>

--- a/aws-cpp-sdk-mediastore-data-integration-tests/MediaStoreDataTest.cpp
+++ b/aws-cpp-sdk-mediastore-data-integration-tests/MediaStoreDataTest.cpp
@@ -26,6 +26,7 @@
 #include <aws/testing/platform/PlatformTesting.h>
 #include <aws/testing/TestingEnvironment.h>
 #include <fstream>
+#include <thread>
 
 using namespace Aws;
 using namespace Aws::Utils;

--- a/aws-cpp-sdk-redshift-integration-tests/RedshiftClientTest.cpp
+++ b/aws-cpp-sdk-redshift-integration-tests/RedshiftClientTest.cpp
@@ -36,6 +36,7 @@
 #include <aws/redshift/model/DeleteSnapshotCopyGrantRequest.h>
 #include <aws/redshift/model/EnableSnapshotCopyRequest.h>
 #include <aws/redshift/model/DisableSnapshotCopyRequest.h>
+#include <thread>
 
 
 using namespace Aws::Auth;

--- a/aws-cpp-sdk-s3control-integration-tests/S3ControlTest.cpp
+++ b/aws-cpp-sdk-s3control-integration-tests/S3ControlTest.cpp
@@ -42,6 +42,7 @@
 #include <aws/cognito-identity/CognitoIdentityClient.h>
 #include <aws/sts/STSClient.h>
 #include <aws/sts/model/AssumeRoleRequest.h>
+#include <thread>
 
 using namespace Aws;
 using namespace Aws::Http;

--- a/aws-cpp-sdk-sqs-integration-tests/QueueOperationTest.cpp
+++ b/aws-cpp-sdk-sqs-integration-tests/QueueOperationTest.cpp
@@ -36,6 +36,7 @@
 #include <aws/testing/TestingEnvironment.h>
 #include <aws/core/utils/UUID.h>
 #include <aws/core/platform/Environment.h>
+#include <thread>
 
 using namespace Aws::Http;
 using namespace Aws;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds missing `#include <thread>` entries. These includes are needed due to calls to `std::this_thread::sleep_for`. Without it, the build fails on Linux.

This PR can be applied on top of PR #1912 as it adds changes to some more files.

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
