### PR TITLE
TransferManager to do not download outside requested directory

### DIFF
--- a/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
@@ -309,6 +309,9 @@ namespace Aws
 
             Aws::Utils::ExclusiveOwnershipResourceManager<unsigned char*> m_bufferManager;
             TransferManagerConfiguration m_transferConfig;
+
+        protected:
+            static bool IsWithinParentDirectory(Aws::String parentDirectory, Aws::String filePath);
         };
 
         


### PR DESCRIPTION
*Issue #, if available:*
Fixed possible security issue in TransferManager’s DownloadToDirectory operation where files could be downloaded to directories outside of the destination directory if the key contained specially-crafted relative paths.
*Description of changes:*

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
