### PR TITLE
Update IMDS GetRegion call.

### DIFF
--- a/aws-cpp-sdk-core-tests/aws/auth/AWSHttpResourceClientTest.cpp
+++ b/aws-cpp-sdk-core-tests/aws/auth/AWSHttpResourceClientTest.cpp
@@ -62,6 +62,34 @@ namespace
             CleanupHttp();
             InitHttp();
         }
+
+        void addGetCredentialsSecurelyMock()
+        {
+            std::shared_ptr<HttpRequest> tokenRequest = CreateHttpRequest(URI("http://169.254.169.254/latest/api/token"),
+                HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+            std::shared_ptr<StandardHttpResponse> tokenResponse = Aws::MakeShared<StandardHttpResponse>(ALLOCATION_TAG, tokenRequest);
+            tokenResponse->SetResponseCode(HttpResponseCode::OK);
+            tokenResponse->GetResponseBody() << "tokenstring";
+            mockHttpClient->Reset();
+
+            std::shared_ptr<HttpRequest> profileRequest = CreateHttpRequest(URI("http://169.254.169.254/latest/meta-data/iam/security-credentials"),
+                HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+            std::shared_ptr<StandardHttpResponse> profileResponse = Aws::MakeShared<StandardHttpResponse>(ALLOCATION_TAG, profileRequest);
+            profileResponse->SetResponseCode(HttpResponseCode::OK);
+            profileResponse->GetResponseBody() << "profilestring";
+            mockHttpClient->Reset();
+
+            std::shared_ptr<HttpRequest> credsRequest = CreateHttpRequest(URI("http://169.254.169.254/latest/meta-data/iam/security-credentials"),
+                HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+            std::shared_ptr<StandardHttpResponse> credsResponse = Aws::MakeShared<StandardHttpResponse>(ALLOCATION_TAG, credsRequest);
+            credsResponse->SetResponseCode(HttpResponseCode::OK);
+            credsResponse->GetResponseBody() << "credsstring";
+            mockHttpClient->Reset();
+
+            mockHttpClient->AddResponseToReturn(tokenResponse);
+            mockHttpClient->AddResponseToReturn(profileResponse);
+            mockHttpClient->AddResponseToReturn(credsResponse);
+        }
     };
 
     static const char EC2_IMDS_TOKEN_TTL_HEADER[] = "x-aws-ec2-metadata-token-ttl-seconds";
@@ -843,6 +871,7 @@ namespace
         // Create EC2MetadataClient with default endpoint http://169.254.169.254
         auto ec2MetadataClient = Aws::MakeShared<Aws::Internal::EC2MetadataClient>(ALLOCATION_TAG, clientConfig);
 
+        addGetCredentialsSecurelyMock();
         // This mocked URI is used to initiate http response and has nothing to do with the requested URI actually sent out.
         std::shared_ptr<HttpRequest> regionRequest = CreateHttpRequest(URI("http://169.254.169.254/latest/meta-data/placement/availability-zone"),
                 HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
@@ -866,6 +895,7 @@ namespace
         // Create EC2MetadataClient with default endpoint http://169.254.169.254
         auto ec2MetadataClient = Aws::MakeShared<Aws::Internal::EC2MetadataClient>(ALLOCATION_TAG, clientConfig);
 
+        addGetCredentialsSecurelyMock();
         // This mocked URI is used to initiate http response and has nothing to do with the requested URI actually sent out.
         std::shared_ptr<HttpRequest> regionRequest = CreateHttpRequest(URI("http://169.254.169.254/latest/meta-data/placement/availability-zone"),
                 HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
@@ -889,6 +919,7 @@ namespace
         // Create EC2MetadataClient with default endpoint http://169.254.169.254
         auto ec2MetadataClient = Aws::MakeShared<Aws::Internal::EC2MetadataClient>(ALLOCATION_TAG, clientConfig);
 
+        addGetCredentialsSecurelyMock();
         // This mocked URI is used to initiate http response and has nothing to do with the requested URI actually sent out.
         std::shared_ptr<HttpRequest> regionRequest = CreateHttpRequest(URI("http://169.254.169.254/latest/meta-data/placement/availability-zone"),
                 HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
@@ -912,6 +943,7 @@ namespace
         // Create EC2MetadataClient with default endpoint http://169.254.169.254
         auto ec2MetadataClient = Aws::MakeShared<Aws::Internal::EC2MetadataClient>(ALLOCATION_TAG, clientConfig);
 
+        addGetCredentialsSecurelyMock();
         // This mocked URI is used to initiate http response and has nothing to do with the requested URI actually sent out.
         std::shared_ptr<HttpRequest> regionRequest = CreateHttpRequest(URI("http://169.254.169.254/latest/meta-data/placement/availability-zone"),
                 HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
@@ -935,6 +967,7 @@ namespace
         // Create EC2MetadataClient with default endpoint http://169.254.169.254
         auto ec2MetadataClient = Aws::MakeShared<Aws::Internal::EC2MetadataClient>(ALLOCATION_TAG, clientConfig);
 
+        addGetCredentialsSecurelyMock();
         // This mocked URI is used to initiate http response and has nothing to do with the requested URI actually sent out.
         std::shared_ptr<HttpRequest> regionRequest = CreateHttpRequest(URI("http://169.254.169.254/latest/meta-data/placement/availability-zone"),
                 HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);

--- a/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
+++ b/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
@@ -311,6 +311,7 @@ namespace Aws
                 std::lock_guard<std::recursive_mutex> locker(m_tokenMutex);
                 if (m_tokenRequired)
                 {
+                    GetDefaultCredentialsSecurely();
                     regionRequest->SetHeaderValue(EC2_IMDS_TOKEN_HEADER, m_token);
                 }
             }


### PR DESCRIPTION
*Description of changes:*

Fixes an issue in client configuration where `GetCurrentRegion` was called before `GetDefaultCredentialsSecurely ` when IMDS V2 is required. [ec2 docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html). previously it would fail the region call because m_token had not been fetched yet.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
