### PR TITLE
Fix code generation on windows or system where mvn is from PATH

### DIFF
--- a/scripts/run_code_generation.py
+++ b/scripts/run_code_generation.py
@@ -87,8 +87,10 @@ def build_generator(generator_dir: str, max_workers: int) -> None:
     :param max_workers: number of threads to use to build generator
     :return: None
     """
+
+    mvn_cmd = shutil.which("mvn")  # subprocess.run does expand Path by default
     max_workers = min(int(max_workers), 8)
-    process = subprocess.run(["mvn", "package", "-T", str(max_workers)], cwd=generator_dir, timeout=5*60, check=True)
+    process = subprocess.run([mvn_cmd, "package", "-T", str(max_workers)], cwd=generator_dir, timeout=5*60, check=True)
     process.check_returncode()
 
 


### PR DESCRIPTION
*Issue #, if available:*
Code gen on windows does not build code generator
*Description of changes:*
`Popen` does not expand env vars by default and `shell=True` is not secure: https://stackoverflow.com/questions/3172470/actual-meaning-of-shell-true-in-subprocess
Solution: fetch `mvn` executable full path before calling `mvn`: https://stackoverflow.com/questions/304319/is-there-an-equivalent-of-which-on-the-windows-command-line

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
