### PR TITLE
Update CurlHttpClient to handle body in DELETE requests

### DIFF
--- a/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -432,7 +432,16 @@ void SetOptCodeForHttpMethod(CURL* requestHandle, const std::shared_ptr<HttpRequ
 
             break;
         case HttpMethod::HTTP_DELETE:
-            curl_easy_setopt(requestHandle, CURLOPT_CUSTOMREQUEST, "DELETE");
+            if ((!request->HasHeader(Aws::Http::CONTENT_LENGTH_HEADER) || request->GetHeaderValue(Aws::Http::CONTENT_LENGTH_HEADER) == "0") &&
+                 !request->HasHeader(Aws::Http::TRANSFER_ENCODING_HEADER))
+            {
+                curl_easy_setopt(requestHandle, CURLOPT_CUSTOMREQUEST, "DELETE");
+            }
+            else
+            {
+                curl_easy_setopt(requestHandle, CURLOPT_POST, 1L);
+                curl_easy_setopt(requestHandle, CURLOPT_CUSTOMREQUEST, "DELETE");
+            }
             break;
         default:
             assert(0);


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
The current implementation of the CurlHttpClient does not handle DELETE requests that have a body, resulting in an inconsistent behavior between CurlHttpClient and other clients in the SDK that support it. This change enables attaching a body to the request, if present.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.) Tested manually by creating DELETE requests with and without body and sending them to a server using CurlHttpClient .
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [X] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
