### PR TITLE
Fixes TransferManager DownloadToDirectory

### DIFF
--- a/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -1109,6 +1109,10 @@ namespace Aws
             {
                 if('/' == filePath[i])
                 {
+                    while (i + 1 < filePath.size() && '/' == filePath[i+1]) // Skip all  "//"
+                    {
+                        ++i;
+                    }
                     if(i + 2 < filePath.size() && '.' == filePath[i+1] && '/' == filePath[i+2]) // if "/./"
                     {
                         continue;


### PR DESCRIPTION
*Description of changes:*

There was one corner case for a previous [potential security issue in TransferManager](https://github.com/aws/aws-sdk-cpp/commit/9742c23bae2c59414a59de74a2feaf76c1385cbb) that was missed. in the event the path `////../` was used it would not ignore duplicate path markers and would compute the location. We will now skip duplicate path markers as intended.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
