### PR TITLE
Correctly support Curl version >= 7.87.0

### DIFF
--- a/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -418,7 +418,11 @@ void SetOptCodeForHttpMethod(CURL* requestHandle, const std::shared_ptr<HttpRequ
             }
             else
             {
+#if LIBCURL_VERSION_NUM >= 0x070c01 // 7.12.1
+                curl_easy_setopt(requestHandle, CURLOPT_UPLOAD, 1L);
+#else
                 curl_easy_setopt(requestHandle, CURLOPT_PUT, 1L);
+#endif
             }
             break;
         case HttpMethod::HTTP_HEAD:


### PR DESCRIPTION
Since Curl 7.12.1, CURLOPT_PUT is deprecated and CURLOPT_UPLOAD should be used.
A warning is issued with Curl 7.87.0 when CURLOPT_PUT is used.

*Issue #, if available:* 
No issue created

*Description of changes:*
Remove a deprecated flag and use the correct one instead.
CURLOPT_PUT is deprecated since Curl 7.12.1 and CURLOPT_UPLOAD should be used instead.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
I don't really know if a test is applicable here. I only saw this because I have a warning when building aws-sdk-cpp with curl 7.87.0
- [x] Checked if this PR is a breaking (APIs have been changed) change.
No issue
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
No issue
- [x] Checked if this PR would require a ReadMe/Wiki update.
No need

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
