### PR TITLE
Fix syntax error in CMakeFile.vm

### DIFF
--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/CMakeFile.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/CMakeFile.vm
@@ -1,6 +1,6 @@
 #set($metadata = $serviceModel.metadata)
 #if($metadata.standalone)
-cmake_minimum_required (VERSION 3.13 FATAL)
+cmake_minimum_required (VERSION 3.13 FATAL_ERROR)
 
 project(aws-cpp-sdk-${metadata.projectName})
 find_package(AWSSDK REQUIRED COMPONENTS core)


### PR DESCRIPTION
This bug only surfaces when `$serviceModel.metadata.standalone` is true.

*Description of changes:*
When `$serviceModel.metadata.standalone` is true the statement `cmake_minimum_required (VERSION 3.13 FATAL)` is emitted. However CMake fails to parse this because the `FATAL` argument should be `FATAL_ERROR` as stated by the [CMake documentation](https://cmake.org/cmake/help/v3.13/command/cmake_minimum_required.html).

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.) 
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
