### PR TITLE
Add AwsQueryCompatible trait, and backfill RequestMetadata for AwsQueryCompatible services

### DIFF
--- a/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/c2j/C2jAwsQueryCompatible.java
+++ b/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/c2j/C2jAwsQueryCompatible.java
@@ -1,0 +1,7 @@
+package com.amazonaws.util.awsclientgenerator.domainmodels.c2j;
+
+import lombok.Data;
+
+@Data
+public class C2jAwsQueryCompatible {
+}

--- a/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/c2j/C2jMetadata.java
+++ b/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/c2j/C2jMetadata.java
@@ -24,4 +24,5 @@ public class C2jMetadata {
     private String uid;
     private String timestampFormat;
     private String serviceId;
+    private C2jAwsQueryCompatible awsQueryCompatible;
 }

--- a/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/Metadata.java
+++ b/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/Metadata.java
@@ -41,4 +41,6 @@ public class Metadata {
 
     // For Pre-signed URL Generation
     private boolean hasPreSignedUrl;
+
+    private boolean awsQueryCompatible;
 }

--- a/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
+++ b/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
@@ -124,6 +124,7 @@ public class C2jModelToGeneratorModelTransformer {
         serviceModel.getMetadata().setHasEndpointDiscoveryTrait(hasEndpointDiscoveryTrait && !endpointOperationName.isEmpty());
         serviceModel.getMetadata().setRequireEndpointDiscovery(requireEndpointDiscovery);
         serviceModel.getMetadata().setEndpointOperationName(endpointOperationName);
+        serviceModel.getMetadata().setAwsQueryCompatible(c2jServiceModel.getMetadata().getAwsQueryCompatible() != null);
 
         if (c2jServiceModel.getEndpointRules() != null) {
             ObjectMapper objectMapper = new ObjectMapper();

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonResultSource.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonResultSource.vm
@@ -70,6 +70,8 @@ ${typeInfo.className}& ${typeInfo.className}::operator =(const Aws::AmazonWebSer
     ${memberVarName} = DateTime(${varName}Iter->second.c_str(), Aws::Utils::DateFormat::$CppViewHelper.computeTimestampFormatInHeader($memberEntry.value.shape));
 #elseif($memberEntry.value.shape.primitive)
      ${memberVarName} = ${CppViewHelper.computeXmlConversionMethodName($memberEntry.value.shape)}(${varName}Iter->second.c_str());
+#elseif($metadata.awsQueryCompatible && $memberEntry.value.shape.structure && $memberEntry.value.shape.name == 'ResponseMetadata')
+     m_responseMetadata.SetRequestId(${varName}Iter->second);
 #end
   }
 


### PR DESCRIPTION
*Description of changes:*

* Support AwsQueryCompatible trait from model
* Bbckfill RequestMetadata for AwsQueryCompatible services, so that user has access to requestId in successful response.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.) Test is done through SQS integration test, which is already in place.
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
