### PR TITLE
Fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,14 @@ Please make sure to check out our resources too before opening an issue:
 
 
 # Using the SDK and Other Topics
-* [Using the SDK](./Docs/SDK_usage_guide.md)
-* [CMake Parameters](./Docs/CMake_Parameters.md)
-* [Credentials Providers](./Docs/Credentials_Providers.md)
-* [Client Configuration Parameters](./Docs/ClientConfiguration_Parameters.md)
-* [Service Client](./Docs/Service_Client.md)
-* [Memory Management](./Docs/Memory_Management.md)
-* [Advanced Topics](./Docs/Advanced_topics.md)
-* [Add as CMake external project](./Docs/CMake_External_Project.md)
-* [Coding Standards](./Docs/CODING_STANDARDS.md)
+* [Using the SDK](./docs/SDK_usage_guide.md)
+* [CMake Parameters](./docs/CMake_Parameters.md)
+* [Credentials Providers](./docs/Credentials_Providers.md)
+* [Client Configuration Parameters](./docs/ClientConfiguration_Parameters.md)
+* [Service Client](./docs/Service_Client.md)
+* [Memory Management](./docs/Memory_Management.md)
+* [Advanced Topics](./docs/Advanced_topics.md)
+* [Add as CMake external project](./docs/CMake_External_Project.md)
+* [Coding Standards](./docs/CODING_STANDARDS.md)
 * [License](./LICENSE)
 * [Code of Conduct](./CODE_OF_CONDUCT.md)


### PR DESCRIPTION
Fix links on readme changed `Docs` -> `docs`

*Issue #, if available:*

*Description of changes:*

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [X] Windows
- [X] Android
- [X] MacOS
- [X] IOS
- [X] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
