### PR TITLE
Adding AL2 build examples

### DIFF
--- a/scripts/build-tests/build-al2-debug-clang-cxx20.sh
+++ b/scripts/build-tests/build-al2-debug-clang-cxx20.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+# This script is an example of how to build the SDK on Debug build-type using clang with c++20 standard flagbuild-al2-debug-clang-cxx20.sh
+# Directories created and files are prefixed with PREFIX_DIR argument
+# A clone of aws-sdk-cpp is expected to be in ${PREFIX_DIR}/aws-sdk-cpp
+# Platform: Amazon Linux 2
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: ${0} PREFIX_DIR"
+    exit 1
+fi
+PREFIX_DIR="$1"
+
+mkdir ${PREFIX_DIR}/al2-build
+mkdir ${PREFIX_DIR}/al2-install
+cd ${PREFIX_DIR}/aws-sdk-cpp
+python ./scripts/endpoints_checker.py
+cd ${PREFIX_DIR}/al2-build
+cmake -GNinja ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../aws-sdk-cpp/toolchains/clang-c++20.cmake -DCMAKE_INSTALL_PREFIX=${PREFIX_DIR}/al2-install
+ninja-build -j `grep -c ^processor /proc/cpuinfo`
+ninja-build install

--- a/scripts/build-tests/build-al2-debug-default.sh
+++ b/scripts/build-tests/build-al2-debug-default.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+# This script is an example of how to build the SDK on Debug build-type with minimize on and address sanitizers
+# Directories created and files are prefixed with PREFIX_DIR argument
+# A clone of aws-sdk-cpp is expected to be in ${PREFIX_DIR}/aws-sdk-cpp
+# Platform: Amazon Linux 2
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: ${0} PREFIX_DIR"
+    exit 1
+fi
+PREFIX_DIR="$1"
+
+mkdir ${PREFIX_DIR}/al2-build
+mkdir ${PREFIX_DIR}/al2-install
+cd ${PREFIX_DIR}/aws-sdk-cpp
+python ./scripts/endpoints_checker.py
+cd ${PREFIX_DIR}/al2-build
+cmake -GNinja ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-ggdb -fsanitize=address" -DMINIMIZE_SIZE=ON -DCMAKE_INSTALL_PREFIX=${PREFIX_DIR}/al2-install
+ninja-build -j `grep -c ^processor /proc/cpuinfo`
+ninja-build install

--- a/scripts/build-tests/build-al2-debug-gcc-cxx20.sh
+++ b/scripts/build-tests/build-al2-debug-gcc-cxx20.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+# This script is an example of how to build the SDK on Debug build-type using gcc10 with c++20 standard flag
+# Directories created and files are prefixed with PREFIX_DIR argument
+# A clone of aws-sdk-cpp is expected to be in ${PREFIX_DIR}/aws-sdk-cpp
+# Platform: Amazon Linux 2
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: ${0} PREFIX_DIR"
+    exit 1
+fi
+PREFIX_DIR="$1"
+
+mkdir ${PREFIX_DIR}/al2-build
+mkdir ${PREFIX_DIR}/al2-install
+cd ${PREFIX_DIR}/aws-sdk-cpp
+python ./scripts/endpoints_checker.py
+cd ${PREFIX_DIR}/al2-build
+cmake -GNinja ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../aws-sdk-cpp/toolchains/gcc10-c++20.cmake -DCMAKE_INSTALL_PREFIX=${PREFIX_DIR}/al2-install
+ninja-build -j `grep -c ^processor /proc/cpuinfo`
+ninja-build install

--- a/scripts/build-tests/build-al2-debug-non-unity-default.sh
+++ b/scripts/build-tests/build-al2-debug-non-unity-default.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+# This script is an example of how to build the SDK on Debug build-type with unity build disabled
+# Directories created and files are prefixed with PREFIX_DIR argument
+# A clone of aws-sdk-cpp is expected to be in ${PREFIX_DIR}/aws-sdk-cpp
+# Platform: Amazon Linux 2
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: ${0} PREFIX_DIR"
+    exit 1
+fi
+PREFIX_DIR="$1"
+
+mkdir ${PREFIX_DIR}/al2-build
+mkdir ${PREFIX_DIR}/al2-install
+cd ${PREFIX_DIR}/aws-sdk-cpp
+python ./scripts/endpoints_checker.py
+cd ${PREFIX_DIR}/al2-build
+cmake -GNinja ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Debug -DENABLE_UNITY_BUILD=OFF -DCMAKE_INSTALL_PREFIX=${PREFIX_DIR}/al2-install
+ninja-build -j `grep -c ^processor /proc/cpuinfo`
+ninja-build install

--- a/scripts/build-tests/build-al2-doxygen-docs.sh
+++ b/scripts/build-tests/build-al2-doxygen-docs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+# This script is an example of how to build the SDK on Debug build-type with minimize on and address sanitizers
+# Directories created and files are prefixed with PREFIX_DIR argument
+# SDK installation is expected to be in ${PREFIX_DIR}/al2-install and a clone of aws-sdk-cpp is expected to be in ${PREFIX_DIR}/aws-sdk-cpp
+# OUTPUT_DIR is relative to the PREFIX_DIR
+# Platform: Amazon Linux 2
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: ${0} PREFIX_DIR OUTPUT_DIR"
+    exit 1
+fi
+PREFIX_DIR="$1"
+OUTPUT_DIR="${PREFIX_DIR}/$2"
+
+mkdir ${PREFIX_DIR}/al2-build
+mkdir ${PREFIX_DIR}/al2-install
+cd ${PREFIX_DIR}/aws-sdk-cpp
+python ./scripts/endpoints_checker.py
+cd ${PREFIX_DIR}/al2-build
+cmake -GNinja ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-ggdb -fsanitize=address" -DMINIMIZE_SIZE=ON -DCMAKE_INSTALL_PREFIX=${PREFIX_DIR}/al2-install
+ninja-build -j `grep -c ^processor /proc/cpuinfo`
+ninja-build install
+
+export VERSION_NUM=$(grep AWS_SDK_VERSION_STRING ${PREFIX_DIR}/aws-sdk-cpp/aws-cpp-sdk-core/include/aws/core/VersionConfig.h | cut -d '\"' -f2)
+echo "Setting config to build docs for version: ${VERSION_NUM}"
+sed -i "s/PROJECT_NUMBER .*/PROJECT_NUMBER         = $VERSION_NUM/" ${PREFIX_DIR}/aws-sdk-cpp/doxygen/modules/static/root.config
+sed -i "s/PROJECT_NUMBER .*/PROJECT_NUMBER         = $VERSION_NUM/" ${PREFIX_DIR}/aws-sdk-cpp/doxygen/modules/template/module-template.config
+echo "Running doc generation"
+cd ${PREFIX_DIR}/aws-sdk-cpp
+python3 ${PREFIX_DIR}/aws-sdk-cpp/doxygen/modules/scripts/run-doc-generation.py
+echo "Staging static files"
+cp ${PREFIX_DIR}/aws-sdk-cpp/LICENSE ${PREFIX_DIR}/aws-sdk-cpp/doxygen/output/root/html
+mkdir -p "${OUTPUT_DIR}/${VERSION_NUM}"
+mkdir -p "${OUTPUT_DIR}/LATEST"
+rsync -av ${PREFIX_DIR}/aws-sdk-cpp/doxygen/output/* "${OUTPUT_DIR}/${VERSION_NUM}"
+rsync -av ${PREFIX_DIR}/aws-sdk-cpp/doxygen/output/* "${OUTPUT_DIR}/LATEST"
+echo "Creating Cross Links"
+python3 doc_crosslinks_new/generate_cross_link_data.py --apiDefinitionsPath ./code-generation/api-descriptions/ --templatePath ./doc_crosslinks/crosslink_redirect.html --outputPath ./crosslink_redirect.html
+cp ${PREFIX_DIR}/aws-sdk-cpp/doxygen/modules/static/index.html -p "${OUTPUT_DIR}/"
+cp ${PREFIX_DIR}/aws-sdk-cpp/doxygen/modules/static/local-index.html "${OUTPUT_DIR}/LATEST/index.html"
+cp ${PREFIX_DIR}/aws-sdk-cpp/doxygen/modules/static/local-index.html "${OUTPUT_DIR}/${VERSION_NUM}/index.html"
+cp ${PREFIX_DIR}/aws-sdk-cpp/crosslink_redirect.html "${OUTPUT_DIR}/"

--- a/scripts/build-tests/build-al2-sample-app.sh
+++ b/scripts/build-tests/build-al2-sample-app.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+# This script builds a sample app
+# Directories created and files are prefixed with PREFIX_DIR argument
+# SDK installation is expected to be in ${PREFIX_DIR}/al2-install and a clone of aws-sdk-cpp is expected to be in ${PREFIX_DIR}/aws-sdk-cpp
+# A AWS_ACCOUNT with proper role setup is required to run the built app, if passed argument, app is tried to run after build
+# Platform: Amazon Linux 2
+
+set -e
+
+if [ "$#" -eq 1 ]; then
+  AUTORUN=0
+elif [ "$#" -eq 3 ]; then
+  AUTORUN=1
+  AWS_ACCOUNT="$2"
+  AWS_ROLE_SESSION_NAME="$3"
+else
+    echo "Usage: ${0} PREFIX_DIR AWS_ACCOUNT ROLE_SESSION_NAME"
+    exit 1
+fi
+PREFIX_DIR="$1"
+
+echo "Building the Sample App"
+
+cd aws-sdk-cpp/CI/install-test
+mkdir ${PREFIX_DIR}/sample-build
+cd ${PREFIX_DIR}/sample-build
+cmake ../aws-sdk-cpp/CI/install-test -G Ninja -DCMAKE_CXX_FLAGS="-ggdb -fsanitize=address" -DCMAKE_PREFIX_PATH=${PREFIX_DIR}/al2-install
+ninja-build
+
+if [ "${AUTORUN}" -eq 0 ]; then
+  # Only continue if there is a scheduled autorun
+  exit 0
+fi
+
+echo "Setting the run environment"
+export TEST_ASSUME_ROLE_ARN=arn:aws:iam::${AWS_ACCOUNT}:role/IntegrationTest
+export TEST_LAMBDA_CODE_PATH=${PREFIX_DIR}/aws-sdk-cpp/aws-cpp-sdk-lambda-integration-tests/resources
+export sts=$(aws sts assume-role --role-arn "$TEST_ASSUME_ROLE_ARN" --role-session-name "${ROLE_SESSION_NAME}" --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]')
+export profile=sdk-integ-test
+aws configure set aws_access_key_id $(echo "$sts" | jq -r \'.[0]\') --profile "$profile"
+aws configure set aws_secret_access_key $(echo "$sts" | jq -r \'.[1]\') --profile "$profile"
+aws configure set aws_session_token $(echo "$sts" | jq -r \'.[2]\') --profile "$profile"
+aws configure list --profile "$profile"
+export AWS_PROFILE=$profile
+./app

--- a/scripts/build-tests/run-al2-integ-tests.sh
+++ b/scripts/build-tests/run-al2-integ-tests.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+# This script runs integration tests previously build
+# Directories created and files are prefixed with PREFIX_DIR argument
+# SDK build to tests is expected to be in ${PREFIX_DIR}/al2-build, the source project in ${PREFIX_DIR}/aws-sdk-cpp,
+# and an installed build to test in ${PREFIX_DIR}/al2-install
+# A AWS_ACCOUNT with proper role setup is required to run the built app is expected
+# Platform: Amazon Linux 2
+
+set -e
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: ${0} PREFIX_DIR AWS_ACCOUNT ROLE_SESSION_NAME"
+    exit 1
+fi
+PREFIX_DIR="$1"
+AWS_ACCOUNT="$2"
+AWS_ROLE_SESSION_NAME="$3"
+
+echo "Setting the run environment"
+export TEST_ASSUME_ROLE_ARN=arn:aws:iam::${AWS_ACCOUNT}:role/IntegrationTest
+export TEST_LAMBDA_CODE_PATH=${PREFIX_DIR}/aws-cpp-sdk-lambda-integration-tests/resources
+export sts=$(aws sts assume-role --role-arn "$TEST_ASSUME_ROLE_ARN" --role-session-name "${ROLE_SESSION_NAME}" --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]')
+export profile=sdk-integ-test
+aws configure set aws_access_key_id $(echo "$sts" | jq -r \'.[0]\') --profile "$profile"
+aws configure set aws_secret_access_key $(echo "$sts" | jq -r \'.[1]\') --profile "$profile"
+aws configure set aws_session_token $(echo "$sts" | jq -r \'.[2]\') --profile "$profile"
+aws configure list --profile "$profile"
+export AWS_PROFILE=$profile
+ldconfig ${PREFIX_DIR}/al2-install/lib64/
+cd ${PREFIX_DIR}/al2-build
+if [ -f ${PREFIX_DIR}/aws-sdk-cpp/scripts/suppressions.txt ]; then export LSAN_OPTIONS=suppressions=${PREFIX_DIR}/aws-sdk-cpp/scripts/suppressions.txt; fi
+python ../aws-sdk-cpp/scripts/run_integration_tests.py --testDir .


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Created a set of scripts in scripts/build-examples where we show how the SDK can be build with different parameters in AmazonLinux 2. Added also script run integration tests against a previously installed build, and a example app build using the SDK.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
