### PR TITLE
Fix consequent calls to a cached discovered endpoints

### DIFF
--- a/cmake/sdksCommon.cmake
+++ b/cmake/sdksCommon.cmake
@@ -174,6 +174,7 @@ list(APPEND SDK_TEST_PROJECT_LIST "transfer:tests/aws-cpp-sdk-transfer-tests")
 list(APPEND SDK_TEST_PROJECT_LIST "text-to-speech:tests/aws-cpp-sdk-text-to-speech-tests,tests/aws-cpp-sdk-polly-sample")
 list(APPEND SDK_TEST_PROJECT_LIST "transcribestreaming:tests/aws-cpp-sdk-transcribestreaming-integration-tests")
 list(APPEND SDK_TEST_PROJECT_LIST "eventbridge:tests/aws-cpp-sdk-eventbridge-tests")
+list(APPEND SDK_TEST_PROJECT_LIST "timestream-query:tests/aws-cpp-sdk-timestream-query-integration-tests")
 
 build_sdk_list()
 

--- a/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClient.cpp
@@ -223,6 +223,7 @@ BatchGetItemOutcome DynamoDBClient::BatchGetItem(const BatchGetItemRequest& requ
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("BatchGetItem", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -265,6 +266,7 @@ BatchWriteItemOutcome DynamoDBClient::BatchWriteItem(const BatchWriteItemRequest
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("BatchWriteItem", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -307,6 +309,7 @@ CreateBackupOutcome DynamoDBClient::CreateBackup(const CreateBackupRequest& requ
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("CreateBackup", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -349,6 +352,7 @@ CreateGlobalTableOutcome DynamoDBClient::CreateGlobalTable(const CreateGlobalTab
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("CreateGlobalTable", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -391,6 +395,7 @@ CreateTableOutcome DynamoDBClient::CreateTable(const CreateTableRequest& request
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("CreateTable", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -433,6 +438,7 @@ DeleteBackupOutcome DynamoDBClient::DeleteBackup(const DeleteBackupRequest& requ
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DeleteBackup", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -475,6 +481,7 @@ DeleteItemOutcome DynamoDBClient::DeleteItem(const DeleteItemRequest& request) c
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DeleteItem", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -517,6 +524,7 @@ DeleteTableOutcome DynamoDBClient::DeleteTable(const DeleteTableRequest& request
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DeleteTable", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -559,6 +567,7 @@ DescribeBackupOutcome DynamoDBClient::DescribeBackup(const DescribeBackupRequest
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DescribeBackup", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -601,6 +610,7 @@ DescribeContinuousBackupsOutcome DynamoDBClient::DescribeContinuousBackups(const
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DescribeContinuousBackups", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -667,6 +677,7 @@ DescribeGlobalTableOutcome DynamoDBClient::DescribeGlobalTable(const DescribeGlo
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DescribeGlobalTable", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -709,6 +720,7 @@ DescribeGlobalTableSettingsOutcome DynamoDBClient::DescribeGlobalTableSettings(c
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DescribeGlobalTableSettings", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -759,6 +771,7 @@ DescribeKinesisStreamingDestinationOutcome DynamoDBClient::DescribeKinesisStream
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DescribeKinesisStreamingDestination", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -801,6 +814,7 @@ DescribeLimitsOutcome DynamoDBClient::DescribeLimits(const DescribeLimitsRequest
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DescribeLimits", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -843,6 +857,7 @@ DescribeTableOutcome DynamoDBClient::DescribeTable(const DescribeTableRequest& r
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DescribeTable", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -893,6 +908,7 @@ DescribeTimeToLiveOutcome DynamoDBClient::DescribeTimeToLive(const DescribeTimeT
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DescribeTimeToLive", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -935,6 +951,7 @@ DisableKinesisStreamingDestinationOutcome DynamoDBClient::DisableKinesisStreamin
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DisableKinesisStreamingDestination", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -977,6 +994,7 @@ EnableKinesisStreamingDestinationOutcome DynamoDBClient::EnableKinesisStreamingD
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("EnableKinesisStreamingDestination", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1043,6 +1061,7 @@ GetItemOutcome DynamoDBClient::GetItem(const GetItemRequest& request) const
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("GetItem", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1093,6 +1112,7 @@ ListBackupsOutcome DynamoDBClient::ListBackups(const ListBackupsRequest& request
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("ListBackups", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1151,6 +1171,7 @@ ListGlobalTablesOutcome DynamoDBClient::ListGlobalTables(const ListGlobalTablesR
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("ListGlobalTables", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1201,6 +1222,7 @@ ListTablesOutcome DynamoDBClient::ListTables(const ListTablesRequest& request) c
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("ListTables", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1243,6 +1265,7 @@ ListTagsOfResourceOutcome DynamoDBClient::ListTagsOfResource(const ListTagsOfRes
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("ListTagsOfResource", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1285,6 +1308,7 @@ PutItemOutcome DynamoDBClient::PutItem(const PutItemRequest& request) const
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("PutItem", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1327,6 +1351,7 @@ QueryOutcome DynamoDBClient::Query(const QueryRequest& request) const
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("Query", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1369,6 +1394,7 @@ RestoreTableFromBackupOutcome DynamoDBClient::RestoreTableFromBackup(const Resto
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("RestoreTableFromBackup", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1411,6 +1437,7 @@ RestoreTableToPointInTimeOutcome DynamoDBClient::RestoreTableToPointInTime(const
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("RestoreTableToPointInTime", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1453,6 +1480,7 @@ ScanOutcome DynamoDBClient::Scan(const ScanRequest& request) const
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("Scan", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1495,6 +1523,7 @@ TagResourceOutcome DynamoDBClient::TagResource(const TagResourceRequest& request
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("TagResource", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1537,6 +1566,7 @@ TransactGetItemsOutcome DynamoDBClient::TransactGetItems(const TransactGetItemsR
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("TransactGetItems", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1579,6 +1609,7 @@ TransactWriteItemsOutcome DynamoDBClient::TransactWriteItems(const TransactWrite
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("TransactWriteItems", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1621,6 +1652,7 @@ UntagResourceOutcome DynamoDBClient::UntagResource(const UntagResourceRequest& r
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("UntagResource", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1663,6 +1695,7 @@ UpdateContinuousBackupsOutcome DynamoDBClient::UpdateContinuousBackups(const Upd
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("UpdateContinuousBackups", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1713,6 +1746,7 @@ UpdateGlobalTableOutcome DynamoDBClient::UpdateGlobalTable(const UpdateGlobalTab
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("UpdateGlobalTable", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1755,6 +1789,7 @@ UpdateGlobalTableSettingsOutcome DynamoDBClient::UpdateGlobalTableSettings(const
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("UpdateGlobalTableSettings", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1797,6 +1832,7 @@ UpdateItemOutcome DynamoDBClient::UpdateItem(const UpdateItemRequest& request) c
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("UpdateItem", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1839,6 +1875,7 @@ UpdateTableOutcome DynamoDBClient::UpdateTable(const UpdateTableRequest& request
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("UpdateTable", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1889,6 +1926,7 @@ UpdateTimeToLiveOutcome DynamoDBClient::UpdateTimeToLive(const UpdateTimeToLiveR
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("UpdateTimeToLive", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else

--- a/generated/src/aws-cpp-sdk-timestream-query/source/TimestreamQueryClient.cpp
+++ b/generated/src/aws-cpp-sdk-timestream-query/source/TimestreamQueryClient.cpp
@@ -175,6 +175,7 @@ CancelQueryOutcome TimestreamQueryClient::CancelQuery(const CancelQueryRequest& 
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("CancelQuery", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -225,6 +226,7 @@ CreateScheduledQueryOutcome TimestreamQueryClient::CreateScheduledQuery(const Cr
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("CreateScheduledQuery", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -275,6 +277,7 @@ DeleteScheduledQueryOutcome TimestreamQueryClient::DeleteScheduledQuery(const De
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DeleteScheduledQuery", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -333,6 +336,7 @@ DescribeScheduledQueryOutcome TimestreamQueryClient::DescribeScheduledQuery(cons
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DescribeScheduledQuery", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -383,6 +387,7 @@ ExecuteScheduledQueryOutcome TimestreamQueryClient::ExecuteScheduledQuery(const 
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("ExecuteScheduledQuery", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -433,6 +438,7 @@ ListScheduledQueriesOutcome TimestreamQueryClient::ListScheduledQueries(const Li
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("ListScheduledQueries", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -483,6 +489,7 @@ ListTagsForResourceOutcome TimestreamQueryClient::ListTagsForResource(const List
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("ListTagsForResource", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -533,6 +540,7 @@ PrepareQueryOutcome TimestreamQueryClient::PrepareQuery(const PrepareQueryReques
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("PrepareQuery", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -583,6 +591,7 @@ QueryOutcome TimestreamQueryClient::Query(const QueryRequest& request) const
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("Query", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -633,6 +642,7 @@ TagResourceOutcome TimestreamQueryClient::TagResource(const TagResourceRequest& 
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("TagResource", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -683,6 +693,7 @@ UntagResourceOutcome TimestreamQueryClient::UntagResource(const UntagResourceReq
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("UntagResource", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -733,6 +744,7 @@ UpdateScheduledQueryOutcome TimestreamQueryClient::UpdateScheduledQuery(const Up
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("UpdateScheduledQuery", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else

--- a/generated/src/aws-cpp-sdk-timestream-write/source/TimestreamWriteClient.cpp
+++ b/generated/src/aws-cpp-sdk-timestream-write/source/TimestreamWriteClient.cpp
@@ -181,6 +181,7 @@ CreateBatchLoadTaskOutcome TimestreamWriteClient::CreateBatchLoadTask(const Crea
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("CreateBatchLoadTask", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -231,6 +232,7 @@ CreateDatabaseOutcome TimestreamWriteClient::CreateDatabase(const CreateDatabase
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("CreateDatabase", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -281,6 +283,7 @@ CreateTableOutcome TimestreamWriteClient::CreateTable(const CreateTableRequest& 
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("CreateTable", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -331,6 +334,7 @@ DeleteDatabaseOutcome TimestreamWriteClient::DeleteDatabase(const DeleteDatabase
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DeleteDatabase", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -381,6 +385,7 @@ DeleteTableOutcome TimestreamWriteClient::DeleteTable(const DeleteTableRequest& 
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DeleteTable", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -431,6 +436,7 @@ DescribeBatchLoadTaskOutcome TimestreamWriteClient::DescribeBatchLoadTask(const 
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DescribeBatchLoadTask", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -481,6 +487,7 @@ DescribeDatabaseOutcome TimestreamWriteClient::DescribeDatabase(const DescribeDa
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DescribeDatabase", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -539,6 +546,7 @@ DescribeTableOutcome TimestreamWriteClient::DescribeTable(const DescribeTableReq
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("DescribeTable", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -589,6 +597,7 @@ ListBatchLoadTasksOutcome TimestreamWriteClient::ListBatchLoadTasks(const ListBa
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("ListBatchLoadTasks", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -639,6 +648,7 @@ ListDatabasesOutcome TimestreamWriteClient::ListDatabases(const ListDatabasesReq
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("ListDatabases", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -689,6 +699,7 @@ ListTablesOutcome TimestreamWriteClient::ListTables(const ListTablesRequest& req
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("ListTables", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -739,6 +750,7 @@ ListTagsForResourceOutcome TimestreamWriteClient::ListTagsForResource(const List
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("ListTagsForResource", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -789,6 +801,7 @@ ResumeBatchLoadTaskOutcome TimestreamWriteClient::ResumeBatchLoadTask(const Resu
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("ResumeBatchLoadTask", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -839,6 +852,7 @@ TagResourceOutcome TimestreamWriteClient::TagResource(const TagResourceRequest& 
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("TagResource", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -889,6 +903,7 @@ UntagResourceOutcome TimestreamWriteClient::UntagResource(const UntagResourceReq
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("UntagResource", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -939,6 +954,7 @@ UpdateDatabaseOutcome TimestreamWriteClient::UpdateDatabase(const UpdateDatabase
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("UpdateDatabase", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -989,6 +1005,7 @@ UpdateTableOutcome TimestreamWriteClient::UpdateTable(const UpdateTableRequest& 
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("UpdateTable", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else
@@ -1039,6 +1056,7 @@ WriteRecordsOutcome TimestreamWriteClient::WriteRecords(const WriteRecordsReques
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("WriteRecords", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else

--- a/tests/aws-cpp-sdk-timestream-query-integration-tests/CMakeLists.txt
+++ b/tests/aws-cpp-sdk-timestream-query-integration-tests/CMakeLists.txt
@@ -1,0 +1,41 @@
+add_project(aws-cpp-sdk-timestream-query-tests 
+    "Tests for the AWS Timestream-query C++ SDK" 
+    aws-cpp-sdk-core 
+    aws-cpp-sdk-timestream-query 
+    testing-resources)
+
+# Headers are included in the source so that they show up in Visual Studio.
+# They are included elsewhere for consistency.
+
+file(GLOB AWS_TIMESTREAM_QUERY_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+)
+
+file(GLOB AWS_TIMESTREAM_QUERY_INTEGRATION_TESTS_SRC
+    ${AWS_TIMESTREAM_QUERY_SRC}
+)
+
+set(AWS_TIMESTREAM_QUERY_INTEGRATION_TEST_APPLICATION_INCLUDES
+    "${AWS_NATIVE_SDK_ROOT}/src/aws-cpp-sdk-core/include/"
+    "${AWS_NATIVE_SDK_ROOT}/generated/src/aws-cpp-sdk-timestream-query/include/"
+    "${AWS_NATIVE_SDK_ROOT}/tests/testing-resources/include/"
+)
+
+include_directories(${AWS_TIMESTREAM_QUERY_INTEGRATION_TEST_APPLICATION_INCLUDES})
+
+if(MSVC AND BUILD_SHARED_LIBS)
+    add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
+endif()
+
+enable_testing()
+
+if(PLATFORM_ANDROID AND BUILD_SHARED_LIBS)
+    add_library(${PROJECT_NAME} ${AWS_TIMESTREAM_QUERY_INTEGRATION_TESTS_SRC})
+else()
+    add_executable(${PROJECT_NAME} ${AWS_TIMESTREAM_QUERY_INTEGRATION_TESTS_SRC})
+endif()
+
+set_compiler_flags(${PROJECT_NAME})
+set_compiler_warnings(${PROJECT_NAME})
+
+target_link_libraries(${PROJECT_NAME} ${PROJECT_LIBS})

--- a/tests/aws-cpp-sdk-timestream-query-integration-tests/RunTests.cpp
+++ b/tests/aws-cpp-sdk-timestream-query-integration-tests/RunTests.cpp
@@ -1,0 +1,30 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <gtest/gtest.h>
+#include <aws/core/Aws.h>
+#include <aws/testing/platform/PlatformTesting.h>
+#include <aws/testing/TestingEnvironment.h>
+#include <aws/testing/MemoryTesting.h>
+
+int main(int argc, char** argv)
+{
+    Aws::Testing::SetDefaultSigPipeHandler();
+    Aws::SDKOptions options;
+    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Trace;
+    AWS_BEGIN_MEMORY_TEST_EX(options, 1024, 128);
+
+    Aws::Testing::InitPlatformTest(options);
+    Aws::Testing::ParseArgs(argc, argv);
+
+    Aws::InitAPI(options);
+    ::testing::InitGoogleTest(&argc, argv);
+    int exitCode = RUN_ALL_TESTS();
+
+    Aws::ShutdownAPI(options);
+    AWS_END_MEMORY_TEST_EX;
+    Aws::Testing::ShutdownPlatformTest(options);
+    return exitCode;
+}

--- a/tests/aws-cpp-sdk-timestream-query-integration-tests/TimeStreamQueryTest.cpp
+++ b/tests/aws-cpp-sdk-timestream-query-integration-tests/TimeStreamQueryTest.cpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <gtest/gtest.h>
+#include <aws/testing/AwsTestHelpers.h>
+
+#include <aws/core/Region.h>
+#include <aws/timestream-query/TimestreamQueryClient.h>
+#include <aws/timestream-query/model/QueryRequest.h>
+
+
+namespace
+{
+
+class TimeStreamQueryOperationTest : public ::testing::Test
+{
+public:
+
+protected:
+
+};
+} // anonymous namespace
+
+TEST_F(TimeStreamQueryOperationTest, TestDoubleCall)
+{
+    Aws::TimestreamQuery::TimestreamQueryClientConfiguration config;
+    config.region = Aws::Region::AWS_TEST_REGION;
+    config.enableEndpointDiscovery = true;
+
+    Aws::TimestreamQuery::TimestreamQueryClient client(config);
+
+    Aws::TimestreamQuery::Model::QueryRequest queryRequest;
+    queryRequest.SetQueryString("SELECT 1");
+    Aws::TimestreamQuery::Model::QueryOutcome outcome = client.Query(queryRequest);
+    AWS_ASSERT_SUCCESS(outcome);
+
+    Aws::TimestreamQuery::Model::QueryRequest queryRequest2;
+    queryRequest2.SetQueryString("SELECT 1");
+    Aws::TimestreamQuery::Model::QueryOutcome outcome2 = client.Query(queryRequest2);
+    AWS_ASSERT_SUCCESS(outcome2);
+}

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientOperationEndpointDiscoveryWithRules.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientOperationEndpointDiscoveryWithRules.vm
@@ -25,6 +25,7 @@
     if (m_endpointsCache.Get(endpointKey, endpoint))
     {
       AWS_LOGSTREAM_TRACE("${operation.name}", "Making request to cached endpoint: " << endpoint);
+      endpoint = Aws::String(SchemeMapper::ToString(m_clientConfiguration.scheme)) + "://" + endpoint;
       endpointResolutionOutcome.GetResult().SetURI(endpoint);
     }
     else


### PR DESCRIPTION
*Issue #, if available:*
#2336 
Cached discovered endpoints are cached without schema
Fixes DynamoDB with enabled discovery and TimeStreamQuery.
*Description of changes:*
Append schema to the values from cache
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
