### PR TITLE
[aws-cpp-sdk-s3-crt]: handle s3 meta_request errors in Get/PutObjectAsync

### DIFF
--- a/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -500,8 +500,12 @@ void S3CrtClient::GetObjectAsync(const GetObjectRequest& request, const GetObjec
   options.message= crtHttpRequest->GetUnderlyingMessage();
   userData->crtHttpRequest = crtHttpRequest;
 
-  std::lock_guard<std::mutex> lockRequest{userData->underlyingS3RequestMutex};
   aws_s3_meta_request *rawRequest = aws_s3_client_make_meta_request(m_s3CrtClient, &options);
+  if (rawRequest == nullptr)
+  {
+    return handler(this, request, GetObjectOutcome(Aws::Client::AWSError<S3CrtErrors>(S3CrtErrors::INTERNAL_FAILURE, "INTERNAL_FAILURE", "Unable to create s3 meta request", false)), context);
+  }
+  std::lock_guard<std::mutex> lockRequest{userData->underlyingS3RequestMutex};
   userData->underlyingS3Request = rawRequest;
 }
 
@@ -570,8 +574,12 @@ void S3CrtClient::PutObjectAsync(const PutObjectRequest& request, const PutObjec
   options.message= crtHttpRequest->GetUnderlyingMessage();
   userData->crtHttpRequest = crtHttpRequest;
 
-  std::lock_guard<std::mutex> lockRequest{userData->underlyingS3RequestMutex};
   aws_s3_meta_request *rawRequest = aws_s3_client_make_meta_request(m_s3CrtClient, &options);
+  if (rawRequest == nullptr)
+  {
+    return handler(this, request, PutObjectOutcome(Aws::Client::AWSError<S3CrtErrors>(S3CrtErrors::INTERNAL_FAILURE, "INTERNAL_FAILURE", "Unable to create s3 meta request", false)), context);
+  }
+  std::lock_guard<std::mutex> lockRequest{userData->underlyingS3RequestMutex};
   userData->underlyingS3Request = rawRequest;
 }
 


### PR DESCRIPTION
When `aws_s3_client_make_meta_request` returns `NULL`, `{Get,Put}ObjectAsync` hang,
since the response handlers never get invoked.

Handle the case by returning an error instead.

Resolves #2076.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
   Tested function via test program that handled the case of a NULL s3 meta_request.
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
