### PR TITLE
Fix adaptive retry for clock drift.

### DIFF
--- a/aws-cpp-sdk-core-tests/aws/client/AdaptiveRetryStrategyTest.cpp
+++ b/aws-cpp-sdk-core-tests/aws/client/AdaptiveRetryStrategyTest.cpp
@@ -191,3 +191,11 @@ TEST(AdaptiveRetryStrategyTest, TestAdaptiveRetryStrategyUpdateClientSendingRate
         EXPECT_NEAR(step.measuredTxRate, retryTokenBucket.T_GetMeasuredTxRate(), EPSILON);
     }
 }
+
+TEST(AdaptiveRetryStrategyTest, TestRetryTokenBucketDateInFutureRuns) {
+    RetryTokenBucket retryTokenBucket;
+    ASSERT_TRUE(retryTokenBucket.Acquire(1));
+    auto oneDayMillis = 86400000;
+    retryTokenBucket.UpdateClientSendingRate(true, Aws::Utils::DateTime::Now() + std::chrono::milliseconds(oneDayMillis));
+    ASSERT_TRUE(retryTokenBucket.Acquire(1));
+}

--- a/aws-cpp-sdk-core/source/client/AdaptiveRetryStrategy.cpp
+++ b/aws-cpp-sdk-core/source/client/AdaptiveRetryStrategy.cpp
@@ -69,7 +69,7 @@ namespace Aws
                 return;
             }
 
-            double fillAmount = (now.Millis() - m_lastTimestamp.Millis())/1000.0 * m_fillRate;
+            double fillAmount = (std::abs(now.Millis() - m_lastTimestamp.Millis()))/1000.0 * m_fillRate;
             m_currentCapacity = (std::min)(m_maxCapacity, m_currentCapacity + fillAmount);
             m_lastTimestamp = now;
         }


### PR DESCRIPTION
*Description of changes:*

There is an issue where if there is a extreme amount of clock drift in the future `Aws::Utils::DateTime` will be in the future and the resulting code

```
double fillAmount = (now.Millis() - m_lastTimestamp.Millis())/1000.0 * m_fillRate;
m_currentCapacity = (std::min)(m_maxCapacity, m_currentCapacity + fillAmount);
```

will result with `fillAmount` being a very large negative number which will in turn make the `std::min` call ineffective because it will be smaller than `m_maxCapacity` creating a retry strategy that will sleep for all intents and purposes forever.

this PR updates it to use `std::abs` so that `m_maxCapacity` is respected properly.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
