### PR TITLE
Add SSO background refresh for credentials.

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/auth/SSOCredentialsProvider.h
+++ b/aws-cpp-sdk-core/include/aws/core/auth/SSOCredentialsProvider.h
@@ -8,6 +8,7 @@
 
 #include <aws/core/Core_EXPORTS.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/auth/bearer-token-provider/SSOBearerTokenProvider.h>
 #include <memory>
 
 namespace Aws {
@@ -39,6 +40,8 @@ namespace Aws {
             Aws::String m_ssoRegion;
             // The expiration time of the accessToken.
             Aws::Utils::DateTime m_expiresAt;
+            // The SSO Token Provider
+            Aws::Auth::SSOBearerTokenProvider m_bearerTokenProvider;
 
             void Reload() override;
             void RefreshIfExpired();

--- a/aws-cpp-sdk-core/include/aws/core/auth/bearer-token-provider/SSOBearerTokenProvider.h
+++ b/aws-cpp-sdk-core/include/aws/core/auth/bearer-token-provider/SSOBearerTokenProvider.h
@@ -11,7 +11,7 @@
 #include <aws/core/internal/AWSHttpResourceClient.h>
 #include <aws/core/utils/threading/ReaderWriterLock.h>
 
-namespace Aws 
+namespace Aws
 {
     namespace Auth 
     {


### PR DESCRIPTION
*Description of changes:*

If an SSO session is specified will allow for the sso credential provider to refresh sso credentials eliminating the need to manually log back in when using non-bearer auth credentials.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
