### PR TITLE
Reduce logging level for frequently logged statements.

### DIFF
--- a/src/aws-cpp-sdk-core/source/endpoint/DefaultEndpointProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/endpoint/DefaultEndpointProvider.cpp
@@ -169,7 +169,7 @@ ResolveEndpointDefaultImpl(const Aws::Crt::Endpoints::RuleEngine& ruleEngine,
             Aws::Endpoint::AWSEndpoint endpoint;
             const auto crtUrl = resolved->GetUrl();
             Aws::String sdkCrtUrl = Aws::String(crtUrl->begin(), crtUrl->end());
-            AWS_LOGSTREAM_INFO(DEFAULT_ENDPOINT_PROVIDER_TAG, "Endpoint rules engine evaluated the endpoint: " << sdkCrtUrl);
+            AWS_LOGSTREAM_DEBUG(DEFAULT_ENDPOINT_PROVIDER_TAG, "Endpoint rules engine evaluated the endpoint: " << sdkCrtUrl);
             endpoint.SetURL(PercentDecode(std::move(sdkCrtUrl)));
 
             // Transform attributes

--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHandleContainer.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHandleContainer.cpp
@@ -43,7 +43,7 @@ CURL* CurlHandleContainer::AcquireCurlHandle()
     }
 
     CURL* handle = m_handleContainer.Acquire();
-    AWS_LOGSTREAM_INFO(CURL_HANDLE_CONTAINER_TAG, "Connection has been released. Continuing.");
+    AWS_LOGSTREAM_DEBUG(CURL_HANDLE_CONTAINER_TAG, "Connection has been released. Continuing.");
     AWS_LOGSTREAM_DEBUG(CURL_HANDLE_CONTAINER_TAG, "Returning connection handle " << handle);
     return handle;
 }


### PR DESCRIPTION
*Description of changes:*

Customers have reported that these two info log statements have a particularly negative effect on the overall size of their log files. Changing default behavior to log these at debug levels.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [x] IOS
- [x] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
