### PR TITLE
TransferManager to track its tasks

### DIFF
--- a/aws-cpp-sdk-transfer-tests/RunTests.cpp
+++ b/aws-cpp-sdk-transfer-tests/RunTests.cpp
@@ -20,7 +20,7 @@ int main(int argc, char** argv)
 
     Aws::InitAPI(options);
     ::testing::InitGoogleTest(&argc, argv);
-    int exitCode = RUN_ALL_TESTS(); 
+    int exitCode = RUN_ALL_TESTS();
     Aws::ShutdownAPI(options);
 
     AWS_END_MEMORY_TEST_EX;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/issues/2274
*Description of changes:*
Transfer Manager to track all it's submitted async tasks and
Provide API to block wait for completion.
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
