### PR TITLE
Fixes warning of potential data loss.

### DIFF
--- a/aws-cpp-sdk-core/source/client/RetryStrategy.cpp
+++ b/aws-cpp-sdk-core/source/client/RetryStrategy.cpp
@@ -23,14 +23,14 @@ namespace Aws
             m_retryQuotaContainer(Aws::MakeShared<DefaultRetryQuotaContainer>("StandardRetryStrategy")),
             m_maxAttempts(maxAttempts)
         {
-          srand(time(NULL));
+          srand((unsigned int)time(NULL));
         }
 
         StandardRetryStrategy::StandardRetryStrategy(std::shared_ptr<RetryQuotaContainer> retryQuotaContainer, long maxAttempts) :
             m_retryQuotaContainer(retryQuotaContainer),
             m_maxAttempts(maxAttempts)
         {
-          srand(time(NULL));
+          srand((unsigned int)time(NULL));
         }
 
         void StandardRetryStrategy::RequestBookkeeping(const HttpResponseOutcome& httpResponseOutcome)


### PR DESCRIPTION
*Description of changes:*

Build fails on windows for the warning

```
warning C4244: 'argument': conversion from 'time_t' to 'unsigned int', possible loss of data [C:\codebuild\tmp\output\src522492691\src\build\aws-cpp-sdk-core\aws-cpp-sdk-core.vcxproj]
```

This fixes the build by casting it as described [here](https://stackoverflow.com/questions/9246536/warning-c4244-argument-conversion-from-time-t-to-unsigned-int-possible)

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
