### PR TITLE
Allow anonymous credentials in crt

### DIFF
--- a/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp
@@ -1601,4 +1601,25 @@ namespace
         PutObjectOutcome putObjectOutcome = Client->PutObject(putObjectRequest);
         AWS_ASSERT_SUCCESS(putObjectOutcome);
     }
+
+    TEST_F(BucketAndObjectOperationTest, NoAuthPublicBucket) {
+        Aws::S3Crt::ClientConfiguration s3ClientConfig;
+        s3ClientConfig.region = Aws::Region::US_EAST_1;
+        s3ClientConfig.scheme = Scheme::HTTPS;
+        s3ClientConfig.executor = Aws::MakeShared<Aws::Utils::Threading::PooledThreadExecutor>(ALLOCATION_TAG, 4);
+        s3ClientConfig.throughputTargetGbps = 2.0;
+        s3ClientConfig.partSize = 5 * 1024 * 1024;
+
+        Client = Aws::MakeShared<S3CrtClient>(ALLOCATION_TAG,
+                                              Aws::Auth::AWSCredentials{"", ""},
+                                              s3ClientConfig,
+                                              Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never);
+
+        //Make a request for one of out public doc pages
+        GetObjectRequest getObjectRequest;
+        getObjectRequest.SetBucket("aws-sdk-cpp-docs");
+        getObjectRequest.SetKey("cpp/api/LATEST/index.html");
+
+        AWS_ASSERT_SUCCESS(Client->GetObject(getObjectRequest));
+    }
 }

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -190,7 +190,14 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
 
   m_crtCredProvider = Aws::Crt::Auth::CredentialsProvider::CreateCredentialsProviderDelegate({
      std::bind([](const std::shared_ptr<AWSCredentialsProvider>& provider) {
+         if (provider == nullptr) {
+             AWS_LOGSTREAM_FATAL(ALLOCATION_TAG, "No provider provided, using anonymous provider")
+             return Aws::MakeShared<Aws::Crt::Auth::Credentials>(ALLOCATION_TAG);
+         }
          AWSCredentials credentials = provider->GetAWSCredentials();
+         if (credentials.GetAWSAccessKeyId().empty() && credentials.GetAWSSecretKey().empty()) {
+             return Aws::MakeShared<Aws::Crt::Auth::Credentials>(ALLOCATION_TAG);
+         }
          return Aws::MakeShared<Aws::Crt::Auth::Credentials>(ALLOCATION_TAG,
              *Aws::MakeShared<Aws::Crt::ByteCursor>(ALLOCATION_TAG, Aws::Crt::ByteCursorFromCString(credentials.GetAWSAccessKeyId().c_str())),
              *Aws::MakeShared<Aws::Crt::ByteCursor>(ALLOCATION_TAG, Aws::Crt::ByteCursorFromCString(credentials.GetAWSSecretKey().c_str())),


### PR DESCRIPTION
*Issue #, if available:*
[issues/1842](https://github.com/aws/aws-sdk-cpp/issues/1842)
[issues/1906](https://github.com/aws/aws-sdk-cpp/issues/1906)

*Description of changes:*

Fixes issue where the s3-crt client was unable to download public objects when no credentials were present.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
