### PR TITLE
fixes build all target

### DIFF
--- a/cmake_legacy/sdks.cmake
+++ b/cmake_legacy/sdks.cmake
@@ -55,7 +55,7 @@ else()
         set(REMOVE_SDK 0)
 
         if(SDK STREQUAL "core")
-            set(SDK_DIR "aws-cpp-sdk-${SDK}")
+            set(SDK_DIR "src/aws-cpp-sdk-${SDK}")
         else()
             set(SDK_DIR "generated/aws-cpp-sdk-${SDK}")
         endif()

--- a/cmake_legacy/sdksCommon.cmake
+++ b/cmake_legacy/sdksCommon.cmake
@@ -72,7 +72,7 @@ endfunction()
 # services have the name format abc.def.ghi will be renamed to ghi-def-abc (dot will not be accepted as Windows directory name )
 # and put into C2J_SPECIAL_NAME_LIST, but rumtime.lex will be renamed to lex based on historical reason.
 function(build_sdk_list)
-    file(GLOB ALL_MODEL_FILES "${CMAKE_CURRENT_SOURCE_DIR}/code-generation/api-descriptions/*-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].normal.json")
+    file(GLOB ALL_MODEL_FILES "${CMAKE_CURRENT_SOURCE_DIR}/tools/code-generation/api-descriptions/*-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].normal.json")
     foreach(model IN LISTS ALL_MODEL_FILES)
         get_filename_component(modelName "${model}" NAME)
         STRING(REGEX MATCH "([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])" date "${modelName}")


### PR DESCRIPTION
*Description of changes:*

Cmake refactor broke the build all target for default builds, This fixes it.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
