### PR TITLE
Updated sample App CMake definition to not depend on larger project internals

### DIFF
--- a/tools/CI/install-test/CMakeLists.txt
+++ b/tools/CI/install-test/CMakeLists.txt
@@ -1,15 +1,53 @@
-cmake_minimum_required(VERSION 3.3)
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13)
+# -- Preamble --
+project("sample_app"
+        LANGUAGES CXX
+        VERSION 1.0
+        DESCRIPTION "A testing app using AWS SDK for C++"
+        )
+
+# -- Project wide setup --
+# Setting C++ minimum requirements
 set(CMAKE_CXX_STANDARD 11)
-project(app LANGUAGES CXX)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Setting build to hide symbols in targets by default
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
+
+# Preventing writes to package registry by default
+set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY YES)
+
+# Validating config type and setting default if needed
+get_property(is_multi_conf_build GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if (NOT is_multi_conf_build)
+    set(allowed_build_types Debug Release RelWithDebInfo MinSizeRel)
+    # cmake-gui helper
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${allowed_build_types}")
+    if (NOT CMAKE_BUILD_TYPE)
+        message(STATUS "Setting build type to 'RelWithDebInfo' as none was specified.")
+        set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose the type of build." FORCE)
+    elseif (NOT CMAKE_BUILD_TYPE IN_LIST allowed_build_types)
+        message(FATAL_ERROR "Unknown build type: ${CMAKE_BUILD_TYPE}")
+    endif ()
+endif ()
+
+# -- Dependencies --
 find_package(AWSSDK REQUIRED COMPONENTS s3-crt)
-add_executable(${PROJECT_NAME} "main.cpp")
-if(MSVC AND BUILD_SHARED_LIBS)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC "USE_IMPORT_EXPORT")
-    add_definitions(-DUSE_IMPORT_EXPORT)
-    # Copy relevant AWS SDK for C++ libraries into the current binary directory for running and debugging.
-    list(APPEND SERVICE_LIST s3-crt)
-    AWSSDK_CPY_DYN_LIBS(SERVICE_LIST "" ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE})
-endif()
-set_compiler_flags(${PROJECT_NAME})
-set_compiler_warnings(${PROJECT_NAME})
-target_link_libraries(${PROJECT_NAME} ${AWSSDK_LINK_LIBRARIES})
+
+# -- main build target --
+add_executable(app "main.cpp")
+target_link_libraries(app ${AWSSDK_LINK_LIBRARIES})
+target_include_directories(app PRIVATE ${AWSSDK_INCLUDE_DIRS})
+
+# -- install target --
+include(GNUInstallDirs)
+set(CMAKE_INSTALL_DOCDIR ${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME})
+
+install(TARGETS app
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )

--- a/tools/scripts/build-tests/build-al2-sample-app.sh
+++ b/tools/scripts/build-tests/build-al2-sample-app.sh
@@ -25,9 +25,11 @@ PREFIX_DIR="$1"
 echo "Building the Sample App"
 
 mkdir "${PREFIX_DIR}/sample-build"
+mkdir "${PREFIX_DIR}/sample-install"
 cd "${PREFIX_DIR}/sample-build"
-cmake ../aws-sdk-cpp/tools/CI/install-test -G Ninja -DCMAKE_CXX_FLAGS="-ggdb -fsanitize=address" -DCMAKE_PREFIX_PATH="${PREFIX_DIR}/al2-install"
-ninja-build
+cmake ../aws-sdk-cpp/tools/CI/install-test -G Ninja -DCMAKE_CXX_FLAGS="-ggdb -fsanitize=address" -DCMAKE_PREFIX_PATH="${PREFIX_DIR}/al2-install" -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}/sample_install"
+cmake --build .
+cmake --build . --target install
 
 if [ "${AUTORUN}" -eq 0 ]; then
   # Only continue if there is a scheduled autorun
@@ -43,5 +45,7 @@ aws configure set aws_secret_access_key $(echo "$sts" | jq -r '.[1]') --profile 
 aws configure set aws_session_token $(echo "$sts" | jq -r '.[2]') --profile "$profile"
 aws configure list --profile "$profile"
 export AWS_PROFILE=$profile
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${PREFIX_DIR}/al2-install/lib64/"
 echo "Running the app"
+cd "${PREFIX_DIR}/sample_install/bin"
 ./app

--- a/tools/scripts/build-tests/build-mac-sample-app.sh
+++ b/tools/scripts/build-tests/build-mac-sample-app.sh
@@ -26,9 +26,11 @@ echo "Building the Sample App"
 
 cd aws-sdk-cpp/tools/CI/install-test
 mkdir "${PREFIX_DIR}/sample-build"
+mkdir "${PREFIX_DIR}/sample-install"
 cd "${PREFIX_DIR}/sample-build"
-cmake ../aws-sdk-cpp/tools/CI/install-test -DCMAKE_CXX_FLAGS="-ggdb -fsanitize=address" -DCMAKE_PREFIX_PATH="${PREFIX_DIR}/mac-install"
+cmake ../aws-sdk-cpp/tools/CI/install-test -DCMAKE_CXX_FLAGS="-ggdb -fsanitize=address" -DCMAKE_PREFIX_PATH="${PREFIX_DIR}/mac-install" -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}/sample_install"
 cmake --build .
+cmake --install .
 
 if [ "${AUTORUN}" -eq 0 ]; then
   # Only continue if there is a scheduled autorun
@@ -45,5 +47,7 @@ aws configure set aws_secret_access_key $(echo "$sts" | jq -r '.[1]') --profile 
 aws configure set aws_session_token $(echo "$sts" | jq -r '.[2]') --profile "$profile"
 aws configure list --profile "$profile"
 export AWS_PROFILE=$profile
+export DYLD_LIBRARY_PATH=$CATAPULT_WORKSPACE_DIR/mac-install/lib
 echo "Running the app"
+cd "${PREFIX_DIR}/sample_install/bin"
 ./app

--- a/tools/scripts/build-tests/build-windows-default.ps1
+++ b/tools/scripts/build-tests/build-windows-default.ps1
@@ -8,6 +8,8 @@
 param($PREFIX_DIR)
 
 mkdir "${PREFIX_DIR}/win-build"
+mkdir "${PREFIX_DIR}/win-install"
 cd "${PREFIX_DIR}/win-build"
-&'C:\\Program Files\\CMake\\bin\\cmake.exe' ../aws-sdk-cpp
+&'C:\\Program Files\\CMake\\bin\\cmake.exe' ../aws-sdk-cpp -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}/win-install"
 &'C:\\Program Files\\CMake\\bin\\cmake.exe' --build . -j 8
+&'C:\\Program Files\\CMake\\bin\\cmake.exe' --build . --target install

--- a/tools/scripts/build-tests/build-windows-sample-app.ps1
+++ b/tools/scripts/build-tests/build-windows-sample-app.ps1
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+# This script builds a sample app
+# Directories created and files are prefixed with PREFIX_DIR argument
+# SDK installation is expected to be in ${PREFIX_DIR}/mac-install and a clone of aws-sdk-cpp is expected to be in ${PREFIX_DIR}/aws-sdk-cpp
+# A AWS_ACCOUNT with proper role setup is required to run the built app, if passed argument, app is tried to run after build
+# Platform: Windows
+
+param($PREFIX_DIR)
+
+cd "${PREFIX_DIR}/aws-sdk-cpp/tools/CI/install-test"
+mkdir "${PREFIX_DIR}/sample-build"
+mkdir "${PREFIX_DIR}/sample-install"
+cd "${PREFIX_DIR}/sample-build"
+&'C:\\Program Files\\CMake\\bin\\cmake.exe' ../aws-sdk-cpp/tools/CI/install-test -DCMAKE_CXX_FLAGS="-ggdb -fsanitize=address" -DCMAKE_PREFIX_PATH="${PREFIX_DIR}/win-install" -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}/sample_install"
+&'C:\\Program Files\\CMake\\bin\\cmake.exe' --build .
+&'C:\\Program Files\\CMake\\bin\\cmake.exe' --build . --target install
+
+echo "Setting the run environment"
+$TEST_ASSUME_ROLE_ARN = "arn:aws:iam::${env:AWS_ACCOUNT}:role/IntegrationTest"
+${env:TEST_LAMBDA_CODE_PATH} = "${env:PREFIX_DIR}/aws-sdk-cpp/tests/aws-cpp-sdk-lambda-integration-tests/resources"
+$sts = aws sts assume-role --role-arn "${TEST_ASSUME_ROLE_ARN}" --role-session-name "${env:AWS_ROLE_SESSION_NAME}" --query "Credentials.[AccessKeyId, SecretAccessKey, SessionToken]"
+$sts
+aws configure set aws_access_key_id (${sts}[1] -replace " " -replace "`"" -replace ",")
+aws configure set aws_secret_access_key (${sts}[2] -replace " " -replace "`"" -replace ",")
+aws configure set aws_session_token (${sts}[3] -replace " " -replace "`"" -replace ",")
+aws configure list
+# Run tests
+cd "${PREFIX_DIR}/sample_install/bin"
+app


### PR DESCRIPTION
*Issue #1888*

*Description of changes:*
Updated sample App CMake definition to not depend on larger project internals. 

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
