### PR TITLE
Fixes compilation with legacy gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,10 @@ if (HAS_UMASK)
     add_definitions(-DHAS_UMASK)
 endif()
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+    add_definitions(-DLEGACY_GCC)
+endif()
+
 add_sdks()
 
 # for user friendly cmake usage

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -67,6 +67,10 @@ macro(set_gcc_warnings)
             endif()
         endif()
     endif()
+    # when using gcc we need to ignore warnings for missing initalizers as it was identified as a bug in gcc
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+        list(APPEND AWS_COMPILER_WARNINGS "-Wno-missing-field-initializers")
+    endif()
 endmacro()
 
 macro(set_msvc_flags)

--- a/testing-resources/CMakeLists.txt
+++ b/testing-resources/CMakeLists.txt
@@ -101,10 +101,6 @@ if(PLATFORM_WINDOWS)
     add_definitions("-DDISABLE_HOME_DIR_REDIRECT")
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
-    add_definitions("-DUSE_INTERNAL_TRIVIAL_COPY")
-endif()
-
 add_library(${PROJECT_NAME} ${TestingResources_SRC})
 add_library(AWS::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 

--- a/testing-resources/include/aws/external/gtest/gtest-aws-helper.h
+++ b/testing-resources/include/aws/external/gtest/gtest-aws-helper.h
@@ -8,7 +8,7 @@
 /**
  * use __has_trivial_copy instead of std for GCC < 5 compatability
  */
-#ifdef USE_INTERNAL_TRIVIAL_COPY
+#ifdef LEGACY_GCC
 #define IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T) __has_trivial_copy(T)
 #else
 #define IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T) std::is_trivially_copy_constructible<T>::value


### PR DESCRIPTION
*Description of changes:*

I recently made a change for fixing legacy gcc compilation of the embedded gtest dependency. It didnt fix it all the way, this however does.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
