### PR TITLE
Revert "Update tests to use template Async API"

### DIFF
--- a/aws-cpp-sdk-dynamodb-integration-tests/TableOperationTest.cpp
+++ b/aws-cpp-sdk-dynamodb-integration-tests/TableOperationTest.cpp
@@ -431,7 +431,7 @@ TEST_F(TableOperationTest, TestThrottling)
         putItemRequest.AddItem(testValueColumnName, testValueAttribute);
         ss.str("");
 
-        putItemResults.push_back(m_client->SubmitCallable(&DynamoDBClient::PutItem, putItemRequest));
+        putItemResults.push_back(m_client->PutItemCallable(putItemRequest));
     }
 
     int throttleCount = 0;
@@ -484,7 +484,7 @@ TEST_F(TableOperationTest, TestCrudOperations)
         putItemRequest.AddItem(testValueColumnName, testValueAttribute);
         ss.str("");
 
-        putItemResults.push_back(m_client->SubmitCallable(&DynamoDBClient::PutItem, putItemRequest));
+        putItemResults.push_back(m_client->PutItemCallable(putItemRequest));
     }
 
     //wait for put operations to finish
@@ -510,7 +510,7 @@ TEST_F(TableOperationTest, TestCrudOperations)
         attributesToGet.push_back(HASH_KEY_NAME);
         attributesToGet.push_back(testValueColumnName);
         ss.str("");
-        getItemOutcomes.push_back(m_client->SubmitCallable(&DynamoDBClient::GetItem, getItemRequest));
+        getItemOutcomes.push_back(m_client->GetItemCallable(getItemRequest));
     }
 
     //verify the values
@@ -554,7 +554,7 @@ TEST_F(TableOperationTest, TestCrudOperations)
         testValueAttribute.SetValue(valueAttribute);
         updateItemRequest.AddAttributeUpdates(testValueColumnName, testValueAttribute);
         ss.str("");
-        updateItemOutcomes.push_back(m_client->SubmitCallable(&DynamoDBClient::UpdateItem, updateItemRequest));
+        updateItemOutcomes.push_back(m_client->UpdateItemCallable(updateItemRequest));
     }
 
     //wait for operations to finish.
@@ -580,7 +580,7 @@ TEST_F(TableOperationTest, TestCrudOperations)
         attributesToGet.push_back(HASH_KEY_NAME);
         attributesToGet.push_back(testValueColumnName);
         ss.str("");
-        getItemOutcomes.push_back(m_client->SubmitCallable(&DynamoDBClient::GetItem,getItemRequest));
+        getItemOutcomes.push_back(m_client->GetItemCallable(getItemRequest));
     }
 
     //verify values.
@@ -611,7 +611,7 @@ TEST_F(TableOperationTest, TestCrudOperations)
         deleteItemRequest.SetReturnValues(ReturnValue::ALL_OLD);
         ss.str("");
 
-        deleteItemOutcomes.push_back(m_client->SubmitCallable(&DynamoDBClient::DeleteItem, deleteItemRequest));
+        deleteItemOutcomes.push_back(m_client->DeleteItemCallable(deleteItemRequest));
     }
 
     //verify that we properly returned the old values.
@@ -664,7 +664,7 @@ TEST_F(TableOperationTest, TestCrudOperationsWithCallbacks)
         testValueAttribute.SetS(ss.str());
         putItemRequest.AddItem(testValueColumnName, testValueAttribute);
         ss.str("");
-        m_client->SubmitAsync(&DynamoDBClient::PutItem, putItemRequest, putItemHandler);
+        m_client->PutItemAsync(putItemRequest, putItemHandler);
     }
 
     //wait for the callbacks to finish.
@@ -686,7 +686,7 @@ TEST_F(TableOperationTest, TestCrudOperationsWithCallbacks)
         attributesToGet.push_back(HASH_KEY_NAME);
         attributesToGet.push_back(testValueColumnName);
         ss.str("");
-        m_client->SubmitAsync(&DynamoDBClient::GetItem, getItemRequest, getItemHandler);
+        m_client->GetItemAsync(getItemRequest, getItemHandler);
     }
 
     //wait for the callbacks to finish.
@@ -739,7 +739,7 @@ TEST_F(TableOperationTest, TestCrudOperationsWithCallbacks)
         testValueAttribute.SetValue(valueAttribute);
         updateItemRequest.AddAttributeUpdates(testValueColumnName, testValueAttribute);
         ss.str("");
-        m_client->SubmitAsync(&DynamoDBClient::UpdateItem, updateItemRequest, updateItemHandler);
+        m_client->UpdateItemAsync(updateItemRequest, updateItemHandler);
     }
 
     //wait for the callbacks to finish.
@@ -765,7 +765,7 @@ TEST_F(TableOperationTest, TestCrudOperationsWithCallbacks)
         attributesToGet.push_back(HASH_KEY_NAME);
         attributesToGet.push_back(testValueColumnName);
         ss.str("");
-        m_client->SubmitAsync(&DynamoDBClient::GetItem, getItemRequest, getItemHandler);
+        m_client->GetItemAsync(getItemRequest, getItemHandler);
     }
 
     //wait for the callbacks to finish.
@@ -802,7 +802,7 @@ TEST_F(TableOperationTest, TestCrudOperationsWithCallbacks)
         deleteItemRequest.SetTableName(crudCallbacksTestTableName);
         deleteItemRequest.SetReturnValues(ReturnValue::ALL_OLD);
         ss.str("");
-        m_client->SubmitAsync(&DynamoDBClient::DeleteItem, deleteItemRequest, deleteItemHandler);
+        m_client->DeleteItemAsync(deleteItemRequest, deleteItemHandler);
     }
 
     //wait for the callbacks to finish.
@@ -853,7 +853,7 @@ void PutBlobs(DynamoDBClient* client, uint32_t blobRowStartIndex)
         testValueAttribute.SetS(ss.str());
         putItemRequest.AddItem(testValueColumnName, testValueAttribute);
 
-        putItemResults.push_back(client->SubmitCallable(&DynamoDBClient::PutItem, putItemRequest));
+        putItemResults.push_back(client->PutItemCallable(putItemRequest));
     }
 
     for (auto& putItemResult : putItemResults)

--- a/aws-cpp-sdk-kinesis-integration-tests/KinesisTests.cpp
+++ b/aws-cpp-sdk-kinesis-integration-tests/KinesisTests.cpp
@@ -160,7 +160,7 @@ TEST_F(KinesisTest, EnhancedFanOut)
         .WithShardId(shardId)
         .WithStartingPosition(position);
     subscribeRequest.SetEventStreamHandler(handler);
-    const auto subscribeOutcome = m_client->SubmitCallable(&KinesisClient::SubscribeToShard, subscribeRequest).get();
+    const auto subscribeOutcome = m_client->SubscribeToShard(subscribeRequest);
     AWS_ASSERT_SUCCESS(subscribeOutcome);
 
     // Deregister the consumer from fan-out (we're only allowed 5, so we must cleanup)

--- a/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp
@@ -222,7 +222,7 @@ namespace
             uploadPart1Request.SetContentLength(static_cast<long>(partStream->tellg()));
             partStream->seekg(startingPoint);
 
-            return Client->SubmitCallable(&S3CrtClient::UploadPart, uploadPart1Request);
+            return Client->UploadPartCallable(uploadPart1Request);
         }
 
         static void VerifyUploadPartOutcome(UploadPartOutcome& outcome, const ByteBuffer& md5OfStream)

--- a/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
@@ -269,7 +269,7 @@ namespace
             uploadPart1Request.SetContentLength(static_cast<long>(partStream->tellg()));
             partStream->seekg(startingPoint);
 
-            return Client->SubmitCallable(&S3Client::UploadPart, uploadPart1Request);
+            return Client->UploadPartCallable(uploadPart1Request);
         }
 
         static void VerifyUploadPartOutcome(UploadPartOutcome& outcome, const ByteBuffer& md5OfStream)
@@ -698,7 +698,7 @@ namespace
         getObjectRequest.SetKey(TEST_OBJ_KEY);
 
         // because we use std::launch::async we know this will go to another thread
-        auto&& getCallable = Client->SubmitCallable(&S3Client::GetObject, getObjectRequest);
+        auto&& getCallable = Client->GetObjectCallable(getObjectRequest);
 
         Client->DisableRequestProcessing();
 
@@ -935,7 +935,7 @@ namespace
             ASSERT_STREQ("TestObjectKey", request.GetKey().c_str());
             sem.ReleaseAll();
         };
-        Client->SubmitAsync(&S3Client::GetObject, getObjectAsyncRequest, getObjectCallback, nullptr);
+        Client->GetObjectAsync(getObjectAsyncRequest, getObjectCallback, nullptr);
         sem.WaitOne();
 
         GetObjectRequest getObjectRequest;


### PR DESCRIPTION
This reverts commit 41b1828a6096ba4ca3a2d10b8895be9bd5b04643.

*Issue #, if available:*
We are not going to remove that API, it is worth testing the old API.
*Description of changes:*
Revert commit that started to use generic template async API.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
