### PR TITLE
Fix openssl memory leak.

### DIFF
--- a/src/aws-cpp-sdk-core/source/utils/crypto/openssl/CryptoImpl.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/crypto/openssl/CryptoImpl.cpp
@@ -425,8 +425,8 @@ namespace Aws
 #elif OPENSSL_VERSION_LESS_3_0
                     m_ctx = HMAC_CTX_new();
 #else
-                    mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
-                    m_ctx = EVP_MAC_CTX_new(mac);
+                    m_mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+                    m_ctx = EVP_MAC_CTX_new(m_mac);
 #endif
                     assert(m_ctx != nullptr);
                 }
@@ -437,6 +437,7 @@ namespace Aws
 #elif OPENSSL_VERSION_LESS_3_0
                     HMAC_CTX_free(m_ctx);
 #else
+                    EVP_MAC_free(m_mac);
                     EVP_MAC_CTX_free(m_ctx);
 #endif
                     m_ctx = nullptr;
@@ -453,7 +454,7 @@ namespace Aws
 #if OPENSSL_VERSION_LESS_3_0
                 HMAC_CTX *m_ctx;
 #else
-                EVP_MAC *mac;
+                EVP_MAC *m_mac;
                 EVP_MAC_CTX *m_ctx;
 #endif
             };


### PR DESCRIPTION
*Issue #, if available:*

[issues/2331](https://github.com/aws/aws-sdk-cpp/issues/2331)

*Description of changes:*

There was a memory leak that was described from valgrind as

```
==21518== HEAP SUMMARY:
==21518==     in use at exit: 2,225 bytes in 16 blocks
==21518==   total heap usage: 245,153 allocs, 245,137 frees, 10,489,940 bytes allocated
==21518==
==21518== 723 (144 direct, 579 indirect) bytes in 1 blocks are definitely lost in loss record 15 of 16
==21518==    at 0x4865058: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==21518==    by 0x5958AD7: CRYPTO_zalloc (in /usr/lib/aarch64-linux-gnu/libcrypto.so.3)
==21518==    by 0x593FD77: ??? (in /usr/lib/aarch64-linux-gnu/libcrypto.so.3)
==21518==    by 0x592CE73: ??? (in /usr/lib/aarch64-linux-gnu/libcrypto.so.3)
==21518==    by 0x59581DB: ??? (in /usr/lib/aarch64-linux-gnu/libcrypto.so.3)
==21518==    by 0x59580EF: ??? (in /usr/lib/aarch64-linux-gnu/libcrypto.so.3)
==21518==    by 0x596B8B3: ??? (in /usr/lib/aarch64-linux-gnu/libcrypto.so.3)
==21518==    by 0x5A2EDFB: ??? (in /usr/lib/aarch64-linux-gnu/libcrypto.so.3)
==21518==    by 0x5A2F43B: ??? (in /usr/lib/aarch64-linux-gnu/libcrypto.so.3)
==21518==    by 0x593B78B: EVP_MAC_fetch (in /usr/lib/aarch64-linux-gnu/libcrypto.so.3)
==21518==    by 0x4EF881B: Aws::Utils::Crypto::HMACRAIIGuard::HMACRAIIGuard() (CryptoImpl.cpp:428)
==21518==    by 0x4EDE88B: Aws::Utils::Crypto::Sha256HMACOpenSSLImpl::Calculate(Aws::Utils::Array<unsigned char> const&, Aws::Utils::Array<unsigned char> const&) (CryptoImpl.cpp:467)
==21518==
==21518== LEAK SUMMARY:
==21518==    definitely lost: 144 bytes in 1 blocks
==21518==    indirectly lost: 579 bytes in 11 blocks
```

upon inspection we call `EVP_MAC_fetch` without calling `EVP_MAC_free()` which can be found in the [open ssl api ref](https://www.openssl.org/docs/man3.0/man3/EVP_MAC_fetch.html)

```
The returned value must eventually be freed with EVP_MAC_free()
```
Upon adding clean up for that we now see

```
==21615== HEAP SUMMARY:
==21615==     in use at exit: 1,502 bytes in 4 blocks
==21615==   total heap usage: 245,153 allocs, 245,149 frees, 10,489,947 bytes allocated
==21615==
==21615== LEAK SUMMARY:
==21615==    definitely lost: 0 bytes in 0 blocks
==21615==    indirectly lost: 0 bytes in 0 blocks
==21615==      possibly lost: 0 bytes in 0 blocks
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
