### PR TITLE
[Aws::Utils::Logging::NullLogSystem] no-op Flush()

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/logging/NullLogSystem.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/logging/NullLogSystem.h
@@ -42,6 +42,8 @@ namespace Aws
                     AWS_UNREFERENCED_PARAM(tag);
                     AWS_UNREFERENCED_PARAM(messageStream);
                 }
+
+                virtual void Flush() override {}
             };
 
         } // namespace Logging


### PR DESCRIPTION
*Description of changes:*
A no-op implementation of the pure virtual method from `LogSystemInterface`, making `NullLogSystem` no longer abstract.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
