### PR TITLE
fixes document shape codegen.

### DIFF
--- a/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
+++ b/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
@@ -135,6 +135,10 @@ public class CppViewHelper {
     public static String computeJsonizeString(Shape shape, boolean isPointer) {
         String memberAccessOp = isPointer ? "->" : ".";
 
+	if (shape.isDocument()) {
+            return memberAccessOp + "View()";
+        }
+
         if(shape.isStructure()) {
             return memberAccessOp + "Jsonize()";
         }


### PR DESCRIPTION
*Description of changes:*

There is an issue with codegen where if a list shape is a list of documents, the correct code is not generated.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
