### PR TITLE
Fail unsigned requests

### DIFF
--- a/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
@@ -195,7 +195,7 @@ bool AWSAuthV4Signer::SignRequest(Aws::Http::HttpRequest& request, const char* r
     //don't sign anonymous requests
     if (credentials.GetAWSAccessKeyId().empty() || credentials.GetAWSSecretKey().empty())
     {
-        return true;
+        return false;
     }
 
     request.SetSigningAccessKey(credentials.GetAWSAccessKeyId());


### PR DESCRIPTION
*Description of changes:*

We have observed an inconsistency against other SDKs in AWS and we are going to reconcile it.

when making a `ListBuckets` request without any credentials specified, `ListBuckets` will return success and a empty list of buckets. This is because S3 returns a redirect to the home page, that fails to parse as a response but returns a `200` so we create a response with 0 buckets.

The Java SDK throws the exception
`Unable to load credentials from any of the providers in the chain AwsCredentialsProviderChain`

The GoSDK returns the error
`failed to sign request: failed to retrieve credentials: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata, http response error StatusCode: 403, request to EC2 IMDS failed`

both of these error are more descriptive and more correct than what is going in the C++ SDK right now. After this change we will return a client side error
```
Failed with error: HTTP response code: -1
Resolved remote host IP address: 
Request ID: 
Exception name: 
Error message: SDK failed to sign the request
0 response headers:
```

So you will know accurately what happened and why the request is failing.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
