### PR TITLE
[aws-cpp-sdk-core] shut down CRT logging after shutting down CRT

### DIFF
--- a/aws-cpp-sdk-core/source/Aws.cpp
+++ b/aws-cpp-sdk-core/source/Aws.cpp
@@ -159,16 +159,12 @@ namespace Aws
 
         Aws::Config::CleanupConfigAndCredentialsCacheManager();
 
-        if(options.loggingOptions.logLevel != Aws::Utils::Logging::LogLevel::Off)
-        {
-            Aws::Utils::Logging::ShutdownAWSLogging();
-        }
-
         Aws::Client::CoreErrorsMapper::CleanupCoreErrorsMapper();
         Aws::CleanupCrt();
         if (options.loggingOptions.logLevel != Aws::Utils::Logging::LogLevel::Off)
         {
             Aws::Utils::Logging::ShutdownCRTLogging();
+            Aws::Utils::Logging::ShutdownAWSLogging();
         }
 #ifdef USE_AWS_MEMORY_MANAGEMENT
         if(options.memoryManagementOptions.memoryManager)

--- a/aws-cpp-sdk-core/source/Aws.cpp
+++ b/aws-cpp-sdk-core/source/Aws.cpp
@@ -161,12 +161,15 @@ namespace Aws
 
         if(options.loggingOptions.logLevel != Aws::Utils::Logging::LogLevel::Off)
         {
-            Aws::Utils::Logging::ShutdownCRTLogging();
             Aws::Utils::Logging::ShutdownAWSLogging();
         }
 
         Aws::Client::CoreErrorsMapper::CleanupCoreErrorsMapper();
         Aws::CleanupCrt();
+        if (options.loggingOptions.logLevel != Aws::Utils::Logging::LogLevel::Off)
+        {
+            Aws::Utils::Logging::ShutdownCRTLogging();
+        }
 #ifdef USE_AWS_MEMORY_MANAGEMENT
         if(options.memoryManagementOptions.memoryManager)
         {


### PR DESCRIPTION
*Issue #, if available:*
Resolves #1995.

*Description of changes:*
Shut down CRT logging only after the CRT subsystem has been shut down, since logging does happen during shutdown.
Currently CRT logging is shut down first, which causes undefined behaviour.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
   Ran before/after tests with `clang` TSAN. Confirmed that this fixes the race condition documented in #1995.
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.