### PR TITLE
Validates embedded errors for multipart upload.

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceRequest.h
+++ b/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceRequest.h
@@ -14,6 +14,7 @@
 #include <aws/core/utils/memory/stl/AWSStreamFwd.h>
 #include <aws/core/utils/stream/ResponseStream.h>
 #include <aws/core/auth/AWSAuthSigner.h>
+#include <aws/core/client/CoreErrors.h>
 
 namespace Aws
 {
@@ -74,6 +75,15 @@ namespace Aws
          * Defaults to true, if this is set to false, then signers, if they support body signing, will not do so
          */
         virtual bool SignBody() const { return true; }
+
+        /**
+         * Defaults to false, if a derived class returns true it indicates that the body has an embedded error.
+         */
+        virtual bool HasEmbeddedError(Aws::IOStream& body, const Aws::Http::HeaderValueCollection& header) const {
+            (void) body;
+            (void) header;
+            return false;
+        }
 
         /**
          * Defaults to false, if this is set to true, it supports chunked transfer encoding.

--- a/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -529,7 +529,7 @@ HttpResponseOutcome AWSClient::AttemptOneRequest(const std::shared_ptr<HttpReque
         }
     }
 
-    if (DoesResponseGenerateError(httpResponse))
+    if (DoesResponseGenerateError(httpResponse) || request.HasEmbeddedError(httpResponse->GetResponseBody(), httpResponse->GetHeaders()))
     {
         AWS_LOGSTREAM_DEBUG(AWS_CLIENT_LOG_TAG, "Request returned error. Attempting to generate appropriate error codes from response");
         auto error = BuildAWSError(httpResponse);
@@ -1297,8 +1297,6 @@ AWSError<CoreErrors> AWSXMLClient::BuildAWSError(const std::shared_ptr<Http::Htt
     }
     else
     {
-        assert(httpResponse->GetResponseCode() != HttpResponseCode::OK);
-
         // When trying to build an AWS Error from a response which is an FStream, we need to rewind the
         // file pointer back to the beginning in order to correctly read the input using the XML string iterator
         if ((httpResponse->GetResponseBody().tellp() > 0)

--- a/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/CompleteMultipartUploadRequest.h
+++ b/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/CompleteMultipartUploadRequest.h
@@ -42,6 +42,7 @@ namespace Model
 
     Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
+    bool HasEmbeddedError(IOStream &body, const Http::HeaderValueCollection &header) const override;
 
     /**
      * <p>Name of the bucket to which the multipart upload was initiated.</p> <p>When

--- a/aws-cpp-sdk-s3-crt/source/model/CompleteMultipartUploadRequest.cpp
+++ b/aws-cpp-sdk-s3-crt/source/model/CompleteMultipartUploadRequest.cpp
@@ -35,6 +35,28 @@ CompleteMultipartUploadRequest::CompleteMultipartUploadRequest() :
 {
 }
 
+bool CompleteMultipartUploadRequest::HasEmbeddedError(Aws::IOStream &body,
+  const Aws::Http::HeaderValueCollection &header) const
+{
+  // Header is unused
+  (void) header;
+
+  auto readPointer = body.tellg();
+  XmlDocument doc = XmlDocument::CreateFromXmlStream(body);
+
+  if (!doc.WasParseSuccessful()) {
+    body.seekg(readPointer);
+    return false;
+  }
+
+  if (doc.GetRootElement().GetName() == "Error") {
+    body.seekg(readPointer);
+    return true;
+  }
+  body.seekg(readPointer);
+  return false;
+}
+
 Aws::String CompleteMultipartUploadRequest::SerializePayload() const
 {
   XmlDocument payloadDoc = XmlDocument::CreateWithRootNode("CompleteMultipartUpload");

--- a/aws-cpp-sdk-s3/include/aws/s3/model/CompleteMultipartUploadRequest.h
+++ b/aws-cpp-sdk-s3/include/aws/s3/model/CompleteMultipartUploadRequest.h
@@ -42,6 +42,7 @@ namespace Model
 
     Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
+    bool HasEmbeddedError(IOStream &body, const Http::HeaderValueCollection &header) const override;
 
     /**
      * <p>Name of the bucket to which the multipart upload was initiated.</p> <p>When

--- a/aws-cpp-sdk-s3/source/model/CompleteMultipartUploadRequest.cpp
+++ b/aws-cpp-sdk-s3/source/model/CompleteMultipartUploadRequest.cpp
@@ -35,6 +35,28 @@ CompleteMultipartUploadRequest::CompleteMultipartUploadRequest() :
 {
 }
 
+bool CompleteMultipartUploadRequest::HasEmbeddedError(Aws::IOStream &body,
+  const Aws::Http::HeaderValueCollection &header) const
+{
+  // Header is unused
+  (void) header;
+
+  auto readPointer = body.tellg();
+  XmlDocument doc = XmlDocument::CreateFromXmlStream(body);
+
+  if (!doc.WasParseSuccessful()) {
+    body.seekg(readPointer);
+    return false;
+  }
+
+  if (doc.GetRootElement().GetName() == "Error") {
+    body.seekg(readPointer);
+    return true;
+  }
+  body.seekg(readPointer);
+  return false;
+}
+
 Aws::String CompleteMultipartUploadRequest::SerializePayload() const
 {
   XmlDocument payloadDoc = XmlDocument::CreateWithRootNode("CompleteMultipartUpload");

--- a/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/Shape.java
+++ b/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/Shape.java
@@ -50,6 +50,7 @@ public class Shape {
     private boolean sensitive;
     private boolean hasPreSignedUrl;
     private boolean document;
+    private boolean hasEmbeddedErrors = false;
 
     public boolean isMap() {
         return "map".equals(type.toLowerCase());
@@ -87,6 +88,14 @@ public class Shape {
 
     public boolean isDocument() {
         return "structure".equals(type.toLowerCase()) && document;
+    }
+
+    public boolean hasEmbeddedErrors() {
+        return this.hasEmbeddedErrors;
+    }
+
+    public void setEmbeddedErrors(boolean hasEmbeddedErrors) {
+        this.hasEmbeddedErrors = hasEmbeddedErrors;
     }
 
     public boolean isPrimitive() {

--- a/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/s3/S3RestXmlCppClientGenerator.java
+++ b/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/s3/S3RestXmlCppClientGenerator.java
@@ -12,13 +12,13 @@ import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.ShapeMe
 import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.cpp.CppShapeInformation;
 import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.cpp.CppViewHelper;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.RestXmlCppClientGenerator;
+import com.google.common.collect.ImmutableSet;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -28,6 +28,7 @@ public class S3RestXmlCppClientGenerator  extends RestXmlCppClientGenerator {
     private static Set<String> opsThatDoNotSupportArnEndpoint = new HashSet<>();
     private static Set<String> opsThatDoNotSupportFutureInS3CRT = new HashSet<>();
     private static Set<String> bucketLocationConstraints = new HashSet<>();
+    private Set<String> functionsWithEmbeddedErrors = ImmutableSet.of("CompleteMultipartUploadRequest");
 
     static {
         opsThatDoNotSupportVirtualAddressing.add("CreateBucket");
@@ -123,6 +124,11 @@ public class S3RestXmlCppClientGenerator  extends RestXmlCppClientGenerator {
         if (indexOfComplete != -1) {
             replicationStatus.getEnumValues().set(indexOfComplete, "COMPLETED");
         }
+
+        // Some S3 operations have embedded errors, and we need to search for errors in the response.
+        serviceModel.getShapes().values().stream()
+                .filter(shape -> functionsWithEmbeddedErrors.contains(shape.getName()))
+                .forEach(shape -> shape.setEmbeddedErrors(true));
 
         // Customized Log Information
         Shape logTagKeyShape = new Shape();

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/RequestHeader.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/RequestHeader.vm
@@ -73,6 +73,9 @@ namespace Model
     Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
 #end
+#if($shape.hasEmbeddedErrors())
+    bool HasEmbeddedError(IOStream &body, const Http::HeaderValueCollection &header) const override;
+#end
 #if($operation.requestAlgorithmMember)
     Aws::String GetChecksumAlgorithmName() const override;
 

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlRequestSource.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlRequestSource.vm
@@ -30,6 +30,30 @@ using namespace Aws::Http;
 ${typeInfo.className}::${typeInfo.className}()$initializers
 {
 }
+#if($shape.hasEmbeddedErrors())
+
+bool CompleteMultipartUploadRequest::HasEmbeddedError(Aws::IOStream &body,
+  const Aws::Http::HeaderValueCollection &header) const
+{
+  // Header is unused
+  (void) header;
+
+  auto readPointer = body.tellg();
+  XmlDocument doc = XmlDocument::CreateFromXmlStream(body);
+
+  if (!doc.WasParseSuccessful()) {
+    body.seekg(readPointer);
+    return false;
+  }
+
+  if (doc.GetRootElement().GetName() == "Error") {
+    body.seekg(readPointer);
+    return true;
+  }
+  body.seekg(readPointer);
+  return false;
+}
+#end
 
 Aws::String ${typeInfo.className}::SerializePayload() const
 {


### PR DESCRIPTION
*Issue #, if available:*

[658](https://github.com/aws/aws-sdk-cpp/issues/658)

*Description of changes:*

`CompleteMultipartUpload` has been known to have errors in the body after a successful return of 200. This change updates for `CompleteMultipartUpload` to check the body for an error.

[S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html)

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
