### PR TITLE
Fix valgrind warning about conditional if on uninit memory

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/client/AdaptiveRetryStrategy.h
+++ b/aws-cpp-sdk-core/include/aws/core/client/AdaptiveRetryStrategy.h
@@ -87,23 +87,23 @@ protected:
     double CUBICThrottle(const double rateToUse) const;
 
     // The rate at which token are replenished.
-    double m_fillRate;
+    double m_fillRate = 0.0;
     // The maximum capacity allowed in the token bucket.
-    double m_maxCapacity;
+    double m_maxCapacity = 0.0;
     // The current capacity of the token bucket.
-    double m_currentCapacity;
+    double m_currentCapacity = 0.0;
     // The last time the token bucket was refilled.
     Aws::Utils::DateTime m_lastTimestamp;
     // The smoothed rate which tokens are being retrieved.
-    double m_measuredTxRate;
+    double m_measuredTxRate = 0.0;
     // The last half second time bucket used.
-    double m_lastTxRateBucket;
+    double m_lastTxRateBucket = 0.0;
     // The number of requests seen within the current time bucket.
-    size_t m_requestCount;
+    size_t m_requestCount = 0;
     // Boolean indicating if the token bucket is enabled.
-    bool m_enabled;
+    bool m_enabled = false;
     // The maximum rate when the client was last throttled.
-    double m_lastMaxRate;
+    double m_lastMaxRate = 0.0;
     // The last time when the client was throttled.
     Aws::Utils::DateTime m_lastThrottleTime;
 


### PR DESCRIPTION
*Issue #, if available:*
Valgrind reports conditional on uninit memory in a newly added test
*Description of changes:*
Init all variables in the class by default.
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
