### PR TITLE
Adding integration testing for CW putMetricData

### DIFF
--- a/cmake/sdksCommon.cmake
+++ b/cmake/sdksCommon.cmake
@@ -162,6 +162,7 @@ list(APPEND SDK_TEST_PROJECT_LIST "kinesis:tests/aws-cpp-sdk-kinesis-integration
 list(APPEND SDK_TEST_PROJECT_LIST "lambda:tests/aws-cpp-sdk-lambda-integration-tests")
 list(APPEND SDK_TEST_PROJECT_LIST "logs:tests/aws-cpp-sdk-logs-integration-tests")
 list(APPEND SDK_TEST_PROJECT_LIST "mediastore-data:tests/aws-cpp-sdk-mediastore-data-integration-tests")
+list(APPEND SDK_TEST_PROJECT_LIST "monitoring:tests/aws-cpp-sdk-monitoring-integration-tests")
 list(APPEND SDK_TEST_PROJECT_LIST "rds:tests/aws-cpp-sdk-rds-integration-tests")
 list(APPEND SDK_TEST_PROJECT_LIST "redshift:tests/aws-cpp-sdk-redshift-integration-tests")
 list(APPEND SDK_TEST_PROJECT_LIST "s3:tests/aws-cpp-sdk-s3-integration-tests")

--- a/tests/aws-cpp-sdk-monitoring-integration-tests/CMakeLists.txt
+++ b/tests/aws-cpp-sdk-monitoring-integration-tests/CMakeLists.txt
@@ -1,0 +1,30 @@
+add_project(aws-cpp-sdk-monitoring-integration-tests
+    "Tests for the AWS CloudWatch Monitoring C++ SDK"
+    aws-cpp-sdk-monitoring
+    testing-resources
+    aws-cpp-sdk-core)
+
+file(GLOB AWS_MONITORING_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+)
+
+file(GLOB AWS_MONITORING_INTEGRATION_TESTS_SRC
+    ${AWS_MONITORING_SRC}
+)
+
+if(MSVC AND BUILD_SHARED_LIBS)
+    add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
+endif()
+
+enable_testing()
+
+if(PLATFORM_ANDROID AND BUILD_SHARED_LIBS)
+    add_library(${PROJECT_NAME} ${AWS_MONITORING_INTEGRATION_TESTS_SRC})
+else()
+    add_executable(${PROJECT_NAME} ${AWS_MONITORING_INTEGRATION_TESTS_SRC})
+endif()
+
+set_compiler_flags(${PROJECT_NAME})
+set_compiler_warnings(${PROJECT_NAME})
+
+target_link_libraries(${PROJECT_NAME} ${PROJECT_LIBS})

--- a/tests/aws-cpp-sdk-monitoring-integration-tests/CloudWatchMonitoringTests.cpp
+++ b/tests/aws-cpp-sdk-monitoring-integration-tests/CloudWatchMonitoringTests.cpp
@@ -1,0 +1,94 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/utils/DateTime.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/core/utils/UUID.h>
+#include <aws/core/utils/memory/AWSMemory.h>
+#include <aws/monitoring/CloudWatchClient.h>
+#include <aws/monitoring/model/PutMetricDataRequest.h>
+#include <aws/testing/AwsTestHelpers.h>
+#include <aws/testing/TestingEnvironment.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+
+using namespace Aws::Auth;
+using namespace Aws::Http;
+using namespace Aws::Client;
+using namespace Aws::CloudWatch;
+using namespace Aws::CloudWatch::Model;
+using namespace Aws::Region;
+
+namespace {
+static const char ALLOCATION_TAG[] = "CloudWatchMonitoringTest";
+
+class CloudWatchMonitoringOperationTest : public ::testing::Test {
+protected:
+  Aws::UniquePtr<Aws::CloudWatch::CloudWatchClient> m_client;
+  Aws::String m_UUID;
+
+  Aws::String BuildResourceName(const char *baseName) {
+    return Aws::Testing::GetAwsResourcePrefix() + baseName + m_UUID;
+  }
+
+  void SetUp() {
+    m_UUID = Aws::Utils::UUID::RandomUUID();
+    ClientConfiguration config;
+    config.scheme = Scheme::HTTPS;
+    config.region = AWS_TEST_REGION;
+    m_client = Aws::MakeUnique<Aws::CloudWatch::CloudWatchClient>(
+        ALLOCATION_TAG, config);
+  }
+
+  void TearDown() {}
+};
+
+TEST_F(CloudWatchMonitoringOperationTest, PutSmallMetricDataTest) {
+  // Preparing small custom metric data to be pushed
+  Aws::CloudWatch::Model::Dimension dimension;
+  dimension.SetName("IntegrationTest");
+  dimension.SetValue(m_UUID);
+  Aws::CloudWatch::Model::MetricDatum datum;
+  datum.SetMetricName("TestMetric1");
+  datum.SetUnit(Aws::CloudWatch::Model::StandardUnit::Count);
+  datum.SetValue(1);
+  datum.AddDimensions(dimension);
+  // Preparing request
+  Aws::CloudWatch::Model::PutMetricDataRequest request;
+  request.SetNamespace("TestingMetrics");
+  request.AddMetricData(datum);
+  // Submit request
+  Aws::CloudWatch::Model::PutMetricDataOutcome outcome =
+      m_client->PutMetricData(request);
+  AWS_ASSERT_SUCCESS(outcome);
+}
+
+TEST_F(CloudWatchMonitoringOperationTest, PutLargeMetricDataTest) {
+  // Preparing large custom metric data to be pushed
+  Aws::CloudWatch::Model::Dimension dimension;
+  dimension.SetName("IntegrationTest");
+  dimension.SetValue(m_UUID);
+  Aws::CloudWatch::Model::MetricDatum datum;
+  datum.SetMetricName("TestMetric1");
+  datum.SetUnit(Aws::CloudWatch::Model::StandardUnit::Count);
+  datum.SetValue(1);
+  datum.AddDimensions(dimension);
+  // Preparing request
+  Aws::CloudWatch::Model::PutMetricDataRequest request;
+  request.SetNamespace("TestingMetrics");
+  // Adding the datum 10 thousand times to inflate the request size above
+  // request compression threshold if enabled
+  for (int i = 0; i < 10000; i++) {
+    request.AddMetricData(datum);
+  }
+  // Submit request
+  Aws::CloudWatch::Model::PutMetricDataOutcome outcome =
+      m_client->PutMetricData(request);
+  AWS_ASSERT_SUCCESS(outcome);
+}
+} // namespace

--- a/tests/aws-cpp-sdk-monitoring-integration-tests/RunTests.cpp
+++ b/tests/aws-cpp-sdk-monitoring-integration-tests/RunTests.cpp
@@ -1,0 +1,30 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <gtest/gtest.h>
+#include <aws/core/Aws.h>
+#include <aws/testing/platform/PlatformTesting.h>
+#include <aws/testing/TestingEnvironment.h>
+#include <aws/testing/MemoryTesting.h>
+
+int main(int argc, char** argv)
+{
+    Aws::Testing::SetDefaultSigPipeHandler();
+    Aws::SDKOptions options;
+    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Trace;
+    AWS_BEGIN_MEMORY_TEST_EX(options, 1024, 128);
+
+    Aws::Testing::InitPlatformTest(options);
+    Aws::Testing::ParseArgs(argc, argv);
+
+    Aws::InitAPI(options);
+    ::testing::InitGoogleTest(&argc, argv);
+    int exitCode = RUN_ALL_TESTS();
+
+    Aws::ShutdownAPI(options);
+    AWS_END_MEMORY_TEST_EX;
+    Aws::Testing::ShutdownPlatformTest(options);
+    return exitCode;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding a test for CloudWatch Custom Metrics to be published for small and large requests. 

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
