### PR TITLE
Fix refresh token call.

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/internal/AWSHttpResourceClient.h
+++ b/aws-cpp-sdk-core/include/aws/core/internal/AWSHttpResourceClient.h
@@ -279,7 +279,11 @@ namespace Aws
 
              SSOCreateTokenResult CreateToken(const SSOCreateTokenRequest& request);
          private:
+             Aws::String buildEndpoint(const Aws::Client::ClientConfiguration& clientConfiguration,
+                 const Aws::String& domain,
+                 const Aws::String& endpoint);
              Aws::String m_endpoint;
+             Aws::String m_oidcEndpoint;
          };
     } // namespace Internal
 } // namespace Aws

--- a/aws-cpp-sdk-core/source/config/AWSConfigFileProfileConfigLoader.cpp
+++ b/aws-cpp-sdk-core/source/config/AWSConfigFileProfileConfigLoader.cpp
@@ -159,10 +159,10 @@ namespace Aws
                         auto hasConflictingStartUrls = !ssoSession.GetSsoStartUrl().empty()
                                                        && !prof.GetSsoStartUrl().empty()
                                                        && ssoSession.GetSsoStartUrl() != prof.GetSsoStartUrl();
-                        auto hasConlflictingRegions = !ssoSession.GetSsoRegion().empty()
+                        auto hasConflictingRegions = !ssoSession.GetSsoRegion().empty()
                                                       && !prof.GetSsoRegion().empty()
                                                       && ssoSession.GetSsoRegion() != prof.GetSsoRegion();
-                        if (hasConflictingStartUrls || hasConlflictingRegions) {
+                        if (hasConflictingStartUrls || hasConflictingRegions) {
                             AWS_LOGSTREAM_ERROR(PARSER_TAG,
                                 "SSO profile has a start url or region conflict with sso session");
                             prof.SetSsoStartUrl("");


### PR DESCRIPTION
*Description of changes:*

Fixes the refresh token call by using the correct uri for internal core odic calls.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
