### PR TITLE
Extend AWSErrorMashallerTest to support awsQueryCompatible

### DIFF
--- a/aws-cpp-sdk-core-tests/aws/client/AWSErrorMashallerTest.cpp
+++ b/aws-cpp-sdk-core-tests/aws/client/AWSErrorMashallerTest.cpp
@@ -67,7 +67,8 @@ static Aws::UniquePtr<Aws::Http::HttpResponse> BuildHttpResponse(const Aws::Stri
         response->AddHeader(ERROR_TYPE_HEADER, exception);
     }
 
-    if (!queryErrorCode.empty()) {
+    if (!queryErrorCode.empty())
+    {
         response->AddHeader(QUERY_ERROR_HEADER, queryErrorCode);
     }
 

--- a/aws-cpp-sdk-core-tests/aws/client/AWSErrorMashallerTest.cpp
+++ b/aws-cpp-sdk-core-tests/aws/client/AWSErrorMashallerTest.cpp
@@ -17,6 +17,7 @@ AWS_CORE_API extern const char MESSAGE_LOWER_CASE[];
 AWS_CORE_API extern const char MESSAGE_CAMEL_CASE[];
 AWS_CORE_API extern const char ERROR_TYPE_HEADER[];
 AWS_CORE_API extern const char REQUEST_ID_HEADER[];
+AWS_CORE_API extern const char QUERY_ERROR_HEADER[];
 AWS_CORE_API extern const char TYPE[];
 
 enum JsonErrorResponseStyle
@@ -36,7 +37,7 @@ enum XmlErrorResponseStyle
 
 static const char ERROR_MARSHALLER_TEST_ALLOC_TAG[] = "ErrorMarshllerTestAllocTag";
 
-static Aws::UniquePtr<Aws::Http::HttpResponse> BuildHttpResponse(const Aws::String& exception, const Aws::String& message, const Aws::String& requestId, int style = LowerCaseMessage)
+static Aws::UniquePtr<Aws::Http::HttpResponse> BuildHttpResponse(const Aws::String& exception, const Aws::String& message, const Aws::String& requestId, int style = LowerCaseMessage, const Aws::String& queryErrorCode = "")
 {
     using namespace Aws::Http;
     using namespace Aws::Http::Standard;
@@ -64,6 +65,10 @@ static Aws::UniquePtr<Aws::Http::HttpResponse> BuildHttpResponse(const Aws::Stri
     {
         *ss << "}";
         response->AddHeader(ERROR_TYPE_HEADER, exception);
+    }
+
+    if (!queryErrorCode.empty()) {
+        response->AddHeader(QUERY_ERROR_HEADER, queryErrorCode);
     }
 
     return response;
@@ -460,6 +465,13 @@ TEST(JsonErrorMashallerTest, TestErrorsWithPrefixParse)
     ASSERT_EQ("Unable to parse ExceptionName: " + exceptionPrefix + "IDon'tExist Message: JunkMessage", error.GetMessage());
     ASSERT_EQ(requestId, error.GetRequestId());
     ASSERT_FALSE(error.ShouldRetry());
+
+    error = awsErrorMarshaller.Marshall(*BuildHttpResponse(exceptionPrefix + "AccessDeniedException", message, requestId, LowerCaseMessage, "AwsQueryErrorCode"));
+    ASSERT_EQ(CoreErrors::ACCESS_DENIED, error.GetErrorType());
+    ASSERT_EQ("AwsQueryErrorCode", error.GetExceptionName());
+    ASSERT_EQ(message, error.GetMessage());
+    ASSERT_EQ(requestId, error.GetRequestId());
+    ASSERT_FALSE(error.ShouldRetry());
 }
 
 TEST(AWSErrorMashallerTest, TestErrorsWithoutPrefixParse)
@@ -718,6 +730,13 @@ TEST(AWSErrorMashallerTest, TestErrorsWithoutPrefixParse)
     ASSERT_EQ(CoreErrors::UNKNOWN, error.GetErrorType());
     ASSERT_EQ(exceptionPrefix + "IDon'tExist", error.GetExceptionName());
     ASSERT_EQ("Unable to parse ExceptionName: " + exceptionPrefix + "IDon'tExist Message: JunkMessage", error.GetMessage());
+    ASSERT_EQ(requestId, error.GetRequestId());
+    ASSERT_FALSE(error.ShouldRetry());
+
+    error = awsErrorMarshaller.Marshall(*BuildHttpResponse(exceptionPrefix + "AccessDeniedException", message, requestId, LowerCaseMessage, "AwsQueryErrorCode"));
+    ASSERT_EQ(CoreErrors::ACCESS_DENIED, error.GetErrorType());
+    ASSERT_EQ("AwsQueryErrorCode", error.GetExceptionName());
+    ASSERT_EQ(message, error.GetMessage());
     ASSERT_EQ(requestId, error.GetRequestId());
     ASSERT_FALSE(error.ShouldRetry());
 }

--- a/aws-cpp-sdk-core/source/client/AWSErrorMarshaller.cpp
+++ b/aws-cpp-sdk-core/source/client/AWSErrorMarshaller.cpp
@@ -23,6 +23,7 @@ AWS_CORE_API extern const char MESSAGE_LOWER_CASE[]     = "message";
 AWS_CORE_API extern const char MESSAGE_CAMEL_CASE[]     = "Message";
 AWS_CORE_API extern const char ERROR_TYPE_HEADER[]      = "x-amzn-ErrorType";
 AWS_CORE_API extern const char REQUEST_ID_HEADER[]      = "x-amzn-RequestId";
+AWS_CORE_API extern const char QUERY_ERROR_HEADER[]      = "x-amzn-query-error";
 AWS_CORE_API extern const char TYPE[]                   = "__type";
 
 AWSError<CoreErrors> JsonErrorMarshaller::Marshall(const Aws::Http::HttpResponse& httpResponse) const
@@ -49,6 +50,23 @@ AWSError<CoreErrors> JsonErrorMarshaller::Marshall(const Aws::Http::HttpResponse
         {
             error = FindErrorByHttpResponseCode(httpResponse.GetResponseCode());
             error.SetMessage(message);
+        }
+
+        if (httpResponse.HasHeader(QUERY_ERROR_HEADER)) {
+            auto errorCodeString = httpResponse.GetHeader(QUERY_ERROR_HEADER);
+            auto locationOfSemicolon = errorCodeString.find_first_of(';');
+            Aws::String errorCode;
+
+            if (locationOfSemicolon != Aws::String::npos)
+            {
+                errorCode = errorCodeString.substr(0, locationOfSemicolon);
+            }
+            else
+            {
+                errorCode = errorCodeString;
+            }
+
+            error.SetExceptionName(errorCode);
         }
     }
     else

--- a/aws-cpp-sdk-core/source/client/AWSErrorMarshaller.cpp
+++ b/aws-cpp-sdk-core/source/client/AWSErrorMarshaller.cpp
@@ -23,7 +23,7 @@ AWS_CORE_API extern const char MESSAGE_LOWER_CASE[]     = "message";
 AWS_CORE_API extern const char MESSAGE_CAMEL_CASE[]     = "Message";
 AWS_CORE_API extern const char ERROR_TYPE_HEADER[]      = "x-amzn-ErrorType";
 AWS_CORE_API extern const char REQUEST_ID_HEADER[]      = "x-amzn-RequestId";
-AWS_CORE_API extern const char QUERY_ERROR_HEADER[]      = "x-amzn-query-error";
+AWS_CORE_API extern const char QUERY_ERROR_HEADER[]     = "x-amzn-query-error";
 AWS_CORE_API extern const char TYPE[]                   = "__type";
 
 AWSError<CoreErrors> JsonErrorMarshaller::Marshall(const Aws::Http::HttpResponse& httpResponse) const
@@ -52,7 +52,8 @@ AWSError<CoreErrors> JsonErrorMarshaller::Marshall(const Aws::Http::HttpResponse
             error.SetMessage(message);
         }
 
-        if (httpResponse.HasHeader(QUERY_ERROR_HEADER)) {
+        if (httpResponse.HasHeader(QUERY_ERROR_HEADER))
+        {
             auto errorCodeString = httpResponse.GetHeader(QUERY_ERROR_HEADER);
             auto locationOfSemicolon = errorCodeString.find_first_of(';');
             Aws::String errorCode;

--- a/aws-cpp-sdk-sqs-integration-tests/QueueOperationTest.cpp
+++ b/aws-cpp-sdk-sqs-integration-tests/QueueOperationTest.cpp
@@ -550,3 +550,16 @@ TEST_F(QueueOperationTest, TagQueueTest)
     ASSERT_EQ(foundExpectedTagIt->second, expectedTag.second);
   }
 }
+
+TEST_F(QueueOperationTest, ErrorCode)
+{
+    SendMessageRequest sendMessageRequest;
+    sendMessageRequest.SetMessageBody("message body");
+    sendMessageRequest.SetQueueUrl("https://queue.amazonaws.com/539743340619/non-existing-queue");
+
+    SendMessageOutcome sendMessageOutcome = sqsClient->SendMessage(sendMessageRequest);
+
+    ASSERT_FALSE(sendMessageOutcome.IsSuccess());
+    EXPECT_EQ(SQSErrors::QUEUE_DOES_NOT_EXIST, sendMessageOutcome.GetError().GetErrorType());
+    EXPECT_EQ("AWS.SimpleQueueService.NonExistentQueue", sendMessageOutcome.GetError().GetExceptionName());
+}

--- a/aws-cpp-sdk-sqs-integration-tests/QueueOperationTest.cpp
+++ b/aws-cpp-sdk-sqs-integration-tests/QueueOperationTest.cpp
@@ -16,6 +16,7 @@
 #include <aws/sqs/model/CreateQueueRequest.h>
 #include <aws/sqs/model/ListQueuesRequest.h>
 #include <aws/sqs/model/DeleteQueueRequest.h>
+#include <aws/sqs/model/GetQueueUrlRequest.h>
 #include <aws/sqs/model/SendMessageRequest.h>
 #include <aws/sqs/model/ReceiveMessageRequest.h>
 #include <aws/sqs/model/DeleteMessageRequest.h>
@@ -61,6 +62,7 @@ static const char BASE_DEAD_LETTER_QUEUE_NAME[]                     = TEST_QUEUE
 static const char BASE_DEAD_LETTER_SOURCE_QUEUE_NAME[]              = TEST_QUEUE_PREFIX "DeadLetterSource";
 static const char BASE_CHANGE_MESSAGE_VISIBILITY_BATCH_QUEUE_NAME[] = TEST_QUEUE_PREFIX "ChangeMsgVisBatch";
 static const char BASE_TAG_QUEUE_NAME[]                             = TEST_QUEUE_PREFIX "SimpleForTagging";
+static const char BASE_NON_EXISTING_QUEUE_NAME[]                    = TEST_QUEUE_PREFIX "NonExisting";
 static const char ALLOCATION_TAG[]                                  = "QueueOperationTest";
 
 class QueueOperationTest : public ::testing::Test
@@ -553,13 +555,12 @@ TEST_F(QueueOperationTest, TagQueueTest)
 
 TEST_F(QueueOperationTest, ErrorCode)
 {
-    SendMessageRequest sendMessageRequest;
-    sendMessageRequest.SetMessageBody("message body");
-    sendMessageRequest.SetQueueUrl("https://queue.amazonaws.com/539743340619/non-existing-queue");
+    GetQueueUrlRequest getQueueUrlRequest;
+    getQueueUrlRequest.SetQueueName(BASE_NON_EXISTING_QUEUE_NAME);
 
-    SendMessageOutcome sendMessageOutcome = sqsClient->SendMessage(sendMessageRequest);
+    auto getQueueUrlOutcome = sqsClient->GetQueueUrl(getQueueUrlRequest);
 
-    ASSERT_FALSE(sendMessageOutcome.IsSuccess());
-    EXPECT_EQ(SQSErrors::QUEUE_DOES_NOT_EXIST, sendMessageOutcome.GetError().GetErrorType());
-    EXPECT_EQ("AWS.SimpleQueueService.NonExistentQueue", sendMessageOutcome.GetError().GetExceptionName());
+    ASSERT_FALSE(getQueueUrlOutcome.IsSuccess());
+    EXPECT_EQ(SQSErrors::QUEUE_DOES_NOT_EXIST, getQueueUrlOutcome.GetError().GetErrorType());
+    EXPECT_EQ("AWS.SimpleQueueService.NonExistentQueue", getQueueUrlOutcome.GetError().GetExceptionName());
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Extend AWSErrorMashallerTest to support awsQueryCompatible: Parse error code when present in HTTP response header.

As we decided to parse AwsQuery Compatible Error in the Http response header, the required changes need to take in place on both SDK client and Service.
This will be a pre-requisite for migrating services from AwsQuery wire protocol to AwsJson.

Error code can be fetched from response content (for example `__type#fooException`). This PR takes another scenario into consideration, of which when `x-amzn-query-error` header with valid value is found from the Http response.

The parsed error code remains unchanged if this header is missing, or contains null or invalid value.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior: No.
- [X] Checked if this PR would require a ReadMe/Wiki update: Not needed.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
