### PR TITLE
Replace HMAC functions marked deprecated as of OpenSSL 3.0

### DIFF
--- a/aws-cpp-sdk-core/source/utils/crypto/openssl/CryptoImpl.cpp
+++ b/aws-cpp-sdk-core/source/utils/crypto/openssl/CryptoImpl.cpp
@@ -51,6 +51,11 @@ namespace Aws
 #define OPENSSL_VERSION_NUMBER 0x1000107fL
 #endif
 #define OPENSSL_VERSION_LESS_1_1 (OPENSSL_VERSION_NUMBER < 0x10100003L)
+#define OPENSSL_VERSION_LESS_3_0 (OPENSSL_VERSION_NUMBER < 0x30000000L)
+
+#if !OPENSSL_VERSION_LESS_3_0
+#include <openssl/core_names.h>
+#endif
 
 #if OPENSSL_VERSION_LESS_1_1
                 static const char* OPENSSL_INTERNALS_TAG = "OpenSSLCallbackState";
@@ -412,8 +417,11 @@ namespace Aws
                 HMACRAIIGuard() {
 #if OPENSSL_VERSION_LESS_1_1
                     m_ctx = Aws::New<HMAC_CTX>("AllocSha256HAMCOpenSSLContext");
-#else
+#elif OPENSSL_VERSION_LESS_3_0
                     m_ctx = HMAC_CTX_new();
+#else
+                    mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+                    m_ctx = EVP_MAC_CTX_new(mac);
 #endif
                     assert(m_ctx != nullptr);
                 }
@@ -421,17 +429,28 @@ namespace Aws
                 ~HMACRAIIGuard() {
 #if OPENSSL_VERSION_LESS_1_1
                     Aws::Delete<HMAC_CTX>(m_ctx);
-#else
+#elif OPENSSL_VERSION_LESS_3_0
                     HMAC_CTX_free(m_ctx);
+#else
+                    EVP_MAC_CTX_free(m_ctx);
 #endif
                     m_ctx = nullptr;
                 }
 
+#if OPENSSL_VERSION_LESS_3_0
                 HMAC_CTX* getResource() {
+#else
+                EVP_MAC_CTX* getResource() {
+#endif
                     return m_ctx;
                 }
             private:
+#if OPENSSL_VERSION_LESS_3_0
                 HMAC_CTX *m_ctx;
+#else
+                EVP_MAC *mac;
+                EVP_MAC_CTX *m_ctx;
+#endif
             };
 
             HashResult Sha256HMACOpenSSLImpl::Calculate(const ByteBuffer& toSign, const ByteBuffer& secret)
@@ -441,20 +460,36 @@ namespace Aws
                 memset(digest.GetUnderlyingData(), 0, length);
 
                 HMACRAIIGuard guard;
+#if OPENSSL_VERSION_LESS_3_0
                 HMAC_CTX* m_ctx = guard.getResource();
+#else
+                EVP_MAC_CTX* m_ctx = guard.getResource();
+#endif
 
 #if OPENSSL_VERSION_LESS_1_1
                 HMAC_CTX_init(m_ctx);
 #endif
 
+#if OPENSSL_VERSION_LESS_3_0
                 HMAC_Init_ex(m_ctx, secret.GetUnderlyingData(), static_cast<int>(secret.GetLength()), EVP_sha256(),
                              NULL);
                 HMAC_Update(m_ctx, toSign.GetUnderlyingData(), toSign.GetLength());
                 HMAC_Final(m_ctx, digest.GetUnderlyingData(), &length);
+#else
+                char sha256[] {"SHA256"};
+                OSSL_PARAM ossl_params[2];
+                ossl_params[0] =
+                  OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST, sha256, 0);
+                ossl_params[1] = OSSL_PARAM_construct_end();
+                EVP_MAC_init(m_ctx, secret.GetUnderlyingData(),
+                             static_cast<int>(secret.GetLength()), ossl_params);
+                EVP_MAC_update(m_ctx, toSign.GetUnderlyingData(), toSign.GetLength());
+                EVP_MAC_final(m_ctx, digest.GetUnderlyingData(), NULL, length);
+#endif
 
 #if OPENSSL_VERSION_LESS_1_1
                 HMAC_CTX_cleanup(m_ctx);
-#else
+#elif OPENSSL_VERSION_LESS_3_0
                 HMAC_CTX_reset(m_ctx);
 #endif
                 return HashResult(std::move(digest));


### PR DESCRIPTION
Resolves #1582.

*Description of changes:*
Since the low level HMAC [functions](https://github.com/openssl/openssl/blob/7fe7cc57af3db1e497877f0329ba17609b2efc8b/include/openssl/hmac.h) have been marked [deprecated](https://www.openssl.org/news/changelog.html#openssl-30) as of OpenSSL 3.0, it has been unable to build the SDK according to [README](https://github.com/aws/aws-sdk-cpp/blob/daac9c204068f561ba628ee97097a43562aed325/README.md) in a modern environment without suppressing warnings.
This pull request resolves the issue by checking the version of provided OpenSSL and use the appropriate functions.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
