### PR TITLE
Give more braces to old buggy gcc version

### DIFF
--- a/aws-cpp-sdk-core/source/endpoint/AWSPartitions.cpp
+++ b/aws-cpp-sdk-core/source/endpoint/AWSPartitions.cpp
@@ -13,7 +13,7 @@ const size_t AWSPartitions::PartitionsBlobStrLen = 1629;
 const size_t AWSPartitions::PartitionsBlobSize = 1630;
 
 using PartitionsBlobT = Aws::Array<const char, AWSPartitions::PartitionsBlobSize>;
-static constexpr PartitionsBlobT PartitionsBlob = {
+static constexpr PartitionsBlobT PartitionsBlob = {{
 '{','"','v','e','r','s','i','o','n','"',':','"','1','.','1','"',',','"','p','a','r','t','i','t','i',
 'o','n','s','"',':','[','{','"','i','d','"',':','"','a','w','s','"',',','"','r','e','g','i','o','n',
 'R','e','g','e','x','"',':','"','^','(','u','s','|','e','u','|','a','p','|','s','a','|','c','a','|',
@@ -80,7 +80,7 @@ static constexpr PartitionsBlobT PartitionsBlob = {
 ':','"','s','c','2','s','.','s','g','o','v','.','g','o','v','"','}',',','"','r','e','g','i','o','n',
 's','"',':','{','"','a','w','s','-','i','s','o','-','b','-','g','l','o','b','a','l','"',':','{','}',
 '}','}',']','}','\0'
-};
+}};
 
 const char* AWSPartitions::GetPartitionsBlob()
 {

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/endpoint/partitions/AWSPartitionsHeader.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/endpoint/partitions/AWSPartitionsHeader.vm
@@ -2,13 +2,14 @@
 
 #set($metadata = $serviceModel.metadata)
 #pragma once
+\#include <aws/core/Core_EXPORTS.h>
 \#include <aws/core/utils/memory/stl/AWSArray.h>
 
 namespace Aws
 {
 namespace Endpoint
 {
-    struct AWSPartitions
+    struct AWS_CORE_API AWSPartitions
     {
     public:
 #set($PartitionsBlobStrLen = $serviceModel.partitionsBlob.length() - 1)

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/endpoint/partitions/AWSPartitionsSource.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/endpoint/partitions/AWSPartitionsSource.vm
@@ -11,7 +11,7 @@ const size_t AWSPartitions::PartitionsBlobStrLen = $PartitionsBlobStrLen;
 const size_t AWSPartitions::PartitionsBlobSize = $serviceModel.partitionsBlob.length();
 
 using PartitionsBlobT = Aws::Array<const char, AWSPartitions::PartitionsBlobSize>;
-static constexpr PartitionsBlobT PartitionsBlob = {
+static constexpr PartitionsBlobT PartitionsBlob = {{
 #set($lineLenth = 0)
 #foreach($tmpChar in $serviceModel.partitionsBlob.toCharArray())
 #if($tmpChar.equals($nl) || $tmpChar == $nl)
@@ -38,7 +38,7 @@ static constexpr PartitionsBlobT PartitionsBlob = {
 #end
 #end
 
-};
+}};
 
 const char* AWSPartitions::GetPartitionsBlob()
 {


### PR DESCRIPTION
*Issue #, if available:*
gcc wants double-braces arround std::array
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25137

*Description of changes:*
Give gcc more braces

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
