### PR TITLE
Refreshing credentials before they expire in STSCredentialsProvider

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/auth/STSCredentialsProvider.h
+++ b/aws-cpp-sdk-core/include/aws/core/auth/STSCredentialsProvider.h
@@ -46,6 +46,7 @@ namespace Aws
             Aws::String m_sessionName;
             Aws::String m_token;
             bool m_initialized;
+            bool ExpiresSoon() const;
         };
     } // namespace Auth
 } // namespace Aws

--- a/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
+++ b/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
@@ -48,7 +48,7 @@ static const char DEFAULT_CREDENTIALS_FILE[] = "credentials";
 extern const char DEFAULT_CONFIG_FILE[] = "config";
 
 
-static const int EXPIRATION_GRACE_PERIOD = 5 * 1000;
+static const int AWS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD = 5 * 1000;
 
 void AWSCredentialsProvider::Reload()
 {
@@ -306,7 +306,7 @@ AWSCredentials TaskRoleCredentialsProvider::GetAWSCredentials()
 
 bool TaskRoleCredentialsProvider::ExpiresSoon() const
 {
-    return ((m_credentials.GetExpiration() - Aws::Utils::DateTime::Now()).count() < EXPIRATION_GRACE_PERIOD);
+    return ((m_credentials.GetExpiration() - Aws::Utils::DateTime::Now()).count() < AWS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD);
 }
 
 void TaskRoleCredentialsProvider::Reload()


### PR DESCRIPTION
*Issue #1569 *

*Description of changes: Refreshing credentials before they expire in STSCredentialsProvider*

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
