### PR TITLE
Do not generate line endings diff on build on windows

### DIFF
--- a/src/aws-cpp-sdk-core/CMakeLists.txt
+++ b/src/aws-cpp-sdk-core/CMakeLists.txt
@@ -20,7 +20,8 @@ if(VERSION_STRING)
     set(AWSSDK_VERSION_PATCH ${AWSSDK_VERSION_PATCH})
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/include/aws/core/VersionConfig.h.in"
-        "${CMAKE_CURRENT_SOURCE_DIR}/include/aws/core/VersionConfig.h")
+        "${CMAKE_CURRENT_SOURCE_DIR}/include/aws/core/VersionConfig.h"
+        NEWLINE_STYLE UNIX)
 else()
     message("Not able to compute versioning string, not updating.")
 endif()
@@ -37,7 +38,8 @@ else()
 endif()
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/include/aws/core/SDKConfig.h.in"
-               "${CMAKE_CURRENT_SOURCE_DIR}/include/aws/core/SDKConfig.h")
+               "${CMAKE_CURRENT_SOURCE_DIR}/include/aws/core/SDKConfig.h"
+               NEWLINE_STYLE UNIX)
 
 file(GLOB AWS_HEADERS "include/aws/core/*.h")
 file(GLOB AWS_AUTH_HEADERS "include/aws/core/auth/*.h")

--- a/src/aws-cpp-sdk-core/include/CMakeLists.txt
+++ b/src/aws-cpp-sdk-core/include/CMakeLists.txt
@@ -2,12 +2,12 @@
     configure_file(
             VersionConfig.h.in
             aws/core/VersionConfig.h
-            @ONLY
+            @ONLY NEWLINE_STYLE UNIX
     )
 
     message(STATUS "Generating source file SDKConfig.h for setting memory management options")
     configure_file(
             SDKConfig.h.in
             aws/core/SDKConfig.h
-            @ONLY
+            @ONLY NEWLINE_STYLE UNIX
     )


### PR DESCRIPTION
*Issue #, if available:*
cmake configure on windows causes a dirty git repo state
*Description of changes:*
Use Unix line endings for Version generated header even on Windows.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
