### PR TITLE
Fix potential namespace collisions in codegen.

### DIFF
--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassMembersAndInlines.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassMembersAndInlines.vm
@@ -63,16 +63,20 @@
 #set($setterWithCopy = " { ${required}${memberVariableName} = value; }")
 #set($setterWithMove = " { ${required}${memberVariableName} = std::move(value); }")
 #end
+#set($getterFunctionName = "Get${memberKeyWithFirstLetterCapitalized}")
+#if($getterFunctionName == ${member.value.shape.name})
+#set($getterFunctionName = "Get${getterFunctionName}")
+#end
 #if($isStream)
     $memberDocumentation
-    ${inline}Aws::IOStream& Get${memberKeyWithFirstLetterCapitalized}() { return ${memberVariableName}.GetUnderlyingStream(); }
+    ${inline}Aws::IOStream& ${getterFunctionName}() { return ${memberVariableName}.GetUnderlyingStream(); }
 
     $memberDocumentation
     ${inline}void ReplaceBody(Aws::IOStream* body) { ${memberVariableName} = Aws::Utils::Stream::ResponseStream(body); }
 
 #elseif ($isEventStreamInput)
     $memberDocumentation
-    std::shared_ptr<${member.value.shape.name}> Get${memberKeyWithFirstLetterCapitalized}() const ${getterBody}
+    std::shared_ptr<${member.value.shape.name}> ${getterFunctionName}() const ${getterBody}
 
     $memberDocumentation
     void Set${memberKeyWithFirstLetterCapitalized}(const std::shared_ptr<${member.value.shape.name}>& value)${setterWithCopy}
@@ -86,7 +90,7 @@
 #set($override = " override ")
 #end
     $memberDocumentation
-    ${inline}${returnType} Get${memberKeyWithFirstLetterCapitalized}() const$override${getterBody}
+    ${inline}${returnType} ${getterFunctionName}() const$override${getterBody}
 
 #end
 #if(!$isStream && !$isEventStreamInput)


### PR DESCRIPTION
*Description of changes:*

Fixes a potential namespace collision when an Operation and Shape have the same name, specifically a Getter method.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
