### PR TITLE
Allow endpoint override for CRT S3

### DIFF
--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceHeaders.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceHeaders.vm
@@ -40,6 +40,7 @@
 \#include <aws/crt/auth/Credentials.h>
 \#include <aws/crt/http/HttpRequestResponse.h>
 \#include <aws/crt/io/Stream.h>
+\#include <aws/crt/io/Uri.h>
 \#include <aws/http/request_response.h>
 \#include <aws/common/string.h>
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
@@ -166,6 +166,9 @@ void S3CrtClient::InitCommonCrtRequestOption(CrtRequestCallbackUserData *userDat
   options->headers_callback = S3CrtRequestHeadersCallback;
   options->body_callback = S3CrtRequestGetBodyCallback;
   options->finish_callback = S3CrtRequestFinishCallback;
+  const auto endpointStr = uri.GetURIString();
+  const auto endpointCursor{ aws_byte_cursor_from_array(endpointStr.c_str(), endpointStr.size()) };
+  aws_uri_init_parse(options->endpoint, Aws::get_aws_allocator(), &endpointCursor);
 }
 
 #foreach($operation in $serviceModel.operations)
@@ -235,6 +238,10 @@ void ${className}::${operation.name}Async(${constText}${operation.request.shape.
   CrtRequestCallbackUserData *userData = Aws::New<CrtRequestCallbackUserData>(ALLOCATION_TAG);
   aws_s3_meta_request_options options;
   AWS_ZERO_STRUCT(options);
+  aws_uri endpoint;
+  AWS_ZERO_STRUCT(endpoint);
+  options.endpoint = &endpoint;
+  std::unique_ptr<aws_uri, void(*)(aws_uri*)> endpointCleanup { options.endpoint, &aws_uri_clean_up };
 
 #if($operation.name == "PutObject")
   userData->putResponseHandler = handler;


### PR DESCRIPTION
*Issue #1844, if available:*

*Description of changes:*

Propagate S3 CRT client endpoint override to the aws_s3_meta_request_options.
As suggested by @TingDaok in https://github.com/aws/aws-sdk-cpp/issues/1844#issuecomment-1372990969

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
