### PR TITLE
[aws-cpp-sdk-s3-crt]: Configure TCP connection-monitoring option

### DIFF
--- a/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -205,7 +205,7 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config, const std::shar
 
   aws_s3_tcp_keep_alive_options tcp_keep_alive_options;
   if (config.enableTcpKeepAlive) {
-    uint16_t configKeepAliveS = static_cast<uint16_t>(std::min(static_cast<long>(std::numeric_limits<uint16_t>::max()), static_cast<long>(config.tcpKeepAliveIntervalMs / 1000)));
+    uint16_t configKeepAliveS = static_cast<uint16_t>(std::min(static_cast<unsigned long>(std::numeric_limits<uint16_t>::max()), config.tcpKeepAliveIntervalMs / 1000ul));
     static const uint16_t MAX_CRT_KEEP_ALIVE = 15; // seconds
     const uint16_t keep_intvl = std::max(MAX_CRT_KEEP_ALIVE, configKeepAliveS);
 
@@ -219,7 +219,7 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config, const std::shar
   aws_http_connection_monitoring_options tcp_monitoring_options;
   if (config.lowSpeedLimit) {
     // Use the same monitor interval default as used by the curl client, but allow override via requestTimeoutMs:
-    uint32_t configMonitoringS = static_cast<uint32_t>(std::min(static_cast<long>(std::numeric_limits<uint32_t>::max()), static_cast<long>(config.requestTimeoutMs / 1000)));
+    uint32_t configMonitoringS = static_cast<uint32_t>(std::min(static_cast<unsigned long>(std::numeric_limits<uint32_t>::max()), config.requestTimeoutMs / 1000ul));
     static const uint32_t MAX_CRT_MONITORING = 3; // seconds
     const uint32_t monitor_intvl = std::max(MAX_CRT_MONITORING, configMonitoringS);
 

--- a/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -205,7 +205,7 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config, const std::shar
 
   aws_s3_tcp_keep_alive_options tcp_keep_alive_options;
   if (config.enableTcpKeepAlive) {
-    uint16_t configKeepAliveS = std::min(static_cast<long>(std::numeric_limits<uint16_t>::max()), static_cast<long>(config.tcpKeepAliveIntervalMs / 1000));
+    uint16_t configKeepAliveS = static_cast<uint16_t>(std::min(static_cast<long>(std::numeric_limits<uint16_t>::max()), static_cast<long>(config.tcpKeepAliveIntervalMs / 1000)));
     static const uint16_t MAX_CRT_KEEP_ALIVE = 15; // seconds
     const uint16_t keep_intvl = std::max(MAX_CRT_KEEP_ALIVE, configKeepAliveS);
 
@@ -219,7 +219,7 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config, const std::shar
   aws_http_connection_monitoring_options tcp_monitoring_options;
   if (config.lowSpeedLimit) {
     // Use the same monitor interval default as used by the curl client, but allow override via requestTimeoutMs:
-    uint32_t configMonitoringS = std::min(static_cast<long>(std::numeric_limits<uint32_t>::max()), static_cast<long>(config.requestTimeoutMs / 1000));
+    uint32_t configMonitoringS = static_cast<uint32_t>(std::min(static_cast<long>(std::numeric_limits<uint32_t>::max()), static_cast<long>(config.requestTimeoutMs / 1000)));
     static const uint32_t MAX_CRT_MONITORING = 3; // seconds
     const uint32_t monitor_intvl = std::max(MAX_CRT_MONITORING, configMonitoringS);
 

--- a/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -205,7 +205,7 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config, const std::shar
 
   aws_s3_tcp_keep_alive_options tcp_keep_alive_options;
   if (config.enableTcpKeepAlive) {
-    const int keep_intvl = std::max<int>(15, config.tcpKeepAliveIntervalMs/1000);
+    const uint16_t keep_intvl = std::max<uint16_t>(15, static_cast<uint16_t>(config.tcpKeepAliveIntervalMs)/1000);
 
     AWS_ZERO_STRUCT(tcp_keep_alive_options);
     tcp_keep_alive_options.keep_alive_interval_sec = keep_intvl;
@@ -217,7 +217,7 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config, const std::shar
   aws_http_connection_monitoring_options tcp_monitoring_options;
   if (config.lowSpeedLimit) {
     // Use the same monitor interval default as used by the curl client, but allow override via requestTimeoutMs:
-    const int monitor_intvl = std::max<int>(3, config.requestTimeoutMs/1000);
+    const uint32_t monitor_intvl = std::max<uint32_t>(3, static_cast<uint32_t>(config.requestTimeoutMs)/1000);
 
     AWS_ZERO_STRUCT(tcp_monitoring_options);
     tcp_monitoring_options.minimum_throughput_bytes_per_second = config.lowSpeedLimit;

--- a/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -205,7 +205,9 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config, const std::shar
 
   aws_s3_tcp_keep_alive_options tcp_keep_alive_options;
   if (config.enableTcpKeepAlive) {
-    const uint16_t keep_intvl = std::max<uint16_t>(15, static_cast<uint16_t>(config.tcpKeepAliveIntervalMs)/1000);
+    uint16_t configKeepAliveS = std::min(static_cast<long>(std::numeric_limits<uint16_t>::max()), static_cast<long>(config.tcpKeepAliveIntervalMs / 1000));
+    static const uint16_t MAX_CRT_KEEP_ALIVE = 15; // seconds
+    const uint16_t keep_intvl = std::max(MAX_CRT_KEEP_ALIVE, configKeepAliveS);
 
     AWS_ZERO_STRUCT(tcp_keep_alive_options);
     tcp_keep_alive_options.keep_alive_interval_sec = keep_intvl;
@@ -217,7 +219,9 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config, const std::shar
   aws_http_connection_monitoring_options tcp_monitoring_options;
   if (config.lowSpeedLimit) {
     // Use the same monitor interval default as used by the curl client, but allow override via requestTimeoutMs:
-    const uint32_t monitor_intvl = std::max<uint32_t>(3, static_cast<uint32_t>(config.requestTimeoutMs)/1000);
+    uint32_t configMonitoringS = std::min(static_cast<long>(std::numeric_limits<uint32_t>::max()), static_cast<long>(config.requestTimeoutMs / 1000));
+    static const uint32_t MAX_CRT_MONITORING = 3; // seconds
+    const uint32_t monitor_intvl = std::max(MAX_CRT_MONITORING, configMonitoringS);
 
     AWS_ZERO_STRUCT(tcp_monitoring_options);
     tcp_monitoring_options.minimum_throughput_bytes_per_second = config.lowSpeedLimit;

--- a/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -203,29 +203,29 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config, const std::shar
   s3CrtConfig.region = Aws::Crt::ByteCursorFromCString(config.region.c_str());
   s3CrtConfig.connect_timeout_ms = config.connectTimeoutMs;
 
-  aws_s3_tcp_keep_alive_options *tcp_keep_alive_options = nullptr;
+  aws_s3_tcp_keep_alive_options tcp_keep_alive_options;
   if (config.enableTcpKeepAlive)
   {
     const uint16_t keep_intvl = std::max<uint16_t>(15, config.tcpKeepAliveIntervalMs/1000);
 
-    tcp_keep_alive_options = static_cast<aws_s3_tcp_keep_alive_options *>(aws_mem_calloc(Aws::get_aws_allocator(),
-                                                                          1, sizeof(*tcp_keep_alive_options)));
-    tcp_keep_alive_options->keep_alive_interval_sec = keep_intvl;
-    tcp_keep_alive_options->keep_alive_timeout_sec = keep_intvl;
-  }
-  s3CrtConfig.tcp_keep_alive_options = tcp_keep_alive_options;
+    AWS_ZERO_STRUCT(tcp_keep_alive_options);
+    tcp_keep_alive_options.keep_alive_interval_sec = keep_intvl;
+    tcp_keep_alive_options.keep_alive_timeout_sec = keep_intvl;
 
-  aws_http_connection_monitoring_options *tcp_monitoring_options = nullptr;
+    s3CrtConfig.tcp_keep_alive_options = &tcp_keep_alive_options;
+  }
+
+  aws_http_connection_monitoring_options tcp_monitoring_options;
   if (config.lowSpeedLimit) {
-      // Use the same monitor interval default as used by the curl client, but allow override via requestTimeoutMs:
-      const uint32_t monitor_intvl = std::max<uint32_t>(3, config.requestTimeoutMs/1000);
+    // Use the same monitor interval default as used by the curl client, but allow override via requestTimeoutMs:
+    const uint32_t monitor_intvl = std::max<uint32_t>(3, config.requestTimeoutMs/1000);
 
-      tcp_monitoring_options = static_cast<aws_http_connection_monitoring_options *>(aws_mem_calloc(Aws::get_aws_allocator(),
-                                                                                     1, sizeof(*tcp_monitoring_options)));
-      tcp_monitoring_options->minimum_throughput_bytes_per_second = config.lowSpeedLimit;
-      tcp_monitoring_options->allowable_throughput_failure_interval_seconds = monitor_intvl;
+    AWS_ZERO_STRUCT(tcp_monitoring_options);
+    tcp_monitoring_options.minimum_throughput_bytes_per_second = config.lowSpeedLimit;
+    tcp_monitoring_options.allowable_throughput_failure_interval_seconds = monitor_intvl;
+
+    s3CrtConfig.monitoring_options = &tcp_monitoring_options;
   }
-  s3CrtConfig.monitoring_options = tcp_monitoring_options;
 
   Aws::Crt::Io::ClientBootstrap* clientBootstrap = config.clientBootstrap ? config.clientBootstrap.get() : Aws::GetDefaultClientBootstrap();
   s3CrtConfig.client_bootstrap = clientBootstrap->GetUnderlyingHandle();
@@ -283,8 +283,6 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config, const std::shar
   {
     aws_tls_connection_options_clean_up(&tlsOptions);
   }
-  aws_mem_release(Aws::get_aws_allocator(), tcp_keep_alive_options);
-  aws_mem_release(Aws::get_aws_allocator(), tcp_monitoring_options);
   if (!m_s3CrtClient)
   {
     AWS_LOGSTREAM_FATAL(ALLOCATION_TAG, "Failed to allocate aws_s3_client instance, abort.");

--- a/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -205,7 +205,7 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config, const std::shar
 
   aws_s3_tcp_keep_alive_options tcp_keep_alive_options;
   if (config.enableTcpKeepAlive) {
-    const uint16_t keep_intvl = std::max<uint16_t>(15, config.tcpKeepAliveIntervalMs/1000);
+    const int keep_intvl = std::max<int>(15, config.tcpKeepAliveIntervalMs/1000);
 
     AWS_ZERO_STRUCT(tcp_keep_alive_options);
     tcp_keep_alive_options.keep_alive_interval_sec = keep_intvl;
@@ -217,7 +217,7 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config, const std::shar
   aws_http_connection_monitoring_options tcp_monitoring_options;
   if (config.lowSpeedLimit) {
     // Use the same monitor interval default as used by the curl client, but allow override via requestTimeoutMs:
-    const uint32_t monitor_intvl = std::max<uint32_t>(3, config.requestTimeoutMs/1000);
+    const int monitor_intvl = std::max<int>(3, config.requestTimeoutMs/1000);
 
     AWS_ZERO_STRUCT(tcp_monitoring_options);
     tcp_monitoring_options.minimum_throughput_bytes_per_second = config.lowSpeedLimit;

--- a/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -204,8 +204,7 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config, const std::shar
   s3CrtConfig.connect_timeout_ms = config.connectTimeoutMs;
 
   aws_s3_tcp_keep_alive_options tcp_keep_alive_options;
-  if (config.enableTcpKeepAlive)
-  {
+  if (config.enableTcpKeepAlive) {
     const uint16_t keep_intvl = std::max<uint16_t>(15, config.tcpKeepAliveIntervalMs/1000);
 
     AWS_ZERO_STRUCT(tcp_keep_alive_options);

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -185,6 +185,31 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
   aws_s3_client_config s3CrtConfig;
   AWS_ZERO_STRUCT(s3CrtConfig);
   s3CrtConfig.region = Aws::Crt::ByteCursorFromCString(config.region.c_str());
+  s3CrtConfig.connect_timeout_ms = config.connectTimeoutMs;
+
+  aws_s3_tcp_keep_alive_options tcp_keep_alive_options;
+  if (config.enableTcpKeepAlive) {
+    const uint16_t keep_intvl = std::max<uint16_t>(15, config.tcpKeepAliveIntervalMs/1000);
+
+    AWS_ZERO_STRUCT(tcp_keep_alive_options);
+    tcp_keep_alive_options.keep_alive_interval_sec = keep_intvl;
+    tcp_keep_alive_options.keep_alive_timeout_sec = keep_intvl;
+
+    s3CrtConfig.tcp_keep_alive_options = &tcp_keep_alive_options;
+  }
+
+  aws_http_connection_monitoring_options tcp_monitoring_options;
+  if (config.lowSpeedLimit) {
+    // Use the same monitor interval default as used by the curl client, but allow override via requestTimeoutMs:
+    const uint32_t monitor_intvl = std::max<uint32_t>(3, config.requestTimeoutMs/1000);
+
+    AWS_ZERO_STRUCT(tcp_monitoring_options);
+    tcp_monitoring_options.minimum_throughput_bytes_per_second = config.lowSpeedLimit;
+    tcp_monitoring_options.allowable_throughput_failure_interval_seconds = monitor_intvl;
+
+    s3CrtConfig.monitoring_options = &tcp_monitoring_options;
+  }
+
   Aws::Crt::Io::ClientBootstrap* clientBootstrap = config.clientBootstrap ? config.clientBootstrap.get() : Aws::GetDefaultClientBootstrap();
   s3CrtConfig.client_bootstrap = clientBootstrap->GetUnderlyingHandle();
 

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -189,7 +189,7 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
 
   aws_s3_tcp_keep_alive_options tcp_keep_alive_options;
   if (config.enableTcpKeepAlive) {
-    const int keep_intvl = std::max<int>(15, config.tcpKeepAliveIntervalMs/1000);
+    const uint16_t keep_intvl = std::max<uint16_t>(15, static_cast<uint16_t>(config.tcpKeepAliveIntervalMs)/1000);
 
     AWS_ZERO_STRUCT(tcp_keep_alive_options);
     tcp_keep_alive_options.keep_alive_interval_sec = keep_intvl;
@@ -201,7 +201,7 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
   aws_http_connection_monitoring_options tcp_monitoring_options;
   if (config.lowSpeedLimit) {
     // Use the same monitor interval default as used by the curl client, but allow override via requestTimeoutMs:
-    const int monitor_intvl = std::max<int>(3, config.requestTimeoutMs/1000);
+    const uint32_t monitor_intvl = std::max<uint32_t>(3, static_cast<uint32_t>(config.requestTimeoutMs)/1000);
 
     AWS_ZERO_STRUCT(tcp_monitoring_options);
     tcp_monitoring_options.minimum_throughput_bytes_per_second = config.lowSpeedLimit;

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -189,7 +189,7 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
 
   aws_s3_tcp_keep_alive_options tcp_keep_alive_options;
   if (config.enableTcpKeepAlive) {
-    uint16_t configKeepAliveS = std::min(static_cast<long>(std::numeric_limits<uint16_t>::max()), static_cast<long>(config.tcpKeepAliveIntervalMs / 1000));
+    uint16_t configKeepAliveS = static_cast<uint16_t>(std::min(static_cast<long>(std::numeric_limits<uint16_t>::max()), static_cast<long>(config.tcpKeepAliveIntervalMs / 1000)));
     static const uint16_t MAX_CRT_KEEP_ALIVE = 15; // seconds
     const uint16_t keep_intvl = std::max(MAX_CRT_KEEP_ALIVE, configKeepAliveS);
 
@@ -203,7 +203,7 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
   aws_http_connection_monitoring_options tcp_monitoring_options;
   if (config.lowSpeedLimit) {
     // Use the same monitor interval default as used by the curl client, but allow override via requestTimeoutMs:
-    uint32_t configMonitoringS = std::min(static_cast<long>(std::numeric_limits<uint32_t>::max()), static_cast<long>(config.requestTimeoutMs / 1000));
+    uint32_t configMonitoringS = static_cast<uint32_t>(std::min(static_cast<long>(std::numeric_limits<uint32_t>::max()), static_cast<long>(config.requestTimeoutMs / 1000)));
     static const uint32_t MAX_CRT_MONITORING = 3; // seconds
     const uint32_t monitor_intvl = std::max(MAX_CRT_MONITORING, configMonitoringS);
 

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -189,7 +189,7 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
 
   aws_s3_tcp_keep_alive_options tcp_keep_alive_options;
   if (config.enableTcpKeepAlive) {
-    uint16_t configKeepAliveS = static_cast<uint16_t>(std::min(static_cast<long>(std::numeric_limits<uint16_t>::max()), static_cast<long>(config.tcpKeepAliveIntervalMs / 1000)));
+    uint16_t configKeepAliveS = static_cast<uint16_t>(std::min(static_cast<unsigned long>(std::numeric_limits<uint16_t>::max()), config.tcpKeepAliveIntervalMs / 1000ul));
     static const uint16_t MAX_CRT_KEEP_ALIVE = 15; // seconds
     const uint16_t keep_intvl = std::max(MAX_CRT_KEEP_ALIVE, configKeepAliveS);
 
@@ -203,7 +203,7 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
   aws_http_connection_monitoring_options tcp_monitoring_options;
   if (config.lowSpeedLimit) {
     // Use the same monitor interval default as used by the curl client, but allow override via requestTimeoutMs:
-    uint32_t configMonitoringS = static_cast<uint32_t>(std::min(static_cast<long>(std::numeric_limits<uint32_t>::max()), static_cast<long>(config.requestTimeoutMs / 1000)));
+    uint32_t configMonitoringS = static_cast<uint32_t>(std::min(static_cast<unsigned long>(std::numeric_limits<uint32_t>::max()), config.requestTimeoutMs / 1000ul));
     static const uint32_t MAX_CRT_MONITORING = 3; // seconds
     const uint32_t monitor_intvl = std::max(MAX_CRT_MONITORING, configMonitoringS);
 

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -189,7 +189,9 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
 
   aws_s3_tcp_keep_alive_options tcp_keep_alive_options;
   if (config.enableTcpKeepAlive) {
-    const uint16_t keep_intvl = std::max<uint16_t>(15, static_cast<uint16_t>(config.tcpKeepAliveIntervalMs)/1000);
+    uint16_t configKeepAliveS = std::min(static_cast<long>(std::numeric_limits<uint16_t>::max()), static_cast<long>(config.tcpKeepAliveIntervalMs / 1000));
+    static const uint16_t MAX_CRT_KEEP_ALIVE = 15; // seconds
+    const uint16_t keep_intvl = std::max(MAX_CRT_KEEP_ALIVE, configKeepAliveS);
 
     AWS_ZERO_STRUCT(tcp_keep_alive_options);
     tcp_keep_alive_options.keep_alive_interval_sec = keep_intvl;
@@ -201,7 +203,9 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
   aws_http_connection_monitoring_options tcp_monitoring_options;
   if (config.lowSpeedLimit) {
     // Use the same monitor interval default as used by the curl client, but allow override via requestTimeoutMs:
-    const uint32_t monitor_intvl = std::max<uint32_t>(3, static_cast<uint32_t>(config.requestTimeoutMs)/1000);
+    uint32_t configMonitoringS = std::min(static_cast<long>(std::numeric_limits<uint32_t>::max()), static_cast<long>(config.requestTimeoutMs / 1000));
+    static const uint32_t MAX_CRT_MONITORING = 3; // seconds
+    const uint32_t monitor_intvl = std::max(MAX_CRT_MONITORING, configMonitoringS);
 
     AWS_ZERO_STRUCT(tcp_monitoring_options);
     tcp_monitoring_options.minimum_throughput_bytes_per_second = config.lowSpeedLimit;

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -189,7 +189,7 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
 
   aws_s3_tcp_keep_alive_options tcp_keep_alive_options;
   if (config.enableTcpKeepAlive) {
-    const uint16_t keep_intvl = std::max<uint16_t>(15, config.tcpKeepAliveIntervalMs/1000);
+    const int keep_intvl = std::max<int>(15, config.tcpKeepAliveIntervalMs/1000);
 
     AWS_ZERO_STRUCT(tcp_keep_alive_options);
     tcp_keep_alive_options.keep_alive_interval_sec = keep_intvl;
@@ -201,7 +201,7 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
   aws_http_connection_monitoring_options tcp_monitoring_options;
   if (config.lowSpeedLimit) {
     // Use the same monitor interval default as used by the curl client, but allow override via requestTimeoutMs:
-    const uint32_t monitor_intvl = std::max<uint32_t>(3, config.requestTimeoutMs/1000);
+    const int monitor_intvl = std::max<int>(3, config.requestTimeoutMs/1000);
 
     AWS_ZERO_STRUCT(tcp_monitoring_options);
     tcp_monitoring_options.minimum_throughput_bytes_per_second = config.lowSpeedLimit;


### PR DESCRIPTION
This is copy of [this issue](https://github.com/aws/aws-sdk-cpp/pull/2101) with the required code gen changes included

The main SDK enables TCP keep-alive and connection-speed monitoring by default, these options are also important for the S3CrtClient (e.g. https://github.com/awslabs/aws-c-s3/issues/210).

Hence, based on https://github.com/awslabs/aws-c-s3/pull/204, expose the following `ClientConfiguration` options to CRT:
- `connect_timeout_ms`: S3 socket connection timeout;
- `enableTcpKeepAlive`: enable TCP keep-alive probes;
- `tcpKeepAliveIntervalMs`: TCP keep-alive wait/probe interval;
- `lowSpeedLimit`: `aws-c-http` TCP connection speed monitoring;
- `requestTimeoutMs`: to provide upper bound on the monitoring interval for `aws-c-http` TCP connection speed monitoring.

*Issue #, if available:* Resolves #2107.

*Description of changes:*

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.