### PR TITLE
[aws-cpp-sdk-s3-crt]: avoid race condition in Get/PutObjectAsync (#2024)

### DIFF
--- a/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
+++ b/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
@@ -5171,7 +5171,7 @@ namespace Aws
           std::shared_ptr<Aws::Http::HttpRequest> request;
           std::shared_ptr<Aws::Http::HttpResponse> response;
           std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest;
-          std::mutex underlyingS3RequestMutex;
+          mutable std::mutex underlyingS3RequestMutex;
           aws_s3_meta_request *underlyingS3Request;
         };
 

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
@@ -188,6 +188,7 @@ namespace Aws
           std::shared_ptr<Aws::Http::HttpRequest> request;
           std::shared_ptr<Aws::Http::HttpResponse> response;
           std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest;
+          mutable std::mutex underlyingS3RequestMutex;
           aws_s3_meta_request *underlyingS3Request;
         };
 

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
@@ -83,6 +83,7 @@ static void S3CrtRequestFinishCallback(struct aws_s3_meta_request *meta_request,
     bodyStream.write(reinterpret_cast<char*>(meta_request_result->error_response_body->buffer), static_cast<std::streamsize>(meta_request_result->error_response_body->len));
   }
 
+  std::lock_guard<std::mutex> lockRequest{userData->underlyingS3RequestMutex};
   aws_s3_meta_request_release(userData->underlyingS3Request);
 }
 
@@ -247,6 +248,8 @@ void ${className}::${operation.name}Async(${constText}${operation.request.shape.
   std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest = userData->request->ToCrtHttpRequest();
   options.message= crtHttpRequest->GetUnderlyingMessage();
   userData->crtHttpRequest = crtHttpRequest;
+
+  std::lock_guard<std::mutex> lockRequest{userData->underlyingS3RequestMutex};
   aws_s3_meta_request *rawRequest = aws_s3_client_make_meta_request(m_s3CrtClient, &options);
   userData->underlyingS3Request = rawRequest;
 }
@@ -307,6 +310,7 @@ void ${className}::${operation.name}Async(${constText}${operation.name}ResponseR
   std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest = userData->request->ToCrtHttpRequest();
   options.message= crtHttpRequest->GetUnderlyingMessage();
   userData->crtHttpRequest = crtHttpRequest;
+  std::lock_guard<std::mutex> lockRequest{userData->underlyingS3RequestMutex};
   aws_s3_meta_request *rawRequest = aws_s3_client_make_meta_request(m_s3CrtClient, &options);
   userData->underlyingS3Request = rawRequest;
 }


### PR DESCRIPTION
*Issue #, if available:*

[#2024](https://github.com/aws/aws-sdk-cpp/issues/2024)

*Description of changes:*

[pull/2025](https://github.com/aws/aws-sdk-cpp/pull/2025) is grrtrr@'s fix for this issue. His fix being valid and being accepted by us. Alongside that we also needed to add code generation for the client which is local to our CI/CD system. So I had to update code generation and run CI/CD tests.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
