### PR TITLE
[aws-cpp-sdk-core]: fix missing include

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/endpoint/AWSPartitions.h
+++ b/aws-cpp-sdk-core/include/aws/core/endpoint/AWSPartitions.h
@@ -4,6 +4,7 @@
  */
 
 #pragma once
+#include <cstddef>
 #include <aws/core/Core_EXPORTS.h>
 #include <aws/core/utils/memory/stl/AWSArray.h>
 


### PR DESCRIPTION
AWSPartitions.h is missing a `cstddef` include. Not all compilers recognize `size_t`, causing errors like:

```c
aws-cpp-sdk-core/include/aws/core/endpoint/AWSPartitions.h:17:22: error: 'size_t' does not name a type
   17 |         static const size_t PartitionsBlobStrLen;
      |                      ^~~~~~
aws-cpp-sdk-core/include/aws/core/endpoint/AWSPartitions.h:9:1: note: 'size_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
    8 | #include <aws/core/utils/memory/stl/AWSArray.h>
  +++ |+#include <cstddef>
    9 |
```

Fix by including the missing `cdstddef`.

*Check all that applies:*
- [X] Did a review by yourself.
- [X]Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.