### PR TITLE
[aws-cpp-sdk-core]: do not flush ResponseStream before deletion

### DIFF
--- a/src/aws-cpp-sdk-core/source/utils/stream/ResponseStream.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/stream/ResponseStream.cpp
@@ -58,7 +58,6 @@ void ResponseStream::ReleaseStream()
 {
     if (m_underlyingStream)
     {
-        m_underlyingStream->flush();
         Aws::Delete(m_underlyingStream);
     }
 


### PR DESCRIPTION
Flushing the `ResponseStream` before deletion causes undefined behaviour and segmentation faults, since the `ResponseStream` is destructed after the actual download has completed.  

Resolves #58, #2319 and in part #1732.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
  Tested with a reproducing command (which reliably produced the segmentation fault described in #2319) that the condition no longer occurs after applying this change.
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.