### PR TITLE
[aws-cpp-sdk-core]: add note that InitAPI and ShutdownAPIshould be called from the same thread

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/Aws.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/Aws.h
@@ -286,7 +286,10 @@ namespace Aws
 
     /**
      * Shutdown SDK wide state for the SDK. This method must be called when you are finished using the SDK.
-     * Do not call any other SDK methods after calling ShutdownAPI.
+     * Notes:
+     * 1) Please call this from the same thread from which InitAPI() has been called (use a dedicated thread
+     *    if necessary). This avoids problems in initializing the dependent Common RunTime C libraries.
+     * 2) Do not call any other SDK methods after calling ShutdownAPI.
      */
     AWS_CORE_API void ShutdownAPI(const SDKOptions& options);
 }


### PR DESCRIPTION
Running `InitAPI()` and `ShutdownAPI()` from different threads can cause subtle problems, see e.g.
- https://github.com/aws/s2n-tls/issues/3525
- https://github.com/awslabs/aws-c-common/pull/891

Add a note for users to use the same thread.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.) - Not applicable.
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
