### PR TITLE
Fix generating shapes with member but empty json response body

### DIFF
--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonSubObjectSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonSubObjectSource.vm
@@ -35,7 +35,7 @@ ${typeInfo.className}::${typeInfo.className}(JsonView jsonValue)$initializers
 
 ${typeInfo.className}& ${typeInfo.className}::operator =(JsonView jsonValue)
 {
-#if($shape.members.size() == 0)
+#if(!$shape.hasPayloadMembers())
   AWS_UNREFERENCED_PARAM(jsonValue);
 #end
 #set($useRequiredField = true)


### PR DESCRIPTION
*Issue #, if available:*
n/a 

*Description of changes:*

Given an exception in a C2J model like this: 

```
<structure name="MyRedirectException">
    <member name="location" target="Location" />
</structure>
<exception target="MyRedirectException" />
<httperror target="MyRedirectException">
    <httpresponsecode value="302"/>
</httperror>
<httpheader target="MyRedirectException$location">
    <header value="Location" />
</httpheader>
```

When we generate the SDK it fails with the following message since the response body is empty: 
```
error : unused parameter 'jsonValue'
```

It looks like this was meant to be handled with `AWS_UNREFERENCED_PARAM(jsonValue);` but the if statement just needs to be tweaked for situations where the shape does have a member but it's bound to the header like `MyRedirectException` so the response body is empty and that value ends up unused. 

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
I didn't see any unit tests for the templates. I generated the full sdk and there was no difference in the generated code before/after my changes. For my custom C2J model this change allows me to build without errors. 

- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
