### PR TITLE
Issue 1655

### DIFF
--- a/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
+++ b/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
@@ -4735,8 +4735,9 @@ namespace Aws
 
         struct CrtRequestCallbackUserData {
           const S3CrtClient *s3CrtClient;
-          const void *userCallback;
-          std::shared_ptr<const Aws::Client::AsyncCallerContext> userCallbackContext;
+          GetObjectResponseReceivedHandler getResponseHandler;
+          PutObjectResponseReceivedHandler putResponseHandler;
+          std::shared_ptr<const Aws::Client::AsyncCallerContext> asyncCallerContext;
           const Aws::AmazonWebServiceRequest *originalRequest;
           std::shared_ptr<Aws::Http::HttpRequest> request;
           std::shared_ptr<Aws::Http::HttpResponse> response;

--- a/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -518,7 +518,7 @@ void S3CrtClient::GetObjectAsync(const GetObjectRequest& request, const GetObjec
   AWS_ZERO_STRUCT(options);
 
   userData->getResponseHandler = handler;
-  userData->asyncCallerContext = context;
+  userData->asyncCallerContext = handlerContext;
   InitCommonCrtRequestOption(userData, &options, &request, endpointResolutionOutcome.GetResult().GetURI(), Aws::Http::HttpMethod::HTTP_GET);
   options.shutdown_callback = GetObjectRequestShutdownCallback;
   options.type = AWS_S3_META_REQUEST_TYPE_GET_OBJECT;
@@ -598,7 +598,7 @@ void S3CrtClient::PutObjectAsync(const PutObjectRequest& request, const PutObjec
   AWS_ZERO_STRUCT(options);
 
   userData->putResponseHandler = handler;
-  userData->asyncCallerContext = context;
+  userData->asyncCallerContext = handlerContext;
   InitCommonCrtRequestOption(userData, &options, &request, endpointResolutionOutcome.GetResult().GetURI(), Aws::Http::HttpMethod::HTTP_PUT);
   options.shutdown_callback = PutObjectRequestShutdownCallback;
   options.type = AWS_S3_META_REQUEST_TYPE_PUT_OBJECT;

--- a/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -484,8 +484,7 @@ static void GetObjectRequestShutdownCallback(void *user_data)
   auto *userData = static_cast<S3CrtClient::CrtRequestCallbackUserData*>(user_data);
   // call user callback and release user_data
   S3Crt::Model::GetObjectOutcome outcome(userData->s3CrtClient->GenerateStreamOutcome(userData->response));
-  auto handler = static_cast<const GetObjectResponseReceivedHandler*>(userData->userCallback);
-  (*handler)(userData->s3CrtClient, *(reinterpret_cast<const GetObjectRequest*>(userData->originalRequest)), std::move(outcome), userData->userCallbackContext);
+  userData->getResponseHandler(userData->s3CrtClient, *(reinterpret_cast<const GetObjectRequest*>(userData->originalRequest)), std::move(outcome), userData->asyncCallerContext);
 
   Aws::Delete(userData);
 }
@@ -518,10 +517,9 @@ void S3CrtClient::GetObjectAsync(const GetObjectRequest& request, const GetObjec
   aws_s3_meta_request_options options;
   AWS_ZERO_STRUCT(options);
 
-  userData->userCallback = static_cast<const void*>(&handler);
-  userData->userCallbackContext = handlerContext;
-
-  InitCommonCrtRequestOption(userData, &options, &request, endpointResolutionOutcome.GetResult().GetURI(), Aws::Http::HttpMethod::HTTP_GET);
+  userData->getResponseHandler = handler;
+  userData->asyncCallerContext = context;
+  InitCommonCrtRequestOption(userData, &options, &request, uri, Aws::Http::HttpMethod::HTTP_GET);
   options.shutdown_callback = GetObjectRequestShutdownCallback;
   options.type = AWS_S3_META_REQUEST_TYPE_GET_OBJECT;
   struct aws_signing_config_aws signing_config_override = m_s3CrtSigningConfig;
@@ -566,8 +564,7 @@ static void PutObjectRequestShutdownCallback(void *user_data)
   auto *userData = static_cast<S3CrtClient::CrtRequestCallbackUserData*>(user_data);
   // call user callback and release user_data
   S3Crt::Model::PutObjectOutcome outcome(userData->s3CrtClient->GenerateXmlOutcome(userData->response));
-  auto handler = static_cast<const PutObjectResponseReceivedHandler*>(userData->userCallback);
-  (*handler)(userData->s3CrtClient, *(reinterpret_cast<const PutObjectRequest*>(userData->originalRequest)), std::move(outcome), userData->userCallbackContext);
+  userData->putResponseHandler(userData->s3CrtClient, *(reinterpret_cast<const PutObjectRequest*>(userData->originalRequest)), std::move(outcome), userData->asyncCallerContext);
 
   Aws::Delete(userData);
 }
@@ -600,10 +597,16 @@ void S3CrtClient::PutObjectAsync(const PutObjectRequest& request, const PutObjec
   aws_s3_meta_request_options options;
   AWS_ZERO_STRUCT(options);
 
+<<<<<<< HEAD
   userData->userCallback = static_cast<const void*>(&handler);
   userData->userCallbackContext = handlerContext;
 
   InitCommonCrtRequestOption(userData, &options, &request, endpointResolutionOutcome.GetResult().GetURI(), Aws::Http::HttpMethod::HTTP_PUT);
+=======
+  userData->putResponseHandler = handler;
+  userData->asyncCallerContext = context;
+  InitCommonCrtRequestOption(userData, &options, &request, uri, Aws::Http::HttpMethod::HTTP_PUT);
+>>>>>>> bc51fa35ec (Resolves #1655)
   options.shutdown_callback = PutObjectRequestShutdownCallback;
   options.type = AWS_S3_META_REQUEST_TYPE_PUT_OBJECT;
   struct aws_signing_config_aws signing_config_override = m_s3CrtSigningConfig;

--- a/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -519,7 +519,7 @@ void S3CrtClient::GetObjectAsync(const GetObjectRequest& request, const GetObjec
 
   userData->getResponseHandler = handler;
   userData->asyncCallerContext = context;
-  InitCommonCrtRequestOption(userData, &options, &request, uri, Aws::Http::HttpMethod::HTTP_GET);
+  InitCommonCrtRequestOption(userData, &options, &request, endpointResolutionOutcome.GetResult().GetURI(), Aws::Http::HttpMethod::HTTP_GET);
   options.shutdown_callback = GetObjectRequestShutdownCallback;
   options.type = AWS_S3_META_REQUEST_TYPE_GET_OBJECT;
   struct aws_signing_config_aws signing_config_override = m_s3CrtSigningConfig;
@@ -599,7 +599,7 @@ void S3CrtClient::PutObjectAsync(const PutObjectRequest& request, const PutObjec
 
   userData->putResponseHandler = handler;
   userData->asyncCallerContext = context;
-  InitCommonCrtRequestOption(userData, &options, &request, uri, Aws::Http::HttpMethod::HTTP_PUT);
+  InitCommonCrtRequestOption(userData, &options, &request, endpointResolutionOutcome.GetResult().GetURI(), Aws::Http::HttpMethod::HTTP_PUT);
   options.shutdown_callback = PutObjectRequestShutdownCallback;
   options.type = AWS_S3_META_REQUEST_TYPE_PUT_OBJECT;
   struct aws_signing_config_aws signing_config_override = m_s3CrtSigningConfig;

--- a/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -597,16 +597,9 @@ void S3CrtClient::PutObjectAsync(const PutObjectRequest& request, const PutObjec
   aws_s3_meta_request_options options;
   AWS_ZERO_STRUCT(options);
 
-<<<<<<< HEAD
-  userData->userCallback = static_cast<const void*>(&handler);
-  userData->userCallbackContext = handlerContext;
-
-  InitCommonCrtRequestOption(userData, &options, &request, endpointResolutionOutcome.GetResult().GetURI(), Aws::Http::HttpMethod::HTTP_PUT);
-=======
   userData->putResponseHandler = handler;
   userData->asyncCallerContext = context;
   InitCommonCrtRequestOption(userData, &options, &request, uri, Aws::Http::HttpMethod::HTTP_PUT);
->>>>>>> bc51fa35ec (Resolves #1655)
   options.shutdown_callback = PutObjectRequestShutdownCallback;
   options.type = AWS_S3_META_REQUEST_TYPE_PUT_OBJECT;
   struct aws_signing_config_aws signing_config_override = m_s3CrtSigningConfig;

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
@@ -188,8 +188,9 @@ namespace ${rootNamespace}
 
         struct CrtRequestCallbackUserData {
           const S3CrtClient *s3CrtClient;
-          const void *userCallback;
-          std::shared_ptr<const Aws::Client::AsyncCallerContext> userCallbackContext;
+          GetObjectResponseReceivedHandler getResponseHandler;
+          PutObjectResponseReceivedHandler putResponseHandler;
+          std::shared_ptr<const Aws::Client::AsyncCallerContext> asyncCallerContext;
           const Aws::AmazonWebServiceRequest *originalRequest;
           std::shared_ptr<Aws::Http::HttpRequest> request;
           std::shared_ptr<Aws::Http::HttpResponse> response;

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
@@ -249,7 +249,7 @@ void ${className}::${operation.name}Async(${constText}${operation.request.shape.
 #elseif($operation.name == "GetObject")
   userData->getResponseHandler = handler;
 #end
-  userData->asyncCallerContext = context;
+  userData->asyncCallerContext = handlerContext;
 #if($serviceModel.endpointRules)
   InitCommonCrtRequestOption(userData, &options, &request, endpointResolutionOutcome.GetResult().GetURI(), Aws::Http::HttpMethod::HTTP_${operation.http.method});
 #else
@@ -331,8 +331,11 @@ void ${className}::${operation.name}Async(${constText}${operation.name}ResponseR
   aws_s3_meta_request_options options;
   AWS_ZERO_STRUCT(options);
 
-  userData->userCallback = static_cast<const void*>(&handler);
-  userData->userCallbackContext = handlerContext;
+#if($operation.name == "PutObject")
+  userData->putResponseHandler = handler;
+#elseif($operation.name == "GetObject")
+  userData->getResponseHandler = handler;
+#end
   InitCommonCrtRequestOption(userData, &options, nullptr, ss.str(), Aws::Http::HttpMethod::HTTP_${operation.http.method});
   options.shutdown_callback = ${operation.name}RequestShutdownCallback;
 #if($operation.name == "PutObject")

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
@@ -187,9 +187,12 @@ static void ${operation.name}RequestShutdownCallback(void *user_data)
 #else
   S3Crt::Model::${operation.name}Outcome outcome(userData->s3CrtClient->GenerateXmlOutcome(userData->response));
 #end
-  auto handler = static_cast<const ${operation.name}ResponseReceivedHandler*>(userData->userCallback);
 #if($operation.request)
-  (*handler)(userData->s3CrtClient, *(reinterpret_cast<const ${operation.request.shape.name}*>(userData->originalRequest)), std::move(outcome), userData->userCallbackContext);
+#if($operation.name == "PutObject")
+  userData->putResponseHandler(userData->s3CrtClient, *(reinterpret_cast<const ${operation.name}Request*>(userData->originalRequest)), std::move(outcome), userData->asyncCallerContext);
+#elseif($operation.name == "GetObject")
+  userData->getResponseHandler(userData->s3CrtClient, *(reinterpret_cast<const ${operation.name}Request*>(userData->originalRequest)), std::move(outcome), userData->asyncCallerContext);
+#end
 #else
   (*handler)(userData->s3CrtClient, outcome, userData->userCallbackContext);
 #end
@@ -241,9 +244,12 @@ void ${className}::${operation.name}Async(${constText}${operation.request.shape.
   aws_s3_meta_request_options options;
   AWS_ZERO_STRUCT(options);
 
-  userData->userCallback = static_cast<const void*>(&handler);
-  userData->userCallbackContext = handlerContext;
-
+#if($operation.name == "PutObject")
+  userData->putResponseHandler = handler;
+#elseif($operation.name == "GetObject")
+  userData->getResponseHandler = handler;
+#end
+  userData->asyncCallerContext = context;
 #if($serviceModel.endpointRules)
   InitCommonCrtRequestOption(userData, &options, &request, endpointResolutionOutcome.GetResult().GetURI(), Aws::Http::HttpMethod::HTTP_${operation.http.method});
 #else


### PR DESCRIPTION
Original PR by @grrtrr: https://github.com/aws/aws-sdk-cpp/pull/1856
_This fixes undefined behaviour in `Get/PutObjecAsync` which results in crashes and program termination._

*Issue #, if available:*
Resolves #1655.

*Description of changes:*

The `Get/PutObjectAsync` methods use const-references to `std::function` as callbacks:
```c++
typedef std::function<void(const S3CrtClient*, const Model::GetObjectRequest&, Model::GetObjectOutcome, const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) > GetObjectResponseReceivedHandler;
typedef std::function<void(const S3CrtClient*, const Model::PutObjectRequest&, const Model::PutObjectOutcome&, const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) > PutObjectResponseReceivedHandler;

void S3CrtClient::GetObjectAsync(const GetObjectRequest& request, const GetObjectResponseReceivedHandler& handler, const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context) const;
void S3CrtClient::PutObjectAsync(const PutObjectRequest& request, const PutObjectResponseReceivedHandler& handler, const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context) const;
```
The _address_ of these const references is taken and later dereferenced (the `PutObjectAsync` path is similar):
```c++
// S3Client.h:
        struct CrtRequestCallbackUserData {
          const S3CrtClient *s3CrtClient;
          const void *userCallback;  // <== HERE
          // ...
   };

// S3CrtClient.cpp:
  CrtRequestCallbackUserData *userData = Aws::New<CrtRequestCallbackUserData>(ALLOCATION_TAG);
  // ...
  userData->userCallback = static_cast<const void*>(&handler);
```
By the time the `userCallback` is executed within `GetObjectRequestShutdownCallback`, the `handler` object is out of scope, since the `GetObjectAsync` function returns quickly. The _address_ now points to a destructed `std::function` object.

### Fix
Rather than taking the address of a (temporary) object and risk its destruction, copy-construct the handlers within `CrtRequestCallbackUserData` to ensure that the required `std::function` objects are still alive when the shutdown callbacks get called.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
  Tested behaviour manually, using the code in #1655 and a similar local application. Please see below for more details.
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
