### PR TITLE
Fix #1536 missing lower-casing in case of DefaultMonitoring enabled

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/standard/StandardHttpRequest.cpp
+++ b/src/aws-cpp-sdk-core/source/http/standard/StandardHttpRequest.cpp
@@ -61,7 +61,7 @@ HeaderValueCollection StandardHttpRequest::GetHeaders() const
 
 const Aws::String& StandardHttpRequest::GetHeaderValue(const char* headerName) const
 {
-    auto iter = headerMap.find(headerName);
+    auto iter = headerMap.find(StringUtils::ToLower(headerName));
     assert (iter != headerMap.end());
     if (iter == headerMap.end()) {
         AWS_LOGSTREAM_ERROR(STANDARD_HTTP_REQUEST_LOG_TAG, "Requested a header value for a missing header key: " << headerName);


### PR DESCRIPTION
*Issue #, if available:*
#1536
*Description of changes:*
All headers are stored with lowercase key, lower case the key before searching for it... like the HasHeader method does.
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
