### PR TITLE
Initializing retry random seed

### DIFF
--- a/aws-cpp-sdk-core/source/client/RetryStrategy.cpp
+++ b/aws-cpp-sdk-core/source/client/RetryStrategy.cpp
@@ -22,12 +22,16 @@ namespace Aws
         StandardRetryStrategy::StandardRetryStrategy(long maxAttempts) :
             m_retryQuotaContainer(Aws::MakeShared<DefaultRetryQuotaContainer>("StandardRetryStrategy")),
             m_maxAttempts(maxAttempts)
-        {}
+        {
+          srand(time(NULL));
+        }
 
         StandardRetryStrategy::StandardRetryStrategy(std::shared_ptr<RetryQuotaContainer> retryQuotaContainer, long maxAttempts) :
             m_retryQuotaContainer(retryQuotaContainer),
             m_maxAttempts(maxAttempts)
-        {}
+        {
+          srand(time(NULL));
+        }
 
         void StandardRetryStrategy::RequestBookkeeping(const HttpResponseOutcome& httpResponseOutcome)
         {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding a call to srand in StandardRetry strategy to get the Seed set before the first call for rand on the retries. 

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
