### PR TITLE
Update RDS test per deprecation campaign.

### DIFF
--- a/aws-cpp-sdk-rds-integration-tests/RDSTest.cpp
+++ b/aws-cpp-sdk-rds-integration-tests/RDSTest.cpp
@@ -261,7 +261,7 @@ namespace
 
         CreateDBClusterRequest createDBClusterRequest;
         createDBClusterRequest.SetDBClusterIdentifier(TESTING_DB_CLUSTER_IDENTIFIER);
-        createDBClusterRequest.SetEngine("aurora");
+        createDBClusterRequest.SetEngine("aurora-mysql");
         createDBClusterRequest.SetStorageEncrypted(true);
         createDBClusterRequest.SetReplicationSourceIdentifier(TESTING_REPLICATION_SOURCE_IDENTIFIER);
         createDBClusterRequest.SetKmsKeyId(TESTING_KMS_KEY_ID);
@@ -269,7 +269,7 @@ namespace
 
         auto createDBClusterOutcome = m_rdsClient.CreateDBCluster(createDBClusterRequest);
         ASSERT_FALSE(createDBClusterOutcome.IsSuccess());
-        ASSERT_EQ(RDSErrors::INVALID_PARAMETER_COMBINATION, createDBClusterOutcome.GetError().GetErrorType());
+        ASSERT_EQ(RDSErrors::INVALID_PARAMETER_VALUE, createDBClusterOutcome.GetError().GetErrorType());
         Aws::String preSignedUrl = ExtractPreSignedUrlFromPayload(TestingMonitoringMetrics::s_lastPayload.c_str());
         QueryStringParameterCollection parameters(URI(preSignedUrl).GetQueryStringParameters());
         ASSERT_NE(parameters.end(), parameters.find("Action"));
@@ -281,7 +281,7 @@ namespace
         ASSERT_NE(parameters.end(), parameters.find("DBClusterIdentifier"));
         ASSERT_STREQ(TESTING_DB_CLUSTER_IDENTIFIER, parameters.find("DBClusterIdentifier")->second.c_str());
         ASSERT_NE(parameters.end(), parameters.find("Engine"));
-        ASSERT_STREQ("aurora", parameters.find("Engine")->second.c_str());
+        ASSERT_STREQ("aurora-mysql", parameters.find("Engine")->second.c_str());
         ASSERT_NE(parameters.end(), parameters.find("StorageEncrypted"));
         ASSERT_STREQ("true", parameters.find("StorageEncrypted")->second.c_str());
         ASSERT_NE(parameters.end(), parameters.find("ReplicationSourceIdentifier"));
@@ -292,13 +292,13 @@ namespace
 
         // Verify signature with fixed credentials and fixed timestamp.
         URI sourceUri("https://" + URI(preSignedUrl).GetAuthority());
-        VerifySignature(createDBClusterRequest, sourceUri, createDBClusterRequest.GetSourceRegion().c_str(), "1f654a3049149ef925f2ad58d4fd71fdf94791eb65848f866a6f451f9be655f7");
+        VerifySignature(createDBClusterRequest, sourceUri, createDBClusterRequest.GetSourceRegion().c_str(), "8c2fe7e0c15a0ca30b9ebbee3ca59760241130160ec14e3b76bddb3ceb0d1a56");
 
         // Ignore SourceRegion if preSignedUrl is specified.
         createDBClusterRequest.SetPreSignedUrl(TESTING_PRESIGNED_URL);
         createDBClusterOutcome = m_rdsClient.CreateDBCluster(createDBClusterRequest);
         ASSERT_FALSE(createDBClusterOutcome.IsSuccess());
-        ASSERT_EQ(RDSErrors::INVALID_PARAMETER_COMBINATION, createDBClusterOutcome.GetError().GetErrorType());
+        ASSERT_EQ(RDSErrors::INVALID_PARAMETER_VALUE, createDBClusterOutcome.GetError().GetErrorType());
         preSignedUrl = ExtractPreSignedUrlFromPayload(TestingMonitoringMetrics::s_lastPayload.c_str());
         ASSERT_STREQ(TESTING_PRESIGNED_URL, preSignedUrl.c_str());
     }


### PR DESCRIPTION
*Description of changes:*

The old integration tests for RDS created a cluster against the engine "aurora" which is being deprecated as part of the [https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.MySQL56.EOL.html](MySQL-Compatible Edition version 1 end of life). per documentation

`
September 27, 2022 – After this time, you can't create new Aurora MySQL version 1 clusters or instances from either the AWS Management Console or the AWS Command Line Interface (AWS CLI).
`

This updates the integration tests to use the supported `aurora-mysql` engine.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
