### PR TITLE
Add an option to fix non-compliant RFC3986 encoding.

### DIFF
--- a/aws-cpp-sdk-core-tests/http/URITest.cpp
+++ b/aws-cpp-sdk-core-tests/http/URITest.cpp
@@ -281,7 +281,20 @@ TEST(URITest, TestParseWithColon)
     EXPECT_EQ(80, complexUri.GetPort());
     EXPECT_STREQ("/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject:1234/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject:Key", complexUri.GetPath().c_str());
     EXPECT_STREQ(strComplexUri, complexUri.GetURIString().c_str());
+}
 
+TEST(URITest, TestParseWithColonCompliant)
+{
+    Aws::Http::SetCompliantRfc3986Encoding(true);
+    const char* strComplexUri = "http://s3.us-east-1.amazonaws.com/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject:1234/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject:Key";
+    URI complexUri(strComplexUri);
+    const char* compliantStrComplexUri = "http://s3.us-east-1.amazonaws.com/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject%3A1234/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject%3AKey";
+    EXPECT_EQ(Scheme::HTTP, complexUri.GetScheme());
+    EXPECT_STREQ("s3.us-east-1.amazonaws.com", complexUri.GetAuthority().c_str());
+    EXPECT_EQ(80, complexUri.GetPort());
+    EXPECT_STREQ("/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject:1234/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject:Key", complexUri.GetPath().c_str());
+    EXPECT_STREQ(compliantStrComplexUri, complexUri.GetURIString().c_str());
+    Aws::Http::SetCompliantRfc3986Encoding(false);
 }
 
 TEST(URITest, TestGetURLEncodedPath)
@@ -327,4 +340,32 @@ TEST(URITest, TestGetRFC3986URLEncodedPath)
 
     uri = "https://test.com/segment+other/b;jsession=1";
     EXPECT_STREQ("/segment%2Bother/b%3Bjsession=1", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
+}
+
+TEST(URITest, TestGetRFC3986URLEncodedPathCompliant)
+{
+    Aws::Http::SetCompliantRfc3986Encoding(true);
+
+    URI uri = "https://test.com/path/1234/";
+    EXPECT_STREQ("/path/1234/", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
+
+    uri = "https://test.com/path/$omething";
+    EXPECT_STREQ("/path/%24omething", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
+
+    uri = "https://test.com/path/$omethingel$e";
+    EXPECT_STREQ("/path/%24omethingel%24e", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
+
+    uri = "https://test.com/path/~something.an0ther";
+    EXPECT_STREQ("/path/~something.an0ther", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
+
+    uri = "https://test.com/path/~something?an0ther";
+    EXPECT_STREQ("/path/~something", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
+
+    uri = "https://test.com/ሴ";
+    EXPECT_STREQ("/%E1%88%B4", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
+
+    uri = "https://test.com/segment+other/b;jsession=1";
+    EXPECT_STREQ("/segment%2Bother/b%3Bjsession%3D1", URI::URLEncodePathRFC3986(uri.GetPath()).c_str());
+
+    Aws::Http::SetCompliantRfc3986Encoding(false);
 }

--- a/aws-cpp-sdk-core/include/aws/core/Aws.h
+++ b/aws-cpp-sdk-core/include/aws/core/Aws.h
@@ -80,7 +80,7 @@ namespace Aws
      */
     struct HttpOptions
     {
-        HttpOptions() : initAndCleanupCurl(true), installSigPipeHandler(false)
+        HttpOptions() : initAndCleanupCurl(true), installSigPipeHandler(false), compliantRfc3986Encoding(false)
         { }
 
         /**
@@ -100,6 +100,10 @@ namespace Aws
          * NOTE: CURLOPT_NOSIGNAL is already being set.
          */
         bool installSigPipeHandler;
+        /**
+         * Disable legacy URL encoding that leaves `$&,:@=` unescaped for legacy purposes.
+         */
+        bool compliantRfc3986Encoding;
     };
 
     /**

--- a/aws-cpp-sdk-core/include/aws/core/http/URI.h
+++ b/aws-cpp-sdk-core/include/aws/core/http/URI.h
@@ -21,6 +21,9 @@ namespace Aws
         static const uint16_t HTTP_DEFAULT_PORT = 80;
         static const uint16_t HTTPS_DEFAULT_PORT = 443;
 
+        static bool s_compliantRfc3986Encoding = false;
+        AWS_CORE_API void SetCompliantRfc3986Encoding(bool compliant);
+
         //per https://tools.ietf.org/html/rfc3986#section-3.4 there is nothing preventing servers from allowing
         //multiple values for the same key. So use a multimap instead of a map.
         typedef Aws::MultiMap<Aws::String, Aws::String> QueryStringParameterCollection;

--- a/aws-cpp-sdk-core/source/Aws.cpp
+++ b/aws-cpp-sdk-core/source/Aws.cpp
@@ -136,6 +136,7 @@ namespace Aws
 
         Aws::Http::SetInitCleanupCurlFlag(options.httpOptions.initAndCleanupCurl);
         Aws::Http::SetInstallSigPipeHandlerFlag(options.httpOptions.installSigPipeHandler);
+        Aws::Http::SetCompliantRfc3986Encoding(options.httpOptions.compliantRfc3986Encoding);
         Aws::Http::InitHttp();
         Aws::InitializeEnumOverflowContainer();
         cJSON_AS4CPP_Hooks hooks;

--- a/aws-cpp-sdk-core/source/http/URI.cpp
+++ b/aws-cpp-sdk-core/source/http/URI.cpp
@@ -24,6 +24,47 @@ namespace Http
 
 const char* SEPARATOR = "://";
 
+void SetCompliantRfc3986Encoding(bool compliant) { s_compliantRfc3986Encoding = compliant; }
+
+Aws::String urlEncodeSegment(const Aws::String& segment)
+{
+    // consolidates legacy escaping logic into one local method
+    if (s_compliantRfc3986Encoding)
+    {
+        return StringUtils::URLEncode(segment.c_str());
+    }
+    else
+    {
+        Aws::StringStream ss;
+        ss << std::hex << std::uppercase;
+        for(unsigned char c : segment) // alnum results in UB if the value of c is not unsigned char & is not EOF
+        {
+            // RFC 3986 §2.3 unreserved characters
+            if (StringUtils::IsAlnum(c))
+            {
+                ss << c;
+                continue;
+            }
+            switch(c)
+            {
+                // §2.3 unreserved characters
+                // The path section of the URL allows unreserved characters to appear unescaped
+                case '-': case '_': case '.': case '~':
+                // RFC 3986 §2.2 Reserved characters
+                // NOTE: this implementation does not accurately implement the RFC on purpose to accommodate for
+                // discrepancies in the implementations of URL encoding between AWS services for legacy reasons.
+                case '$': case '&': case ',':
+                case ':': case '=': case '@':
+                    ss << c;
+                    break;
+                default:
+                    ss << '%' << std::setfill('0') << std::setw(2) << (int)c << std::setw(0);
+            }
+        }
+        return ss.str();
+    }
+}
+
 } // namespace Http
 } // namespace Aws
 
@@ -101,7 +142,7 @@ void URI::SetScheme(Scheme value)
 
 Aws::String URI::URLEncodePathRFC3986(const Aws::String& path)
 {
-    if(path.empty())
+    if (path.empty())
     {
         return path;
     }
@@ -113,34 +154,10 @@ Aws::String URI::URLEncodePathRFC3986(const Aws::String& path)
     // escape characters appearing in a URL path according to RFC 3986
     for (const auto& segment : pathParts)
     {
-        ss << '/';
-        for(unsigned char c : segment) // alnum results in UB if the value of c is not unsigned char & is not EOF
-        {
-            // §2.3 unreserved characters
-            if (StringUtils::IsAlnum(c))
-            {
-                ss << c;
-                continue;
-            }
-            switch(c)
-            {
-                // §2.3 unreserved characters
-                case '-': case '_': case '.': case '~':
-                // The path section of the URL allow reserved characters to appear unescaped
-                // RFC 3986 §2.2 Reserved characters
-                // NOTE: this implementation does not accurately implement the RFC on purpose to accommodate for
-                // discrepancies in the implementations of URL encoding between AWS services for legacy reasons.
-                case '$': case '&': case ',':
-                case ':': case '=': case '@':
-                    ss << c;
-                    break;
-                default:
-                    ss << '%' << std::setfill('0') << std::setw(2) << (int)((unsigned char)c) << std::setw(0);
-            }
-        }
+        ss << '/' << urlEncodeSegment(segment);
     }
 
-    //if the last character was also a slash, then add that back here.
+    // if the last character was also a slash, then add that back here.
     if (path.back() == '/')
     {
         ss << '/';
@@ -216,33 +233,10 @@ Aws::String URI::GetURLEncodedPathRFC3986() const
     ss << std::hex << std::uppercase;
 
     // escape characters appearing in a URL path according to RFC 3986
+    // (mostly; there is some non-standards legacy support that can be disabled)
     for (const auto& segment : m_pathSegments)
     {
-        ss << '/';
-        for(unsigned char c : segment) // alnum results in UB if the value of c is not unsigned char & is not EOF
-        {
-            // §2.3 unreserved characters
-            if (StringUtils::IsAlnum(c))
-            {
-                ss << c;
-                continue;
-            }
-            switch(c)
-            {
-                // §2.3 unreserved characters
-                case '-': case '_': case '.': case '~':
-                // The path section of the URL allow reserved characters to appear unescaped
-                // RFC 3986 §2.2 Reserved characters
-                // NOTE: this implementation does not accurately implement the RFC on purpose to accommodate for
-                // discrepancies in the implementations of URL encoding between AWS services for legacy reasons.
-                case '$': case '&': case ',':
-                case ':': case '=': case '@':
-                    ss << c;
-                    break;
-                default:
-                    ss << '%' << std::setfill('0') << std::setw(2) << (int)((unsigned char)c) << std::setw(0);
-            }
-        }
+        ss << '/' << urlEncodeSegment(segment);
     }
 
     if (m_pathSegments.empty() || m_pathHasTrailingSlash)

--- a/aws-cpp-sdk-s3-integration-tests/RunTests.cpp
+++ b/aws-cpp-sdk-s3-integration-tests/RunTests.cpp
@@ -9,6 +9,26 @@
 #include <aws/testing/TestingEnvironment.h>
 #include <aws/testing/MemoryTesting.h>
 
+void ParseArgs(int argc, char** argv, Aws::SDKOptions& options)
+{
+    // std::string rather than Aws::String since this happens before the memory manager is initialized
+    const std::string resourcePrefixOption = "--rfc3986_compliant=";
+    // list other options here
+    for(int i = 1; i < argc; i++)
+    {
+        std::string arg = argv[i];
+        if(arg.find(resourcePrefixOption) == 0)
+        {
+            arg = arg.substr(resourcePrefixOption.length()); // get whatever value after the '='
+            if (arg == "true" || arg == "1")
+            {
+                std::cout << "Set RFC3986 compliance mode ON." << std::endl;
+                options.httpOptions.compliantRfc3986Encoding = true;
+            }
+        }
+    }
+}
+
 int main(int argc, char** argv)
 {
     Aws::SDKOptions options;
@@ -16,6 +36,7 @@ int main(int argc, char** argv)
     AWS_BEGIN_MEMORY_TEST_EX(options, 1024, 128);
     Aws::Testing::InitPlatformTest(options);
     Aws::Testing::ParseArgs(argc, argv);
+    ParseArgs(argc, argv, options);
 
     Aws::InitAPI(options);
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
*Issue #, if available:*

This fixes #1196
This closes #1202

*Description of changes:*

Based on legacy design (see description in #1202 for one case) the SDK core URI encoder does not treat the characters `$&,:=@` as encodable.  This causes problems when using the SDK code against third party implementations of some of the AWS APIs, most notably the S3 API.

The Python SDK does not contain this legacy encoding strategy and is compatible with third party implementations.  Additionally, the Python SDK is compatible with AWS services as well, so this change is compatible all around.  To solve this in a manner which did not affect backwards compatibility, I added an opt-in HttpOption called `compliantRfc3986Encoding`.  If this option is set, or if `Aws::Http::SetCompliantRfc3986Encoding(true);` is called, the legacy behavior will be defeated.

I first added the option and refactored some duplicated code paths in URI.cpp, and ensured all the tests were still passing and no backwards compatibility issues were introduced.  Then I added test code explicitly for when this option is enabled.

I also augmented the S3 integration test to optionally set this flag (by default it does not, maintaining baseline behavior) and ran it without errors when the flag is set and without the flag set.

*Note:*

If accepted, I will need and provide a backport to the 1.8.x branch.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [X] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
