### PR TITLE
switch sprintf to snprintf

### DIFF
--- a/aws-cpp-sdk-core/source/external/cjson/cJSON.cpp
+++ b/aws-cpp-sdk-core/source/external/cjson/cJSON.cpp
@@ -1018,7 +1018,7 @@ static cJSON_AS4CPP_bool print_string_ptr(const unsigned char * const input, pri
                     break;
                 default:
                     /* escape and print as unicode codepoint */
-                    snprintf((char*)output_pointer, sizeof(output_pointer), "u%04x", *input_pointer);
+                    snprintf((char*)output_pointer, output_buffer->length - (output_pointer - output_buffer->buffer), "u%04x", *input_pointer);
                     output_pointer += 4;
                     break;
             }

--- a/aws-cpp-sdk-core/source/external/cjson/cJSON.cpp
+++ b/aws-cpp-sdk-core/source/external/cjson/cJSON.cpp
@@ -120,7 +120,7 @@ CJSON_AS4CPP_PUBLIC(double) cJSON_AS4CPP_GetNumberValue(const cJSON * const item
 CJSON_AS4CPP_PUBLIC(const char*) cJSON_AS4CPP_Version(void)
 {
     static char version[15];
-    sprintf(version, "%i.%i.%i", CJSON_AS4CPP_VERSION_MAJOR, CJSON_AS4CPP_VERSION_MINOR, CJSON_AS4CPP_VERSION_PATCH);
+    snprintf(version, sizeof(version), "%i.%i.%i", CJSON_AS4CPP_VERSION_MAJOR, CJSON_AS4CPP_VERSION_MINOR, CJSON_AS4CPP_VERSION_PATCH);
 
     return version;
 }
@@ -569,27 +569,27 @@ static cJSON_AS4CPP_bool print_number(const cJSON * const item, printbuffer * co
     /* For integer which is out of the range of [INT_MIN, INT_MAX], valuestring is an integer literal. */
     if (item->valuestring)
     {
-        length = sprintf((char*)number_buffer, "%s", item->valuestring);
+        length = snprintf((char*)number_buffer, sizeof(number_buffer), "%s", item->valuestring);
     }
     /* This checks for NaN and Infinity */
     else if (isnan(d) || isinf(d))
     {
-        length = sprintf((char*)number_buffer, "null");
+        length = snprintf((char*)number_buffer, sizeof(number_buffer), "null");
     }
     else
     {
         /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
-        length = sprintf((char*)number_buffer, "%1.15g", d);
+        length = snprintf((char*)number_buffer, sizeof(number_buffer), "%1.15g", d);
 
         /* Check whether the original double can be recovered */
         if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || !compare_double((double)test, d))
         {
             /* If not, print with 17 decimal places of precision */
-            length = sprintf((char*)number_buffer, "%1.17g", d);
+            length = snprintf((char*)number_buffer, sizeof(number_buffer), "%1.17g", d);
         }
     }
 
-    /* sprintf failed or buffer overrun occurred */
+    /* snprintf failed or buffer overrun occurred */
     if ((length < 0) || (length > (int)(sizeof(number_buffer) - 1)))
     {
         return false;
@@ -1018,7 +1018,7 @@ static cJSON_AS4CPP_bool print_string_ptr(const unsigned char * const input, pri
                     break;
                 default:
                     /* escape and print as unicode codepoint */
-                    sprintf((char*)output_pointer, "u%04x", *input_pointer);
+                    snprintf((char*)output_pointer, sizeof(output_pointer), "u%04x", *input_pointer);
                     output_pointer += 4;
                     break;
             }
@@ -2470,7 +2470,7 @@ CJSON_AS4CPP_PUBLIC(cJSON *) cJSON_AS4CPP_CreateInt64(long long num)
         if (num > INT_MAX || num < INT_MIN)
         {
             char buf[21];
-            sprintf(buf, "%lld", num);
+            snprintf(buf, sizeof(buf), "%lld", num);
             item->valuestring = (char*)cJSON_AS4CPP_strdup((const unsigned char*)buf, &global_hooks);
         }
 


### PR DESCRIPTION
*Issue #, if available:*
Ran into this warning when building on mac:
```
"This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead."
```

*Description of changes:*
switch sprintf to snprintf
```cpp
//from
sprintf(buf, "%lld", num);
//to
snprintf(buf, sizeof(buf), "%lld", num);
```
*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [X] Windows
- [ ] Android
- [X] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
