### PR TITLE
libcrypto does not depend on libssl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ if (LEGACY_BUILD)
         set(CRYPTO_LIBS_ABSTRACT_NAME Bcrypt)
     elseif (ENABLE_OPENSSL_ENCRYPTION)
         set(CRYPTO_LIBS ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARIES})
-        set(CRYPTO_LIBS_ABSTRACT_NAME crypto ssl z)
+        set(CRYPTO_LIBS_ABSTRACT_NAME crypto z)
     endif ()
 
     if (ENABLE_CURL_CLIENT)

--- a/cmake/external_dependencies.cmake
+++ b/cmake/external_dependencies.cmake
@@ -51,7 +51,7 @@ elseif(ENABLE_OPENSSL_ENCRYPTION)
     endif()
     set(CRYPTO_LIBS ${CRYPTO_TARGET_NAME} ${ZLIB_LIBRARIES})
     # ssl depends on libcrypto
-    set(CRYPTO_LIBS_ABSTRACT_NAME ${CRYPTO_TARGET_NAME} ssl z)
+    set(CRYPTO_LIBS_ABSTRACT_NAME ${CRYPTO_TARGET_NAME} z)
 elseif(ENABLE_COMMONCRYPTO_ENCRYPTION)
     add_definitions(-DENABLE_COMMONCRYPTO_ENCRYPTION)
     message(STATUS "Encryption: CommonCrypto")


### PR DESCRIPTION
*Issue #, if available:*
CRYPTO_LIBS_ABSTRACT_NAME lists libssl as a dependency of libcrypto
While in fact non of checked libcrypto implementations (aws-lc and OpenSSL) declare/have a dependency on libssl.
It is libcurl that has a dependency on libssl and that should be handled by curl cmake module.
*Description of changes:*
Remove libssl from CRYPTO_LIBS_ABSTRACT_NAME
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
