### PR TITLE
ResponseStream underlying buffer improvements

### DIFF
--- a/generated/src/aws-cpp-sdk-apigateway/include/aws/apigateway/model/GetExportResult.h
+++ b/generated/src/aws-cpp-sdk-apigateway/include/aws/apigateway/model/GetExportResult.h
@@ -125,7 +125,7 @@ namespace Model
     /**
      * <p>The binary blob response to GetExport, which contains the export.</p>
      */
-    inline Aws::IOStream& GetBody() { return m_body.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBody() const { return m_body.GetUnderlyingStream(); }
 
     /**
      * <p>The binary blob response to GetExport, which contains the export.</p>
@@ -138,7 +138,7 @@ namespace Model
 
     Aws::String m_contentDisposition;
 
-  Aws::Utils::Stream::ResponseStream m_body;
+    Aws::Utils::Stream::ResponseStream m_body;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-apigateway/include/aws/apigateway/model/GetSdkResult.h
+++ b/generated/src/aws-cpp-sdk-apigateway/include/aws/apigateway/model/GetSdkResult.h
@@ -118,7 +118,7 @@ namespace Model
     /**
      * <p>The binary blob response to GetSdk, which contains the generated SDK.</p>
      */
-    inline Aws::IOStream& GetBody() { return m_body.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBody() const { return m_body.GetUnderlyingStream(); }
 
     /**
      * <p>The binary blob response to GetSdk, which contains the generated SDK.</p>
@@ -131,7 +131,7 @@ namespace Model
 
     Aws::String m_contentDisposition;
 
-  Aws::Utils::Stream::ResponseStream m_body;
+    Aws::Utils::Stream::ResponseStream m_body;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-apigatewayv2/include/aws/apigatewayv2/model/ExportApiResult.h
+++ b/generated/src/aws-cpp-sdk-apigatewayv2/include/aws/apigatewayv2/model/ExportApiResult.h
@@ -37,14 +37,14 @@ namespace Model
 
 
     
-    inline Aws::IOStream& GetBody() { return m_body.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBody() const { return m_body.GetUnderlyingStream(); }
 
     
     inline void ReplaceBody(Aws::IOStream* body) { m_body = Aws::Utils::Stream::ResponseStream(body); }
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_body;
+    Aws::Utils::Stream::ResponseStream m_body;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-appconfig/include/aws/appconfig/model/CreateHostedConfigurationVersionResult.h
+++ b/generated/src/aws-cpp-sdk-appconfig/include/aws/appconfig/model/CreateHostedConfigurationVersionResult.h
@@ -164,7 +164,7 @@ namespace Model
     /**
      * <p>The content of the configuration or the configuration data.</p>
      */
-    inline Aws::IOStream& GetContent() { return m_content.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetContent() const { return m_content.GetUnderlyingStream(); }
 
     /**
      * <p>The content of the configuration or the configuration data.</p>
@@ -267,7 +267,7 @@ namespace Model
 
     Aws::String m_description;
 
-  Aws::Utils::Stream::ResponseStream m_content;
+    Aws::Utils::Stream::ResponseStream m_content;
 
     Aws::String m_contentType;
 

--- a/generated/src/aws-cpp-sdk-appconfig/include/aws/appconfig/model/GetHostedConfigurationVersionResult.h
+++ b/generated/src/aws-cpp-sdk-appconfig/include/aws/appconfig/model/GetHostedConfigurationVersionResult.h
@@ -164,7 +164,7 @@ namespace Model
     /**
      * <p>The content of the configuration or the configuration data.</p>
      */
-    inline Aws::IOStream& GetContent() { return m_content.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetContent() const { return m_content.GetUnderlyingStream(); }
 
     /**
      * <p>The content of the configuration or the configuration data.</p>
@@ -267,7 +267,7 @@ namespace Model
 
     Aws::String m_description;
 
-  Aws::Utils::Stream::ResponseStream m_content;
+    Aws::Utils::Stream::ResponseStream m_content;
 
     Aws::String m_contentType;
 

--- a/generated/src/aws-cpp-sdk-appconfigdata/include/aws/appconfigdata/model/GetLatestConfigurationResult.h
+++ b/generated/src/aws-cpp-sdk-appconfigdata/include/aws/appconfigdata/model/GetLatestConfigurationResult.h
@@ -170,7 +170,7 @@ namespace Model
      * <p>The data of the configuration. This may be empty if the client already has
      * the latest version of configuration.</p>
      */
-    inline Aws::IOStream& GetConfiguration() { return m_configuration.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetConfiguration() const { return m_configuration.GetUnderlyingStream(); }
 
     /**
      * <p>The data of the configuration. This may be empty if the client already has
@@ -243,7 +243,7 @@ namespace Model
 
     Aws::String m_contentType;
 
-  Aws::Utils::Stream::ResponseStream m_configuration;
+    Aws::Utils::Stream::ResponseStream m_configuration;
 
     Aws::String m_versionLabel;
   };

--- a/generated/src/aws-cpp-sdk-appsync/include/aws/appsync/model/GetIntrospectionSchemaResult.h
+++ b/generated/src/aws-cpp-sdk-appsync/include/aws/appsync/model/GetIntrospectionSchemaResult.h
@@ -41,7 +41,7 @@ namespace Model
      * more information, see the <a href="http://graphql.org/learn/schema/">GraphQL SDL
      * documentation</a>.</p>
      */
-    inline Aws::IOStream& GetSchema() { return m_schema.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetSchema() const { return m_schema.GetUnderlyingStream(); }
 
     /**
      * <p>The schema, in GraphQL Schema Definition Language (SDL) format.</p> <p>For
@@ -52,7 +52,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_schema;
+    Aws::Utils::Stream::ResponseStream m_schema;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-backupstorage/include/aws/backupstorage/model/GetChunkResult.h
+++ b/generated/src/aws-cpp-sdk-backupstorage/include/aws/backupstorage/model/GetChunkResult.h
@@ -41,7 +41,7 @@ namespace Model
     /**
      * Chunk data
      */
-    inline Aws::IOStream& GetData() { return m_data.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetData() const { return m_data.GetUnderlyingStream(); }
 
     /**
      * Chunk data
@@ -128,7 +128,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_data;
+    Aws::Utils::Stream::ResponseStream m_data;
 
     long long m_length;
 

--- a/generated/src/aws-cpp-sdk-backupstorage/include/aws/backupstorage/model/GetObjectMetadataResult.h
+++ b/generated/src/aws-cpp-sdk-backupstorage/include/aws/backupstorage/model/GetObjectMetadataResult.h
@@ -77,7 +77,7 @@ namespace Model
     /**
      * Metadata blob.
      */
-    inline Aws::IOStream& GetMetadataBlob() { return m_metadataBlob.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetMetadataBlob() const { return m_metadataBlob.GetUnderlyingStream(); }
 
     /**
      * Metadata blob.
@@ -166,7 +166,7 @@ namespace Model
 
     Aws::String m_metadataString;
 
-  Aws::Utils::Stream::ResponseStream m_metadataBlob;
+    Aws::Utils::Stream::ResponseStream m_metadataBlob;
 
     long long m_metadataBlobLength;
 

--- a/generated/src/aws-cpp-sdk-cloudfront/include/aws/cloudfront/model/GetFunction2020_05_31Result.h
+++ b/generated/src/aws-cpp-sdk-cloudfront/include/aws/cloudfront/model/GetFunction2020_05_31Result.h
@@ -40,7 +40,7 @@ namespace Model
     /**
      * <p>The function code of a CloudFront function.</p>
      */
-    inline Aws::IOStream& GetFunctionCode() { return m_functionCode.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetFunctionCode() const { return m_functionCode.GetUnderlyingStream(); }
 
     /**
      * <p>The function code of a CloudFront function.</p>
@@ -128,7 +128,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_functionCode;
+    Aws::Utils::Stream::ResponseStream m_functionCode;
 
     Aws::String m_eTag;
 

--- a/generated/src/aws-cpp-sdk-codeartifact/include/aws/codeartifact/model/GetPackageVersionAssetResult.h
+++ b/generated/src/aws-cpp-sdk-codeartifact/include/aws/codeartifact/model/GetPackageVersionAssetResult.h
@@ -40,7 +40,7 @@ namespace Model
     /**
      * <p> The binary file, or asset, that is downloaded.</p>
      */
-    inline Aws::IOStream& GetAsset() { return m_asset.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetAsset() const { return m_asset.GetUnderlyingStream(); }
 
     /**
      * <p> The binary file, or asset, that is downloaded.</p>
@@ -171,7 +171,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_asset;
+    Aws::Utils::Stream::ResponseStream m_asset;
 
     Aws::String m_assetName;
 

--- a/generated/src/aws-cpp-sdk-codeguruprofiler/include/aws/codeguruprofiler/model/GetProfileResult.h
+++ b/generated/src/aws-cpp-sdk-codeguruprofiler/include/aws/codeguruprofiler/model/GetProfileResult.h
@@ -132,7 +132,7 @@ namespace Model
     /**
      * <p>Information about the profile.</p>
      */
-    inline Aws::IOStream& GetProfile() { return m_profile.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetProfile() const { return m_profile.GetUnderlyingStream(); }
 
     /**
      * <p>Information about the profile.</p>
@@ -145,7 +145,7 @@ namespace Model
 
     Aws::String m_contentType;
 
-  Aws::Utils::Stream::ResponseStream m_profile;
+    Aws::Utils::Stream::ResponseStream m_profile;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-dataexchange/include/aws/dataexchange/model/SendApiAssetResult.h
+++ b/generated/src/aws-cpp-sdk-dataexchange/include/aws/dataexchange/model/SendApiAssetResult.h
@@ -40,7 +40,7 @@ namespace Model
     /**
      * <p>The response body from the underlying API tracked by the API asset.</p>
      */
-    inline Aws::IOStream& GetBody() { return m_body.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBody() const { return m_body.GetUnderlyingStream(); }
 
     /**
      * <p>The response body from the underlying API tracked by the API asset.</p>
@@ -110,7 +110,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_body;
+    Aws::Utils::Stream::ResponseStream m_body;
 
     Aws::Map<Aws::String, Aws::String> m_responseHeaders;
   };

--- a/generated/src/aws-cpp-sdk-ebs/include/aws/ebs/model/GetSnapshotBlockResult.h
+++ b/generated/src/aws-cpp-sdk-ebs/include/aws/ebs/model/GetSnapshotBlockResult.h
@@ -57,7 +57,7 @@ namespace Model
     /**
      * <p>The data content of the block.</p>
      */
-    inline Aws::IOStream& GetBlockData() { return m_blockData.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBlockData() const { return m_blockData.GetUnderlyingStream(); }
 
     /**
      * <p>The data content of the block.</p>
@@ -135,7 +135,7 @@ namespace Model
 
     int m_dataLength;
 
-  Aws::Utils::Stream::ResponseStream m_blockData;
+    Aws::Utils::Stream::ResponseStream m_blockData;
 
     Aws::String m_checksum;
 

--- a/generated/src/aws-cpp-sdk-glacier/include/aws/glacier/model/GetJobOutputResult.h
+++ b/generated/src/aws-cpp-sdk-glacier/include/aws/glacier/model/GetJobOutputResult.h
@@ -46,7 +46,7 @@ namespace Model
     /**
      * <p>The job data, either archive data or inventory data.</p>
      */
-    inline Aws::IOStream& GetBody() { return m_body.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBody() const { return m_body.GetUnderlyingStream(); }
 
     /**
      * <p>The job data, either archive data or inventory data.</p>
@@ -380,7 +380,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_body;
+    Aws::Utils::Stream::ResponseStream m_body;
 
     Aws::String m_checksum;
 

--- a/generated/src/aws-cpp-sdk-iot-data/include/aws/iot-data/model/DeleteThingShadowResult.h
+++ b/generated/src/aws-cpp-sdk-iot-data/include/aws/iot-data/model/DeleteThingShadowResult.h
@@ -45,7 +45,7 @@ namespace Model
     /**
      * <p>The state information, in JSON format.</p>
      */
-    inline Aws::IOStream& GetPayload() { return m_payload.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetPayload() const { return m_payload.GetUnderlyingStream(); }
 
     /**
      * <p>The state information, in JSON format.</p>
@@ -54,7 +54,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_payload;
+    Aws::Utils::Stream::ResponseStream m_payload;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-iot-data/include/aws/iot-data/model/GetThingShadowResult.h
+++ b/generated/src/aws-cpp-sdk-iot-data/include/aws/iot-data/model/GetThingShadowResult.h
@@ -44,7 +44,7 @@ namespace Model
     /**
      * <p>The state information, in JSON format.</p>
      */
-    inline Aws::IOStream& GetPayload() { return m_payload.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetPayload() const { return m_payload.GetUnderlyingStream(); }
 
     /**
      * <p>The state information, in JSON format.</p>
@@ -53,7 +53,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_payload;
+    Aws::Utils::Stream::ResponseStream m_payload;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-iot-data/include/aws/iot-data/model/UpdateThingShadowResult.h
+++ b/generated/src/aws-cpp-sdk-iot-data/include/aws/iot-data/model/UpdateThingShadowResult.h
@@ -45,7 +45,7 @@ namespace Model
     /**
      * <p>The state information, in JSON format.</p>
      */
-    inline Aws::IOStream& GetPayload() { return m_payload.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetPayload() const { return m_payload.GetUnderlyingStream(); }
 
     /**
      * <p>The state information, in JSON format.</p>
@@ -54,7 +54,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_payload;
+    Aws::Utils::Stream::ResponseStream m_payload;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-iotwireless/include/aws/iotwireless/model/GetPositionEstimateResult.h
+++ b/generated/src/aws-cpp-sdk-iotwireless/include/aws/iotwireless/model/GetPositionEstimateResult.h
@@ -42,7 +42,7 @@ namespace Model
      * data structures. For more information, see <a
      * href="https://geojson.org/">GeoJSON</a>.</p>
      */
-    inline Aws::IOStream& GetGeoJsonPayload() { return m_geoJsonPayload.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetGeoJsonPayload() const { return m_geoJsonPayload.GetUnderlyingStream(); }
 
     /**
      * <p>The position information of the resource, displayed as a JSON payload. The
@@ -54,7 +54,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_geoJsonPayload;
+    Aws::Utils::Stream::ResponseStream m_geoJsonPayload;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-iotwireless/include/aws/iotwireless/model/GetResourcePositionResult.h
+++ b/generated/src/aws-cpp-sdk-iotwireless/include/aws/iotwireless/model/GetResourcePositionResult.h
@@ -42,7 +42,7 @@ namespace Model
      * data structures. For more information, see <a
      * href="https://geojson.org/">GeoJSON</a>.</p>
      */
-    inline Aws::IOStream& GetGeoJsonPayload() { return m_geoJsonPayload.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetGeoJsonPayload() const { return m_geoJsonPayload.GetUnderlyingStream(); }
 
     /**
      * <p>The position information of the resource, displayed as a JSON payload. The
@@ -54,7 +54,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_geoJsonPayload;
+    Aws::Utils::Stream::ResponseStream m_geoJsonPayload;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-kinesis-video-archived-media/include/aws/kinesis-video-archived-media/model/GetClipResult.h
+++ b/generated/src/aws-cpp-sdk-kinesis-video-archived-media/include/aws/kinesis-video-archived-media/model/GetClipResult.h
@@ -80,7 +80,7 @@ namespace Model
      * href="https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/limits.html">Kinesis
      * Video Streams Limits</a>. </p>
      */
-    inline Aws::IOStream& GetPayload() { return m_payload.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetPayload() const { return m_payload.GetUnderlyingStream(); }
 
     /**
      * <p>Traditional MP4 file that contains the media clip from the specified video
@@ -95,7 +95,7 @@ namespace Model
 
     Aws::String m_contentType;
 
-  Aws::Utils::Stream::ResponseStream m_payload;
+    Aws::Utils::Stream::ResponseStream m_payload;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-kinesis-video-archived-media/include/aws/kinesis-video-archived-media/model/GetMediaForFragmentListResult.h
+++ b/generated/src/aws-cpp-sdk-kinesis-video-archived-media/include/aws/kinesis-video-archived-media/model/GetMediaForFragmentListResult.h
@@ -90,7 +90,7 @@ namespace Model
      * code of the exception</p> </li> <li> <p>AWS_KINESISVIDEO_EXCEPTION_MESSAGE - A
      * text description of the exception</p> </li> </ul>
      */
-    inline Aws::IOStream& GetPayload() { return m_payload.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetPayload() const { return m_payload.GetUnderlyingStream(); }
 
     /**
      * <p>The payload that Kinesis Video Streams returns is a sequence of chunks from
@@ -115,7 +115,7 @@ namespace Model
 
     Aws::String m_contentType;
 
-  Aws::Utils::Stream::ResponseStream m_payload;
+    Aws::Utils::Stream::ResponseStream m_payload;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-kinesis-video-media/include/aws/kinesis-video-media/model/GetMediaResult.h
+++ b/generated/src/aws-cpp-sdk-kinesis-video-media/include/aws/kinesis-video-media/model/GetMediaResult.h
@@ -101,7 +101,7 @@ namespace Model
      * the stream</p> </li> <li> <p>4506 - Unable to find the KMS key specified in the
      * stream</p> </li> <li> <p>5000 - Internal error</p> </li> </ul>
      */
-    inline Aws::IOStream& GetPayload() { return m_payload.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetPayload() const { return m_payload.GetUnderlyingStream(); }
 
     /**
      * <p> The payload Kinesis Video Streams returns is a sequence of chunks from the
@@ -137,7 +137,7 @@ namespace Model
 
     Aws::String m_contentType;
 
-  Aws::Utils::Stream::ResponseStream m_payload;
+    Aws::Utils::Stream::ResponseStream m_payload;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-lakeformation/include/aws/lakeformation/model/GetWorkUnitResultsResult.h
+++ b/generated/src/aws-cpp-sdk-lakeformation/include/aws/lakeformation/model/GetWorkUnitResultsResult.h
@@ -45,7 +45,7 @@ namespace Model
      * <p>Rows returned from the <code>GetWorkUnitResults</code> operation as a stream
      * of Apache Arrow v1.0 messages.</p>
      */
-    inline Aws::IOStream& GetResultStream() { return m_resultStream.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetResultStream() const { return m_resultStream.GetUnderlyingStream(); }
 
     /**
      * <p>Rows returned from the <code>GetWorkUnitResults</code> operation as a stream
@@ -55,7 +55,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_resultStream;
+    Aws::Utils::Stream::ResponseStream m_resultStream;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-lambda/include/aws/lambda/model/InvokeResult.h
+++ b/generated/src/aws-cpp-sdk-lambda/include/aws/lambda/model/InvokeResult.h
@@ -144,7 +144,7 @@ namespace Model
     /**
      * <p>The response from the function, or an error object.</p>
      */
-    inline Aws::IOStream& GetPayload() { return m_payload.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetPayload() const { return m_payload.GetUnderlyingStream(); }
 
     /**
      * <p>The response from the function, or an error object.</p>
@@ -202,7 +202,7 @@ namespace Model
 
     Aws::String m_logResult;
 
-  Aws::Utils::Stream::ResponseStream m_payload;
+    Aws::Utils::Stream::ResponseStream m_payload;
 
     Aws::String m_executedVersion;
   };

--- a/generated/src/aws-cpp-sdk-lex/include/aws/lex/model/PostContentResult.h
+++ b/generated/src/aws-cpp-sdk-lex/include/aws/lex/model/PostContentResult.h
@@ -924,7 +924,7 @@ namespace Model
      * Lambda function successfully fulfilled the intent, and sent a message to convey
      * to the user. Then Amazon Lex sends that message in the response. </p>
      */
-    inline Aws::IOStream& GetAudioStream() { return m_audioStream.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetAudioStream() const { return m_audioStream.GetUnderlyingStream(); }
 
     /**
      * <p>The prompt (or statement) to convey to the user. This is based on the bot
@@ -1113,7 +1113,7 @@ namespace Model
 
     Aws::String m_encodedInputTranscript;
 
-  Aws::Utils::Stream::ResponseStream m_audioStream;
+    Aws::Utils::Stream::ResponseStream m_audioStream;
 
     Aws::String m_botVersion;
 

--- a/generated/src/aws-cpp-sdk-lex/include/aws/lex/model/PutSessionResult.h
+++ b/generated/src/aws-cpp-sdk-lex/include/aws/lex/model/PutSessionResult.h
@@ -498,7 +498,7 @@ namespace Model
     /**
      * <p>The audio version of the message to convey to the user.</p>
      */
-    inline Aws::IOStream& GetAudioStream() { return m_audioStream.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetAudioStream() const { return m_audioStream.GetUnderlyingStream(); }
 
     /**
      * <p>The audio version of the message to convey to the user.</p>
@@ -595,7 +595,7 @@ namespace Model
 
     Aws::String m_slotToElicit;
 
-  Aws::Utils::Stream::ResponseStream m_audioStream;
+    Aws::Utils::Stream::ResponseStream m_audioStream;
 
     Aws::String m_sessionId;
 

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/model/PutSessionResult.h
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/model/PutSessionResult.h
@@ -270,7 +270,7 @@ namespace Model
      * <p>If the requested content type was audio, the audio version of the message to
      * convey to the user.</p>
      */
-    inline Aws::IOStream& GetAudioStream() { return m_audioStream.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetAudioStream() const { return m_audioStream.GetUnderlyingStream(); }
 
     /**
      * <p>If the requested content type was audio, the audio version of the message to
@@ -290,7 +290,7 @@ namespace Model
 
     Aws::String m_sessionId;
 
-  Aws::Utils::Stream::ResponseStream m_audioStream;
+    Aws::Utils::Stream::ResponseStream m_audioStream;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/model/RecognizeUtteranceResult.h
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/model/RecognizeUtteranceResult.h
@@ -537,7 +537,7 @@ namespace Model
      * Lambda function successfully fulfilled the intent, and sent a message to convey
      * to the user. Then Amazon Lex V2 sends that message in the response.</p>
      */
-    inline Aws::IOStream& GetAudioStream() { return m_audioStream.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetAudioStream() const { return m_audioStream.GetUnderlyingStream(); }
 
     /**
      * <p>The prompt or statement to send to the user. This is based on the bot
@@ -604,7 +604,7 @@ namespace Model
 
     Aws::String m_inputTranscript;
 
-  Aws::Utils::Stream::ResponseStream m_audioStream;
+    Aws::Utils::Stream::ResponseStream m_audioStream;
 
     Aws::String m_recognizedBotMember;
   };

--- a/generated/src/aws-cpp-sdk-location/include/aws/location/model/GetMapGlyphsResult.h
+++ b/generated/src/aws-cpp-sdk-location/include/aws/location/model/GetMapGlyphsResult.h
@@ -40,7 +40,7 @@ namespace Model
     /**
      * <p>The blob's content type.</p>
      */
-    inline Aws::IOStream& GetBlob() { return m_blob.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBlob() const { return m_blob.GetUnderlyingStream(); }
 
     /**
      * <p>The blob's content type.</p>
@@ -92,7 +92,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_blob;
+    Aws::Utils::Stream::ResponseStream m_blob;
 
     Aws::String m_contentType;
   };

--- a/generated/src/aws-cpp-sdk-location/include/aws/location/model/GetMapSpritesResult.h
+++ b/generated/src/aws-cpp-sdk-location/include/aws/location/model/GetMapSpritesResult.h
@@ -40,7 +40,7 @@ namespace Model
     /**
      * <p>Contains the body of the sprite sheet or JSON offset ﬁle.</p>
      */
-    inline Aws::IOStream& GetBlob() { return m_blob.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBlob() const { return m_blob.GetUnderlyingStream(); }
 
     /**
      * <p>Contains the body of the sprite sheet or JSON offset ﬁle.</p>
@@ -99,7 +99,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_blob;
+    Aws::Utils::Stream::ResponseStream m_blob;
 
     Aws::String m_contentType;
   };

--- a/generated/src/aws-cpp-sdk-location/include/aws/location/model/GetMapStyleDescriptorResult.h
+++ b/generated/src/aws-cpp-sdk-location/include/aws/location/model/GetMapStyleDescriptorResult.h
@@ -40,7 +40,7 @@ namespace Model
     /**
      * <p>Contains the body of the style descriptor.</p>
      */
-    inline Aws::IOStream& GetBlob() { return m_blob.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBlob() const { return m_blob.GetUnderlyingStream(); }
 
     /**
      * <p>Contains the body of the style descriptor.</p>
@@ -92,7 +92,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_blob;
+    Aws::Utils::Stream::ResponseStream m_blob;
 
     Aws::String m_contentType;
   };

--- a/generated/src/aws-cpp-sdk-location/include/aws/location/model/GetMapTileResult.h
+++ b/generated/src/aws-cpp-sdk-location/include/aws/location/model/GetMapTileResult.h
@@ -40,7 +40,7 @@ namespace Model
     /**
      * <p>Contains Mapbox Vector Tile (MVT) data.</p>
      */
-    inline Aws::IOStream& GetBlob() { return m_blob.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBlob() const { return m_blob.GetUnderlyingStream(); }
 
     /**
      * <p>Contains Mapbox Vector Tile (MVT) data.</p>
@@ -92,7 +92,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_blob;
+    Aws::Utils::Stream::ResponseStream m_blob;
 
     Aws::String m_contentType;
   };

--- a/generated/src/aws-cpp-sdk-medialive/include/aws/medialive/model/DescribeInputDeviceThumbnailResult.h
+++ b/generated/src/aws-cpp-sdk-medialive/include/aws/medialive/model/DescribeInputDeviceThumbnailResult.h
@@ -49,7 +49,7 @@ namespace Model
      * The binary data for the thumbnail that the Link device has most recently sent to
      * MediaLive.
      */
-    inline Aws::IOStream& GetBody() { return m_body.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBody() const { return m_body.GetUnderlyingStream(); }
 
     /**
      * The binary data for the thumbnail that the Link device has most recently sent to
@@ -163,7 +163,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_body;
+    Aws::Utils::Stream::ResponseStream m_body;
 
     ContentType m_contentType;
 

--- a/generated/src/aws-cpp-sdk-mediastore-data/include/aws/mediastore-data/model/GetObjectResult.h
+++ b/generated/src/aws-cpp-sdk-mediastore-data/include/aws/mediastore-data/model/GetObjectResult.h
@@ -41,7 +41,7 @@ namespace Model
     /**
      * <p>The bytes of the object. </p>
      */
-    inline Aws::IOStream& GetBody() { return m_body.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBody() const { return m_body.GetUnderlyingStream(); }
 
     /**
      * <p>The bytes of the object. </p>
@@ -286,7 +286,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_body;
+    Aws::Utils::Stream::ResponseStream m_body;
 
     Aws::String m_cacheControl;
 

--- a/generated/src/aws-cpp-sdk-omics/include/aws/omics/model/GetReadSetResult.h
+++ b/generated/src/aws-cpp-sdk-omics/include/aws/omics/model/GetReadSetResult.h
@@ -39,7 +39,7 @@ namespace Model
     /**
      * <p>The read set file payload.</p>
      */
-    inline Aws::IOStream& GetPayload() { return m_payload.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetPayload() const { return m_payload.GetUnderlyingStream(); }
 
     /**
      * <p>The read set file payload.</p>
@@ -48,7 +48,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_payload;
+    Aws::Utils::Stream::ResponseStream m_payload;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-omics/include/aws/omics/model/GetReferenceResult.h
+++ b/generated/src/aws-cpp-sdk-omics/include/aws/omics/model/GetReferenceResult.h
@@ -39,7 +39,7 @@ namespace Model
     /**
      * <p>The reference file payload.</p>
      */
-    inline Aws::IOStream& GetPayload() { return m_payload.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetPayload() const { return m_payload.GetUnderlyingStream(); }
 
     /**
      * <p>The reference file payload.</p>
@@ -48,7 +48,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_payload;
+    Aws::Utils::Stream::ResponseStream m_payload;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-polly/include/aws/polly/model/SynthesizeSpeechResult.h
+++ b/generated/src/aws-cpp-sdk-polly/include/aws/polly/model/SynthesizeSpeechResult.h
@@ -40,7 +40,7 @@ namespace Model
     /**
      * <p> Stream containing the synthesized speech. </p>
      */
-    inline Aws::IOStream& GetAudioStream() { return m_audioStream.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetAudioStream() const { return m_audioStream.GetUnderlyingStream(); }
 
     /**
      * <p> Stream containing the synthesized speech. </p>
@@ -171,7 +171,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_audioStream;
+    Aws::Utils::Stream::ResponseStream m_audioStream;
 
     Aws::String m_contentType;
 

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/GetBucketPolicyResult.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/GetBucketPolicyResult.h
@@ -39,7 +39,7 @@ namespace Model
     /**
      * <p>The bucket policy as a JSON document.</p>
      */
-    inline Aws::IOStream& GetPolicy() { return m_policy.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetPolicy() const { return m_policy.GetUnderlyingStream(); }
 
     /**
      * <p>The bucket policy as a JSON document.</p>
@@ -48,7 +48,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_policy;
+    Aws::Utils::Stream::ResponseStream m_policy;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/GetObjectResult.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/GetObjectResult.h
@@ -48,7 +48,7 @@ namespace Model
     /**
      * <p>Object data.</p>
      */
-    inline Aws::IOStream& GetBody() { return m_body.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBody() const { return m_body.GetUnderlyingStream(); }
 
     /**
      * <p>Object data.</p>
@@ -1455,7 +1455,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_body;
+    Aws::Utils::Stream::ResponseStream m_body;
 
     bool m_deleteMarker;
 

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/GetObjectTorrentResult.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/GetObjectTorrentResult.h
@@ -40,7 +40,7 @@ namespace Model
     /**
      * <p>A Bencoded dictionary as defined by the BitTorrent specification</p>
      */
-    inline Aws::IOStream& GetBody() { return m_body.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBody() const { return m_body.GetUnderlyingStream(); }
 
     /**
      * <p>A Bencoded dictionary as defined by the BitTorrent specification</p>
@@ -65,7 +65,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_body;
+    Aws::Utils::Stream::ResponseStream m_body;
 
     RequestCharged m_requestCharged;
   };

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/GetBucketPolicyResult.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/GetBucketPolicyResult.h
@@ -39,7 +39,7 @@ namespace Model
     /**
      * <p>The bucket policy as a JSON document.</p>
      */
-    inline Aws::IOStream& GetPolicy() { return m_policy.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetPolicy() const { return m_policy.GetUnderlyingStream(); }
 
     /**
      * <p>The bucket policy as a JSON document.</p>
@@ -48,7 +48,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_policy;
+    Aws::Utils::Stream::ResponseStream m_policy;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/GetObjectResult.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/GetObjectResult.h
@@ -48,7 +48,7 @@ namespace Model
     /**
      * <p>Object data.</p>
      */
-    inline Aws::IOStream& GetBody() { return m_body.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBody() const { return m_body.GetUnderlyingStream(); }
 
     /**
      * <p>Object data.</p>
@@ -1455,7 +1455,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_body;
+    Aws::Utils::Stream::ResponseStream m_body;
 
     bool m_deleteMarker;
 

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/GetObjectTorrentResult.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/GetObjectTorrentResult.h
@@ -40,7 +40,7 @@ namespace Model
     /**
      * <p>A Bencoded dictionary as defined by the BitTorrent specification</p>
      */
-    inline Aws::IOStream& GetBody() { return m_body.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBody() const { return m_body.GetUnderlyingStream(); }
 
     /**
      * <p>A Bencoded dictionary as defined by the BitTorrent specification</p>
@@ -65,7 +65,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_body;
+    Aws::Utils::Stream::ResponseStream m_body;
 
     RequestCharged m_requestCharged;
   };

--- a/generated/src/aws-cpp-sdk-sagemaker-geospatial/include/aws/sagemaker-geospatial/model/GetTileResult.h
+++ b/generated/src/aws-cpp-sdk-sagemaker-geospatial/include/aws/sagemaker-geospatial/model/GetTileResult.h
@@ -39,7 +39,7 @@ namespace Model
     /**
      * <p>The output binary file.</p>
      */
-    inline Aws::IOStream& GetBinaryFile() { return m_binaryFile.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBinaryFile() const { return m_binaryFile.GetUnderlyingStream(); }
 
     /**
      * <p>The output binary file.</p>
@@ -48,7 +48,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_binaryFile;
+    Aws::Utils::Stream::ResponseStream m_binaryFile;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-sagemaker-runtime/include/aws/sagemaker-runtime/model/InvokeEndpointResult.h
+++ b/generated/src/aws-cpp-sdk-sagemaker-runtime/include/aws/sagemaker-runtime/model/InvokeEndpointResult.h
@@ -47,7 +47,7 @@ namespace Model
      * href="https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-online-explainability-invoke-endpoint.html#clarify-online-explainability-response">Invoke
      * the Endpoint</a> in the Developer Guide.</p>
      */
-    inline Aws::IOStream& GetBody() { return m_body.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBody() const { return m_body.GetUnderlyingStream(); }
 
     /**
      * <p>Includes the inference provided by the model. </p> <p>For information about
@@ -276,7 +276,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_body;
+    Aws::Utils::Stream::ResponseStream m_body;
 
     Aws::String m_contentType;
 

--- a/generated/src/aws-cpp-sdk-schemas/include/aws/schemas/model/GetCodeBindingSourceResult.h
+++ b/generated/src/aws-cpp-sdk-schemas/include/aws/schemas/model/GetCodeBindingSourceResult.h
@@ -37,14 +37,14 @@ namespace Model
 
 
     
-    inline Aws::IOStream& GetBody() { return m_body.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetBody() const { return m_body.GetUnderlyingStream(); }
 
     
     inline void ReplaceBody(Aws::IOStream* body) { m_body = Aws::Utils::Stream::ResponseStream(body); }
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_body;
+    Aws::Utils::Stream::ResponseStream m_body;
   };
 
 } // namespace Model

--- a/generated/src/aws-cpp-sdk-workmailmessageflow/include/aws/workmailmessageflow/model/GetRawMessageContentResult.h
+++ b/generated/src/aws-cpp-sdk-workmailmessageflow/include/aws/workmailmessageflow/model/GetRawMessageContentResult.h
@@ -39,7 +39,7 @@ namespace Model
     /**
      * <p>The raw content of the email message, in MIME format.</p>
      */
-    inline Aws::IOStream& GetMessageContent() { return m_messageContent.GetUnderlyingStream(); }
+    inline Aws::IOStream& GetMessageContent() const { return m_messageContent.GetUnderlyingStream(); }
 
     /**
      * <p>The raw content of the email message, in MIME format.</p>
@@ -48,7 +48,7 @@ namespace Model
 
   private:
 
-  Aws::Utils::Stream::ResponseStream m_messageContent;
+    Aws::Utils::Stream::ResponseStream m_messageContent;
   };
 
 } // namespace Model

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/stream/ResponseStream.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/stream/ResponseStream.h
@@ -49,14 +49,22 @@ namespace Aws
                 /**
                  * Gives access to underlying stream, but keep in mind that this changes state of the stream
                  */
-                inline Aws::IOStream& GetUnderlyingStream() const { return *m_underlyingStream; }
+                Aws::IOStream& GetUnderlyingStream() const;
 
             private:
                 void ReleaseStream();
+                void RegisterStream();
+                void DeregisterStream();
 
-                Aws::IOStream* m_underlyingStream;
+                Aws::IOStream* m_underlyingStream = nullptr;
+
+                static const int xindex;
+                static void StreamCallback(Aws::IOStream::event evt, std::ios_base& str, int idx);
             };
 
+            /**
+             * A default IOStream for ResponseStream.
+             */
             class AWS_CORE_API DefaultUnderlyingStream : public Aws::IOStream
             {
             public:

--- a/src/aws-cpp-sdk-core/source/utils/stream/ResponseStream.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/stream/ResponseStream.cpp
@@ -5,6 +5,7 @@
 
 #include <aws/core/utils/stream/ResponseStream.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
+#include <aws/core/utils/logging/LogMacros.h>
 
 #if defined(_GLIBCXX_FULLY_DYNAMIC_STRING) && _GLIBCXX_FULLY_DYNAMIC_STRING == 0 && defined(__ANDROID__)
 #include <aws/core/utils/stream/SimpleStreamBuf.h>
@@ -15,6 +16,8 @@ using DefaultStreamBufType = Aws::StringBuf;
 
 using namespace Aws::Utils::Stream;
 
+const int ResponseStream::ResponseStream::xindex = std::ios_base::xalloc();
+
 ResponseStream::ResponseStream(void) :
     m_underlyingStream(nullptr)
 {
@@ -23,16 +26,20 @@ ResponseStream::ResponseStream(void) :
 ResponseStream::ResponseStream(Aws::IOStream* underlyingStreamToManage) :
     m_underlyingStream(underlyingStreamToManage)
 {
+    RegisterStream();
 }
 
 ResponseStream::ResponseStream(const Aws::IOStreamFactory& factory) :
     m_underlyingStream(factory())
 {
+    RegisterStream();
 }
 
 ResponseStream::ResponseStream(ResponseStream&& toMove) : m_underlyingStream(toMove.m_underlyingStream)
 {
+    toMove.DeregisterStream();
     toMove.m_underlyingStream = nullptr;
+    RegisterStream();
 }
 
 ResponseStream& ResponseStream::operator=(ResponseStream&& toMove)
@@ -43,10 +50,24 @@ ResponseStream& ResponseStream::operator=(ResponseStream&& toMove)
     }
 
     ReleaseStream();
+    toMove.DeregisterStream();
     m_underlyingStream = toMove.m_underlyingStream;
     toMove.m_underlyingStream = nullptr;
+    RegisterStream();
 
     return *this;
+}
+
+Aws::IOStream& ResponseStream::GetUnderlyingStream() const
+{
+    if (!m_underlyingStream)
+    {
+        assert(m_underlyingStream);
+        AWS_LOGSTREAM_FATAL("ResponseStream", "Unexpected nullptr m_underlyingStream");
+        static DefaultUnderlyingStream fallbackStream; // we are already in UB, let's just not crash existing apps
+        return fallbackStream;
+    }
+    return *m_underlyingStream;
 }
 
 ResponseStream::~ResponseStream()
@@ -58,10 +79,51 @@ void ResponseStream::ReleaseStream()
 {
     if (m_underlyingStream)
     {
+        DeregisterStream();
         Aws::Delete(m_underlyingStream);
     }
 
     m_underlyingStream = nullptr;
+}
+
+void ResponseStream::RegisterStream()
+{
+    if (m_underlyingStream)
+    {
+        ResponseStream* pThat = static_cast<ResponseStream*>(m_underlyingStream->pword(ResponseStream::xindex));
+        if (pThat != nullptr)
+        {
+            // callback is already registered
+            assert(pThat != this); // Underlying stream must not be owned by more than one ResponseStream
+        }
+        else
+        {
+            m_underlyingStream->register_callback(ResponseStream::StreamCallback, ResponseStream::xindex);
+        }
+        m_underlyingStream->pword(ResponseStream::xindex) = this;
+    }
+}
+
+void ResponseStream::DeregisterStream()
+{
+    if (m_underlyingStream)
+    {
+        assert(static_cast<ResponseStream*>(m_underlyingStream->pword(ResponseStream::xindex)) == this); // Attempt to deregister another ResponseStream's stream
+        m_underlyingStream->pword(ResponseStream::xindex) = nullptr; // ios does not support deregister, so just erasing the context
+    }
+}
+
+void ResponseStream::StreamCallback(Aws::IOStream::event evt, std::ios_base& stream, int idx)
+{
+    if (evt == std::ios_base::erase_event)
+    {
+        ResponseStream* pThis = static_cast<ResponseStream*>(stream.pword(idx));
+        if (pThis)
+        {
+            // m_underlyingStream is being destructed, let's avoid double destruction or having a dangling pointer
+            pThis->m_underlyingStream = nullptr;
+        }
+    }
 }
 
 static const char *DEFAULT_STREAM_TAG = "DefaultUnderlyingStream";

--- a/src/aws-cpp-sdk-core/source/utils/stream/ResponseStream.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/stream/ResponseStream.cpp
@@ -58,7 +58,6 @@ void ResponseStream::ReleaseStream()
 {
     if (m_underlyingStream)
     {
-        m_underlyingStream->flush();
         Aws::Delete(m_underlyingStream);
     }
 

--- a/tests/aws-cpp-sdk-core-tests/utils/stream/ResponseStreamTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/stream/ResponseStreamTest.cpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <gtest/gtest.h>
+#include <aws/core/utils/stream/ResponseStream.h>
+#include <aws/core/utils/memory/stl/AWSStringStream.h>
+
+using Aws::Utils::Stream::ResponseStream;
+using Aws::StringStream;
+
+static_assert(!std::is_copy_constructible<ResponseStream>::value, "This is a move only type.");
+static_assert(std::is_move_constructible<ResponseStream>::value, "This is a move only type.");
+static_assert(!std::is_assignable<ResponseStream, ResponseStream&>::value, "This is a move only type.");
+static_assert(!std::is_assignable<ResponseStream, const ResponseStream&>::value, "This is a move only type.");
+static_assert(std::is_assignable<ResponseStream, ResponseStream&&>::value, "This is a move only type.");
+static_assert(std::is_default_constructible<ResponseStream>::value, "Must support default construction.");
+
+TEST(ResponseStreamTest, TestResponseStreamBasic)
+{
+    ResponseStream defaultResponseStream;
+
+    Aws::IOStream* pStream = Aws::Utils::Stream::DefaultResponseStreamFactoryMethod();
+    ResponseStream defaultResponseStreamWithStream(pStream);
+    EXPECT_EQ(&defaultResponseStreamWithStream.GetUnderlyingStream(), pStream);
+
+    defaultResponseStream = std::move(defaultResponseStreamWithStream);
+    EXPECT_EQ(&defaultResponseStream.GetUnderlyingStream(), pStream);
+
+    ResponseStream moveCtorResponseStream(std::move(defaultResponseStream));
+    EXPECT_EQ(&moveCtorResponseStream.GetUnderlyingStream(), pStream);
+}
+
+TEST(ResponseStreamTest, TestUnderlyingStreamGoneBeforeWrapper)
+{
+    Aws::IOStream* pStream = Aws::Utils::Stream::DefaultResponseStreamFactoryMethod();
+    ResponseStream responseStream(pStream);
+    Aws::Delete(pStream);
+    // must not crash in ~ResponseStream
+}
+
+TEST(ResponseStreamTest, TestUnderlyingStreamOutlivesWrapper)
+{
+    Aws::IOStream* pStream = Aws::Utils::Stream::DefaultResponseStreamFactoryMethod();
+    {
+        ResponseStream responseStream(pStream);
+    }
+    // must not crash and must not memory leak, pStream is deleted by ~ResponseStream
+}
+

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassMembersAndInlines.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassMembersAndInlines.vm
@@ -70,7 +70,7 @@
 #end
 #if($isStream)
     $memberDocumentation
-    ${inline}Aws::IOStream& ${getterFunctionName}() { return ${memberVariableName}.GetUnderlyingStream(); }
+    ${inline}Aws::IOStream& ${getterFunctionName}() const { return ${memberVariableName}.GetUnderlyingStream(); }
 
     $memberDocumentation
     ${inline}void ReplaceBody(Aws::IOStream* body) { ${memberVariableName} = Aws::Utils::Stream::ResponseStream(body); }
@@ -219,7 +219,7 @@
 #set($isEventStreamInput = false)
 #end
 #if((($shape.payload && ($shape.payload == $member.key && !$member.value.shape.structure && !$member.value.shape.list)) || $member.value.streaming) && $shape.result)
-  Aws::Utils::Stream::ResponseStream $CppViewHelper.computeMemberVariableName($member.key);
+    Aws::Utils::Stream::ResponseStream $CppViewHelper.computeMemberVariableName($member.key);
 #elseif(($shape.payload && ($shape.payload == $member.key && !$member.value.shape.structure && !$member.value.shape.list)) && $shape.request)
 #else
 #if($member.value.shape.getName() == $shape.getName() && $member.value.shape.list)


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/58, https://github.com/aws/aws-sdk-cpp/issues/1732, https://github.com/aws/aws-sdk-cpp/issues/2319

The issue: 
* ResponseStream design can attach to an underlying buffer it does not own, a double destruction may occur;
* TransferManager marks a download as complete before the actual destination buffer is flushed.

*Description of changes:*
* Use [std::ios_base::register_callback](https://en.cppreference.com/w/cpp/io/ios_base/register_callback) to get notified if underlying stream is destructed;
* Do not flush in ResponseStream d-tor: it does not make sense, on the next line, proper underlying stream implementation should do it anyway in it's destructor (and should not if flush is not required in their design).
* Flush outcome's bodies in TransferManager before sending a complete notification;
* Update Result's Get<Aws::IOStream object> to be const (for the change above);
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
