### PR TITLE
Adds define for gtest on old gcc releases.

### DIFF
--- a/testing-resources/CMakeLists.txt
+++ b/testing-resources/CMakeLists.txt
@@ -101,6 +101,10 @@ if(PLATFORM_WINDOWS)
     add_definitions("-DDISABLE_HOME_DIR_REDIRECT")
 endif()
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+    add_definitions("-DUSE_INTERNAL_TRIVIAL_COPY")
+endif()
+
 add_library(${PROJECT_NAME} ${TestingResources_SRC})
 add_library(AWS::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 

--- a/testing-resources/include/aws/external/gtest/gtest-aws-helper.h
+++ b/testing-resources/include/aws/external/gtest/gtest-aws-helper.h
@@ -1,0 +1,15 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+/**
+ * use __has_trivial_copy instead of std for GCC < 5 compatability
+ */
+#ifdef USE_INTERNAL_TRIVIAL_COPY
+#define IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T) __has_trivial_copy(T)
+#else
+#define IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T) std::is_trivially_copy_constructible<T>::value
+#endif

--- a/testing-resources/include/aws/external/gtest/gtest-matchers.h
+++ b/testing-resources/include/aws/external/gtest/gtest-matchers.h
@@ -48,6 +48,7 @@
 #include "gtest/gtest-printers.h"
 #include "gtest/internal/gtest-internal.h"
 #include "gtest/internal/gtest-port.h"
+#include "gtest/gtest-aws-helper.h"
 
 // MSVC warning C5046 is new as of VS2017 version 15.8.
 #if defined(_MSC_VER) && _MSC_VER >= 1915
@@ -431,7 +432,7 @@ class MatcherBase : private MatcherDescriberInterface {
   template <typename M>
   static constexpr bool IsInlined() {
     return sizeof(M) <= sizeof(Buffer) && alignof(M) <= alignof(Buffer) &&
-           std::is_trivially_copy_constructible<M>::value &&
+           IS_TRIVIALLY_COPY_CONSTRUCTIBLE(M) &&
            std::is_trivially_destructible<M>::value;
   }
 


### PR DESCRIPTION
*Description of changes:*

Right now with GCC < 5 compilation will fail because the embedded dependency on [gtest does not support gcc < 5.0](https://google.github.io/googletest/platforms.html#compilers) this will use the gcc trait [__has_trivial_copy](https://gcc.gnu.org/onlinedocs/gcc-4.9.2/gcc/Type-Traits.html#:%7E:text=bound.-,__has_trivial_copy,-(type)) when compiled with previous gcc versions.

[workaround suggested is from this stack overflow](https://stackoverflow.com/questions/12754886/has-trivial-copy-behaves-differently-in-clang-and-gcc-whos-right)

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
