### PR TITLE
Use a more unique ID for tests

### DIFF
--- a/scripts/run_integration_tests.py
+++ b/scripts/run_integration_tests.py
@@ -7,6 +7,7 @@ import stat
 import subprocess
 import platform
 import random
+import string
 
 def ParseArguments():
     argMap = {}
@@ -56,7 +57,7 @@ def Main():
         if not os.path.isfile(test_exe):
             print("Test: \"{}\" doesn't exist, skipped.".format(test_exe))
             continue
-        prefix = "--aws_resource_prefix=" + platform.system().lower()
+        prefix = "--aws_resource_prefix=" + ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(8))
         print("testExe = " + test_exe)
         print("prefix = " + prefix)
         AddExecutableBit(test_exe)


### PR DESCRIPTION
*Description of changes:*

Integration tests run with conflicting unique prefix id's. This changes them to be random causing less conflicts during CI/CD

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
