### PR TITLE
[aws-cpp-sdk-s3-crt]: avoid race condition in Get/PutObjectAsync (#2024)

### DIFF
--- a/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
+++ b/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
@@ -5171,6 +5171,7 @@ namespace Aws
           std::shared_ptr<Aws::Http::HttpRequest> request;
           std::shared_ptr<Aws::Http::HttpResponse> response;
           std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest;
+          std::mutex underlyingS3RequestMutex;
           aws_s3_meta_request *underlyingS3Request;
         };
 

--- a/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -360,6 +360,7 @@ static void S3CrtRequestFinishCallback(struct aws_s3_meta_request *meta_request,
     bodyStream.write(reinterpret_cast<char*>(meta_request_result->error_response_body->buffer), static_cast<std::streamsize>(meta_request_result->error_response_body->len));
   }
 
+  std::lock_guard<std::mutex> lockRequest{userData->underlyingS3RequestMutex};
   aws_s3_meta_request_release(userData->underlyingS3Request);
 }
 
@@ -498,6 +499,8 @@ void S3CrtClient::GetObjectAsync(const GetObjectRequest& request, const GetObjec
   std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest = userData->request->ToCrtHttpRequest();
   options.message= crtHttpRequest->GetUnderlyingMessage();
   userData->crtHttpRequest = crtHttpRequest;
+
+  std::lock_guard<std::mutex> lockRequest{userData->underlyingS3RequestMutex};
   aws_s3_meta_request *rawRequest = aws_s3_client_make_meta_request(m_s3CrtClient, &options);
   userData->underlyingS3Request = rawRequest;
 }
@@ -566,6 +569,8 @@ void S3CrtClient::PutObjectAsync(const PutObjectRequest& request, const PutObjec
   std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest = userData->request->ToCrtHttpRequest();
   options.message= crtHttpRequest->GetUnderlyingMessage();
   userData->crtHttpRequest = crtHttpRequest;
+
+  std::lock_guard<std::mutex> lockRequest{userData->underlyingS3RequestMutex};
   aws_s3_meta_request *rawRequest = aws_s3_client_make_meta_request(m_s3CrtClient, &options);
   userData->underlyingS3Request = rawRequest;
 }


### PR DESCRIPTION
*Issue #, if available:* Resolves #2024.

*Description of changes:*
The `underlyingS3Request` can be accessed (read/write) from different threads, due to the use of callbacks.
Use a mutex to avoid a race condition in concurrently accessing the aws s3 meta_request structure.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
  Tested with `clang` thread sanitizer that race condition described in #2024 no longer occurs.
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.