### PR TITLE
Rely on metadata serviceId to generate the namespace

### DIFF
--- a/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
+++ b/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
@@ -9,6 +9,7 @@ import com.amazonaws.util.awsclientgenerator.domainmodels.c2j.*;
 import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.Error;
 import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.*;
 import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.cpp.CppViewHelper;
+import com.amazonaws.util.awsclientgenerator.generators.exceptions.SourceGenerationFailedException;
 import org.apache.commons.lang.WordUtils;
 
 import java.util.*;
@@ -29,12 +30,70 @@ public class C2jModelToGeneratorModelTransformer {
     String endpointOperationName;
 
     public static final HashSet<String> UNSUPPORTEDHTMLTAGS = new HashSet<>();
-
     static {
         UNSUPPORTEDHTMLTAGS.add("<note>");
         UNSUPPORTEDHTMLTAGS.add("</note>");
         UNSUPPORTEDHTMLTAGS.add("<important>");
         UNSUPPORTEDHTMLTAGS.add("</important>");
+    }
+
+    // A list of non-compliant service models that are already released, so we keep them backward-compatible.
+    public static final HashSet<String> LEGACY_SERVICE_IDS = new HashSet<>();
+    static {
+        LEGACY_SERVICE_IDS.add("amp");
+        LEGACY_SERVICE_IDS.add("appintegrations");
+        LEGACY_SERVICE_IDS.add("billingconductor");
+        LEGACY_SERVICE_IDS.add("clouddirectory");
+        LEGACY_SERVICE_IDS.add("cloudfront");
+        LEGACY_SERVICE_IDS.add("cloudsearch");
+        LEGACY_SERVICE_IDS.add("cloudsearchdomain");
+        LEGACY_SERVICE_IDS.add("codeartifact");
+        LEGACY_SERVICE_IDS.add("codestar-notifications");
+        LEGACY_SERVICE_IDS.add("config");
+        LEGACY_SERVICE_IDS.add("databrew");
+        LEGACY_SERVICE_IDS.add("ec2");
+        LEGACY_SERVICE_IDS.add("elasticache");
+        LEGACY_SERVICE_IDS.add("emr-containers");
+        LEGACY_SERVICE_IDS.add("entitlement.marketplace");
+        LEGACY_SERVICE_IDS.add("events");
+        LEGACY_SERVICE_IDS.add("evidently");
+        LEGACY_SERVICE_IDS.add("forecast");
+        LEGACY_SERVICE_IDS.add("forecastquery");
+        LEGACY_SERVICE_IDS.add("grafana");
+        LEGACY_SERVICE_IDS.add("importexport");
+        LEGACY_SERVICE_IDS.add("inspector");
+        LEGACY_SERVICE_IDS.add("lambda");
+        LEGACY_SERVICE_IDS.add("location");
+        LEGACY_SERVICE_IDS.add("lookoutvision");
+        LEGACY_SERVICE_IDS.add("m2");
+        LEGACY_SERVICE_IDS.add("migrationhubstrategy");
+        LEGACY_SERVICE_IDS.add("mobile");
+        LEGACY_SERVICE_IDS.add("mobileanalytics");
+        LEGACY_SERVICE_IDS.add("mq");
+        LEGACY_SERVICE_IDS.add("nimble");
+        LEGACY_SERVICE_IDS.add("opensearch");
+        LEGACY_SERVICE_IDS.add("rbin");
+        LEGACY_SERVICE_IDS.add("rds-data");
+        LEGACY_SERVICE_IDS.add("redshift-data");
+        LEGACY_SERVICE_IDS.add("resiliencehub");
+        LEGACY_SERVICE_IDS.add("rum");
+        LEGACY_SERVICE_IDS.add("sagemaker-a2i-runtime");
+        LEGACY_SERVICE_IDS.add("sagemaker-edge");
+        LEGACY_SERVICE_IDS.add("schemas");
+        LEGACY_SERVICE_IDS.add("sdb");
+        LEGACY_SERVICE_IDS.add("transcribe");
+        LEGACY_SERVICE_IDS.add("transcribe-streaming");
+        LEGACY_SERVICE_IDS.add("wisdom");
+
+        // remaps
+        LEGACY_SERVICE_IDS.add("lex");
+        LEGACY_SERVICE_IDS.add("lexv2-runtime");
+        LEGACY_SERVICE_IDS.add("lexv2-models");
+        LEGACY_SERVICE_IDS.add("marketplace-entitlement");
+        LEGACY_SERVICE_IDS.add("sagemaker-runtime");
+        LEGACY_SERVICE_IDS.add("awstransfer");
+        LEGACY_SERVICE_IDS.add("transcribestreaming");
+        LEGACY_SERVICE_IDS.add("dynamodbstreams");
     }
 
     public C2jModelToGeneratorModelTransformer(C2jServiceModel c2jServiceModel, boolean standalone) {
@@ -110,7 +169,6 @@ public class C2jModelToGeneratorModelTransformer {
         metadata.setApiVersion(c2jMetadata.getApiVersion());
         metadata.setConcatAPIVersion(c2jMetadata.getApiVersion().replace("-", ""));
         metadata.setSigningName(c2jMetadata.getSigningName() != null ? c2jMetadata.getSigningName() : c2jMetadata.getEndpointPrefix());
-        metadata.setServiceId(c2jMetadata.getServiceId() != null ? c2jMetadata.getServiceId() : c2jMetadata.getEndpointPrefix());
 
         metadata.setJsonVersion(c2jMetadata.getJsonVersion());
         if("api-gateway".equalsIgnoreCase(c2jMetadata.getProtocol())) {
@@ -129,10 +187,18 @@ public class C2jModelToGeneratorModelTransformer {
         metadata.setTimestampFormat(c2jMetadata.getTimestampFormat());
 
         if (metadata.getNamespace() == null || metadata.getNamespace().isEmpty()) {
-            metadata.setNamespace(sanitizeServiceAbbreviation(metadata.getServiceFullName()));
+            String serviceId = c2jMetadata.getServiceId();
+            if(LEGACY_SERVICE_IDS.contains(this.c2jServiceModel.getServiceName())) {
+                serviceId = c2jMetadata.getServiceFullName(); // fallback to full name for legacy already released models
+            }
+            if(serviceId == null || serviceId.isEmpty()) {
+                throw new SourceGenerationFailedException(String.format("Service model file %s must have metadata.serviceId present", c2jServiceModel.getServiceName()));
+            }
+            metadata.setNamespace(sanitizeServiceAbbreviation(serviceId));
         } else {
             metadata.setNamespace(sanitizeServiceAbbreviation(metadata.getNamespace()));
         }
+        metadata.setServiceId(c2jMetadata.getServiceId() != null ? c2jMetadata.getServiceId() : c2jMetadata.getEndpointPrefix());
 
         if ("S3-CRT".equalsIgnoreCase(c2jServiceModel.getServiceName())) {
             metadata.setNamespace("S3Crt");

--- a/code-generation/generator/src/test/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformerTest.java
+++ b/code-generation/generator/src/test/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformerTest.java
@@ -32,6 +32,7 @@ public class C2jModelToGeneratorModelTransformerTest {
         c2jMetadata.setServiceFullName("Amazon AWS Service Abbr Full Name");
         c2jMetadata.setSignatureVersion("v4");
         c2jMetadata.setTargetPrefix("ServiceAbbr.");
+        c2jMetadata.setServiceId("ServiceAbbr");
         c2jMetadata.setUid("service-9089-34-54");
         c2jMetadata.setTimestampFormat("iso8601");
 
@@ -55,7 +56,7 @@ public class C2jModelToGeneratorModelTransformerTest {
         assertEquals(c2jMetadata.getEndpointPrefix(), metadata.getEndpointPrefix());
         assertEquals(c2jMetadata.getJsonVersion(), metadata.getJsonVersion());
         assertEquals(c2jMetadata.getProtocol(), metadata.getProtocol());
-        assertEquals("ServiceAbbrFullName", metadata.getNamespace());
+        assertEquals("ServiceAbbr", metadata.getNamespace());
         assertEquals(c2jMetadata.getServiceFullName(), metadata.getServiceFullName());
         assertEquals(c2jMetadata.getSignatureVersion(), metadata.getSignatureVersion());
         assertEquals(c2jMetadata.getTargetPrefix(), metadata.getTargetPrefix());


### PR DESCRIPTION
*Issue #, if available:*
Namespace got screwed up for a new service model
*Description of changes:*
Use metadata.serviceId to generate service client namespace.
Validated by running code gen for all clients.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
