### PR TITLE
Update CRT to v0.19.5

### DIFF
--- a/prefetch_crt_dependency.sh
+++ b/prefetch_crt_dependency.sh
@@ -3,21 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 CRT_URI_PREFIX=https://codeload.github.com/awslabs
-CRT_URI=${CRT_URI_PREFIX}/aws-crt-cpp/zip/8ee94e26804070e2279dc7451c5ac87d695dba13  # v0.19.2
+CRT_URI=${CRT_URI_PREFIX}/aws-crt-cpp/zip/f2adef31d778cfe90b8a5bb377425f825ebf92f0  # v0.19.5
 
-AWS_C_AUTH_URI=${CRT_URI_PREFIX}/aws-c-auth/zip/57b7f0db21258750af138e80823123212f0925de  # v0.6.21
+AWS_C_AUTH_URI=${CRT_URI_PREFIX}/aws-c-auth/zip/bad1066f0a93f3a7df86c94cc03076fa6b901bd2  # v0.6.22
 AWS_C_CAL_URI=${CRT_URI_PREFIX}/aws-c-cal/zip/ac4216b78d5323b5b8ce95a3dd4a8fc0f95e2d33  # v0.5.20
-AWS_C_COMMON_URI=${CRT_URI_PREFIX}/aws-c-common/zip/3973e3c89bbb532f5c3d2327b602836a57bd4db6  # v0.8.6
+AWS_C_COMMON_URI=${CRT_URI_PREFIX}/aws-c-common/zip/5e64b039356c72d17fcf1fb0bfc7637f8c2270f7  # v0.8.9
 AWS_C_COMPRESSION_URI=${CRT_URI_PREFIX}/aws-c-compression/zip/b517b7decd0dac30be2162f5186c250221c53aff  # v0.2.16
-AWS_C_EVENT_STREAM_URI=${CRT_URI_PREFIX}/aws-c-event-stream/zip/e812dd4df0fcc350ad7b5b7babe82cfe5664f4a4  # v0.2.17
+AWS_C_EVENT_STREAM_URI=${CRT_URI_PREFIX}/aws-c-event-stream/zip/2f9b60c42f90840ec11822acda3d8cdfa97a773d  # v0.2.18
 AWS_C_HTTP_URI=${CRT_URI_PREFIX}/aws-c-http/zip/dd34461987947672444d0bc872c5a733dfdb9711  # v0.7.3
-AWS_C_IO_URI=${CRT_URI_PREFIX}/aws-c-io/zip/6c19e25f55fa060d4e42010756967b979361dc66  # v0.13.12
-AWS_C_MQTT_URI=${CRT_URI_PREFIX}/aws-c-mqtt/zip/5cbde90916a1f9945e2a1ef36f3db58e1c976167  # v0.8.4
-AWS_C_S3_URI=${CRT_URI_PREFIX}/aws-c-s3/zip/374191a730faf7e040a776c7244b5b79c5eeed76  # v0.2.1
+AWS_C_IO_URI=${CRT_URI_PREFIX}/aws-c-io/zip/b52181af655c090713fe01f14d7ccb95aab8dec5  # v0.13.14
+AWS_C_MQTT_URI=${CRT_URI_PREFIX}/aws-c-mqtt/zip/33c3455cec82b16feb940e12006cefd7b3ef4194  # v0.8.6
+AWS_C_S3_URI=${CRT_URI_PREFIX}/aws-c-s3/zip/d7bfe602d6925948f1fff95784e3613cca6a3900  # v0.2.3
 AWS_C_SDKUTILS_URI=${CRT_URI_PREFIX}/aws-c-sdkutils/zip/208a701fa01e99c7c8cc3dcebc8317da71362972  # v0.1.7
 AWS_CHECKSUMS_URI=${CRT_URI_PREFIX}/aws-checksums/zip/ad53be196a25bbefa3700a01187fdce573a7d2d0  # v0.1.14
 AWS_LC_URI=${CRT_URI_PREFIX}/aws-lc/zip/75a73bfabf1be384b49c7f92da6fdfd9d867069e  # v1.3.0
-S2N_URI=${CRT_URI_PREFIX}/s2n/zip/2663f20bdc801f0d94657db3e6cec4c4fed0db94  # v1.3.32
+S2N_URI=${CRT_URI_PREFIX}/s2n/zip/52661e933c99825f208f376c98a6a292b49be680  # v1.3.33
 
 
 echo "Removing CRT"

--- a/tools/scripts/ops/update_crt.py
+++ b/tools/scripts/ops/update_crt.py
@@ -104,7 +104,7 @@ def main():
         sh_var_name = c_module_dir.upper().replace("-", "_")
         crt_cpp_c_modules.append({"var_name": sh_var_name, "file_path": c_module_dir, "hash": c_module_hash, "tag": c_module_tag})
 
-    jinja2_env = jinja2.Environment()
+    jinja2_env = jinja2.Environment(autoescape=jinja2.select_autoescape(['html', 'xml']))
     jinja2_template = jinja2_env.from_string(PREFETCH_DEPS_TEMPLATE)
     rendered_script = jinja2_template.render(t_crt_cpp_hash=crt_cpp_hash,
                                              t_crt_cpp_tag=latest_crt_version,


### PR DESCRIPTION
*Issue #, if available:*
n/a
*Description of changes:*
Just bumping the CRT and disabling autoescape
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
