### PR TITLE
Add basic benchmark test for s3 put object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ if (LEGACY_BUILD)
     option(REGENERATE_DEFAULTS "If set to ON, defaults mode configuration will be regenerated from the JSON definitions, this option involves some setup of python, java 8+, and maven" OFF)
     option(ENABLE_ZLIB_REQUEST_COMPRESSION "For services that support it, request content will be compressed. On by default if dependency available" ON)
     option(DISABLE_INTERNAL_IMDSV1_CALLS "Disables IMDSv1 internal client calls" OFF)
+    option(BUILD_BENCHMARKS "Enables building the benchmark executable" OFF)
 
     set(AWS_USER_AGENT_CUSTOMIZATION "" CACHE STRING "User agent extension")
     set(AWS_TEST_REGION "US_EAST_1" CACHE STRING "Region to target integration tests against")

--- a/cmake/sdks.cmake
+++ b/cmake/sdks.cmake
@@ -279,6 +279,10 @@ function(add_sdks)
         endif()
     endif()
 
+    if (BUILD_BENCHMARKS)
+        add_subdirectory(tests/benchmark)
+    endif ()
+
     # the catch-all config needs to list all the targets in a dependency-sorted order
     include(dependencies)
     sort_links(EXPORTS)

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+#
+
+add_project(benchmark
+        "A Cli for running benchmark tests"
+        aws-cpp-sdk-s3
+        aws-cpp-sdk-monitoring
+        aws-cpp-sdk-core)
+
+add_executable(${PROJECT_NAME} benchmark.cpp
+        include/Configuration.h
+        src/Configuration.cpp
+        include/TestDelegator.h
+        src/TestDelegator.cpp
+        include/service/S3PutObject.h
+        src/service/S3PutObject.cpp
+        include/Util.h
+        include/metric/Metrics.h
+        src/metric/Metrics.cpp
+        include/metric/PrintMetrics.h
+        src/metric/PrintMetrics.cpp
+        include/metric/CloudWatchMetrics.h
+        src/metric/CloudWatchMetrics.cpp)
+set_compiler_flags(${PROJECT_NAME})
+set_compiler_warnings(${PROJECT_NAME})
+target_include_directories(${PROJECT_NAME} PRIVATE include)
+target_link_libraries(${PROJECT_NAME} ${PROJECT_LIBS})
+

--- a/tests/benchmark/benchmark.cpp
+++ b/tests/benchmark/benchmark.cpp
@@ -1,0 +1,30 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/core/Aws.h>
+#include <Configuration.h>
+#include <TestDelegator.h>
+#include <metric/Metrics.h>
+#include <metric/PrintMetrics.h>
+#include <metric/CloudWatchMetrics.h>
+
+int main(int argc, char *argv[]) {
+    Aws::SDKOptions options;
+    Aws::InitAPI(options);
+    {
+        auto configuration = Benchmark::Configuration::FromArgs(argc, argv);
+        auto testDelegator = Benchmark::TestDelegator::BuildTestDelegator();
+        auto testFunc = testDelegator.GetTestRunForConfiguration(configuration);
+        auto metricsEmitter = [&]() -> std::shared_ptr<Benchmark::MetricsEmitter> {
+            if (configuration.GetConfiguration().shouldReportToCloudWatch) {
+                return std::make_shared<Benchmark::CloudWatchMetrics>();
+            }
+            return std::make_shared<Benchmark::PrintMetrics>();
+        }();
+        auto metrics = testFunc(configuration);
+        metricsEmitter->EmitMetric(std::move(metrics));
+    }
+    Aws::ShutdownAPI(options);
+    return 0;
+}

--- a/tests/benchmark/include/Configuration.h
+++ b/tests/benchmark/include/Configuration.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+#include <string>
+
+namespace Benchmark {
+    struct RunConfiguration {
+        std::string service;
+        std::string api;
+        long durationMillis;
+        bool shouldReportToCloudWatch;
+    };
+
+    class Configuration {
+    public:
+        static Configuration FromArgs(int argc, char *argv[]);
+        inline RunConfiguration GetConfiguration() const { return this->runConfiguration; }
+    private:
+        explicit Configuration(RunConfiguration runConfiguration);
+        static char* GetCmdOption(char **begin, char **end, const std::string &option);
+        static bool CmdOptionExists(char** begin, char** end, const std::string& option);
+        RunConfiguration runConfiguration;
+    };
+}
+

--- a/tests/benchmark/include/TestDelegator.h
+++ b/tests/benchmark/include/TestDelegator.h
@@ -1,0 +1,26 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+
+#include <metric/Metrics.h>
+#include <Configuration.h>
+#include <functional>
+#include <map>
+#include <vector>
+
+namespace Benchmark {
+    using TestFunction = std::function<std::vector<Benchmark::Metric>(const Benchmark::Configuration &configuration)>;
+    using StringPair = std::pair<std::string, std::string>;
+
+    class TestDelegator {
+    public:
+        static TestDelegator BuildTestDelegator();
+        TestFunction GetTestRunForConfiguration(const Benchmark::Configuration &configuration) const;
+    private:
+        explicit TestDelegator(const std::map<StringPair, TestFunction> &testFunctionMap);
+        std::map<StringPair, TestFunction> testFunctionMap;
+    };
+}
+

--- a/tests/benchmark/include/Util.h
+++ b/tests/benchmark/include/Util.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+
+#include <aws/core/utils/memory/stl/AWSString.h>
+#include <random>
+
+namespace Benchmark {
+    static std::string RandomString(size_t length) {
+        auto randchar = []() -> char {
+            const char charset[] =
+                "0123456789"
+                "abcdefghijklmnopqrstuvwxyz";
+            const size_t max_index = (sizeof(charset) - 1);
+            return charset[rand() % max_index];
+        };
+        std::string str(length, 0);
+        std::generate_n(str.begin(), length, randchar);
+        return str;
+    }
+}

--- a/tests/benchmark/include/metric/CloudWatchMetrics.h
+++ b/tests/benchmark/include/metric/CloudWatchMetrics.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+
+#include <aws/monitoring/CloudWatchClient.h>
+#include <aws/monitoring/model/MetricDatum.h>
+#include <metric/Metrics.h>
+
+static const char *ALLOC_TAG = "CloudWatchMetrics";
+
+namespace Benchmark {
+    class CloudWatchMetrics : public MetricsEmitter {
+    public:
+        explicit CloudWatchMetrics(const std::shared_ptr<Aws::CloudWatch::CloudWatchClient> &cloudWatchClient =
+                Aws::MakeShared<Aws::CloudWatch::CloudWatchClient>(ALLOC_TAG));
+        void EmitMetric(std::vector<Metric> &&metrics) const override;
+    private:
+        std::shared_ptr<Aws::CloudWatch::CloudWatchClient> cloudWatchClient;
+        Aws::CloudWatch::Model::MetricDatum ConvertToCloudWatchMetric(const Benchmark::Metric &metric) const;
+    };
+}

--- a/tests/benchmark/include/metric/Metrics.h
+++ b/tests/benchmark/include/metric/Metrics.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+
+#include <vector>
+#include <string>
+#include <chrono>
+#include <tuple>
+#include <functional>
+
+namespace Benchmark {
+    enum METRIC_TYPE {
+        DURATION,
+        SUCCESS
+    };
+
+    struct Dimension {
+        std::string name;
+        std::string value;
+    };
+
+    struct Metric {
+        std::string name;
+        METRIC_TYPE metricType;
+        std::vector<Dimension> dimensions;
+        std::string value;
+    };
+
+    class MetricsEmitter {
+    public:
+        static void CreateMetricsForOp(
+            const std::string &metricName,
+            const std::vector<Dimension> &dimensions,
+            std::vector<Benchmark::Metric> &trackingMetrics,
+            const std::function<bool()> &op);
+
+        virtual ~MetricsEmitter() = default;
+
+        virtual void EmitMetric(std::vector<Metric> &&metrics) const = 0;
+    };
+}

--- a/tests/benchmark/include/metric/PrintMetrics.h
+++ b/tests/benchmark/include/metric/PrintMetrics.h
@@ -1,0 +1,14 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+
+#include <metric/Metrics.h>
+
+namespace Benchmark {
+    class PrintMetrics : public MetricsEmitter {
+    public:
+        void EmitMetric(std::vector<Metric> &&metrics) const override;
+    };
+}

--- a/tests/benchmark/include/service/S3PutObject.h
+++ b/tests/benchmark/include/service/S3PutObject.h
@@ -1,0 +1,14 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+
+#include <TestDelegator.h>
+
+namespace Benchmark {
+    class S3PutObject {
+    public:
+        static TestFunction CreateTestFunction();
+    };
+}

--- a/tests/benchmark/src/Configuration.cpp
+++ b/tests/benchmark/src/Configuration.cpp
@@ -1,0 +1,31 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <Configuration.h>
+#include <algorithm>
+#include <utility>
+
+Benchmark::Configuration::Configuration(Benchmark::RunConfiguration runConfiguration) :
+    runConfiguration(std::move(runConfiguration)) {}
+
+Benchmark::Configuration Benchmark::Configuration::FromArgs(int argc, char *argv[]) {
+    return Benchmark::Configuration({
+        Benchmark::Configuration::GetCmdOption(argv, argv + argc, "--service"),
+        Benchmark::Configuration::GetCmdOption(argv, argv + argc, "--api"),
+        std::stol(Benchmark::Configuration::GetCmdOption(argv, argv + argc, "--durationMillis")),
+        Benchmark::Configuration::CmdOptionExists(argv, argv + argc, "--withMetrics"),
+    });
+}
+
+char *Benchmark::Configuration::GetCmdOption(char **begin, char **end, const std::string &option) {
+    char **itr = std::find(begin, end, option);
+    if (itr != end && ++itr != end) {
+        return *itr;
+    }
+    return nullptr;
+}
+
+bool Benchmark::Configuration::CmdOptionExists(char **begin, char **end, const std::string &option) {
+    return std::find(begin, end, option) != end;
+}

--- a/tests/benchmark/src/TestDelegator.cpp
+++ b/tests/benchmark/src/TestDelegator.cpp
@@ -1,0 +1,30 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <service/S3PutObject.h>
+#include <TestDelegator.h>
+#include <iostream>
+
+Benchmark::TestDelegator::TestDelegator(const std::map<StringPair, TestFunction> &testFunctionMap) :
+    testFunctionMap(testFunctionMap) {}
+
+Benchmark::TestFunction
+Benchmark::TestDelegator::GetTestRunForConfiguration(const Benchmark::Configuration &configuration) const {
+    auto it = this->testFunctionMap.find(std::make_pair(configuration.GetConfiguration().service,
+        configuration.GetConfiguration().api));
+    if (it != testFunctionMap.end()) {
+        return it->second;
+    }
+    return [](const Benchmark::Configuration &configuration) -> std::vector<Metric> {
+        std::cout << "Could not find test to run for service: " << configuration.GetConfiguration().service
+                  << "and api: " << configuration.GetConfiguration().api << "\n";
+        return {};
+    };
+}
+
+Benchmark::TestDelegator Benchmark::TestDelegator::BuildTestDelegator() {
+    return Benchmark::TestDelegator({
+        {std::make_pair("s3", "PutObject"), S3PutObject::CreateTestFunction()}
+    });
+}

--- a/tests/benchmark/src/metric/CloudWatchMetrics.cpp
+++ b/tests/benchmark/src/metric/CloudWatchMetrics.cpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <metric/CloudWatchMetrics.h>
+#include <aws/monitoring/model/PutMetricDataRequest.h>
+#include <algorithm>
+
+using namespace Aws;
+using namespace Aws::CloudWatch;
+using namespace Aws::CloudWatch::Model;
+
+Benchmark::CloudWatchMetrics::CloudWatchMetrics(
+    const std::shared_ptr<Aws::CloudWatch::CloudWatchClient> &cloudWatchClient) : cloudWatchClient(cloudWatchClient) {}
+
+void Benchmark::CloudWatchMetrics::EmitMetric(std::vector<Metric> &&metrics) const {
+    std::vector<MetricDatum> data{metrics.size()};
+    std::transform(metrics.cbegin(),
+        metrics.cend(),
+        data.begin(),
+        [this](const Metric &metric) -> MetricDatum { return this->ConvertToCloudWatchMetric(metric); });
+
+    this->cloudWatchClient->PutMetricData(PutMetricDataRequest()
+        .WithNamespace("AwsCppSdkBenchmarks")
+        .WithMetricData(std::move(data)));
+}
+
+Aws::CloudWatch::Model::MetricDatum
+Benchmark::CloudWatchMetrics::ConvertToCloudWatchMetric(const Benchmark::Metric &metric) const {
+    std::vector<CloudWatch::Model::Dimension> dimensions{metric.dimensions.size()};
+    std::transform(metric.dimensions.cbegin(),
+        metric.dimensions.cend(),
+        dimensions.begin(),
+        [](const Benchmark::Dimension &dimension) {
+            return CloudWatch::Model::Dimension().WithName(dimension.name).WithValue(dimension.value);
+        });
+
+    auto data = MetricDatum().WithDimensions(dimensions);
+    if (metric.metricType == SUCCESS) {
+        data = data.WithMetricName(metric.name + "Success");
+        metric.value == "false" ?
+            data = data.WithUnit(StandardUnit::None).WithValue(1) :
+            data = data.WithUnit(StandardUnit::None).WithValue(0);
+    } else if (metric.metricType == DURATION) {
+        data = data.WithMetricName(metric.name + "Latency")
+            .WithUnit(StandardUnit::Milliseconds)
+            .WithValue(std::atof(metric.value.c_str()));
+    }
+    return data;
+}

--- a/tests/benchmark/src/metric/Metrics.cpp
+++ b/tests/benchmark/src/metric/Metrics.cpp
@@ -1,0 +1,26 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <metric/Metrics.h>
+#include <chrono>
+
+using namespace std::chrono;
+
+void Benchmark::MetricsEmitter::CreateMetricsForOp(const std::string &metricName,
+    const std::vector<Dimension> &dimensions,
+    std::vector<Benchmark::Metric> &trackingMetrics,
+    const std::function<bool()> &op) {
+    std::vector<Metric> metrics;
+
+    auto before = steady_clock::now();
+    auto success = op();
+    auto after = steady_clock::now();
+    auto duration = duration_cast<milliseconds>(after - before);
+    if (success) {
+        trackingMetrics.push_back({metricName, SUCCESS, dimensions, "true"});
+    } else {
+        trackingMetrics.push_back({metricName, SUCCESS, dimensions, "false"});
+    }
+    trackingMetrics.push_back({metricName, DURATION, dimensions, std::to_string(duration.count())});
+}

--- a/tests/benchmark/src/metric/PrintMetrics.cpp
+++ b/tests/benchmark/src/metric/PrintMetrics.cpp
@@ -1,0 +1,36 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <metric/PrintMetrics.h>
+#include <metric/Metrics.h>
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <iterator>
+
+const char *const delim = ", ";
+
+void Benchmark::PrintMetrics::EmitMetric(std::vector<Metric> &&metrics) const {
+    std::for_each(metrics.cbegin(), metrics.cend(), [](const Metric &metric) {
+        std::vector<std::string> dimensionStrings{metric.dimensions.size()};
+        std::transform(metric.dimensions.cbegin(),
+            metric.dimensions.cend(),
+            dimensionStrings.begin(),
+            [](const Dimension &dimension) {
+                return "{ name: " + dimension.name + ", value: " + dimension.value + "}";
+            });
+        std::ostringstream dimensionString;
+        std::copy(dimensionStrings.cbegin(),
+            dimensionStrings.cend(),
+            std::ostream_iterator<std::string>(dimensionString, delim));
+        std::cout << "Metric:" << "{ "
+                  << metric.name
+                  << ", "
+                  << dimensionString.str()
+                  << metric.metricType
+                  << ", "
+                  << metric.value
+                  << "}\n";
+    });
+}

--- a/tests/benchmark/src/service/S3PutObject.cpp
+++ b/tests/benchmark/src/service/S3PutObject.cpp
@@ -1,0 +1,83 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <service/S3PutObject.h>
+#include <Util.h>
+#include <metric/Metrics.h>
+#include <aws/core/Aws.h>
+#include <aws/core/utils/UUID.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/CreateBucketRequest.h>
+#include <aws/s3/model/DeleteBucketRequest.h>
+#include <aws/s3/model/PutObjectRequest.h>
+#include <aws/s3/model/DeleteObjectRequest.h>
+#include <iostream>
+#include <chrono>
+
+using namespace Aws;
+using namespace Aws::Utils;
+using namespace Aws::S3;
+using namespace Aws::S3::Model;
+using namespace std::chrono;
+
+const static char *ALLOC_TAG = "PUT_OBJECT_BENCHMARK";
+
+Benchmark::TestFunction Benchmark::S3PutObject::CreateTestFunction() {
+    return [](const Configuration &configuration) -> std::vector<Metric> {
+        std::vector<Metric> metrics;
+
+        //Create Bucket
+        auto s3 = Aws::MakeUnique<S3Client>(ALLOC_TAG);
+        const auto bucketName = "put-bucket-benchmark-" + RandomString(8);
+        Benchmark::MetricsEmitter::CreateMetricsForOp("CreateBucket",
+            {{"Service", "S3"}, {"Operation", "CreateBucket"}},
+            metrics,
+            [&]() -> bool {
+                auto response = s3->CreateBucket(CreateBucketRequest().WithBucket(bucketName));
+                return response.IsSuccess();
+            });
+
+        //Make put requests
+        const auto randomBody64K = RandomString(64000);
+        std::vector<std::string> keysToDelete;
+        const auto timeToEnd = duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count() +
+                               configuration.GetConfiguration().durationMillis;
+        while (duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count() < timeToEnd) {
+            auto key = RandomString(8);
+            keysToDelete.push_back(key);
+            auto putObjectRequest = PutObjectRequest().WithBucket(bucketName).WithKey(key);
+            const std::shared_ptr<Aws::IOStream> inputData = Aws::MakeShared<Aws::StringStream>("");
+            *inputData << randomBody64K.c_str();
+            putObjectRequest.SetBody(inputData);
+            Benchmark::MetricsEmitter::CreateMetricsForOp(
+                "PutObject",
+                {{"Service", "S3"}, {"Operation", "PutObject"}},
+                metrics,
+                [&]() -> bool {
+                    auto response = s3->PutObject(putObjectRequest);
+                    return response.IsSuccess();
+                });
+        }
+
+        // Clean up
+        std::for_each(keysToDelete.begin(), keysToDelete.end(), [&](const std::string &key) {
+            Benchmark::MetricsEmitter::CreateMetricsForOp("DeleteObject",
+                {{"Service", "S3"}, {"Operation", "DeleteObject"}},
+                metrics,
+                [&]() -> bool {
+                    auto response = s3->DeleteObject(DeleteObjectRequest().WithKey(key));
+                    return response.IsSuccess();
+                });
+        });
+
+        Benchmark::MetricsEmitter::CreateMetricsForOp(
+            "DeleteBucket",
+            {{"Service", "S3"}, {"Operation", "DeleteBucket"}}, metrics, [&]() -> bool {
+                auto response = s3->DeleteBucket(DeleteBucketRequest().WithBucket(bucketName));
+                return response.IsSuccess();
+            });
+
+        return metrics;
+    };
+}


### PR DESCRIPTION
*Description of changes:*

Adds a simple benchmark test that will run against S3 running put object requests. The test can be run like

```
benchmark --service s3 --api PutObject --durationMillis 10000 --withMetrics
```

right now the benchmark test only supports put object but we will be expanding it in the future to include more operations and more configurations to be run with. if specified `--withMetrics` will run the test with a cloud.watch metrics publisher so that you can view results in cloudwatch. Results will print out to stdout otherwise so that this can be run outside of a cloudwatch context.

this test will be gated by the cmake var `BUILD_BENCHMARKS`. By default these tests will not be built with SDK.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
