### PR TITLE
Revert "Removed non win parameters from cmake"

### DIFF
--- a/tools/scripts/build-tests/build-windows-sample-app.ps1
+++ b/tools/scripts/build-tests/build-windows-sample-app.ps1
@@ -14,7 +14,7 @@ cd "${PREFIX_DIR}/aws-sdk-cpp/tools/CI/install-test"
 mkdir "${PREFIX_DIR}/sample-build"
 mkdir "${PREFIX_DIR}/sample-install"
 cd "${PREFIX_DIR}/sample-build"
-&'C:\\Program Files\\CMake\\bin\\cmake.exe' ../aws-sdk-cpp/tools/CI/install-test -DCMAKE_PREFIX_PATH="${PREFIX_DIR}/win-install" -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}/sample_install"
+&'C:\\Program Files\\CMake\\bin\\cmake.exe' ../aws-sdk-cpp/tools/CI/install-test -DCMAKE_CXX_FLAGS="-ggdb -fsanitize=address" -DCMAKE_PREFIX_PATH="${PREFIX_DIR}/win-install" -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}/sample_install"
 &'C:\\Program Files\\CMake\\bin\\cmake.exe' --build .
 &'C:\\Program Files\\CMake\\bin\\cmake.exe' --build . --target install
 
@@ -28,4 +28,5 @@ aws configure set aws_secret_access_key (${sts}[2] -replace " " -replace "`"" -r
 aws configure set aws_session_token (${sts}[3] -replace " " -replace "`"" -replace ",")
 aws configure list
 # Run tests
-&"${PREFIX_DIR}/sample_install/bin/app.exe"
+cd "${PREFIX_DIR}/sample_install/bin"
+app


### PR DESCRIPTION
This reverts commit cb1bec314549f8f9e344780a93e43ef3d389594f.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
