### PR TITLE
[aws-cpp-sdk-core] Add missing rvalue reference

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceResult.h
+++ b/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceResult.h
@@ -57,7 +57,7 @@ namespace Aws
         /**
          * Get the payload from the response and take ownership of it.
          */
-        inline PAYLOAD_TYPE TakeOwnershipOfPayload() { return std::move(m_payload); }
+        inline PAYLOAD_TYPE&& TakeOwnershipOfPayload() { return std::move(m_payload); }
         /**
         * Get the headers from the response
         */


### PR DESCRIPTION
This seems to be an oversight.

`TakeOwnershipOfPayload` returns an rvalue reference, due to missing `&&`, a temporary object is constructed.

*Description of changes:*
Add missing `&&`.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.