### PR TITLE
Prohibit copy constructor on endpoint parameters to avoid accidental copy

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/endpoint/BuiltInParameters.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/endpoint/BuiltInParameters.h
@@ -20,6 +20,8 @@ namespace Aws
         public:
             using EndpointParameter = Aws::Endpoint::EndpointParameter;
 
+            BuiltInParameters() = default;
+            BuiltInParameters(const BuiltInParameters&) = delete; // avoid accidental copy
             virtual ~BuiltInParameters(){};
 
             virtual void SetFromClientConfiguration(const Client::ClientConfiguration& config);

--- a/src/aws-cpp-sdk-core/include/aws/core/endpoint/ClientContextParameters.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/endpoint/ClientContextParameters.h
@@ -18,6 +18,10 @@ namespace Aws
         public:
             using EndpointParameter = Aws::Endpoint::EndpointParameter;
 
+            ClientContextParameters() = default;
+            // avoid accidental copy from endpointProvider::AccessClientContextParameters()
+            ClientContextParameters(const ClientContextParameters&) = delete;
+
             virtual ~ClientContextParameters(){};
 
             const EndpointParameter& GetParameter(const Aws::String& name) const;

--- a/src/aws-cpp-sdk-core/source/endpoint/DefaultEndpointProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/endpoint/DefaultEndpointProvider.cpp
@@ -128,10 +128,12 @@ ResolveEndpointDefaultImpl(const Aws::Crt::Endpoints::RuleEngine& ruleEngine,
         {
             if(EndpointParameter::ParameterType::BOOLEAN == parameter.GetStoredType())
             {
+                AWS_LOGSTREAM_TRACE(DEFAULT_ENDPOINT_PROVIDER_TAG, "Endpoint bool eval parameter: " << parameter.GetName() << " = " << parameter.GetBoolValueNoCheck());
                 crtRequestCtx.AddBoolean(Aws::Crt::ByteCursorFromCString(parameter.GetName().c_str()), parameter.GetBoolValueNoCheck());
             }
             else if(EndpointParameter::ParameterType::STRING == parameter.GetStoredType())
             {
+                AWS_LOGSTREAM_TRACE(DEFAULT_ENDPOINT_PROVIDER_TAG, "Endpoint str eval parameter: " << parameter.GetName() << " = " << parameter.GetStrValueNoCheck());
                 crtRequestCtx.AddString(Aws::Crt::ByteCursorFromCString(parameter.GetName().c_str()), Aws::Crt::ByteCursorFromCString(parameter.GetStrValueNoCheck().c_str()));
             }
             else
@@ -175,6 +177,7 @@ ResolveEndpointDefaultImpl(const Aws::Crt::Endpoints::RuleEngine& ruleEngine,
             const auto crtProps = resolved->GetProperties();
             if (crtProps && crtProps->size() > 2) {
                 Aws::String sdkCrtProps = crtProps ? Aws::String(crtProps->begin(), crtProps->end()) : "";
+                AWS_LOGSTREAM_TRACE(DEFAULT_ENDPOINT_PROVIDER_TAG, "Endpoint rules evaluated props: " << sdkCrtProps);
 
                 Internal::Endpoint::EndpointAttributes epAttributes = Internal::Endpoint::EndpointAttributes::BuildEndpointAttributesFromJson(
                         sdkCrtProps);


### PR DESCRIPTION
*Issue #, if available:*
```
auto clientContextParameters = endpointProvider->AccessClientContextParameters();
```
will implicitly create a copy instead of a reference leading to unintended behavior
*Description of changes:*
prohibit copy constructor
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
