### PR TITLE
Fix poor implementation of string hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .metadata
 .build
 .idea
+.vscode
 *.d
 compile_commands.json
 Debug

--- a/aws-cpp-sdk-core/include/aws/core/utils/HashingUtils.h
+++ b/aws-cpp-sdk-core/include/aws/core/utils/HashingUtils.h
@@ -11,6 +11,8 @@
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/utils/Array.h>
 
+#include <aws/crt/StringUtils.h>
+
 namespace Aws
 {
     namespace Utils
@@ -107,7 +109,17 @@ namespace Aws
              */
             static ByteBuffer CalculateCRC32C(Aws::IOStream& stream);
 
-            static int HashString(const char* strToHash);
+            /**
+             * Hash a string to a 32-bit number.  Returning the native size_t
+             * would be better, but there seems to be a lot of code that expects
+             * this to return a signed int, so keeping it that way for now.
+             */
+            static inline int HashString(const char* strToHash) {
+                // take 0x00000FFFFFFFF000 from the 64-bit value
+                // this choice is based on trial and error, as taking
+                // just the lower bits caused one collision in the test
+                return static_cast<int>(Aws::Crt::HashString(strToHash) << 12UL >> 32UL);
+            }
 
         };
 

--- a/aws-cpp-sdk-core/source/utils/HashingUtils.cpp
+++ b/aws-cpp-sdk-core/source/utils/HashingUtils.cpp
@@ -258,17 +258,3 @@ ByteBuffer HashingUtils::CalculateCRC32C(Aws::IOStream& stream)
     CRC32C hash;
     return hash.Calculate(stream).GetResult();
 }
-
-int HashingUtils::HashString(const char* strToHash)
-{
-    if (!strToHash)
-        return 0;
-
-    unsigned hash = 0;
-    while (char charValue = *strToHash++)
-    {
-        hash = charValue + 31 * hash;
-    }
-
-    return hash;
-}


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

The original hashing algorithm used in the SDK produced 56,897 collisions on an input sample of 65,536 two-character strings. Changing to use `Aws::Crt::HashString` has made the hash more reliable.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [X] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
