### PR TITLE
Use libcrypto name from OPENSSL_CRYPTO_LIBRARY if set

### DIFF
--- a/cmake/Findcrypto.cmake
+++ b/cmake/Findcrypto.cmake
@@ -39,8 +39,14 @@ else()
         PATH_SUFFIXES include
     )
 
+    if (OPENSSL_CRYPTO_LIBRARY)
+        get_filename_component(libcrypto_name ${OPENSSL_CRYPTO_LIBRARY} NAME_WE)
+    else()
+        set(libcrypto_name "libcrypto")
+    endif()
+
     find_library(crypto_SHARED_LIBRARY
-        NAMES libcrypto.so libcrypto.dylib
+        NAMES ${libcrypto_name}.so ${libcrypto_name}.dylib
         HINTS
         "${CMAKE_PREFIX_PATH}"
         "${CMAKE_INSTALL_PREFIX}"
@@ -48,7 +54,7 @@ else()
     )
 
     find_library(crypto_STATIC_LIBRARY
-        NAMES libcrypto.a
+        NAMES ${libcrypto_name}.a
         HINTS
         "${CMAKE_PREFIX_PATH}"
         "${CMAKE_INSTALL_PREFIX}"


### PR DESCRIPTION
Hello,

When building the SDK in shared libraries mode on linux, we provide the OPENSSL_SSL_LIBRARY and OPENSSL_CRYPTO_LIBRARY definition.

With aws sdk v1.9.157, that were no issue, the correct package was used and linked with.
With aws sdk v1.11, the linked is done with both the OPENSSL_CRYPTO_LIBRARY and the system file libcrypto.so.1
This is mainly because we changed the name of the built libcrypto by adding a suffix.
Note that we also rebuild the openssl code to use opensll 3.

So this PR may be of low interest for you.

*Description of changes:*
From log history, the file cmake/Findcrypto.cmake has been added for 1.9.235

I changed it to use the name from OPENSSL_CRYPTO_LIBRARY when setting crypto_SHARED_LIBRARY and crypto_SHARED_LIBRARY.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
