### PR TITLE
issue-2409: CRT logging thread runs beyond usable lifetime of CRT and dependents

### DIFF
--- a/src/aws-cpp-sdk-core/source/Aws.cpp
+++ b/src/aws-cpp-sdk-core/source/Aws.cpp
@@ -157,19 +157,21 @@ namespace Aws
         Aws::Monitoring::CleanupMonitoring();
         Aws::Internal::CleanupEC2MetadataClient();
         Aws::Net::CleanupNetwork();
+        cJSON_AS4CPP_InitHooks(nullptr);
         Aws::CleanupEnumOverflowContainer();
         Aws::Http::CleanupHttp();
         Aws::Utils::Crypto::CleanupCrypto();
 
         Aws::Config::CleanupConfigAndCredentialsCacheManager();
 
-        Aws::Client::CoreErrorsMapper::CleanupCoreErrorsMapper();
-        Aws::CleanupCrt();
         if (options.loggingOptions.logLevel != Aws::Utils::Logging::LogLevel::Off)
         {
             Aws::Utils::Logging::ShutdownCRTLogging();
             Aws::Utils::Logging::ShutdownAWSLogging();
         }
+
+        Aws::Client::CoreErrorsMapper::CleanupCoreErrorsMapper();
+        Aws::CleanupCrt();
 #ifdef USE_AWS_MEMORY_MANAGEMENT
         if(options.memoryManagementOptions.memoryManager)
         {

--- a/tests/aws-cpp-sdk-core-tests/RunTests.cpp
+++ b/tests/aws-cpp-sdk-core-tests/RunTests.cpp
@@ -13,6 +13,8 @@
 #include <sys/stat.h>
 #endif
 
+Aws::SDKOptions options;
+
 int main(int argc, char** argv)
 {
 #if defined(HAS_UMASK)
@@ -23,12 +25,12 @@ int main(int argc, char** argv)
 
     Aws::Testing::RedirectHomeToTempIfAppropriate();
 
-    Aws::SDKOptions options;
     options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Trace;
     options.httpOptions.installSigPipeHandler = true;
     AWS_BEGIN_MEMORY_TEST_EX(options, 1024, 128);
 
     Aws::Testing::InitPlatformTest(options);
+
     Aws::InitAPI(options);
     // Disable EC2 metadata in client configuration to avoid requests retrieving EC2 metadata in unit tests.
     Aws::Testing::SaveEnvironmentVariable("AWS_EC2_METADATA_DISABLED");
@@ -42,4 +44,12 @@ int main(int argc, char** argv)
     Aws::Testing::ShutdownPlatformTest(options);
 
     return retVal;
+}
+
+TEST(InitShutdown, Repeatable)
+{
+    for (unsigned ii = 0; ii < 10; ++ii) {
+        Aws::ShutdownAPI(options);
+        Aws::InitAPI(options);
+    }
 }


### PR DESCRIPTION
The CRT logging thread was outliving the CRT and dependents, including aws-c-common.  If one is using CUSTOM_MEMORY_MANAGEMENT then the aws-c-common allocator will be NULL, but the logging thread is still running, and may try to allocate, causing an assert.

In general, shutdown should be the reverse sequence of init to avoid situations like this.  #1996 may have fixed something, but the fix is in the wrong place.

*Issue #, if available:*

This fixes #2409 

*Description of changes:*

1. Restore the correct shutdown sequence, an inverse of the init sequence.
2. Clean up cJSON for good measure, properly.
3. Add a test that proves it is okay to Init and Shutdown many times in the same executable run.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [X] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
