### PR TITLE
Update checking IMDS response

### DIFF
--- a/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
+++ b/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
@@ -140,12 +140,12 @@ namespace Aws
                 }
 
                 const Aws::Client::AWSError<Aws::Client::CoreErrors> error = [this, &response]() {
-                    if (response->HasClientError() || response->GetResponseBody().tellp() < 1)
+                    if (response->HasClientError() || response->GetResponseCode() == HttpResponseCode::REQUEST_NOT_MADE)
                     {
                         AWS_LOGSTREAM_ERROR(m_logtag.c_str(), "Http request to retrieve credentials failed");
                         return AWSError<CoreErrors>(CoreErrors::NETWORK_CONNECTION, true); // Retryable
                     }
-                    else if (m_errorMarshaller)
+                    else if (m_errorMarshaller && response->GetResponseBody().tellp() > 0)
                     {
                         return m_errorMarshaller->Marshall(*response);
                     }

--- a/tests/aws-cpp-sdk-core-tests/aws/auth/AWSHttpResourceClientTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/aws/auth/AWSHttpResourceClientTest.cpp
@@ -663,7 +663,7 @@ namespace
                                                                        HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
         std::shared_ptr<StandardHttpResponse> profileResponse = Aws::MakeShared<StandardHttpResponse>(ALLOCATION_TAG, profileRequest);
         profileResponse->SetResponseCode(HttpResponseCode::UNAUTHORIZED);
-        profileResponse->GetResponseBody() << "token required";
+        // Do not send a body as IMDS also doesn't send one. Just the HTTP error code.
         mockHttpClient->AddResponseToReturn(profileResponse);
 
         auto cred = ec2MetadataClient->GetDefaultCredentialsSecurely();


### PR DESCRIPTION
Do not check the body presence so we keep the 401 Unauthorized error returned when the token is missing in an empty response from IMDS. This should flip back the m_tokenRequired boolean and a retry will get the credentials through the secure method again.

Keep the body check when using a Marshall for the error response as used in the STS client from a subclass.

This is a rebase of the original PR: https://github.com/aws/aws-sdk-cpp/pull/2283

Fixes #2282

*Issue #, if available:*

*Description of changes:*

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
