### PR TITLE
#1850 fix multiple destructor invocations of a static UniquePtr

### DIFF
--- a/aws-cpp-sdk-core-tests/utils/memory/AWSMemoryTest.cpp
+++ b/aws-cpp-sdk-core-tests/utils/memory/AWSMemoryTest.cpp
@@ -29,3 +29,89 @@ TEST(AWSMemory, DeleteViaSecondInterface)
     Aws::Delete(b);
 }
 #endif
+
+
+/* static UniquePtr destruction order test begin*/
+struct TestDummy
+{
+    enum class Status
+    {
+        NOT_SET = 0,
+        INITIALIZED,
+        DESTRUCTED
+    };
+
+    int32_t* m_buffer = nullptr;
+
+    static Status status;
+    TestDummy()
+    {
+        if (status != Status::NOT_SET)
+        {
+            std::cerr << "Abnormal status " << (size_t) status << ", status NOT_SET(0) is expected on the first (and only) instance creation";
+            std::terminate();
+        }
+        m_buffer = new int32_t[100];
+        status = Status::INITIALIZED;
+    }
+
+    virtual ~TestDummy()
+    {
+        if (status != Status::INITIALIZED)
+        {
+            std::cerr << "Abnormal status " << (size_t) status << ", status INITIALIZED(1) is expected on the first (and only) instance destruction";
+            std::terminate();
+        }
+        delete[] m_buffer;
+        status = Status::DESTRUCTED;
+    }
+};
+
+// The static objects are destructed in the reverse order of construction
+// Objects defined in the same compilation unit will be constructed in the order of definition
+struct StaticUniquePtrDtorOrderTestWrapper;
+static Aws::UniquePtr<StaticUniquePtrDtorOrderTestWrapper> s_testWrapperPtr(nullptr);
+
+// In this test, we want s_TestDummyPtr to be destructed first and then inspect its value and state _after_ by using another static helper that is still alive
+// static Aws::UniquePtr<TestDummy> s_TestDummyPtr(nullptr); <- this would result in double UniquePtr destruction in Release because of compiler optimization removing the ptr nullifying.
+static Aws::UniquePtr<TestDummy, Aws::StaticUniquePtrDeleter<TestDummy> >
+        s_TestDummyPtr(nullptr, Aws::StaticUniquePtrDeleter<TestDummy>(nullptr));
+TestDummy::Status TestDummy::status = TestDummy::Status::NOT_SET;
+
+struct StaticUniquePtrDtorOrderTestWrapper
+{
+    virtual ~StaticUniquePtrDtorOrderTestWrapper()
+    {
+        // this class' variable has to be defined _before_ s_TestDummyPtr, so ~s_TestDummyPtr() had to be already called at this point
+        if (TestDummy::status != TestDummy::Status::DESTRUCTED ||
+                s_TestDummyPtr.get() != nullptr)
+        {
+            std::cerr << "Static unique ptr is expected to be already destructed AND set to nullptr at this stage\n";
+            std::cerr << "Current status " << (size_t) TestDummy::status << ", ptr value " << s_TestDummyPtr.get() << "\n";
+            // (the stage after main() when static variables are destructed and s_TestDummyPtr had to be already destructed)
+            std::terminate(); // too late to rely on gtest to report failure
+        }
+    }
+};
+
+static bool staticTestIsRun = false;
+
+TEST(AWSMemory, StaticUniquePtrDtorOrder)
+{
+    if(staticTestIsRun) {
+        GTEST_SKIP() << "Skipping the repeat of StaticUniquePtrDtorOrder test as it cannot be repeated.";
+    } else {
+        staticTestIsRun = true;
+    }
+
+    // s_TestDummyPtr is already defined (to nullptr above) and defined _after_ s_testWrapperPtr, let's initialize it with a dummy class
+    s_TestDummyPtr = Aws::MakeUniqueWithDeleter<TestDummy, Aws::StaticUniquePtrDeleter<TestDummy> >(
+            ALLOCATION_TAG, Aws::StaticUniquePtrDeleter<TestDummy>(&s_TestDummyPtr));
+    AWS_UNREFERENCED_PARAM(s_TestDummyPtr);
+
+    // s_testWrapperPtr is already defined (to nullptr above) and defined _before_ s_TestDummyPtr, let's initialize it.
+    // It has to be a ptr type due to declaration ordering (d-tor of this class contains an actual test body).
+    s_testWrapperPtr = Aws::MakeUnique<StaticUniquePtrDtorOrderTestWrapper>(ALLOCATION_TAG);
+    AWS_UNREFERENCED_PARAM(s_testWrapperPtr);
+}
+/* static UniquePtr destruction order test end*/

--- a/aws-cpp-sdk-core/source/client/CoreErrors.cpp
+++ b/aws-cpp-sdk-core/source/client/CoreErrors.cpp
@@ -18,7 +18,9 @@ using namespace Aws::Http;
 #pragma warning(disable : 4592)
 #endif
 
-static Aws::UniquePtr<Aws::Map<Aws::String, AWSError<CoreErrors> > > s_CoreErrorsMapper(nullptr);
+using ErrorsMapperContainer = Aws::Map<Aws::String, AWSError<CoreErrors> >;
+using ErrorsMapperDeleter = Aws::StaticUniquePtrDeleter<ErrorsMapperContainer>;
+static Aws::UniquePtr<ErrorsMapperContainer, ErrorsMapperDeleter> s_CoreErrorsMapper(nullptr, ErrorsMapperDeleter(nullptr));
 
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -30,7 +32,7 @@ void CoreErrorsMapper::InitCoreErrorsMapper()
     {
       return;
     }
-    s_CoreErrorsMapper = Aws::MakeUnique<Aws::Map<Aws::String, AWSError<CoreErrors> > >("InitCoreErrorsMapper");
+    s_CoreErrorsMapper = Aws::MakeUniqueWithDeleter<ErrorsMapperContainer>("InitCoreErrorsMapper", ErrorsMapperDeleter(&s_CoreErrorsMapper));
 
     s_CoreErrorsMapper->emplace("IncompleteSignature", AWSError<CoreErrors>(CoreErrors::INCOMPLETE_SIGNATURE, false));
     s_CoreErrorsMapper->emplace("IncompleteSignatureException", AWSError<CoreErrors>(CoreErrors::INCOMPLETE_SIGNATURE, false));

--- a/aws-cpp-sdk-core/source/config/ConfigAndCredentialsCacheManager.cpp
+++ b/aws-cpp-sdk-core/source/config/ConfigAndCredentialsCacheManager.cpp
@@ -15,14 +15,16 @@ namespace Aws
     {
         using namespace Aws::Utils;
         using namespace Aws::Auth;
+        using CACCacheManagerUniquePtrDeleter = Aws::StaticUniquePtrDeleter<ConfigAndCredentialsCacheManager>;
+        using ConfigAndCredsCacheManagerUniquePtr = Aws::UniquePtr<ConfigAndCredentialsCacheManager, CACCacheManagerUniquePtrDeleter>;
 
         #ifdef _MSC_VER
             // VS2015 compiler's bug, warning s_CoreErrorsMapper: symbol will be dynamically initialized (implementation limitation)
             AWS_SUPPRESS_WARNING(4592,
-                static Aws::UniquePtr<ConfigAndCredentialsCacheManager> s_configManager(nullptr);
+                static ConfigAndCredsCacheManagerUniquePtr s_configManager(nullptr, CACCacheManagerUniquePtrDeleter(nullptr));
             )
         #else
-            static Aws::UniquePtr<ConfigAndCredentialsCacheManager> s_configManager(nullptr);
+            static ConfigAndCredsCacheManagerUniquePtr s_configManager(nullptr, CACCacheManagerUniquePtrDeleter(nullptr));
         #endif
 
         static const char CONFIG_CREDENTIALS_CACHE_MANAGER_TAG[] = "ConfigAndCredentialsCacheManager";
@@ -128,7 +130,8 @@ namespace Aws
             {
                 return;
             }
-            s_configManager = Aws::MakeUnique<ConfigAndCredentialsCacheManager>(CONFIG_CREDENTIALS_CACHE_MANAGER_TAG);
+            s_configManager = Aws::MakeUniqueWithDeleter<ConfigAndCredentialsCacheManager>(
+                    CONFIG_CREDENTIALS_CACHE_MANAGER_TAG, CACCacheManagerUniquePtrDeleter(&s_configManager));
         }
 
         void CleanupConfigAndCredentialsCacheManager()

--- a/aws-cpp-sdk-core/source/monitoring/MonitoringManager.cpp
+++ b/aws-cpp-sdk-core/source/monitoring/MonitoringManager.cpp
@@ -25,7 +25,8 @@ namespace Aws
         /**
          * Global factory to create global metrics instance.
          */
-        static Aws::UniquePtr<Monitors> s_monitors;
+        using MonitorsDeleter = Aws::StaticUniquePtrDeleter<Monitors>;
+        static Aws::UniquePtr<Monitors, MonitorsDeleter> s_monitors(nullptr, MonitorsDeleter(nullptr));
 
         Aws::Vector<void*> OnRequestStarted(const Aws::String& serviceName, const Aws::String& requestName, const std::shared_ptr<const Aws::Http::HttpRequest>& request)
         {
@@ -93,7 +94,7 @@ namespace Aws
             {
                 return;
             }
-            s_monitors = Aws::MakeUnique<Monitors>(MonitoringTag);
+            s_monitors = Aws::MakeUniqueWithDeleter<Monitors>(MonitoringTag, MonitorsDeleter(&s_monitors));
             for (const auto& function: monitoringFactoryCreateFunctions)
             {
                 auto factory = function();


### PR DESCRIPTION
*Issue #, if available:*
[#1850 ](aws-core: segfault if CleanupConfigAndCredentialsCacheManager() is called too late #1850)
*Description of changes:*
Try to avoid compiler optimizations that skips unique_ptr underlying pointer nullifying.
*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
