### PR TITLE
Add support for passing CA path (and file) when going through a proxy

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -199,11 +199,21 @@ namespace Aws
              */
             Aws::String caPath;
             /**
+             * Same as caPath, but useful if you have users going through a proxy.
+             * Used to set CURLOPT_PROXY_CAPATH in libcurl.
+             */
+            Aws::String proxyCaPath;
+            /**
              * If you certificate file is different from the default, you can tell clients that
              * aren't using the default trust store where to find your ca file.
              * If you are on windows or apple, you likely don't want this.
              */
              Aws::String caFile;
+             /**
+              * Same as caFile, but useful if you have users going through a proxy.
+              * Used to set CURLOPT_PROXY_CAINFO in libcurl.
+              */
+             Aws::String proxyCaFile;
             /**
              * Rate Limiter implementation for outgoing bandwidth. Default is wide-open.
              */

--- a/src/aws-cpp-sdk-core/include/aws/core/http/curl/CurlHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/curl/CurlHttpClient.h
@@ -64,6 +64,8 @@ private:
     bool m_verifySSL;
     Aws::String m_caPath;
     Aws::String m_caFile;
+    Aws::String m_proxyCaPath;
+    Aws::String m_proxyCaFile;
     bool m_disableExpectHeader;
     bool m_allowRedirects;
     static std::atomic<bool> isInit;

--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -536,7 +536,7 @@ CurlHttpClient::CurlHttpClient(const ClientConfiguration& clientConfig) :
     m_proxySSLKeyPath(clientConfig.proxySSLKeyPath), m_proxySSLKeyType(clientConfig.proxySSLKeyType),
     m_proxyKeyPasswd(clientConfig.proxySSLKeyPassword),
     m_proxyPort(clientConfig.proxyPort), m_verifySSL(clientConfig.verifySSL), m_caPath(clientConfig.caPath),
-    m_caFile(clientConfig.caFile),
+    m_caFile(clientConfig.caFile), m_proxyCaPath(clientConfig.proxyCaPath), m_proxyCaFile(clientConfig.proxyCaFile),
     m_disableExpectHeader(clientConfig.disableExpectHeader)
 {
     if (clientConfig.followRedirects == FollowRedirectsPolicy::NEVER ||
@@ -684,6 +684,14 @@ std::shared_ptr<HttpResponse> CurlHttpClient::MakeRequest(const std::shared_ptr<
             ss << m_proxyScheme << "://" << m_proxyHost;
             curl_easy_setopt(connectionHandle, CURLOPT_PROXY, ss.str().c_str());
             curl_easy_setopt(connectionHandle, CURLOPT_PROXYPORT, (long) m_proxyPort);
+            if(!m_proxyCaPath.empty())
+            {
+                curl_easy_setopt(connectionHandle, CURLOPT_PROXY_CAPATH, m_proxyCaPath.c_str());
+            }
+            if(!m_proxyCaFile.empty())
+            {
+                curl_easy_setopt(connectionHandle, CURLOPT_PROXY_CAINFO, m_proxyCaFile.c_str());
+            }
             if (!m_proxyUserName.empty() || !m_proxyPassword.empty())
             {
                 curl_easy_setopt(connectionHandle, CURLOPT_PROXYUSERNAME, m_proxyUserName.c_str());


### PR DESCRIPTION
Copy of https://github.com/aws/aws-sdk-cpp/pull/1742 with simple rebase done, no conflict found

The SDK allows to specify caPath (CURLOPT_CAPATH) and caFile (CURLOPT_CAINFO) options in ClientConfiguration, but these options are not enough when going through a proxy. There is a need to additionally specify CURLOPT_PROXY_CAPATH and CURLOPT_PROXY_CAINFO. proxyCaPath and proxyCaFile are new options that allow to do this.

*Description of changes:*

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [X] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Copy of https://github.com/aws/aws-sdk-cpp/pull/1742 with simple rebase done, no conflict found