### PR TITLE
Use map key type as a type not a string by default in json deserialize

### DIFF
--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/ModelInternalMapOrListJsonDeserializer.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/ModelInternalMapOrListJsonDeserializer.vm
@@ -14,7 +14,7 @@
 #end
 #if($template.recursionDepth > 1)
 #set($template.containerVar = ${template.lowerCaseVarName} + "Map")
-  ${template.currentSpaces}Aws::Map<Aws::String, ${CppViewHelper.computeCppType($template.currentShape.mapValue.shape)}> ${template.lowerCaseVarName}Map;
+  ${template.currentSpaces}Aws::Map<${CppViewHelper.computeCppType($template.currentShape.mapKey.shape)}, ${CppViewHelper.computeCppType($template.currentShape.mapValue.shape)}> ${template.lowerCaseVarName}Map;
 #end
   ${template.currentSpaces}for(auto& ${template.lowerCaseVarName}Item : ${template.lowerCaseVarName}JsonMap)
   ${template.currentSpaces}{


### PR DESCRIPTION
*Issue #, if available:*
Internal
*Description of changes:*
Compute map key type instead of hardcoding to the Aws::String.
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
