### PR TITLE
Include public aws-c-auth header, instead of private one

### DIFF
--- a/aws-cpp-sdk-core-tests/aws/auth/AWSAuthSignerTest.cpp
+++ b/aws-cpp-sdk-core-tests/aws/auth/AWSAuthSignerTest.cpp
@@ -14,7 +14,7 @@
 #include <aws/core/platform/Platform.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/HashingUtils.h>
-#include <aws/auth/private/aws_signing.h>
+#include <aws/auth/signing.h>
 #include <aws/cal/ecc.h>
 #include <aws/common/encoding.h>
 #include <fstream>


### PR DESCRIPTION
In the past, we needed to get at a function hidden in this private header. But that function isn't hidden anymore, so we can include the public header.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
