### PR TITLE
Fixes stream signers for legacy constructors.

### DIFF
--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceLegacyConstructors.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceLegacyConstructors.vm
@@ -59,7 +59,7 @@
 #set($clientConfigurationNamespace = "Client")
 #set($defaultCredentialsProviderChainParam = "Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG)")
 #set($simpleCredentialsProviderParam = "Aws::MakeShared<SimpleAWSCredentialsProvider>(ALLOCATION_TAG, credentials)")
-#set($hasEventStreamInputOperation = $serviceModel.hasEventStreamOperationRequestShapes())
+#set($hasEventStreamInputOperation = $serviceModel.hasStreamingRequestShapes())
 #set($signerToMake = "AWSAuthV4Signer")
 #if($serviceModel.hasOnlyBearerAuth())
     #set($signerToMake = "Aws::Auth::BearerTokenAuthSignerProvider")


### PR DESCRIPTION
*Description of changes:*

There was a typo in codegen that effected how constructors were created and omitted the stream signer in cases when it was needed. We [attempted to fix it before](https://github.com/aws/aws-sdk-cpp/pull/2180) but due to a refactor forgot to fix the legacy constructors. This updates to fix the legacy constructors.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
