### PR TITLE
Workaround a memory leak on libcurl found in a recent version 7.88.1-1

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHandleContainer.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHandleContainer.cpp
@@ -52,6 +52,7 @@ void CurlHandleContainer::ReleaseCurlHandle(CURL* handle)
 {
     if (handle)
     {
+        curl_easy_setopt(handle, CURLOPT_COOKIEFILE, NULL); // workaround a mem leak on curl
         curl_easy_reset(handle);
         SetDefaultOptionsOnHandle(handle);
         AWS_LOGSTREAM_DEBUG(CURL_HANDLE_CONTAINER_TAG, "Releasing curl handle " << handle);


### PR DESCRIPTION
*Issue #, if available:*
```
curl_easy_setopt(connectionHandle, CURLOPT_COOKIEFILE, "");
```
with
```
curl_easy_reset(connectionHandle);
```
Results in a memory leak starting v7.88.1

https://github.com/curl/curl/issues/10694#issuecomment-1458619157

*Description of changes:*
Workaround by disabling the cookie engine before calling the `curl_easy_reset`.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
