### PR TITLE
Fix EventStream code to work with latest version of aws-c-event-stream

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/utils/event/EventStreamEncoder.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/event/EventStreamEncoder.h
@@ -41,8 +41,8 @@ namespace Aws
                  */
                 Aws::Vector<unsigned char> EncodeAndSign(const Aws::Utils::Event::Message& msg);
             private:
-                aws_event_stream_message Encode(const Aws::Utils::Event::Message& msg);
-                aws_event_stream_message Sign(aws_event_stream_message* msg);
+                bool Encode(aws_event_stream_message* dstMsg, const Aws::Utils::Event::Message& srcMsg);
+                bool Sign(aws_event_stream_message* dstMsg, const aws_event_stream_message* srcMsg);
                 Aws::Client::AWSAuthSigner* m_signer;
                 Aws::String m_signatureSeed;
             };

--- a/aws-cpp-sdk-core/include/aws/core/utils/event/EventStreamEncoder.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/event/EventStreamEncoder.h
@@ -41,8 +41,8 @@ namespace Aws
                  */
                 Aws::Vector<unsigned char> EncodeAndSign(const Aws::Utils::Event::Message& msg);
             private:
-                bool Encode(aws_event_stream_message* dstMsg, const Aws::Utils::Event::Message& srcMsg);
-                bool Sign(aws_event_stream_message* dstMsg, const aws_event_stream_message* srcMsg);
+                bool Encode(aws_event_stream_message* encoded, const Aws::Utils::Event::Message& msg);
+                bool Sign(aws_event_stream_message* signedmsg, const aws_event_stream_message* msg);
                 Aws::Client::AWSAuthSigner* m_signer;
                 Aws::String m_signatureSeed;
             };

--- a/aws-cpp-sdk-core/include/aws/core/utils/event/EventStreamEncoder.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/event/EventStreamEncoder.h
@@ -41,8 +41,20 @@ namespace Aws
                  */
                 Aws::Vector<unsigned char> EncodeAndSign(const Aws::Utils::Event::Message& msg);
             private:
-                bool Encode(aws_event_stream_message* encoded, const Aws::Utils::Event::Message& msg);
-                bool Sign(aws_event_stream_message* signedmsg, const aws_event_stream_message* msg);
+                /**
+                 * Initialize C struct based on C++ object.
+                 * Returns true if successful.
+                 * A successfully initialized struct must be cleaned up when you're done with it.
+                 */
+                bool InitEncodedStruct(const Aws::Utils::Event::Message& msg, aws_event_stream_message* encoded);
+
+                /**
+                 * Initialize signed C struct based on unsigned C struct.
+                 * Returns true if successful.
+                 * A successfully initialized struct must be cleaned up when you're done with it.
+                 */
+                bool InitSignedStruct(const aws_event_stream_message* msg, aws_event_stream_message* signedmsg);
+
                 Aws::Client::AWSAuthSigner* m_signer;
                 Aws::String m_signatureSeed;
             };


### PR DESCRIPTION
*Issue:*
The latest aws-c-event-stream changed a struct's members, which breaks code here that was accessing these members.

*Description of changes:*
Make code compatible with older and newer versions of aws-c-event-stream. Also revamp logic to be a bit safer, specifically:
- Don't access struct members directly. Instead, use public functions.
- Don't touch a struct that failed initialization. Report failed initialization rather than trying to detect it later by inspecting the struct's members.

*Check all that applies:*
- [ X ] Did a review by yourself.
- [ NOPE ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
  - Not sure how to make the failure branches occur
- [ X ] Checked if this PR is a breaking (APIs have been changed) change.
- [ X ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ X ] Checked if this PR would require a ReadMe/Wiki update.

*Check which platforms you have built SDK on to verify the correctness of this PR:*
I've only compiled, not run any tests. I compiled against an old version of aws-c-event-stream and a new version of aws-c-event-stream to confirm it works with both.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
