### PR TITLE
Bump zip4j version used in code generator

### DIFF
--- a/code-generation/generator/pom.xml
+++ b/code-generation/generator/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.2</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
*Issue #, if available:*
dependabot reported a vulnerability in zip4j
Although it does not affect the project, we still prefer to keep the noise low
https://github.com/aws/aws-sdk-cpp/security/dependabot/7
*Description of changes:*
Bump zip4j maven package.
Tested by running code generator and checking that no difference is generated
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
