### PR TITLE
[aws-cpp-sdk-s3-crt] Fix stuck Get/PutObject and handle errors

### DIFF
--- a/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
+++ b/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
@@ -4721,8 +4721,6 @@ namespace Aws
           std::shared_ptr<Aws::Http::HttpRequest> request;
           std::shared_ptr<Aws::Http::HttpResponse> response;
           std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest;
-          mutable std::mutex underlyingS3RequestMutex;
-          aws_s3_meta_request *underlyingS3Request;
         };
 
         Aws::Client::XmlOutcome GenerateXmlOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;


### PR DESCRIPTION
This fixes a condition that can cause hang-up: `aws_s3_client_make_meta_request` may have completed the transfer by the time it returns. This causes a failure in the `finish_callback` to decrement the reference count of the `aws_s3_meta_request` (since the internal reference it uses is still NULL, it does nothing), hence Put/GetObject never complete.

The PR also fixes a hang-up when `aws_s3_client_make_meta_request` returns NULL, which would cause the caller to wait for the completion callback indefinitely.

Resolves #2024, #2076, #2111

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.