### PR TITLE
Fix shadow warning.

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
@@ -31,17 +31,17 @@ namespace Aws
             * Create a configuration based on settings in the aws configuration file for the given profile name.
             * The configuration file location can be set via the environment variable AWS_CONFIG_FILE
             * @param profileName the aws profile name.
-            * @param disableIMDS whether or not to disable IMDS calls.
+            * @param shouldDisableIMDS whether or not to disable IMDS calls.
             */
-            S3CrtClientConfiguration(const char* profileName, bool disableIMDS = false);
+            S3CrtClientConfiguration(const char* profileName, bool shouldDisableIMDS = false);
 
             /**
             * Create a configuration with a predefined smart defaults
             * @param useSmartDefaults, required to differentiate c-tors
             * @param defaultMode, default mode to use
-            * @param disableIMDS whether or not to disable IMDS calls.
+            * @param shouldDisableIMDS whether or not to disable IMDS calls.
             */
-            S3CrtClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool disableIMDS = false);
+            S3CrtClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool shouldDisableIMDS = false);
 
             /**
             * Converting constructors for compatibility with a legacy code

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClientConfiguration.cpp
@@ -60,14 +60,14 @@ S3CrtClientConfiguration::S3CrtClientConfiguration()
   LoadS3CrtSpecificConfig(this->profileName);
 }
 
-S3CrtClientConfiguration::S3CrtClientConfiguration(const char* inputProfileName, bool disableIMDS)
-: BaseClientConfigClass(inputProfileName, disableIMDS)
+S3CrtClientConfiguration::S3CrtClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS)
+: BaseClientConfigClass(inputProfileName, shouldDisableIMDS)
 {
   LoadS3CrtSpecificConfig(Aws::String(inputProfileName));
 }
 
-S3CrtClientConfiguration::S3CrtClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool disableIMDS)
-: BaseClientConfigClass(useSmartDefaults, defaultMode, disableIMDS)
+S3CrtClientConfiguration::S3CrtClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool shouldDisableIMDS)
+: BaseClientConfigClass(useSmartDefaults, defaultMode, shouldDisableIMDS)
 {
   LoadS3CrtSpecificConfig(this->profileName);
 }

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ClientConfiguration.h
@@ -31,17 +31,17 @@ namespace Aws
             * Create a configuration based on settings in the aws configuration file for the given profile name.
             * The configuration file location can be set via the environment variable AWS_CONFIG_FILE
             * @param profileName the aws profile name.
-            * @param disableIMDS whether or not to disable IMDS calls.
+            * @param shouldDisableIMDS whether or not to disable IMDS calls.
             */
-            S3ClientConfiguration(const char* profileName, bool disableIMDS = false);
+            S3ClientConfiguration(const char* profileName, bool shouldDisableIMDS = false);
 
             /**
             * Create a configuration with a predefined smart defaults
             * @param useSmartDefaults, required to differentiate c-tors
             * @param defaultMode, default mode to use
-            * @param disableIMDS whether or not to disable IMDS calls.
+            * @param shouldDisableIMDS whether or not to disable IMDS calls.
             */
-            S3ClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool disableIMDS = false);
+            S3ClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool shouldDisableIMDS = false);
 
             /**
             * Converting constructors for compatibility with a legacy code

--- a/generated/src/aws-cpp-sdk-s3/source/S3ClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3ClientConfiguration.cpp
@@ -60,14 +60,14 @@ S3ClientConfiguration::S3ClientConfiguration()
   LoadS3SpecificConfig(this->profileName);
 }
 
-S3ClientConfiguration::S3ClientConfiguration(const char* inputProfileName, bool disableIMDS)
-: BaseClientConfigClass(inputProfileName, disableIMDS)
+S3ClientConfiguration::S3ClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS)
+: BaseClientConfigClass(inputProfileName, shouldDisableIMDS)
 {
   LoadS3SpecificConfig(Aws::String(inputProfileName));
 }
 
-S3ClientConfiguration::S3ClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool disableIMDS)
-: BaseClientConfigClass(useSmartDefaults, defaultMode, disableIMDS)
+S3ClientConfiguration::S3ClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool shouldDisableIMDS)
+: BaseClientConfigClass(useSmartDefaults, defaultMode, shouldDisableIMDS)
 {
   LoadS3SpecificConfig(this->profileName);
 }

--- a/generated/src/aws-cpp-sdk-s3control/include/aws/s3control/S3ControlClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3control/include/aws/s3control/S3ControlClientConfiguration.h
@@ -24,17 +24,17 @@ namespace Aws
             * Create a configuration based on settings in the aws configuration file for the given profile name.
             * The configuration file location can be set via the environment variable AWS_CONFIG_FILE
             * @param profileName the aws profile name.
-            * @param disableIMDS whether or not to disable IMDS calls.
+            * @param shouldDisableIMDS whether or not to disable IMDS calls.
             */
-            S3ControlClientConfiguration(const char* profileName, bool disableIMDS = false);
+            S3ControlClientConfiguration(const char* profileName, bool shouldDisableIMDS = false);
 
             /**
             * Create a configuration with a predefined smart defaults
             * @param useSmartDefaults, required to differentiate c-tors
             * @param defaultMode, default mode to use
-            * @param disableIMDS whether or not to disable IMDS calls.
+            * @param shouldDisableIMDS whether or not to disable IMDS calls.
             */
-            S3ControlClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool disableIMDS = false);
+            S3ControlClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool shouldDisableIMDS = false);
 
             /**
             * Converting constructors for compatibility with a legacy code

--- a/generated/src/aws-cpp-sdk-s3control/source/S3ControlClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/S3ControlClientConfiguration.cpp
@@ -32,14 +32,14 @@ S3ControlClientConfiguration::S3ControlClientConfiguration()
   LoadS3ControlSpecificConfig(this->profileName);
 }
 
-S3ControlClientConfiguration::S3ControlClientConfiguration(const char* inputProfileName, bool disableIMDS)
-: BaseClientConfigClass(inputProfileName, disableIMDS)
+S3ControlClientConfiguration::S3ControlClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS)
+: BaseClientConfigClass(inputProfileName, shouldDisableIMDS)
 {
   LoadS3ControlSpecificConfig(Aws::String(inputProfileName));
 }
 
-S3ControlClientConfiguration::S3ControlClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool disableIMDS)
-: BaseClientConfigClass(useSmartDefaults, defaultMode, disableIMDS)
+S3ControlClientConfiguration::S3ControlClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool shouldDisableIMDS)
+: BaseClientConfigClass(useSmartDefaults, defaultMode, shouldDisableIMDS)
 {
   LoadS3ControlSpecificConfig(this->profileName);
 }

--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -66,17 +66,17 @@ namespace Aws
              * Create a configuration based on settings in the aws configuration file for the given profile name.
              * The configuration file location can be set via the environment variable AWS_CONFIG_FILE
              * @param profileName the aws profile name.
-             * @param disableIMDS whether or not to disable IMDS calls.
+             * @param shouldDisableIMDS whether or not to disable IMDS calls.
              */
-            ClientConfiguration(const char* profileName, bool disableIMDS = false);
+            ClientConfiguration(const char* profileName, bool shouldDisableIMDS = false);
 
             /**
              * Create a configuration with a predefined smart defaults
              * @param useSmartDefaults, required to differentiate c-tors
              * @param defaultMode, default mode to use
-             * @param disableIMDS whether or not to disable IMDS calls.
+             * @param shouldDisableIMDS whether or not to disable IMDS calls.
              */
-            explicit ClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool disableIMDS = false);
+            explicit ClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool shouldDisableIMDS = false);
 
             /**
              * User Agent string user for http calls. This is filled in for you in the constructor. Don't override this unless you have a really good reason.

--- a/src/aws-cpp-sdk-core/include/aws/core/client/GenericClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/GenericClientConfiguration.h
@@ -28,20 +28,20 @@ namespace Aws
              * Create a configuration based on settings in the aws configuration file for the given profile name.
              * The configuration file location can be set via the environment variable AWS_CONFIG_FILE
              * @param profileName the aws profile name.
-             * @param disableIMDS whether or not to disable IMDS calls.
+             * @param shouldDisableIMDS whether or not to disable IMDS calls.
              */
-            GenericClientConfiguration(const char* inputProfileName, bool disableIMDS = false)
-              : ClientConfiguration(inputProfileName, disableIMDS)
+            GenericClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS = false)
+              : ClientConfiguration(inputProfileName, shouldDisableIMDS)
             {}
 
             /**
              * Create a configuration with a predefined smart defaults
              * @param useSmartDefaults, required to differentiate c-tors
              * @param defaultMode, default mode to use
-             * @param disableIMDS whether or not to disable IMDS calls.
+             * @param shouldDisableIMDS whether or not to disable IMDS calls.
              */
-            explicit GenericClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool disableIMDS = false)
-              : ClientConfiguration(useSmartDefaults, defaultMode, disableIMDS)
+            explicit GenericClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool shouldDisableIMDS = false)
+              : ClientConfiguration(useSmartDefaults, defaultMode, shouldDisableIMDS)
             {}
 
             GenericClientConfiguration(const ClientConfiguration& config)
@@ -57,8 +57,8 @@ namespace Aws
             static const bool EndpointDiscoverySupported = true;
 
             GenericClientConfiguration();
-            GenericClientConfiguration(const char* profileName, bool disableIMDSV1 = false);
-            explicit GenericClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool disableIMDSV1 = false);
+            GenericClientConfiguration(const char* profileName, bool shouldDisableIMDS = false);
+            explicit GenericClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool shouldDisableIMDS = false);
             GenericClientConfiguration(const ClientConfiguration& config);
             GenericClientConfiguration(const GenericClientConfiguration&);
             GenericClientConfiguration& operator=(const GenericClientConfiguration&);

--- a/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
@@ -144,9 +144,9 @@ ClientConfiguration::ClientConfiguration()
     region = Aws::String(Aws::Region::US_EAST_1);
 }
 
-ClientConfiguration::ClientConfiguration(const char* profile, bool disableIMDS)
+ClientConfiguration::ClientConfiguration(const char* profile, bool shouldDisableIMDS)
 {
-    this->disableIMDS = disableIMDS;
+    this->disableIMDS = shouldDisableIMDS;
     setLegacyClientConfigurationParameters(*this);
     // Call EC2 Instance Metadata service only once
     Aws::String ec2MetadataRegion;
@@ -190,9 +190,9 @@ ClientConfiguration::ClientConfiguration(const char* profile, bool disableIMDS)
     AWS_LOGSTREAM_WARN(CLIENT_CONFIG_TAG, "User specified profile: [" << profile << "] is not found, will use the SDK resolved one.");
 }
 
-ClientConfiguration::ClientConfiguration(bool /*useSmartDefaults*/, const char* defaultMode, bool disableIMDS)
+ClientConfiguration::ClientConfiguration(bool /*useSmartDefaults*/, const char* defaultMode, bool shouldDisableIMDS)
 {
-    this->disableIMDS = disableIMDS;
+    this->disableIMDS = shouldDisableIMDS;
     setLegacyClientConfigurationParameters(*this);
 
     // Call EC2 Instance Metadata service only once

--- a/src/aws-cpp-sdk-core/source/client/GenericClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/GenericClientConfiguration.cpp
@@ -53,8 +53,8 @@ GenericClientConfiguration<true>::GenericClientConfiguration()
     enableHostPrefixInjection = false; // disabled by default in the SDK
 }
 
-GenericClientConfiguration<true>::GenericClientConfiguration(const char* inputProfileName, bool disableIMDS)
-    : ClientConfiguration(inputProfileName, disableIMDS),
+GenericClientConfiguration<true>::GenericClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS)
+    : ClientConfiguration(inputProfileName, shouldDisableIMDS),
       enableHostPrefixInjection(ClientConfiguration::enableHostPrefixInjection),
       enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
 {
@@ -62,8 +62,8 @@ GenericClientConfiguration<true>::GenericClientConfiguration(const char* inputPr
     enableHostPrefixInjection = false; // disabled by default in the SDK
 }
 
-GenericClientConfiguration<true>::GenericClientConfiguration(bool useSmartDefaults, const char* inputDefaultMode, bool disableIMDS)
-    : ClientConfiguration(useSmartDefaults, inputDefaultMode, disableIMDS),
+GenericClientConfiguration<true>::GenericClientConfiguration(bool useSmartDefaults, const char* inputDefaultMode, bool shouldDisableIMDS)
+    : ClientConfiguration(useSmartDefaults, inputDefaultMode, shouldDisableIMDS),
       enableHostPrefixInjection(ClientConfiguration::enableHostPrefixInjection),
       enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
 {

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationHeader.vm
@@ -40,17 +40,17 @@ namespace ${rootNamespace}
             * Create a configuration based on settings in the aws configuration file for the given profile name.
             * The configuration file location can be set via the environment variable AWS_CONFIG_FILE
             * @param profileName the aws profile name.
-            * @param disableIMDS whether or not to disable IMDS calls.
+            * @param shouldDisableIMDS whether or not to disable IMDS calls.
             */
-            ${metadata.classNamePrefix}ClientConfiguration(const char* profileName, bool disableIMDS = false);
+            ${metadata.classNamePrefix}ClientConfiguration(const char* profileName, bool shouldDisableIMDS = false);
 
             /**
             * Create a configuration with a predefined smart defaults
             * @param useSmartDefaults, required to differentiate c-tors
             * @param defaultMode, default mode to use
-            * @param disableIMDS whether or not to disable IMDS calls.
+            * @param shouldDisableIMDS whether or not to disable IMDS calls.
             */
-            ${metadata.classNamePrefix}ClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool disableIMDS = false);
+            ${metadata.classNamePrefix}ClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool shouldDisableIMDS = false);
 
             /**
             * Converting constructors for compatibility with a legacy code

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationSource.vm
@@ -69,14 +69,14 @@ ${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}Clien
   Load${serviceNamespace}SpecificConfig(this->profileName);
 }
 
-${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(const char* inputProfileName, bool disableIMDS)
-: BaseClientConfigClass(inputProfileName, disableIMDS)
+${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS)
+: BaseClientConfigClass(inputProfileName, shouldDisableIMDS)
 {
   Load${serviceNamespace}SpecificConfig(Aws::String(inputProfileName));
 }
 
-${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool disableIMDS)
-: BaseClientConfigClass(useSmartDefaults, defaultMode, disableIMDS)
+${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool shouldDisableIMDS)
+: BaseClientConfigClass(useSmartDefaults, defaultMode, shouldDisableIMDS)
 {
   Load${serviceNamespace}SpecificConfig(this->profileName);
 }


### PR DESCRIPTION
*Description of changes:*

customers saw a issue with a added warning of a shadowed variable

`
include/aws/core/client/GenericClientConfiguration.h:34:15: error: declaration of 'disableIMDS' shadows a member of 'Aws::Client::GenericClientConfiguration<HasEndpointDiscovery>' [-Werror=shadow] 
`

this renames the parameter to avoid this.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
