### PR TITLE
Fix deadlock in InstanceProfileCredentialsProvider

### DIFF
--- a/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
@@ -259,7 +259,6 @@ AWSCredentials InstanceProfileCredentialsProvider::GetAWSCredentials()
 
 bool InstanceProfileCredentialsProvider::ExpiresSoon() const
 {
-    ReaderLockGuard guard(m_reloadLock);
     auto profileIter = m_ec2MetadataConfigLoader->GetProfiles().find(Aws::Config::INSTANCE_PROFILE_KEY);
     AWSCredentials credentials;
 


### PR DESCRIPTION
*Issue #, if available:*
2251

*Description of changes:*
The read-write lock was being used reentrant which causes deadlocks, even in a single thread. Remove the lock from an internal function to avoid this deadlock.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
