### PR TITLE
S3Client::GeneratePresignedUrl return invalid url when key contains spaces

### DIFF
--- a/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp
@@ -2027,9 +2027,7 @@ Aws::String S3Client::GeneratePresignedUrl(const Aws::String& bucket,
         return {};
     }
     Aws::Endpoint::AWSEndpoint& endpoint = computeEndpointOutcome.GetResult();
-    URI uri(endpoint.GetURL());
-    uri.SetPath(uri.GetPath() + "/" + key);
-    endpoint.SetURL(uri.GetURIString());
+    endpoint.AddPathSegments(key);
     return AWSClient::GeneratePresignedUrl(endpoint, method, customizedHeaders, expirationInSeconds);
 }
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientSource.vm
@@ -121,9 +121,7 @@ Aws::String ${className}::GeneratePresignedUrl(const Aws::String& bucket,
         return {};
     }
     Aws::Endpoint::AWSEndpoint& endpoint = computeEndpointOutcome.GetResult();
-    URI uri(endpoint.GetURL());
-    uri.SetPath(uri.GetPath() + "/" + key);
-    endpoint.SetURL(uri.GetURIString());
+    endpoint.AddPathSegments(key);
     return AWSClient::GeneratePresignedUrl(endpoint, method, customizedHeaders, expirationInSeconds);
 #end
 }


### PR DESCRIPTION

*Issue #, if available:*
The issue is here: https://github.com/aws/aws-sdk-cpp/issues/2396

*Description of changes:*
Change urlencode twice to urlencode once.

*Check all that applies:*
- [ *] Did a review by yourself.
- [ *] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ *] Checked if this PR is a breaking (APIs have been changed) change.
- [ *] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ *] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ *] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
