### PR TITLE
Add ostream overload for HttpResponseCode

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/http/HttpResponse.h
+++ b/aws-cpp-sdk-core/include/aws/core/http/HttpResponse.h
@@ -105,6 +105,11 @@ namespace Aws
             NETWORK_CONNECT_TIMEOUT = 599
         };
 
+        /**
+         * Overload ostream operator<< for HttpResponseCode enum class for a prettier output such as "200"
+         */
+        AWS_CORE_API Aws::OStream& operator<< (Aws::OStream& oStream, HttpResponseCode code);
+
         inline bool IsRetryableHttpResponseCode(HttpResponseCode responseCode)
         {
             switch (responseCode)

--- a/aws-cpp-sdk-core/source/http/HttpResponse.cpp
+++ b/aws-cpp-sdk-core/source/http/HttpResponse.cpp
@@ -1,0 +1,24 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/core/http/HttpResponse.h>
+
+#include <aws/core/utils/memory/stl/AWSStreamFwd.h>
+#include <aws/core/utils/StringUtils.h>
+
+namespace Aws
+{
+    namespace Http
+    {
+        /**
+         * Overload ostream operator<< for HttpResponseCode enum class for a prettier output such as "200" and not "<C8-00 00-00>"
+         */
+        Aws::OStream& operator<< (Aws::OStream& oStream, HttpResponseCode code)
+        {
+            oStream << Aws::Utils::StringUtils::to_string(static_cast<typename std::underlying_type<HttpResponseCode>::type>(code));
+            return oStream;
+        }
+    } // Http
+} // Aws


### PR DESCRIPTION
*Issue #, if available:*
Annoying gtest tracing in failing flaky tests
*Description of changes:*
Add overload for ostream operator<< to see HTTP value
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
