### PR TITLE
Update CMake docs: `ENABLE_UNITY_BUILD` defaults to `ON`

### DIFF
--- a/Docs/CMake_Parameters.md
+++ b/Docs/CMake_Parameters.md
@@ -50,7 +50,7 @@ Windows example:
 For more information, see the CMake documentation for your platform.
 
 ### ENABLE_UNITY_BUILD
-(Defaults to OFF) If enabled, most SDK libraries will be built as a single, generated .cpp file.  This can significantly reduce static library size as well as speed up compilation time.
+(Defaults to ON) If enabled, most SDK libraries will be built as a single, generated .cpp file.  This can significantly reduce static library size as well as speed up compilation time.
 
 ### MINIMIZE_SIZE
 (Defaults to OFF) A superset of ENABLE_UNITY_BUILD, if enabled this option turns on ENABLE_UNITY_BUILD as well as some additional binary size reduction settings.  This is a work-in-progress and may change in the future (symbol stripping in particular).


### PR DESCRIPTION
In the current docs, it [shows](https://github.com/aws/aws-sdk-cpp/blob/5775352eaa8881e0880533784af0af06a9130a31/Docs/CMake_Parameters.md#enable_unity_build) `ENABLE_UNITY_BUILD` as defaulting to `OFF`, even though it's been [defaulting](https://github.com/aws/aws-sdk-cpp/blob/5775352eaa8881e0880533784af0af06a9130a31/CMakeLists.txt#L33) to `ON` in `CMakeLists.txt` since the change in 2d17946f02b4fb7acd242759ca3bfc88102cb137, with the docs [updated](https://github.com/aws/aws-sdk-cpp/commit/2d17946f02b4fb7acd242759ca3bfc88102cb137#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) accordingly.

However, that updated information appears to have got [lost](https://github.com/aws/aws-sdk-cpp/commit/8117dc96e61444428a2639da8343a28bc92a7f05#diff-c197cf864efd5a7adec5228fde06befac296b7773a982b72b7a16fb4111daf4bR46) when the CMake parameter documentation was separated out from the README in 8117dc96e61444428a2639da8343a28bc92a7f05.

- - -

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
