### PR TITLE
reapply test region

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ option(ENABLE_VIRTUAL_OPERATIONS "This option usually works with REGENERATE_CLIE
                                 You can utilize this feature to work with your linker to reduce binary size of your application on Unix platforms when doing static linking in Release mode." ON)
 option(REGENERATE_DEFAULTS "If set to ON, defaults mode configuration will be regenerated from the JSON definitions, this option involves some setup of python, java 8+, and maven" OFF)
 
+set(AWS_TEST_REGION "US_EAST_1" CACHE STRING "Region to target integration tests against")
 set(BUILD_ONLY "" CACHE STRING "A semi-colon delimited list of the projects to build")
 set(CPP_STANDARD "11" CACHE STRING "Flag to upgrade the C++ standard used. The default is 11. The minimum is 11.")
 
@@ -285,6 +286,8 @@ endif()
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
     add_definitions(-DLEGACY_GCC)
 endif()
+
+add_definitions("-DAWS_TEST_REGION=${AWS_TEST_REGION}")
 
 add_sdks()
 

--- a/aws-cpp-sdk-cognitoidentity-integration-tests/IdentityPoolOperationTest.cpp
+++ b/aws-cpp-sdk-cognitoidentity-integration-tests/IdentityPoolOperationTest.cpp
@@ -36,6 +36,7 @@
 using namespace Aws::CognitoIdentity;
 using namespace Aws::CognitoIdentity::Model;
 using namespace Aws::Client;
+using namespace Aws::Region;
 
 #define TEST_POOL_PREFIX  "IntegrationTest_"
 
@@ -61,7 +62,8 @@ protected:
     void SetUp()
     {
         Aws::Client::ClientConfiguration config;
-        config.region = Aws::Region::US_EAST_1;
+        config.region = AWS_TEST_REGION;
+
         //TODO: move this over to profile config file.
         client = Aws::MakeShared<CognitoIdentityClient>(ALLOCATION_TAG, config);
         CleanupPreviousFailedTests();
@@ -253,7 +255,7 @@ TEST_F(IdentityPoolOperationTest, TestIdentityActions)
     getIdRequest.WithIdentityPoolId(identityPoolId);
 
     ClientConfiguration clientConfig;
-    clientConfig.region = Aws::Region::US_EAST_1;
+    clientConfig.region = AWS_TEST_REGION;
 
     auto accountId = Aws::Environment::GetEnv("CATAPULT_TEST_ACCOUNT");
     if (accountId.empty()) {

--- a/aws-cpp-sdk-ec2-integration-tests/EC2Tests.cpp
+++ b/aws-cpp-sdk-ec2-integration-tests/EC2Tests.cpp
@@ -30,6 +30,7 @@
 using namespace Aws::Auth;
 using namespace Aws::Http;
 using namespace Aws::Client;
+using namespace Aws::Region;
 
 namespace
 {
@@ -64,7 +65,7 @@ protected:
     {
         ClientConfiguration config;
         config.scheme = Scheme::HTTPS;
-        config.region = Aws::Region::US_EAST_1;
+        config.region = AWS_TEST_REGION;
 
         m_EC2Client = Aws::MakeShared<Aws::EC2::EC2Client>(ALLOCATION_TAG, Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG), config);
 

--- a/aws-cpp-sdk-elasticfilesystem-integration-tests/ElasticFileSystemTest.cpp
+++ b/aws-cpp-sdk-elasticfilesystem-integration-tests/ElasticFileSystemTest.cpp
@@ -23,6 +23,7 @@ using namespace Aws::Http;
 using namespace Aws::Client;
 using namespace Aws::EFS;
 using namespace Aws::EFS::Model;
+using namespace Aws::Region;
 
 namespace
 {
@@ -38,7 +39,7 @@ namespace
         {
             // Create a client
             ClientConfiguration config;
-            config.region = Aws::Region::US_WEST_2;
+            config.region = AWS_TEST_REGION;
             config.scheme = Scheme::HTTPS;
             config.connectTimeoutMs = 30000;
             config.requestTimeoutMs = 30000;

--- a/aws-cpp-sdk-kinesis-integration-tests/KinesisTests.cpp
+++ b/aws-cpp-sdk-kinesis-integration-tests/KinesisTests.cpp
@@ -29,6 +29,7 @@
 using namespace Aws;
 using namespace Aws::Kinesis;
 using namespace Aws::Kinesis::Model;
+using namespace Aws::Region;
 
 namespace {
 const char ALLOC_TAG[]   = "KinesisIntegrationTest";
@@ -44,7 +45,7 @@ protected:
         m_UUID = Aws::Utils::UUID::RandomUUID();
         streamName = BuildResourceName("stream");
         Client::ClientConfiguration config;
-        config.region = Aws::Region::US_EAST_1;
+        config.region = AWS_TEST_REGION;
         m_client.reset(Aws::New<KinesisClient>(ALLOC_TAG, config));
 
         // Create stream

--- a/aws-cpp-sdk-logs-integration-tests/CloudWatchLogsTests.cpp
+++ b/aws-cpp-sdk-logs-integration-tests/CloudWatchLogsTests.cpp
@@ -26,6 +26,7 @@ using namespace Aws::Http;
 using namespace Aws::Client;
 using namespace Aws::CloudWatchLogs;
 using namespace Aws::CloudWatchLogs::Model;
+using namespace Aws::Region;
 
 namespace
 {
@@ -49,7 +50,7 @@ namespace
             m_UUID = Aws::Utils::UUID::RandomUUID();
             ClientConfiguration config;
             config.scheme = Scheme::HTTPS;
-            config.region = Aws::Region::US_WEST_2;
+            config.region = AWS_TEST_REGION;
             m_client = Aws::MakeUnique<Aws::CloudWatchLogs::CloudWatchLogsClient>(ALLOCATION_TAG, config);
             CreateLogsGroup(BuildResourceName(BASE_CLOUD_WATCH_LOGS_GROUP));
         }

--- a/aws-cpp-sdk-s3-encryption-integration-tests/LiveClientTests.cpp
+++ b/aws-cpp-sdk-s3-encryption-integration-tests/LiveClientTests.cpp
@@ -43,6 +43,7 @@ using namespace Aws::S3Encryption::Materials;
 using namespace Aws::Utils;
 using namespace Aws::Client;
 using namespace Aws::Utils::Crypto;
+using namespace Aws::Region;
 
 static const char* ENCRYPTED_BUCKET_TEST_NAME = "awsnativesdks3encotest";
 static const char* ALLOCATION_TAG = "LiveClientTest";
@@ -68,7 +69,7 @@ public:
         TimeStamp = DateTime::Now().CalculateLocalTimestampAsString("%Y%m%dt%H%M%Sz").c_str();
 
         ClientConfiguration config;
-        config.region = Aws::Region::US_EAST_1;
+        config.region = AWS_TEST_REGION;
         StandardClient = Aws::MakeShared<Aws::S3::S3Client>(ALLOCATION_TAG, config);
         BucketName = ComputeUniqueBucketName(ENCRYPTED_BUCKET_TEST_NAME).c_str();
         Model::CreateBucketRequest createBucketRequest;
@@ -123,7 +124,7 @@ TEST_F(LiveClientTest, TestEOMode)
     configuration.SetStorageMethod(StorageMethod::METADATA);
 
     ClientConfiguration s3ClientConfig;
-    s3ClientConfig.region = Aws::Region::US_EAST_1;
+    s3ClientConfig.region = AWS_TEST_REGION;
 
     auto key = SymmetricCipher::GenerateKey();
     auto simpleEncryptionMaterials = Aws::MakeShared<Materials::SimpleEncryptionMaterialsWithGCMAAD>(ALLOCATION_TAG, key);
@@ -204,7 +205,7 @@ TEST_F(LiveClientTest, TestAEMode)
     configuration.SetStorageMethod(StorageMethod::METADATA);
 
     ClientConfiguration s3ClientConfig;
-    s3ClientConfig.region = Aws::Region::US_EAST_1;
+    s3ClientConfig.region = AWS_TEST_REGION;
 
     auto key = SymmetricCipher::GenerateKey();
     auto simpleEncryptionMaterials = Aws::MakeShared<Materials::SimpleEncryptionMaterialsWithGCMAAD>(ALLOCATION_TAG, key);
@@ -291,7 +292,7 @@ TEST_F(LiveClientTest, TestAEModeRangeGet)
     configuration.SetStorageMethod(StorageMethod::METADATA);
 
     ClientConfiguration s3ClientConfig;
-    s3ClientConfig.region = Aws::Region::US_EAST_1;
+    s3ClientConfig.region = AWS_TEST_REGION;
 
     auto key = SymmetricCipher::GenerateKey();
     auto simpleEncryptionMaterials = Aws::MakeShared<Materials::SimpleEncryptionMaterialsWithGCMAAD>(ALLOCATION_TAG, key);
@@ -375,7 +376,7 @@ TEST_F(LiveClientTest, TestAEModeRangeGet)
 TEST_F(LiveClientTest, TestS3EncryptionError)
 {
     ClientConfiguration s3ClientConfig;
-    s3ClientConfig.region = Aws::Region::US_EAST_1;
+    s3ClientConfig.region = AWS_TEST_REGION;
 
     auto kmsMaterials = Aws::MakeShared<Aws::S3Encryption::Materials::KMSWithContextEncryptionMaterials>("s3Encryption", "badKey");
     Aws::S3Encryption::CryptoConfiguration cryptoConfiguration(Aws::S3Encryption::StorageMethod::METADATA, Aws::S3Encryption::CryptoMode::ENCRYPTION_ONLY);
@@ -409,7 +410,7 @@ TEST_F(LiveClientTest, TestS3EncryptionError)
 TEST_F(LiveClientTest, TestV2AEMode)
 {
     ClientConfiguration s3ClientConfig;
-    s3ClientConfig.region = Aws::Region::US_EAST_1;
+    s3ClientConfig.region = AWS_TEST_REGION;
 
     auto key = SymmetricCipher::GenerateKey();
     auto simpleEncryptionMaterials = Aws::MakeShared<Materials::SimpleEncryptionMaterialsWithGCMAAD>(ALLOCATION_TAG, key);
@@ -493,7 +494,7 @@ TEST_F(LiveClientTest, TestV2AEMode)
 TEST_F(LiveClientTest, TestV2AEModeRangeGetPass)
 {
     ClientConfiguration s3ClientConfig;
-    s3ClientConfig.region = Aws::Region::US_EAST_1;
+    s3ClientConfig.region = AWS_TEST_REGION;
 
     auto key = SymmetricCipher::GenerateKey();
     auto simpleEncryptionMaterials = Aws::MakeShared<Materials::SimpleEncryptionMaterialsWithGCMAAD>(ALLOCATION_TAG, key);
@@ -578,7 +579,7 @@ TEST_F(LiveClientTest, TestV2AEModeRangeGetPass)
 TEST_F(LiveClientTest, TestV2AEModeRangeGetFailWithoutSetting)
 {
     ClientConfiguration s3ClientConfig;
-    s3ClientConfig.region = Aws::Region::US_EAST_1;
+    s3ClientConfig.region = AWS_TEST_REGION;
 
     auto key = SymmetricCipher::GenerateKey();
     auto simpleEncryptionMaterials = Aws::MakeShared<Materials::SimpleEncryptionMaterialsWithGCMAAD>(ALLOCATION_TAG, key);
@@ -616,7 +617,7 @@ TEST_F(LiveClientTest, TestV2AEModeRangeGetFailWithoutSetting)
 TEST_F(LiveClientTest, TestV2AEModeRangeGetPassWithRangeUpperBoundOverflow)
 {
     ClientConfiguration s3ClientConfig;
-    s3ClientConfig.region = Aws::Region::US_EAST_1;
+    s3ClientConfig.region = AWS_TEST_REGION;
 
     auto key = SymmetricCipher::GenerateKey();
     auto simpleEncryptionMaterials = Aws::MakeShared<Materials::SimpleEncryptionMaterialsWithGCMAAD>(ALLOCATION_TAG, key);
@@ -701,7 +702,7 @@ TEST_F(LiveClientTest, TestV2AEModeRangeGetPassWithRangeUpperBoundOverflow)
 TEST_F(LiveClientTest, TestV2S3EncryptionError)
 {
     ClientConfiguration s3ClientConfig;
-    s3ClientConfig.region = Aws::Region::US_EAST_1;
+    s3ClientConfig.region = AWS_TEST_REGION;
 
     auto kmsMaterials = Aws::MakeShared<Aws::S3Encryption::Materials::KMSWithContextEncryptionMaterials>("s3Encryption", "badKey");
     Aws::S3Encryption::CryptoConfigurationV2 cryptoConfiguration(kmsMaterials);

--- a/aws-cpp-sdk-sqs-integration-tests/QueueOperationTest.cpp
+++ b/aws-cpp-sdk-sqs-integration-tests/QueueOperationTest.cpp
@@ -50,6 +50,7 @@ using namespace Aws::SQS;
 using namespace Aws::SQS::Model;
 using namespace Aws::Utils;
 using namespace Aws::Utils::Json;
+using namespace Aws::Region;
 
 namespace
 {
@@ -93,7 +94,7 @@ protected:
     static ClientConfiguration GetConfig()
     {
         ClientConfiguration config("default");
-        config.region = Aws::Region::US_EAST_1;
+        config.region = AWS_TEST_REGION;
 
 #if USE_PROXY_FOR_TESTS
         config.scheme = Scheme::HTTP;

--- a/aws-cpp-sdk-transfer-tests/TransferTests.cpp
+++ b/aws-cpp-sdk-transfer-tests/TransferTests.cpp
@@ -42,6 +42,7 @@ using namespace Aws::Transfer;
 using namespace Aws::Client;
 using namespace Aws::Http;
 using namespace Aws::Utils;
+using namespace Aws::Region;
 
 static const char* MULTI_PART_CONTENT_KEY = "MultiContentKey";
 static const char* MULTI_PART_CONTENT_TEXT = "This is a test..##";
@@ -608,6 +609,7 @@ protected:
         config.scheme = Scheme::HTTP;
         config.connectTimeoutMs = 3000;
         config.requestTimeoutMs = 60000;
+        config.region = AWS_TEST_REGION;
         // executor used for s3Client
         config.executor = Aws::MakeShared<Aws::Utils::Threading::PooledThreadExecutor>(ALLOCATION_TAG, 5);
         m_s3Client = Aws::MakeShared<MockS3Client>(ALLOCATION_TAG, config);
@@ -616,7 +618,7 @@ protected:
         createBucket.WithBucket(GetTestBucketName())
             .WithACL(BucketCannedACL::private_);
 
-        if (config.region != Aws::Region::US_EAST_1)
+        if (config.region != AWS_TEST_REGION)
         {
             CreateBucketConfiguration createBucketConfiguration;
             createBucketConfiguration.WithLocationConstraint(BucketLocationConstraintMapper::GetBucketLocationConstraintForName(config.region));


### PR DESCRIPTION
- Making target region of integration tests configurable

*Issue #, if available:*

*Description of changes:*
Adding cmake parameter to allow targetting test that are not multi region to a different region, they default to us-east-1 when no argument passed.

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
