### PR TITLE
Fix multiple destructor invocations of a static UniquePtr #1850

### DIFF
--- a/aws-cpp-sdk-core-tests/utils/memory/AWSMemoryTest.cpp
+++ b/aws-cpp-sdk-core-tests/utils/memory/AWSMemoryTest.cpp
@@ -29,3 +29,93 @@ TEST(AWSMemory, DeleteViaSecondInterface)
     Aws::Delete(b);
 }
 #endif
+
+
+/* static UniquePtr destruction order test begin*/
+struct TestDummy
+{
+    enum class Status
+    {
+        NOT_SET = 0,
+        INITIALIZED,
+        DESTRUCTED
+    };
+
+    int32_t* m_buffer = nullptr;
+
+    static Status status;
+    TestDummy()
+    {
+        if (status != Status::NOT_SET)
+        {
+            std::cerr << "Abnormal status " << (size_t) status << ", status NOT_SET(0) is expected on the first (and only) instance creation";
+            std::terminate();
+        }
+        m_buffer = new int32_t[100];
+        status = Status::INITIALIZED;
+    }
+
+    virtual ~TestDummy()
+    {
+        if (status != Status::INITIALIZED)
+        {
+            std::cerr << "Abnormal status " << (size_t) status << ", status INITIALIZED(1) is expected on the first (and only) instance destruction";
+            std::terminate();
+        }
+        delete[] m_buffer;
+        status = Status::DESTRUCTED;
+    }
+};
+
+// The static objects are destructed in the reverse order of construction
+// Objects defined in the same compilation unit will be constructed in the order of definition
+struct StaticUniquePtrDtorOrderTestWrapper;
+static Aws::UniquePtr<StaticUniquePtrDtorOrderTestWrapper> s_testWrapperPtr(nullptr);
+
+// In this test, we want s_TestDummyPtr to be destructed first and then inspect its value and state _after_ by using another static helper that is still alive
+//static Aws::UniquePtr<TestDummy> s_TestDummyPtr(nullptr); // <- this would result in double UniquePtr destruction in Release because of compiler optimization removing the ptr nullifying.
+static Aws::UniquePtrSafeDeleted<TestDummy> s_TestDummyPtr(nullptr);
+TestDummy::Status TestDummy::status = TestDummy::Status::NOT_SET;
+
+struct StaticUniquePtrDtorOrderTestWrapper
+{
+    virtual ~StaticUniquePtrDtorOrderTestWrapper()
+    {
+        // this class' variable has to be defined _before_ s_TestDummyPtr, so ~s_TestDummyPtr() had to be already called at this point
+        if (TestDummy::status != TestDummy::Status::DESTRUCTED ||
+                s_TestDummyPtr.get() != nullptr)
+        {
+            std::cerr << "Static unique ptr is expected to be already destructed AND set to nullptr at this stage\n";
+            std::cerr << "Current status " << (size_t) TestDummy::status << ", ptr value " << s_TestDummyPtr.get() << "\n";
+            // (the stage after main() when static variables are destructed and s_TestDummyPtr had to be already destructed)
+            std::terminate(); // too late to rely on gtest to report failure
+        }
+    }
+};
+
+static bool staticTestIsRun = false;
+
+TEST(AWSMemory, StaticUniquePtrDtorOrder)
+{
+    if(staticTestIsRun) {
+        GTEST_SKIP() << "Skipping the repeat of StaticUniquePtrDtorOrder test as it cannot be repeated.";
+    } else {
+        staticTestIsRun = true;
+    }
+    // This test ensures that global static Aws::UniquePtr(SafeDeleted) variables are setting underlying pointer to NULL on destruction
+    // The issue is that a compiler may optimize out setting underlying pointer to NULL on destruction AND the SDK is designed with global vars...
+    // And if client app is calling Aws::ShutdownAPI from their static object destruction, a double delete in Aws::UniquePtr may occur
+
+    // s_TestDummyPtr is already defined (to nullptr above) and defined _after_ s_testWrapperPtr, let's initialize it with a dummy class,
+    // it is not null after main() returns
+    s_TestDummyPtr = Aws::MakeUniqueSafeDeleted<TestDummy>(ALLOCATION_TAG);
+    AWS_UNREFERENCED_PARAM(s_TestDummyPtr);
+
+    // s_testWrapperPtr is already defined (to nullptr above) and defined _before_ s_TestDummyPtr, let's initialize it.
+    // It has to be a ptr type due to declaration ordering (d-tor of this class contains an actual test body).
+    s_testWrapperPtr = Aws::MakeUnique<StaticUniquePtrDtorOrderTestWrapper>(ALLOCATION_TAG);
+    AWS_UNREFERENCED_PARAM(s_testWrapperPtr);
+
+    // After main returns, s_TestDummyPtr will be destructed first and the destructor of s_testWrapperPtr will ensure that s_TestDummyPtr is NULL.
+}
+/* static UniquePtr destruction order test end*/

--- a/aws-cpp-sdk-core/source/client/CoreErrors.cpp
+++ b/aws-cpp-sdk-core/source/client/CoreErrors.cpp
@@ -18,7 +18,8 @@ using namespace Aws::Http;
 #pragma warning(disable : 4592)
 #endif
 
-static Aws::UniquePtr<Aws::Map<Aws::String, AWSError<CoreErrors> > > s_CoreErrorsMapper(nullptr);
+using ErrorsMapperContainer = Aws::Map<Aws::String, AWSError<CoreErrors> >;
+static Aws::UniquePtrSafeDeleted<ErrorsMapperContainer> s_CoreErrorsMapper(nullptr);
 
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -30,7 +31,7 @@ void CoreErrorsMapper::InitCoreErrorsMapper()
     {
       return;
     }
-    s_CoreErrorsMapper = Aws::MakeUnique<Aws::Map<Aws::String, AWSError<CoreErrors> > >("InitCoreErrorsMapper");
+    s_CoreErrorsMapper = Aws::MakeUniqueSafeDeleted<ErrorsMapperContainer>("InitCoreErrorsMapper");
 
     s_CoreErrorsMapper->emplace("IncompleteSignature", AWSError<CoreErrors>(CoreErrors::INCOMPLETE_SIGNATURE, false));
     s_CoreErrorsMapper->emplace("IncompleteSignatureException", AWSError<CoreErrors>(CoreErrors::INCOMPLETE_SIGNATURE, false));

--- a/aws-cpp-sdk-core/source/config/ConfigAndCredentialsCacheManager.cpp
+++ b/aws-cpp-sdk-core/source/config/ConfigAndCredentialsCacheManager.cpp
@@ -15,14 +15,15 @@ namespace Aws
     {
         using namespace Aws::Utils;
         using namespace Aws::Auth;
+        using ConfigAndCredsCacheManagerUniquePtr = Aws::UniquePtrSafeDeleted<ConfigAndCredentialsCacheManager>;
 
         #ifdef _MSC_VER
             // VS2015 compiler's bug, warning s_CoreErrorsMapper: symbol will be dynamically initialized (implementation limitation)
             AWS_SUPPRESS_WARNING(4592,
-                static Aws::UniquePtr<ConfigAndCredentialsCacheManager> s_configManager(nullptr);
+                static ConfigAndCredsCacheManagerUniquePtr s_configManager(nullptr);
             )
         #else
-            static Aws::UniquePtr<ConfigAndCredentialsCacheManager> s_configManager(nullptr);
+            static ConfigAndCredsCacheManagerUniquePtr s_configManager(nullptr);
         #endif
 
         static const char CONFIG_CREDENTIALS_CACHE_MANAGER_TAG[] = "ConfigAndCredentialsCacheManager";
@@ -128,7 +129,8 @@ namespace Aws
             {
                 return;
             }
-            s_configManager = Aws::MakeUnique<ConfigAndCredentialsCacheManager>(CONFIG_CREDENTIALS_CACHE_MANAGER_TAG);
+            s_configManager = Aws::MakeUniqueSafeDeleted<ConfigAndCredentialsCacheManager>(
+                    CONFIG_CREDENTIALS_CACHE_MANAGER_TAG);
         }
 
         void CleanupConfigAndCredentialsCacheManager()

--- a/aws-cpp-sdk-core/source/monitoring/MonitoringManager.cpp
+++ b/aws-cpp-sdk-core/source/monitoring/MonitoringManager.cpp
@@ -25,7 +25,7 @@ namespace Aws
         /**
          * Global factory to create global metrics instance.
          */
-        static Aws::UniquePtr<Monitors> s_monitors;
+        static Aws::UniquePtrSafeDeleted<Monitors> s_monitors(nullptr);
 
         Aws::Vector<void*> OnRequestStarted(const Aws::String& serviceName, const Aws::String& requestName, const std::shared_ptr<const Aws::Http::HttpRequest>& request)
         {
@@ -93,7 +93,7 @@ namespace Aws
             {
                 return;
             }
-            s_monitors = Aws::MakeUnique<Monitors>(MonitoringTag);
+            s_monitors = Aws::MakeUniqueSafeDeleted<Monitors>(MonitoringTag);
             for (const auto& function: monitoringFactoryCreateFunctions)
             {
                 auto factory = function();


### PR DESCRIPTION
*Issue #, if available:*
#1850
*Description of changes:*
This is an alternative take on #1850 
The first idea was to use custom deleter in #2105, however, #2105 is not safe to be used in a regular unique_ptr scenarios (where regular unique_ptr move will occur).
In this attempt, a unique_ptr wrapper is created that ensures that underlying pointer value is erased in reset() or destructor.

Both approaches are atrocious:
- the first is not safe and have known possible issue if mis-used (no static assert way to prohibit such usage).
- the second reinvents the wheel (the std unique_ptr class) and may have some typical issues that arise when one attempts to re-implement std:: (none found so far, but who knows).

The best option would be never using static global variables with global Init/Shutdown API functions, but time travel machine is not yet invented.
 
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
