### PR TITLE
Fixes Enum code generation.

### DIFF
--- a/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/PlatformAndKeywordSanitizer.java
+++ b/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/PlatformAndKeywordSanitizer.java
@@ -142,6 +142,7 @@ public class PlatformAndKeywordSanitizer {
     static {
         Map<Character,Character> mapping = new HashMap<>();
         mapping.put('-', '_');
+        mapping.put('+', '_');
         mapping.put(':', '_');
         mapping.put('.', '_');
         mapping.put('*', '_');

--- a/code-generation/generator/src/test/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/EnumModelTest.java
+++ b/code-generation/generator/src/test/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/EnumModelTest.java
@@ -18,12 +18,13 @@ public class EnumModelTest {
     public void invalidChars() {
 
         EnumModel testEnum = new EnumModel("TestNamespace", "TESTENUM",
-                asList("PACKAGE.NAME", "HYPHENS-ROCK", "OH:DARK:THIRTY"));
+                asList("PACKAGE.NAME", "HYPHENS-ROCK", "OH:DARK:THIRTY", "Evangelion: 3.0+1.0"));
 
-        assertEquals(3, testEnum.getMembers().size());
+        assertEquals(4, testEnum.getMembers().size());
         assertEquals("PACKAGE_NAME", testEnum.getMembers().get(0).getMemberName());
         assertEquals("HYPHENS_ROCK", testEnum.getMembers().get(1).getMemberName());
         assertEquals("OH_DARK_THIRTY", testEnum.getMembers().get(2).getMemberName());
+        assertEquals("Evangelion_3_0_1_0", testEnum.getMembers().get(3).getMemberName());
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*

Saw issues during code gen where the `+` symbol was causing issues when creating enums. We typically normalize names with reserved symbols words. It would seem `+` was forgotten though. The adds `+` and adds a test case.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
