### PR TITLE
Modify sqs sdk operations to by default use uri as resolved endpoint

### DIFF
--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/sqs/SQSServiceClientSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/sqs/SQSServiceClientSource.vm
@@ -44,12 +44,15 @@ const char* ${className}::ALLOCATION_TAG = "${className}";
 ${operation.name}Outcome ${className}::${operation.name}(const ${operation.request.shape.name}& request) const
 {
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientOperationRequestRequiredMemberValidate.vm")
-#if($operation.name == "CreateQueue" || $operation.name == "ListQueues" || $operation.name == "GetQueueUrl")
+#set($operationsUseQueueUrlEndpoint = ['AddPermission' , 'RemovePermission' , 'ChangeMessageVisibility', 'DeleteQueue', 'DeleteMessage', 'GetQueueAttributes',
+  'ReceiveMessage', 'SetQueueAttributes', 'SendMessage', 'SendMessageBatch', 'ChangeMessageVisibilityBatch',
+  'DeleteMessageBatch', 'ListDeadLetterSourceQueues', 'PurgeQueue', 'TagQueue', 'UntagQueue', 'ListQueueTags'])
+#if($operationsUseQueueUrlEndpoint.contains($operation.name))
+  return ${operation.name}Outcome(MakeRequest(request.GetQueueUrl(), request, Aws::Http::HttpMethod::HTTP_${operation.http.method}));
+#else
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientOperationEndpointPrepareCommonBody.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/common/UriRequestQueryParams.vm")
   return ${operation.name}Outcome(MakeRequest(request, endpointResolutionOutcome.GetResult(), Aws::Http::HttpMethod::HTTP_${operation.http.method}));
-#else
-  return ${operation.name}Outcome(MakeRequest(request.GetQueueUrl(), request, Aws::Http::HttpMethod::HTTP_${operation.http.method}));
 #end
 }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Modify sqs sdk operations to by default use uri as resolved endpoint.
Allowlisted current sqs apis that still use queue url, hence there should be no functional changes for current logic.

The benefit is mainly for future coming new APIs, uri as resolved endpoint is more recommended.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.) N/A since there is no functional changes.
- [ ] Checked if this PR is a breaking (APIs have been changed) change. No
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior. No cross-platform related changes
- [ ] Checked if this PR would require a ReadMe/Wiki update. No, no customer facing changes

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [X] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
