### PR TITLE
Set static/shared msvc runtime flags using a CMake property instead of overwriting the flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0.
 #
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 option(LEGACY_BUILD "If enabled, the SDK will use 1.11.0 version of CMake files to build" ON)
 if (LEGACY_BUILD)
@@ -16,6 +16,7 @@ if (LEGACY_BUILD)
     if (POLICY CMP0077)
         cmake_policy(SET CMP0077 OLD) # CMP0077: option() honors normal variables. Introduced in 3.13
     endif ()
+    cmake_policy(SET CMP0091 NEW)
 
     get_filename_component(AWS_NATIVE_SDK_ROOT "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
 
@@ -146,6 +147,12 @@ if (LEGACY_BUILD)
         set(STATIC_CRT OFF)
     else ()
         set(STATIC_CRT ON)
+    endif ()
+	
+    if (${STATIC_CRT})
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    else ()
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
     endif ()
 
     # Add Linker search paths to RPATH so as to fix the problem where some linkers can't find cross-compiled dependent libraries in customer paths when linking executables.

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -75,18 +75,6 @@ endmacro()
 
 macro(set_msvc_flags)
     if(MSVC)
-        # Based on the FORCE_SHARED_CRT and BUILD_SHARED_LIBS options, make sure our compile/link flags bring in the right CRT library
-        # modified from gtest's version; while only the else clause is actually necessary, do both for completeness/future-proofing
-        foreach (var
-                CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-                CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-            if(BUILD_SHARED_LIBS OR FORCE_SHARED_CRT)
-                string(REPLACE "/MT" "/MD" ${var} "${${var}}")
-            else()
-                string(REPLACE "/MD" "/MT" ${var} "${${var}}")
-            endif()
-        endforeach()
-
         # enable parallel builds
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
         # some of the clients are exceeding the 16-bit code section limit when building x64 debug, so use /bigobj when we build


### PR DESCRIPTION
**Issue #, if available:** #2056

**Description of changes:**
This PR changes how the flags for the MSVC C++ runtime linkage are set. Before this PR, the CMAKE_CXX_FLAGS were changed. WIth CMake 3.15, there exists the property [CMAKE_MSVC_RUNTIME_LIBRARY](https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html). Based on the options provided by this SDK, this property is set instead of changing the flags.

Defining the property so early has 2 advantages:
- it is close to the option handing
- from the CMake doc `This variable is used to initialize the MSVC_RUNTIME_LIBRARY property on all targets as they are created` which results in that all targets have the right runtime. This solves the problem described in #2056


As you can read in the CMake documentation, any non msvc builds are not affected by defining the property. 
> The value is ignored on compilers not targeting the MSVC ABI, but an unsupported value will be rejected as an error when using a compiler targeting the MSVC ABI.

Please ask and/or edit, if I missed something.

**Check all that applies:**
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
_Changes in the buildsystem. Test would be, if the project compiled or not. I cannot see any CI builds in the .guthub/workflows. If I should add a build target, please let me know._ 
- [x] Checked if this PR is a breaking (APIs have been changed) change.
_Requires CMake 3.15 instead of 3.12. CMake 3.15 is from 2019, so I don't see it as a big problem_
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
_Only Windows is affected._
- [x] Checked if this PR would require a ReadMe/Wiki update.
_No Readme changes required. Options are still the same with the same semantic._

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [x] Windows 
_Build and unit-tested locally with dynamic and static linkage_
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
