### PR TITLE
Fix USE_OPENSSL is ignored

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,9 @@ if(NOT USE_OPENSSL)
     message(WARNING "Turning off USE_OPENSSL will install AWS-LC as replacement of OpenSSL in the system default directory. This is an experimental feature. Do not use if you have an OpenSSL installation in your system already.")
 endif()
 
+# link USE_OPENSSL with ENABLE_OPENSSL_ENCRYPTION
+set(ENABLE_OPENSSL_ENCRYPTION ${USE_OPENSSL})
+
 # backwards compatibility with old command line params
 if("${STATIC_LINKING}" STREQUAL "1")
     set(BUILD_SHARED_LIBS OFF)


### PR DESCRIPTION
Currently, `-DUSE_OPENSSL` has no effect. In its stead, an undocumented variable – `ENABLE_OPENSSL_ENCRYPTION` –  is what gets evaluated to verify if OpenSSL was requested. `ENABLE_OPENSSL_ENCRYPTION` defaults to undefined/OFF, which invariably means OpenSSL is actually never used, regardless of the value of `USE_OPENSSL`. This push proposes a fix by linking `USE_OPENSSL` to `ENABLE_OPENSSL_ENCRYPTION`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
