### PR TITLE
[aws-cpp-sdk-core] keep MonitoringManager alive until shutdown completes

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/monitoring/MonitoringManager.h
+++ b/aws-cpp-sdk-core/include/aws/core/monitoring/MonitoringManager.h
@@ -57,7 +57,8 @@ namespace Aws
         AWS_CORE_API void InitMonitoring(const std::vector<MonitoringFactoryCreateFunction>& monitoringFactoryCreateFunctions);
 
         /**
-         * Clean up monitoring related global variables
+         * Clean up monitoring related global variables. This should not be called at shutdown, since
+         * detached threads with completing transfers may still issue calls to the MonitoringManager.
          */
         AWS_CORE_API void CleanupMonitoring();
     }

--- a/aws-cpp-sdk-core/source/Aws.cpp
+++ b/aws-cpp-sdk-core/source/Aws.cpp
@@ -150,7 +150,6 @@ namespace Aws
 
     void ShutdownAPI(const SDKOptions& options)
     {
-        Aws::Monitoring::CleanupMonitoring();
         Aws::Internal::CleanupEC2MetadataClient();
         Aws::Net::CleanupNetwork();
         Aws::CleanupEnumOverflowContainer();


### PR DESCRIPTION
The MonitoringManager can not be shut down via Aws::ShutdownAPI, since there is the possibility of detached threads with completing transfers that still need to call methods of the MonitoringManager.

The MonitoringManager needs to stay alive (not be cleaned up via CleanupMonitoring) as long as there are completing threads. Since it is difficult to time detached threads, it is better to not call CleanupMonitoring at all during shutdown.

*Issue #, if available:* Resolves #2135

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
       Tested with program that reproduced MonitoringManager crash at shutdown that problem no longer occurs.
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.