### PR TITLE
[aws-cpp-sdk-core]: replace MonitoringManager assertions with guard statements

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/monitoring/MonitoringManager.h
+++ b/aws-cpp-sdk-core/include/aws/core/monitoring/MonitoringManager.h
@@ -57,8 +57,8 @@ namespace Aws
         AWS_CORE_API void InitMonitoring(const std::vector<MonitoringFactoryCreateFunction>& monitoringFactoryCreateFunctions);
 
         /**
-         * Clean up monitoring related global variables. This should not be called at shutdown, since
-         * detached threads with completing transfers may still issue calls to the MonitoringManager.
+         * Clean up monitoring related global variables. This should be done first at shutdown, to avoid a race condition in
+         * testing whether the global Monitoring instance has been destructed.
          */
         AWS_CORE_API void CleanupMonitoring();
     }

--- a/aws-cpp-sdk-core/source/Aws.cpp
+++ b/aws-cpp-sdk-core/source/Aws.cpp
@@ -150,6 +150,7 @@ namespace Aws
 
     void ShutdownAPI(const SDKOptions& options)
     {
+        Aws::Monitoring::CleanupMonitoring();
         Aws::Internal::CleanupEC2MetadataClient();
         Aws::Net::CleanupNetwork();
         Aws::CleanupEnumOverflowContainer();

--- a/aws-cpp-sdk-core/source/monitoring/MonitoringManager.cpp
+++ b/aws-cpp-sdk-core/source/monitoring/MonitoringManager.cpp
@@ -29,12 +29,14 @@ namespace Aws
 
         Aws::Vector<void*> OnRequestStarted(const Aws::String& serviceName, const Aws::String& requestName, const std::shared_ptr<const Aws::Http::HttpRequest>& request)
         {
-            assert(s_monitors);
             Aws::Vector<void*> contexts;
-            contexts.reserve(s_monitors->size());
-            for (const auto& interface: *s_monitors)
+            if (s_monitors)
             {
-                contexts.emplace_back(interface->OnRequestStarted(serviceName, requestName, request));
+                contexts.reserve(s_monitors->size());
+                for (const auto& interface: *s_monitors)
+                {
+                    contexts.emplace_back(interface->OnRequestStarted(serviceName, requestName, request));
+                }
             }
             return contexts;
         }
@@ -42,48 +44,56 @@ namespace Aws
         void OnRequestSucceeded(const Aws::String& serviceName, const Aws::String& requestName, const std::shared_ptr<const Aws::Http::HttpRequest>& request,
                 const Aws::Client::HttpResponseOutcome& outcome, const CoreMetricsCollection& metricsFromCore, const Aws::Vector<void*>& contexts)
         {
-            assert(s_monitors);
-            assert(contexts.size() == s_monitors->size());
-            size_t index = 0;
-            for (const auto& interface: *s_monitors)
+            if (s_monitors)
             {
-                interface->OnRequestSucceeded(serviceName, requestName, request, outcome, metricsFromCore, contexts[index++]);
+                assert(contexts.size() == s_monitors->size());
+                size_t index = 0;
+                for (const auto& interface: *s_monitors)
+                {
+                    interface->OnRequestSucceeded(serviceName, requestName, request, outcome, metricsFromCore, contexts[index++]);
+                }
             }
         }
 
         void OnRequestFailed(const Aws::String& serviceName, const Aws::String& requestName, const std::shared_ptr<const Aws::Http::HttpRequest>& request,
                 const Aws::Client::HttpResponseOutcome& outcome, const CoreMetricsCollection& metricsFromCore, const Aws::Vector<void*>& contexts)
         {
-            assert(s_monitors);
-            assert(contexts.size() == s_monitors->size());
-            size_t index = 0;
-            for (const auto& interface: *s_monitors)
+            if (s_monitors)
             {
-                interface->OnRequestFailed(serviceName, requestName, request, outcome, metricsFromCore, contexts[index++]);
+                assert(contexts.size() == s_monitors->size());
+                size_t index = 0;
+                for (const auto& interface: *s_monitors)
+                {
+                    interface->OnRequestFailed(serviceName, requestName, request, outcome, metricsFromCore, contexts[index++]);
+                }
             }
         }
 
         void OnRequestRetry(const Aws::String& serviceName, const Aws::String& requestName,
                 const std::shared_ptr<const Aws::Http::HttpRequest>& request, const Aws::Vector<void*>& contexts)
         {
-            assert(s_monitors);
-            assert(contexts.size() == s_monitors->size());
-            size_t index = 0;
-            for (const auto& interface: *s_monitors)
+            if (s_monitors)
             {
-                interface->OnRequestRetry(serviceName, requestName, request, contexts[index++]);
+                assert(contexts.size() == s_monitors->size());
+                size_t index = 0;
+                for (const auto& interface: *s_monitors)
+                {
+                    interface->OnRequestRetry(serviceName, requestName, request, contexts[index++]);
+                }
             }
         }
 
         void OnFinish(const Aws::String& serviceName, const Aws::String& requestName,
                 const std::shared_ptr<const Aws::Http::HttpRequest>& request, const Aws::Vector<void*>& contexts)
         {
-            assert(s_monitors);
-            assert(contexts.size() == s_monitors->size());
-            size_t index = 0;
-            for (const auto& interface: *s_monitors)
+            if (s_monitors)
             {
-                interface->OnFinish(serviceName, requestName, request, contexts[index++]);
+                assert(contexts.size() == s_monitors->size());
+                size_t index = 0;
+                for (const auto& interface: *s_monitors)
+                {
+                    interface->OnFinish(serviceName, requestName, request, contexts[index++]);
+                }
             }
         }
 


### PR DESCRIPTION
Due to using _detached threads_, `Aws::Monitoring` functions may be called at any time even after `main()` has exited.

This triggers asserting `s_monitors` to not be `NULL`, causing successfully completed programs to fail at exit.

Fix the problem by using guard statements in place of assertions. Also revert the changes in #2136, to avoid
a race condition of testing `s_monitors` to be NULL during shutdown.

Resolves #2243.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
