### PR TITLE
Fixes Enum Codegen Edgecase.

### DIFF
--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/EnumSource.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/EnumSource.vm
@@ -96,7 +96,7 @@ namespace ${rootNamespace}
           return ${enumModel.name}::NOT_SET;
 #else
 #set($elseText = "")
-#set($maxHelperIndex = $enumModel.members.size() / 122)
+#set($maxHelperIndex = ($enumModel.members.size() - 1) / 122)
           ${enumModel.name} enumValue;
 #foreach($helperIndex in [0..$maxHelperIndex])
           ${elseText}if (GetEnumForNameHelper${helperIndex}(hashCode, enumValue))
@@ -135,7 +135,7 @@ namespace ${rootNamespace}
             return {};
           }
 #else
-#set($maxHelperIndex = $enumModel.members.size() / 122)
+#set($maxHelperIndex = ($enumModel.members.size() - 1) / 122)
           Aws::String value;
 #set($elseText = "")
 #foreach($helperIndex in [0..$maxHelperIndex])


### PR DESCRIPTION
*Description of changes:*

There is an edge case in code generation where if a service model has exactly 122 enums the logic in how we break up helper methods for visual studio compiler limits breaks. This will fix the edge case. I tested by regenerating the code from the model that was causing failures.

The compared diff between before and after shows nothing except difference in the crt:
```
$diff -r -x .git -x target -x build src dst
Only in src: .attach_pid10558
Only in src: .attach_pid17069
Only in dst: .attach_pid19353
Only in src: .attach_pid23166
Only in src: .attach_pid23738
Only in src: .attach_pid25190
Only in dst: .attach_pid30061
Only in src: .attach_pid4747
Only in dst: .attach_pid662
diff -r -x .git -x target -x build src/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/EnumSource.vm dst/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/EnumSource.vm
99c99
< #set($maxHelperIndex = $enumModel.members.size() / 122)
---
> #set($maxHelperIndex = ($enumModel.members.size() - 1) / 122)
138c138
< #set($maxHelperIndex = $enumModel.members.size() / 122)
---
> #set($maxHelperIndex = ($enumModel.members.size() - 1) / 122)
diff: src/crt/aws-crt-cpp/crt/aws-c-common/verification/cbmc/proofs/prepare.py: No such file or directory
diff: dst/crt/aws-crt-cpp/crt/aws-c-common/verification/cbmc/proofs/prepare.py: No such file or directory
diff -r -x .git -x target -x build src/crt/aws-crt-cpp/include/aws/crt/Config.h dst/crt/aws-crt-cpp/include/aws/crt/Config.h
6c6
< #define AWS_CRT_CPP_VERSION "1.9.287-1-g9c059110e0"
---
> #define AWS_CRT_CPP_VERSION "1.9.287-2-g77341e2ce6"
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
