### PR TITLE
debug benchmark metrics

### DIFF
--- a/tests/benchmark/include/metric/CloudWatchMetrics.h
+++ b/tests/benchmark/include/metric/CloudWatchMetrics.h
@@ -19,5 +19,7 @@ namespace Benchmark {
     private:
         std::shared_ptr<Aws::CloudWatch::CloudWatchClient> cloudWatchClient;
         Aws::CloudWatch::Model::MetricDatum ConvertToCloudWatchMetric(const Benchmark::Metric &metric) const;
+        std::vector<std::vector<Aws::CloudWatch::Model::MetricDatum>>
+        divideIntoSizedChunks(const std::vector<Aws::CloudWatch::Model::MetricDatum>& data, int chunkSize = 1000) const;
     };
 }


### PR DESCRIPTION
*Description of changes:*

Benchmark cloudwatch metrics would occasionally go over the batch limit of 1000 metrics per request, this batches metrics to appropriate sizes.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
