### PR TITLE
Fix streaming request errors.

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/http/HttpRequest.h
+++ b/aws-cpp-sdk-core/include/aws/core/http/HttpRequest.h
@@ -61,6 +61,7 @@ namespace Aws
         extern AWS_CORE_API const char X_AMZN_TRACE_ID_HEADER[];
         extern AWS_CORE_API const char CHUNKED_VALUE[];
         extern AWS_CORE_API const char AWS_CHUNKED_VALUE[];
+        extern AWS_CORE_API const char X_AMZN_ERROR_TYPE[];
 
         class HttpRequest;
         class HttpResponse;

--- a/aws-cpp-sdk-core/source/http/HttpRequest.cpp
+++ b/aws-cpp-sdk-core/source/http/HttpRequest.cpp
@@ -41,6 +41,7 @@ namespace Aws
         const char AWS_CHUNKED_VALUE[] = "aws-chunked";
         const char X_AMZN_TRACE_ID_HEADER[] = "X-Amzn-Trace-Id";
         const char ALLOCATION_TAG[] = "HttpRequestConversion";
+        const char X_AMZN_ERROR_TYPE[] = "x-amzn-errortype";
 
         std::shared_ptr<Aws::Crt::Http::HttpRequest> HttpRequest::ToCrtHttpRequest()
         {

--- a/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -187,7 +187,7 @@ static size_t WriteData(char* ptr, size_t size, size_t nmemb, void* userdata)
         }
 
         response->GetResponseBody().write(ptr, static_cast<std::streamsize>(sizeToWrite));
-        if (context->m_request->IsEventStreamRequest())
+        if (context->m_request->IsEventStreamRequest() && !response->HasHeader(Aws::Http::X_AMZN_ERROR_TYPE))
         {
             response->GetResponseBody().flush();
         }
@@ -224,8 +224,7 @@ static size_t WriteHeader(char* ptr, size_t size, size_t nmemb, void* userdata)
     return 0;
 }
 
-
-static size_t ReadBody(char* ptr, size_t size, size_t nmemb, void* userdata)
+static size_t ReadBody(char* ptr, size_t size, size_t nmemb, void* userdata, bool isStreaming)
 {
     CurlReadCallbackContext* context = reinterpret_cast<CurlReadCallbackContext*>(userdata);
     if(context == nullptr)
@@ -255,7 +254,7 @@ static size_t ReadBody(char* ptr, size_t size, size_t nmemb, void* userdata)
 
     if (ioStream != nullptr && amountToRead > 0)
     {
-        if (request->IsEventStreamRequest())
+        if (isStreaming)
         {
             if (ioStream->readsome(ptr, amountToRead) == 0 && !ioStream->eof())
             {
@@ -315,6 +314,14 @@ static size_t ReadBody(char* ptr, size_t size, size_t nmemb, void* userdata)
     }
 
     return 0;
+}
+
+static size_t ReadBodyStreaming(char* ptr, size_t size, size_t nmemb, void* userdata) {
+    return ReadBody(ptr, size, nmemb, userdata, true);
+}
+
+static size_t ReadBodyFunc(char* ptr, size_t size, size_t nmemb, void* userdata) {
+    return ReadBody(ptr, size, nmemb, userdata, false);
 }
 
 static size_t SeekBody(void* userdata, curl_off_t offset, int origin)
@@ -709,12 +716,13 @@ std::shared_ptr<HttpResponse> CurlHttpClient::MakeRequest(const std::shared_ptr<
 
         if (request->GetContentBody())
         {
-            curl_easy_setopt(connectionHandle, CURLOPT_READFUNCTION, ReadBody);
+            curl_easy_setopt(connectionHandle, CURLOPT_READFUNCTION, ReadBodyFunc);
             curl_easy_setopt(connectionHandle, CURLOPT_READDATA, &readContext);
             curl_easy_setopt(connectionHandle, CURLOPT_SEEKFUNCTION, SeekBody);
             curl_easy_setopt(connectionHandle, CURLOPT_SEEKDATA, &readContext);
-            if (request->IsEventStreamRequest())
+            if (request->IsEventStreamRequest() && !response->HasHeader(Aws::Http::X_AMZN_ERROR_TYPE))
             {
+                curl_easy_setopt(connectionHandle, CURLOPT_READFUNCTION, ReadBodyStreaming);
                 curl_easy_setopt(connectionHandle, CURLOPT_NOPROGRESS, 0L);
 #if LIBCURL_VERSION_NUM >= 0x072000 // 7.32.0
                 curl_easy_setopt(connectionHandle, CURLOPT_XFERINFOFUNCTION, CurlProgressCallback);


### PR DESCRIPTION
*Description of changes:*

There is an issue in event streaming requests where we will return the error

```
CRC Mismatch. prelude_crc ...
```

masking a real error i.e.

```
INVALID_REQUEST - Invalid bot name or alias\"}
```

This error is [aws-c-event-stream](https://github.com/awslabs/aws-c-event-stream/blob/main/source/event_stream.c#L1302-L1307) that is being shown, but what i believe is happening is that the intial request is failing, and is being returned as a normal http response, and not a streaming response. So we try to read the response as a streaming response when in reality it is a normal http error. This checks to make sure that we have NOT received and error before continuing.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
