### PR TITLE
Add ClientConfigurationType and EndpointProviderType typedefs to service clients

### DIFF
--- a/generated/src/aws-cpp-sdk-AWSMigrationHub/include/aws/AWSMigrationHub/MigrationHubClient.h
+++ b/generated/src/aws-cpp-sdk-AWSMigrationHub/include/aws/AWSMigrationHub/MigrationHubClient.h
@@ -30,6 +30,9 @@ namespace MigrationHub
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MigrationHubClientConfiguration ClientConfigurationType;
+      typedef MigrationHubEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-accessanalyzer/include/aws/accessanalyzer/AccessAnalyzerClient.h
+++ b/generated/src/aws-cpp-sdk-accessanalyzer/include/aws/accessanalyzer/AccessAnalyzerClient.h
@@ -38,6 +38,9 @@ namespace AccessAnalyzer
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AccessAnalyzerClientConfiguration ClientConfigurationType;
+      typedef AccessAnalyzerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-account/include/aws/account/AccountClient.h
+++ b/generated/src/aws-cpp-sdk-account/include/aws/account/AccountClient.h
@@ -25,6 +25,9 @@ namespace Account
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AccountClientConfiguration ClientConfigurationType;
+      typedef AccountEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-acm-pca/include/aws/acm-pca/ACMPCAClient.h
+++ b/generated/src/aws-cpp-sdk-acm-pca/include/aws/acm-pca/ACMPCAClient.h
@@ -46,6 +46,9 @@ namespace ACMPCA
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ACMPCAClientConfiguration ClientConfigurationType;
+      typedef ACMPCAEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-acm/include/aws/acm/ACMClient.h
+++ b/generated/src/aws-cpp-sdk-acm/include/aws/acm/ACMClient.h
@@ -29,6 +29,9 @@ namespace ACM
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ACMClientConfiguration ClientConfigurationType;
+      typedef ACMEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-alexaforbusiness/include/aws/alexaforbusiness/AlexaForBusinessClient.h
+++ b/generated/src/aws-cpp-sdk-alexaforbusiness/include/aws/alexaforbusiness/AlexaForBusinessClient.h
@@ -34,6 +34,9 @@ namespace AlexaForBusiness
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AlexaForBusinessClientConfiguration ClientConfigurationType;
+      typedef AlexaForBusinessEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-amp/include/aws/amp/PrometheusServiceClient.h
+++ b/generated/src/aws-cpp-sdk-amp/include/aws/amp/PrometheusServiceClient.h
@@ -25,6 +25,9 @@ namespace PrometheusService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef PrometheusServiceClientConfiguration ClientConfigurationType;
+      typedef PrometheusServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-amplify/include/aws/amplify/AmplifyClient.h
+++ b/generated/src/aws-cpp-sdk-amplify/include/aws/amplify/AmplifyClient.h
@@ -32,6 +32,9 @@ namespace Amplify
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AmplifyClientConfiguration ClientConfigurationType;
+      typedef AmplifyEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-amplifybackend/include/aws/amplifybackend/AmplifyBackendClient.h
+++ b/generated/src/aws-cpp-sdk-amplifybackend/include/aws/amplifybackend/AmplifyBackendClient.h
@@ -25,6 +25,9 @@ namespace AmplifyBackend
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AmplifyBackendClientConfiguration ClientConfigurationType;
+      typedef AmplifyBackendEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-amplifyuibuilder/include/aws/amplifyuibuilder/AmplifyUIBuilderClient.h
+++ b/generated/src/aws-cpp-sdk-amplifyuibuilder/include/aws/amplifyuibuilder/AmplifyUIBuilderClient.h
@@ -38,6 +38,9 @@ namespace AmplifyUIBuilder
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AmplifyUIBuilderClientConfiguration ClientConfigurationType;
+      typedef AmplifyUIBuilderEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-apigateway/include/aws/apigateway/APIGatewayClient.h
+++ b/generated/src/aws-cpp-sdk-apigateway/include/aws/apigateway/APIGatewayClient.h
@@ -29,6 +29,9 @@ namespace APIGateway
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef APIGatewayClientConfiguration ClientConfigurationType;
+      typedef APIGatewayEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-apigatewaymanagementapi/include/aws/apigatewaymanagementapi/ApiGatewayManagementApiClient.h
+++ b/generated/src/aws-cpp-sdk-apigatewaymanagementapi/include/aws/apigatewaymanagementapi/ApiGatewayManagementApiClient.h
@@ -30,6 +30,9 @@ namespace ApiGatewayManagementApi
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ApiGatewayManagementApiClientConfiguration ClientConfigurationType;
+      typedef ApiGatewayManagementApiEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-apigatewayv2/include/aws/apigatewayv2/ApiGatewayV2Client.h
+++ b/generated/src/aws-cpp-sdk-apigatewayv2/include/aws/apigatewayv2/ApiGatewayV2Client.h
@@ -25,6 +25,9 @@ namespace ApiGatewayV2
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ApiGatewayV2ClientConfiguration ClientConfigurationType;
+      typedef ApiGatewayV2EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-appconfig/include/aws/appconfig/AppConfigClient.h
+++ b/generated/src/aws-cpp-sdk-appconfig/include/aws/appconfig/AppConfigClient.h
@@ -55,6 +55,9 @@ namespace AppConfig
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AppConfigClientConfiguration ClientConfigurationType;
+      typedef AppConfigEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-appconfigdata/include/aws/appconfigdata/AppConfigDataClient.h
+++ b/generated/src/aws-cpp-sdk-appconfigdata/include/aws/appconfigdata/AppConfigDataClient.h
@@ -64,6 +64,9 @@ namespace AppConfigData
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AppConfigDataClientConfiguration ClientConfigurationType;
+      typedef AppConfigDataEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-appflow/include/aws/appflow/AppflowClient.h
+++ b/generated/src/aws-cpp-sdk-appflow/include/aws/appflow/AppflowClient.h
@@ -51,6 +51,9 @@ namespace Appflow
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AppflowClientConfiguration ClientConfigurationType;
+      typedef AppflowEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-appintegrations/include/aws/appintegrations/AppIntegrationsServiceClient.h
+++ b/generated/src/aws-cpp-sdk-appintegrations/include/aws/appintegrations/AppIntegrationsServiceClient.h
@@ -32,6 +32,9 @@ namespace AppIntegrationsService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AppIntegrationsServiceClientConfiguration ClientConfigurationType;
+      typedef AppIntegrationsServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-application-autoscaling/include/aws/application-autoscaling/ApplicationAutoScalingClient.h
+++ b/generated/src/aws-cpp-sdk-application-autoscaling/include/aws/application-autoscaling/ApplicationAutoScalingClient.h
@@ -55,6 +55,9 @@ namespace ApplicationAutoScaling
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ApplicationAutoScalingClientConfiguration ClientConfigurationType;
+      typedef ApplicationAutoScalingEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-application-insights/include/aws/application-insights/ApplicationInsightsClient.h
+++ b/generated/src/aws-cpp-sdk-application-insights/include/aws/application-insights/ApplicationInsightsClient.h
@@ -37,6 +37,9 @@ namespace ApplicationInsights
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ApplicationInsightsClientConfiguration ClientConfigurationType;
+      typedef ApplicationInsightsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-applicationcostprofiler/include/aws/applicationcostprofiler/ApplicationCostProfilerClient.h
+++ b/generated/src/aws-cpp-sdk-applicationcostprofiler/include/aws/applicationcostprofiler/ApplicationCostProfilerClient.h
@@ -31,6 +31,9 @@ namespace ApplicationCostProfiler
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ApplicationCostProfilerClientConfiguration ClientConfigurationType;
+      typedef ApplicationCostProfilerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-appmesh/include/aws/appmesh/AppMeshClient.h
+++ b/generated/src/aws-cpp-sdk-appmesh/include/aws/appmesh/AppMeshClient.h
@@ -40,6 +40,9 @@ namespace AppMesh
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AppMeshClientConfiguration ClientConfigurationType;
+      typedef AppMeshEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-apprunner/include/aws/apprunner/AppRunnerClient.h
+++ b/generated/src/aws-cpp-sdk-apprunner/include/aws/apprunner/AppRunnerClient.h
@@ -44,6 +44,9 @@ namespace AppRunner
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AppRunnerClientConfiguration ClientConfigurationType;
+      typedef AppRunnerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-appstream/include/aws/appstream/AppStreamClient.h
+++ b/generated/src/aws-cpp-sdk-appstream/include/aws/appstream/AppStreamClient.h
@@ -41,6 +41,9 @@ namespace AppStream
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AppStreamClientConfiguration ClientConfigurationType;
+      typedef AppStreamEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-appsync/include/aws/appsync/AppSyncClient.h
+++ b/generated/src/aws-cpp-sdk-appsync/include/aws/appsync/AppSyncClient.h
@@ -26,6 +26,9 @@ namespace AppSync
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AppSyncClientConfiguration ClientConfigurationType;
+      typedef AppSyncEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-arc-zonal-shift/include/aws/arc-zonal-shift/ARCZonalShiftClient.h
+++ b/generated/src/aws-cpp-sdk-arc-zonal-shift/include/aws/arc-zonal-shift/ARCZonalShiftClient.h
@@ -47,6 +47,9 @@ namespace ARCZonalShift
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ARCZonalShiftClientConfiguration ClientConfigurationType;
+      typedef ARCZonalShiftEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-athena/include/aws/athena/AthenaClient.h
+++ b/generated/src/aws-cpp-sdk-athena/include/aws/athena/AthenaClient.h
@@ -41,6 +41,9 @@ namespace Athena
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AthenaClientConfiguration ClientConfigurationType;
+      typedef AthenaEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-auditmanager/include/aws/auditmanager/AuditManagerClient.h
+++ b/generated/src/aws-cpp-sdk-auditmanager/include/aws/auditmanager/AuditManagerClient.h
@@ -49,6 +49,9 @@ namespace AuditManager
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AuditManagerClientConfiguration ClientConfigurationType;
+      typedef AuditManagerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-autoscaling-plans/include/aws/autoscaling-plans/AutoScalingPlansClient.h
+++ b/generated/src/aws-cpp-sdk-autoscaling-plans/include/aws/autoscaling-plans/AutoScalingPlansClient.h
@@ -39,6 +39,9 @@ namespace AutoScalingPlans
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AutoScalingPlansClientConfiguration ClientConfigurationType;
+      typedef AutoScalingPlansEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-autoscaling/include/aws/autoscaling/AutoScalingClient.h
+++ b/generated/src/aws-cpp-sdk-autoscaling/include/aws/autoscaling/AutoScalingClient.h
@@ -33,6 +33,9 @@ namespace AutoScaling
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AutoScalingClientConfiguration ClientConfigurationType;
+      typedef AutoScalingEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-awstransfer/include/aws/awstransfer/TransferClient.h
+++ b/generated/src/aws-cpp-sdk-awstransfer/include/aws/awstransfer/TransferClient.h
@@ -36,6 +36,9 @@ namespace Transfer
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef TransferClientConfiguration ClientConfigurationType;
+      typedef TransferEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-backup-gateway/include/aws/backup-gateway/BackupGatewayClient.h
+++ b/generated/src/aws-cpp-sdk-backup-gateway/include/aws/backup-gateway/BackupGatewayClient.h
@@ -35,6 +35,9 @@ namespace BackupGateway
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef BackupGatewayClientConfiguration ClientConfigurationType;
+      typedef BackupGatewayEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-backup/include/aws/backup/BackupClient.h
+++ b/generated/src/aws-cpp-sdk-backup/include/aws/backup/BackupClient.h
@@ -28,6 +28,9 @@ namespace Backup
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef BackupClientConfiguration ClientConfigurationType;
+      typedef BackupEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-backupstorage/include/aws/backupstorage/BackupStorageClient.h
+++ b/generated/src/aws-cpp-sdk-backupstorage/include/aws/backupstorage/BackupStorageClient.h
@@ -25,6 +25,9 @@ namespace BackupStorage
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef BackupStorageClientConfiguration ClientConfigurationType;
+      typedef BackupStorageEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-batch/include/aws/batch/BatchClient.h
+++ b/generated/src/aws-cpp-sdk-batch/include/aws/batch/BatchClient.h
@@ -38,6 +38,9 @@ namespace Batch
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef BatchClientConfiguration ClientConfigurationType;
+      typedef BatchEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-billingconductor/include/aws/billingconductor/BillingConductorClient.h
+++ b/generated/src/aws-cpp-sdk-billingconductor/include/aws/billingconductor/BillingConductorClient.h
@@ -44,6 +44,9 @@ namespace BillingConductor
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef BillingConductorClientConfiguration ClientConfigurationType;
+      typedef BillingConductorEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-braket/include/aws/braket/BraketClient.h
+++ b/generated/src/aws-cpp-sdk-braket/include/aws/braket/BraketClient.h
@@ -29,6 +29,9 @@ namespace Braket
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef BraketClientConfiguration ClientConfigurationType;
+      typedef BraketEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-budgets/include/aws/budgets/BudgetsClient.h
+++ b/generated/src/aws-cpp-sdk-budgets/include/aws/budgets/BudgetsClient.h
@@ -50,6 +50,9 @@ namespace Budgets
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef BudgetsClientConfiguration ClientConfigurationType;
+      typedef BudgetsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ce/include/aws/ce/CostExplorerClient.h
+++ b/generated/src/aws-cpp-sdk-ce/include/aws/ce/CostExplorerClient.h
@@ -34,6 +34,9 @@ namespace CostExplorer
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CostExplorerClientConfiguration ClientConfigurationType;
+      typedef CostExplorerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-chime-sdk-identity/include/aws/chime-sdk-identity/ChimeSDKIdentityClient.h
+++ b/generated/src/aws-cpp-sdk-chime-sdk-identity/include/aws/chime-sdk-identity/ChimeSDKIdentityClient.h
@@ -30,6 +30,9 @@ namespace ChimeSDKIdentity
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ChimeSDKIdentityClientConfiguration ClientConfigurationType;
+      typedef ChimeSDKIdentityEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-chime-sdk-media-pipelines/include/aws/chime-sdk-media-pipelines/ChimeSDKMediaPipelinesClient.h
+++ b/generated/src/aws-cpp-sdk-chime-sdk-media-pipelines/include/aws/chime-sdk-media-pipelines/ChimeSDKMediaPipelinesClient.h
@@ -30,6 +30,9 @@ namespace ChimeSDKMediaPipelines
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ChimeSDKMediaPipelinesClientConfiguration ClientConfigurationType;
+      typedef ChimeSDKMediaPipelinesEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-chime-sdk-meetings/include/aws/chime-sdk-meetings/ChimeSDKMeetingsClient.h
+++ b/generated/src/aws-cpp-sdk-chime-sdk-meetings/include/aws/chime-sdk-meetings/ChimeSDKMeetingsClient.h
@@ -30,6 +30,9 @@ namespace ChimeSDKMeetings
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ChimeSDKMeetingsClientConfiguration ClientConfigurationType;
+      typedef ChimeSDKMeetingsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-chime-sdk-messaging/include/aws/chime-sdk-messaging/ChimeSDKMessagingClient.h
+++ b/generated/src/aws-cpp-sdk-chime-sdk-messaging/include/aws/chime-sdk-messaging/ChimeSDKMessagingClient.h
@@ -30,6 +30,9 @@ namespace ChimeSDKMessaging
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ChimeSDKMessagingClientConfiguration ClientConfigurationType;
+      typedef ChimeSDKMessagingEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-chime-sdk-voice/include/aws/chime-sdk-voice/ChimeSDKVoiceClient.h
+++ b/generated/src/aws-cpp-sdk-chime-sdk-voice/include/aws/chime-sdk-voice/ChimeSDKVoiceClient.h
@@ -29,6 +29,9 @@ namespace ChimeSDKVoice
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ChimeSDKVoiceClientConfiguration ClientConfigurationType;
+      typedef ChimeSDKVoiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-chime/include/aws/chime/ChimeClient.h
+++ b/generated/src/aws-cpp-sdk-chime/include/aws/chime/ChimeClient.h
@@ -61,6 +61,9 @@ namespace Chime
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ChimeClientConfiguration ClientConfigurationType;
+      typedef ChimeEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cleanrooms/include/aws/cleanrooms/CleanRoomsClient.h
+++ b/generated/src/aws-cpp-sdk-cleanrooms/include/aws/cleanrooms/CleanRoomsClient.h
@@ -32,6 +32,9 @@ namespace CleanRooms
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CleanRoomsClientConfiguration ClientConfigurationType;
+      typedef CleanRoomsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cloud9/include/aws/cloud9/Cloud9Client.h
+++ b/generated/src/aws-cpp-sdk-cloud9/include/aws/cloud9/Cloud9Client.h
@@ -50,6 +50,9 @@ namespace Cloud9
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef Cloud9ClientConfiguration ClientConfigurationType;
+      typedef Cloud9EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cloudcontrol/include/aws/cloudcontrol/CloudControlApiClient.h
+++ b/generated/src/aws-cpp-sdk-cloudcontrol/include/aws/cloudcontrol/CloudControlApiClient.h
@@ -27,6 +27,9 @@ namespace CloudControlApi
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudControlApiClientConfiguration ClientConfigurationType;
+      typedef CloudControlApiEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-clouddirectory/include/aws/clouddirectory/CloudDirectoryClient.h
+++ b/generated/src/aws-cpp-sdk-clouddirectory/include/aws/clouddirectory/CloudDirectoryClient.h
@@ -34,6 +34,9 @@ namespace CloudDirectory
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudDirectoryClientConfiguration ClientConfigurationType;
+      typedef CloudDirectoryEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cloudformation/include/aws/cloudformation/CloudFormationClient.h
+++ b/generated/src/aws-cpp-sdk-cloudformation/include/aws/cloudformation/CloudFormationClient.h
@@ -42,6 +42,9 @@ namespace CloudFormation
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudFormationClientConfiguration ClientConfigurationType;
+      typedef CloudFormationEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cloudfront/include/aws/cloudfront/CloudFrontClient.h
+++ b/generated/src/aws-cpp-sdk-cloudfront/include/aws/cloudfront/CloudFrontClient.h
@@ -29,6 +29,9 @@ namespace CloudFront
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudFrontClientConfiguration ClientConfigurationType;
+      typedef CloudFrontEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cloudhsm/include/aws/cloudhsm/CloudHSMClient.h
+++ b/generated/src/aws-cpp-sdk-cloudhsm/include/aws/cloudhsm/CloudHSMClient.h
@@ -38,6 +38,9 @@ namespace CloudHSM
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudHSMClientConfiguration ClientConfigurationType;
+      typedef CloudHSMEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cloudhsmv2/include/aws/cloudhsmv2/CloudHSMV2Client.h
+++ b/generated/src/aws-cpp-sdk-cloudhsmv2/include/aws/cloudhsmv2/CloudHSMV2Client.h
@@ -28,6 +28,9 @@ namespace CloudHSMV2
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudHSMV2ClientConfiguration ClientConfigurationType;
+      typedef CloudHSMV2EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cloudsearch/include/aws/cloudsearch/CloudSearchClient.h
+++ b/generated/src/aws-cpp-sdk-cloudsearch/include/aws/cloudsearch/CloudSearchClient.h
@@ -36,6 +36,9 @@ namespace CloudSearch
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudSearchClientConfiguration ClientConfigurationType;
+      typedef CloudSearchEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cloudsearchdomain/include/aws/cloudsearchdomain/CloudSearchDomainClient.h
+++ b/generated/src/aws-cpp-sdk-cloudsearchdomain/include/aws/cloudsearchdomain/CloudSearchDomainClient.h
@@ -34,6 +34,9 @@ namespace CloudSearchDomain
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudSearchDomainClientConfiguration ClientConfigurationType;
+      typedef CloudSearchDomainEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cloudtrail-data/include/aws/cloudtrail-data/CloudTrailDataClient.h
+++ b/generated/src/aws-cpp-sdk-cloudtrail-data/include/aws/cloudtrail-data/CloudTrailDataClient.h
@@ -32,6 +32,9 @@ namespace CloudTrailData
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudTrailDataClientConfiguration ClientConfigurationType;
+      typedef CloudTrailDataEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cloudtrail/include/aws/cloudtrail/CloudTrailClient.h
+++ b/generated/src/aws-cpp-sdk-cloudtrail/include/aws/cloudtrail/CloudTrailClient.h
@@ -43,6 +43,9 @@ namespace CloudTrail
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudTrailClientConfiguration ClientConfigurationType;
+      typedef CloudTrailEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-codeartifact/include/aws/codeartifact/CodeArtifactClient.h
+++ b/generated/src/aws-cpp-sdk-codeartifact/include/aws/codeartifact/CodeArtifactClient.h
@@ -155,6 +155,9 @@ namespace CodeArtifact
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CodeArtifactClientConfiguration ClientConfigurationType;
+      typedef CodeArtifactEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-codebuild/include/aws/codebuild/CodeBuildClient.h
+++ b/generated/src/aws-cpp-sdk-codebuild/include/aws/codebuild/CodeBuildClient.h
@@ -35,6 +35,9 @@ namespace CodeBuild
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CodeBuildClientConfiguration ClientConfigurationType;
+      typedef CodeBuildEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-codecatalyst/include/aws/codecatalyst/CodeCatalystClient.h
+++ b/generated/src/aws-cpp-sdk-codecatalyst/include/aws/codecatalyst/CodeCatalystClient.h
@@ -67,6 +67,9 @@ namespace CodeCatalyst
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CodeCatalystClientConfiguration ClientConfigurationType;
+      typedef CodeCatalystEndpointProvider EndpointProviderType;
+
         /**
         * Initializes client to use BearerTokenAuthSignerProvider, with default http client factory, and optional client config.
         */

--- a/generated/src/aws-cpp-sdk-codecommit/include/aws/codecommit/CodeCommitClient.h
+++ b/generated/src/aws-cpp-sdk-codecommit/include/aws/codecommit/CodeCommitClient.h
@@ -182,6 +182,9 @@ namespace CodeCommit
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CodeCommitClientConfiguration ClientConfigurationType;
+      typedef CodeCommitEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-codedeploy/include/aws/codedeploy/CodeDeployClient.h
+++ b/generated/src/aws-cpp-sdk-codedeploy/include/aws/codedeploy/CodeDeployClient.h
@@ -79,6 +79,9 @@ namespace CodeDeploy
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CodeDeployClientConfiguration ClientConfigurationType;
+      typedef CodeDeployEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-codeguru-reviewer/include/aws/codeguru-reviewer/CodeGuruReviewerClient.h
+++ b/generated/src/aws-cpp-sdk-codeguru-reviewer/include/aws/codeguru-reviewer/CodeGuruReviewerClient.h
@@ -40,6 +40,9 @@ namespace CodeGuruReviewer
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CodeGuruReviewerClientConfiguration ClientConfigurationType;
+      typedef CodeGuruReviewerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-codeguruprofiler/include/aws/codeguruprofiler/CodeGuruProfilerClient.h
+++ b/generated/src/aws-cpp-sdk-codeguruprofiler/include/aws/codeguruprofiler/CodeGuruProfilerClient.h
@@ -41,6 +41,9 @@ namespace CodeGuruProfiler
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CodeGuruProfilerClientConfiguration ClientConfigurationType;
+      typedef CodeGuruProfilerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-codepipeline/include/aws/codepipeline/CodePipelineClient.h
+++ b/generated/src/aws-cpp-sdk-codepipeline/include/aws/codepipeline/CodePipelineClient.h
@@ -104,6 +104,9 @@ namespace CodePipeline
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CodePipelineClientConfiguration ClientConfigurationType;
+      typedef CodePipelineEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-codestar-connections/include/aws/codestar-connections/CodeStarconnectionsClient.h
+++ b/generated/src/aws-cpp-sdk-codestar-connections/include/aws/codestar-connections/CodeStarconnectionsClient.h
@@ -63,6 +63,9 @@ namespace CodeStarconnections
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CodeStarconnectionsClientConfiguration ClientConfigurationType;
+      typedef CodeStarconnectionsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-codestar-notifications/include/aws/codestar-notifications/CodeStarNotificationsClient.h
+++ b/generated/src/aws-cpp-sdk-codestar-notifications/include/aws/codestar-notifications/CodeStarNotificationsClient.h
@@ -52,6 +52,9 @@ namespace CodeStarNotifications
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CodeStarNotificationsClientConfiguration ClientConfigurationType;
+      typedef CodeStarNotificationsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-codestar/include/aws/codestar/CodeStarClient.h
+++ b/generated/src/aws-cpp-sdk-codestar/include/aws/codestar/CodeStarClient.h
@@ -54,6 +54,9 @@ namespace CodeStar
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CodeStarClientConfiguration ClientConfigurationType;
+      typedef CodeStarEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cognito-identity/include/aws/cognito-identity/CognitoIdentityClient.h
+++ b/generated/src/aws-cpp-sdk-cognito-identity/include/aws/cognito-identity/CognitoIdentityClient.h
@@ -40,6 +40,9 @@ namespace CognitoIdentity
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CognitoIdentityClientConfiguration ClientConfigurationType;
+      typedef CognitoIdentityEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cognito-idp/include/aws/cognito-idp/CognitoIdentityProviderClient.h
+++ b/generated/src/aws-cpp-sdk-cognito-idp/include/aws/cognito-idp/CognitoIdentityProviderClient.h
@@ -31,6 +31,9 @@ namespace CognitoIdentityProvider
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CognitoIdentityProviderClientConfiguration ClientConfigurationType;
+      typedef CognitoIdentityProviderEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cognito-sync/include/aws/cognito-sync/CognitoSyncClient.h
+++ b/generated/src/aws-cpp-sdk-cognito-sync/include/aws/cognito-sync/CognitoSyncClient.h
@@ -44,6 +44,9 @@ namespace CognitoSync
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CognitoSyncClientConfiguration ClientConfigurationType;
+      typedef CognitoSyncEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-comprehend/include/aws/comprehend/ComprehendClient.h
+++ b/generated/src/aws-cpp-sdk-comprehend/include/aws/comprehend/ComprehendClient.h
@@ -28,6 +28,9 @@ namespace Comprehend
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ComprehendClientConfiguration ClientConfigurationType;
+      typedef ComprehendEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-comprehendmedical/include/aws/comprehendmedical/ComprehendMedicalClient.h
+++ b/generated/src/aws-cpp-sdk-comprehendmedical/include/aws/comprehendmedical/ComprehendMedicalClient.h
@@ -26,6 +26,9 @@ namespace ComprehendMedical
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ComprehendMedicalClientConfiguration ClientConfigurationType;
+      typedef ComprehendMedicalEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-compute-optimizer/include/aws/compute-optimizer/ComputeOptimizerClient.h
+++ b/generated/src/aws-cpp-sdk-compute-optimizer/include/aws/compute-optimizer/ComputeOptimizerClient.h
@@ -39,6 +39,9 @@ namespace ComputeOptimizer
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ComputeOptimizerClientConfiguration ClientConfigurationType;
+      typedef ComputeOptimizerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-config/include/aws/config/ConfigServiceClient.h
+++ b/generated/src/aws-cpp-sdk-config/include/aws/config/ConfigServiceClient.h
@@ -47,6 +47,9 @@ namespace ConfigService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ConfigServiceClientConfiguration ClientConfigurationType;
+      typedef ConfigServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-connect-contact-lens/include/aws/connect-contact-lens/ConnectContactLensClient.h
+++ b/generated/src/aws-cpp-sdk-connect-contact-lens/include/aws/connect-contact-lens/ConnectContactLensClient.h
@@ -33,6 +33,9 @@ namespace ConnectContactLens
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ConnectContactLensClientConfiguration ClientConfigurationType;
+      typedef ConnectContactLensEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-connect/include/aws/connect/ConnectClient.h
+++ b/generated/src/aws-cpp-sdk-connect/include/aws/connect/ConnectClient.h
@@ -38,6 +38,9 @@ namespace Connect
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ConnectClientConfiguration ClientConfigurationType;
+      typedef ConnectEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-connectcampaigns/include/aws/connectcampaigns/ConnectCampaignsClient.h
+++ b/generated/src/aws-cpp-sdk-connectcampaigns/include/aws/connectcampaigns/ConnectCampaignsClient.h
@@ -25,6 +25,9 @@ namespace ConnectCampaigns
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ConnectCampaignsClientConfiguration ClientConfigurationType;
+      typedef ConnectCampaignsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-connectcases/include/aws/connectcases/ConnectCasesClient.h
+++ b/generated/src/aws-cpp-sdk-connectcases/include/aws/connectcases/ConnectCasesClient.h
@@ -31,6 +31,9 @@ namespace ConnectCases
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ConnectCasesClientConfiguration ClientConfigurationType;
+      typedef ConnectCasesEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-connectparticipant/include/aws/connectparticipant/ConnectParticipantClient.h
+++ b/generated/src/aws-cpp-sdk-connectparticipant/include/aws/connectparticipant/ConnectParticipantClient.h
@@ -34,6 +34,9 @@ namespace ConnectParticipant
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ConnectParticipantClientConfiguration ClientConfigurationType;
+      typedef ConnectParticipantEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-controltower/include/aws/controltower/ControlTowerClient.h
+++ b/generated/src/aws-cpp-sdk-controltower/include/aws/controltower/ControlTowerClient.h
@@ -68,6 +68,9 @@ namespace ControlTower
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ControlTowerClientConfiguration ClientConfigurationType;
+      typedef ControlTowerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-cur/include/aws/cur/CostandUsageReportServiceClient.h
+++ b/generated/src/aws-cpp-sdk-cur/include/aws/cur/CostandUsageReportServiceClient.h
@@ -33,6 +33,9 @@ namespace CostandUsageReportService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CostandUsageReportServiceClientConfiguration ClientConfigurationType;
+      typedef CostandUsageReportServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-customer-profiles/include/aws/customer-profiles/CustomerProfilesClient.h
+++ b/generated/src/aws-cpp-sdk-customer-profiles/include/aws/customer-profiles/CustomerProfilesClient.h
@@ -33,6 +33,9 @@ namespace CustomerProfiles
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CustomerProfilesClientConfiguration ClientConfigurationType;
+      typedef CustomerProfilesEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-databrew/include/aws/databrew/GlueDataBrewClient.h
+++ b/generated/src/aws-cpp-sdk-databrew/include/aws/databrew/GlueDataBrewClient.h
@@ -29,6 +29,9 @@ namespace GlueDataBrew
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef GlueDataBrewClientConfiguration ClientConfigurationType;
+      typedef GlueDataBrewEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-dataexchange/include/aws/dataexchange/DataExchangeClient.h
+++ b/generated/src/aws-cpp-sdk-dataexchange/include/aws/dataexchange/DataExchangeClient.h
@@ -42,6 +42,9 @@ namespace DataExchange
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DataExchangeClientConfiguration ClientConfigurationType;
+      typedef DataExchangeEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-datapipeline/include/aws/datapipeline/DataPipelineClient.h
+++ b/generated/src/aws-cpp-sdk-datapipeline/include/aws/datapipeline/DataPipelineClient.h
@@ -42,6 +42,9 @@ namespace DataPipeline
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DataPipelineClientConfiguration ClientConfigurationType;
+      typedef DataPipelineEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-datasync/include/aws/datasync/DataSyncClient.h
+++ b/generated/src/aws-cpp-sdk-datasync/include/aws/datasync/DataSyncClient.h
@@ -32,6 +32,9 @@ namespace DataSync
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DataSyncClientConfiguration ClientConfigurationType;
+      typedef DataSyncEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-dax/include/aws/dax/DAXClient.h
+++ b/generated/src/aws-cpp-sdk-dax/include/aws/dax/DAXClient.h
@@ -30,6 +30,9 @@ namespace DAX
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DAXClientConfiguration ClientConfigurationType;
+      typedef DAXEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-detective/include/aws/detective/DetectiveClient.h
+++ b/generated/src/aws-cpp-sdk-detective/include/aws/detective/DetectiveClient.h
@@ -69,6 +69,9 @@ namespace Detective
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DetectiveClientConfiguration ClientConfigurationType;
+      typedef DetectiveEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-devicefarm/include/aws/devicefarm/DeviceFarmClient.h
+++ b/generated/src/aws-cpp-sdk-devicefarm/include/aws/devicefarm/DeviceFarmClient.h
@@ -36,6 +36,9 @@ namespace DeviceFarm
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DeviceFarmClientConfiguration ClientConfigurationType;
+      typedef DeviceFarmEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-devops-guru/include/aws/devops-guru/DevOpsGuruClient.h
+++ b/generated/src/aws-cpp-sdk-devops-guru/include/aws/devops-guru/DevOpsGuruClient.h
@@ -42,6 +42,9 @@ namespace DevOpsGuru
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DevOpsGuruClientConfiguration ClientConfigurationType;
+      typedef DevOpsGuruEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-directconnect/include/aws/directconnect/DirectConnectClient.h
+++ b/generated/src/aws-cpp-sdk-directconnect/include/aws/directconnect/DirectConnectClient.h
@@ -33,6 +33,9 @@ namespace DirectConnect
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DirectConnectClientConfiguration ClientConfigurationType;
+      typedef DirectConnectEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-discovery/include/aws/discovery/ApplicationDiscoveryServiceClient.h
+++ b/generated/src/aws-cpp-sdk-discovery/include/aws/discovery/ApplicationDiscoveryServiceClient.h
@@ -84,6 +84,9 @@ namespace ApplicationDiscoveryService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ApplicationDiscoveryServiceClientConfiguration ClientConfigurationType;
+      typedef ApplicationDiscoveryServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-dlm/include/aws/dlm/DLMClient.h
+++ b/generated/src/aws-cpp-sdk-dlm/include/aws/dlm/DLMClient.h
@@ -32,6 +32,9 @@ namespace DLM
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DLMClientConfiguration ClientConfigurationType;
+      typedef DLMEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-dms/include/aws/dms/DatabaseMigrationServiceClient.h
+++ b/generated/src/aws-cpp-sdk-dms/include/aws/dms/DatabaseMigrationServiceClient.h
@@ -35,6 +35,9 @@ namespace DatabaseMigrationService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DatabaseMigrationServiceClientConfiguration ClientConfigurationType;
+      typedef DatabaseMigrationServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-docdb-elastic/include/aws/docdb-elastic/DocDBElasticClient.h
+++ b/generated/src/aws-cpp-sdk-docdb-elastic/include/aws/docdb-elastic/DocDBElasticClient.h
@@ -25,6 +25,9 @@ namespace DocDBElastic
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DocDBElasticClientConfiguration ClientConfigurationType;
+      typedef DocDBElasticEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-docdb/include/aws/docdb/DocDBClient.h
+++ b/generated/src/aws-cpp-sdk-docdb/include/aws/docdb/DocDBClient.h
@@ -26,6 +26,9 @@ namespace DocDB
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DocDBClientConfiguration ClientConfigurationType;
+      typedef DocDBEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-drs/include/aws/drs/DrsClient.h
+++ b/generated/src/aws-cpp-sdk-drs/include/aws/drs/DrsClient.h
@@ -25,6 +25,9 @@ namespace drs
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DrsClientConfiguration ClientConfigurationType;
+      typedef DrsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ds/include/aws/ds/DirectoryServiceClient.h
+++ b/generated/src/aws-cpp-sdk-ds/include/aws/ds/DirectoryServiceClient.h
@@ -40,6 +40,9 @@ namespace DirectoryService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DirectoryServiceClientConfiguration ClientConfigurationType;
+      typedef DirectoryServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBClient.h
+++ b/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBClient.h
@@ -40,6 +40,9 @@ namespace DynamoDB
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DynamoDBClientConfiguration ClientConfigurationType;
+      typedef DynamoDBEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-dynamodbstreams/include/aws/dynamodbstreams/DynamoDBStreamsClient.h
+++ b/generated/src/aws-cpp-sdk-dynamodbstreams/include/aws/dynamodbstreams/DynamoDBStreamsClient.h
@@ -30,6 +30,9 @@ namespace DynamoDBStreams
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef DynamoDBStreamsClientConfiguration ClientConfigurationType;
+      typedef DynamoDBStreamsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ebs/include/aws/ebs/EBSClient.h
+++ b/generated/src/aws-cpp-sdk-ebs/include/aws/ebs/EBSClient.h
@@ -49,6 +49,9 @@ namespace EBS
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef EBSClientConfiguration ClientConfigurationType;
+      typedef EBSEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ec2-instance-connect/include/aws/ec2-instance-connect/EC2InstanceConnectClient.h
+++ b/generated/src/aws-cpp-sdk-ec2-instance-connect/include/aws/ec2-instance-connect/EC2InstanceConnectClient.h
@@ -27,6 +27,9 @@ namespace EC2InstanceConnect
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef EC2InstanceConnectClientConfiguration ClientConfigurationType;
+      typedef EC2InstanceConnectEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ec2/include/aws/ec2/EC2Client.h
+++ b/generated/src/aws-cpp-sdk-ec2/include/aws/ec2/EC2Client.h
@@ -46,6 +46,9 @@ namespace EC2
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef EC2ClientConfiguration ClientConfigurationType;
+      typedef EC2EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ecr-public/include/aws/ecr-public/ECRPublicClient.h
+++ b/generated/src/aws-cpp-sdk-ecr-public/include/aws/ecr-public/ECRPublicClient.h
@@ -34,6 +34,9 @@ namespace ECRPublic
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ECRPublicClientConfiguration ClientConfigurationType;
+      typedef ECRPublicEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ecr/include/aws/ecr/ECRClient.h
+++ b/generated/src/aws-cpp-sdk-ecr/include/aws/ecr/ECRClient.h
@@ -35,6 +35,9 @@ namespace ECR
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ECRClientConfiguration ClientConfigurationType;
+      typedef ECREndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ecs/include/aws/ecs/ECSClient.h
+++ b/generated/src/aws-cpp-sdk-ecs/include/aws/ecs/ECSClient.h
@@ -39,6 +39,9 @@ namespace ECS
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ECSClientConfiguration ClientConfigurationType;
+      typedef ECSEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-eks/include/aws/eks/EKSClient.h
+++ b/generated/src/aws-cpp-sdk-eks/include/aws/eks/EKSClient.h
@@ -35,6 +35,9 @@ namespace EKS
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef EKSClientConfiguration ClientConfigurationType;
+      typedef EKSEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-elastic-inference/include/aws/elastic-inference/ElasticInferenceClient.h
+++ b/generated/src/aws-cpp-sdk-elastic-inference/include/aws/elastic-inference/ElasticInferenceClient.h
@@ -32,6 +32,9 @@ namespace ElasticInference
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ElasticInferenceClientConfiguration ClientConfigurationType;
+      typedef ElasticInferenceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-elasticache/include/aws/elasticache/ElastiCacheClient.h
+++ b/generated/src/aws-cpp-sdk-elasticache/include/aws/elasticache/ElastiCacheClient.h
@@ -34,6 +34,9 @@ namespace ElastiCache
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ElastiCacheClientConfiguration ClientConfigurationType;
+      typedef ElastiCacheEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/include/aws/elasticbeanstalk/ElasticBeanstalkClient.h
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/include/aws/elasticbeanstalk/ElasticBeanstalkClient.h
@@ -39,6 +39,9 @@ namespace ElasticBeanstalk
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ElasticBeanstalkClientConfiguration ClientConfigurationType;
+      typedef ElasticBeanstalkEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-elasticfilesystem/include/aws/elasticfilesystem/EFSClient.h
+++ b/generated/src/aws-cpp-sdk-elasticfilesystem/include/aws/elasticfilesystem/EFSClient.h
@@ -34,6 +34,9 @@ namespace EFS
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef EFSClientConfiguration ClientConfigurationType;
+      typedef EFSEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/include/aws/elasticloadbalancing/ElasticLoadBalancingClient.h
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/include/aws/elasticloadbalancing/ElasticLoadBalancingClient.h
@@ -45,6 +45,9 @@ namespace ElasticLoadBalancing
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ElasticLoadBalancingClientConfiguration ClientConfigurationType;
+      typedef ElasticLoadBalancingEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/include/aws/elasticloadbalancingv2/ElasticLoadBalancingv2Client.h
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/include/aws/elasticloadbalancingv2/ElasticLoadBalancingv2Client.h
@@ -47,6 +47,9 @@ namespace ElasticLoadBalancingv2
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ElasticLoadBalancingv2ClientConfiguration ClientConfigurationType;
+      typedef ElasticLoadBalancingv2EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-elasticmapreduce/include/aws/elasticmapreduce/EMRClient.h
+++ b/generated/src/aws-cpp-sdk-elasticmapreduce/include/aws/elasticmapreduce/EMRClient.h
@@ -29,6 +29,9 @@ namespace EMR
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef EMRClientConfiguration ClientConfigurationType;
+      typedef EMREndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-elastictranscoder/include/aws/elastictranscoder/ElasticTranscoderClient.h
+++ b/generated/src/aws-cpp-sdk-elastictranscoder/include/aws/elastictranscoder/ElasticTranscoderClient.h
@@ -26,6 +26,9 @@ namespace ElasticTranscoder
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ElasticTranscoderClientConfiguration ClientConfigurationType;
+      typedef ElasticTranscoderEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-email/include/aws/email/SESClient.h
+++ b/generated/src/aws-cpp-sdk-email/include/aws/email/SESClient.h
@@ -36,6 +36,9 @@ namespace SES
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SESClientConfiguration ClientConfigurationType;
+      typedef SESEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-emr-containers/include/aws/emr-containers/EMRContainersClient.h
+++ b/generated/src/aws-cpp-sdk-emr-containers/include/aws/emr-containers/EMRContainersClient.h
@@ -45,6 +45,9 @@ namespace EMRContainers
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef EMRContainersClientConfiguration ClientConfigurationType;
+      typedef EMRContainersEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-emr-serverless/include/aws/emr-serverless/EMRServerlessClient.h
+++ b/generated/src/aws-cpp-sdk-emr-serverless/include/aws/emr-serverless/EMRServerlessClient.h
@@ -40,6 +40,9 @@ namespace EMRServerless
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef EMRServerlessClientConfiguration ClientConfigurationType;
+      typedef EMRServerlessEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-es/include/aws/es/ElasticsearchServiceClient.h
+++ b/generated/src/aws-cpp-sdk-es/include/aws/es/ElasticsearchServiceClient.h
@@ -37,6 +37,9 @@ namespace ElasticsearchService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ElasticsearchServiceClientConfiguration ClientConfigurationType;
+      typedef ElasticsearchServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-eventbridge/include/aws/eventbridge/EventBridgeClient.h
+++ b/generated/src/aws-cpp-sdk-eventbridge/include/aws/eventbridge/EventBridgeClient.h
@@ -38,6 +38,9 @@ namespace EventBridge
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef EventBridgeClientConfiguration ClientConfigurationType;
+      typedef EventBridgeEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-events/include/aws/events/CloudWatchEventsClient.h
+++ b/generated/src/aws-cpp-sdk-events/include/aws/events/CloudWatchEventsClient.h
@@ -38,6 +38,9 @@ namespace CloudWatchEvents
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudWatchEventsClientConfiguration ClientConfigurationType;
+      typedef CloudWatchEventsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-evidently/include/aws/evidently/CloudWatchEvidentlyClient.h
+++ b/generated/src/aws-cpp-sdk-evidently/include/aws/evidently/CloudWatchEvidentlyClient.h
@@ -34,6 +34,9 @@ namespace CloudWatchEvidently
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudWatchEvidentlyClientConfiguration ClientConfigurationType;
+      typedef CloudWatchEvidentlyEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-finspace-data/include/aws/finspace-data/FinSpaceDataClient.h
+++ b/generated/src/aws-cpp-sdk-finspace-data/include/aws/finspace-data/FinSpaceDataClient.h
@@ -25,6 +25,9 @@ namespace FinSpaceData
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef FinSpaceDataClientConfiguration ClientConfigurationType;
+      typedef FinSpaceDataEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-finspace/include/aws/finspace/FinspaceClient.h
+++ b/generated/src/aws-cpp-sdk-finspace/include/aws/finspace/FinspaceClient.h
@@ -26,6 +26,9 @@ namespace finspace
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef FinspaceClientConfiguration ClientConfigurationType;
+      typedef FinspaceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-firehose/include/aws/firehose/FirehoseClient.h
+++ b/generated/src/aws-cpp-sdk-firehose/include/aws/firehose/FirehoseClient.h
@@ -29,6 +29,9 @@ namespace Firehose
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef FirehoseClientConfiguration ClientConfigurationType;
+      typedef FirehoseEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-fis/include/aws/fis/FISClient.h
+++ b/generated/src/aws-cpp-sdk-fis/include/aws/fis/FISClient.h
@@ -29,6 +29,9 @@ namespace FIS
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef FISClientConfiguration ClientConfigurationType;
+      typedef FISEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-fms/include/aws/fms/FMSClient.h
+++ b/generated/src/aws-cpp-sdk-fms/include/aws/fms/FMSClient.h
@@ -33,6 +33,9 @@ namespace FMS
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef FMSClientConfiguration ClientConfigurationType;
+      typedef FMSEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-forecast/include/aws/forecast/ForecastServiceClient.h
+++ b/generated/src/aws-cpp-sdk-forecast/include/aws/forecast/ForecastServiceClient.h
@@ -25,6 +25,9 @@ namespace ForecastService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ForecastServiceClientConfiguration ClientConfigurationType;
+      typedef ForecastServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-forecastquery/include/aws/forecastquery/ForecastQueryServiceClient.h
+++ b/generated/src/aws-cpp-sdk-forecastquery/include/aws/forecastquery/ForecastQueryServiceClient.h
@@ -25,6 +25,9 @@ namespace ForecastQueryService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ForecastQueryServiceClientConfiguration ClientConfigurationType;
+      typedef ForecastQueryServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-frauddetector/include/aws/frauddetector/FraudDetectorClient.h
+++ b/generated/src/aws-cpp-sdk-frauddetector/include/aws/frauddetector/FraudDetectorClient.h
@@ -41,6 +41,9 @@ namespace FraudDetector
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef FraudDetectorClientConfiguration ClientConfigurationType;
+      typedef FraudDetectorEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-fsx/include/aws/fsx/FSxClient.h
+++ b/generated/src/aws-cpp-sdk-fsx/include/aws/fsx/FSxClient.h
@@ -26,6 +26,9 @@ namespace FSx
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef FSxClientConfiguration ClientConfigurationType;
+      typedef FSxEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-gamelift/include/aws/gamelift/GameLiftClient.h
+++ b/generated/src/aws-cpp-sdk-gamelift/include/aws/gamelift/GameLiftClient.h
@@ -60,6 +60,9 @@ namespace GameLift
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef GameLiftClientConfiguration ClientConfigurationType;
+      typedef GameLiftEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-gamesparks/include/aws/gamesparks/GameSparksClient.h
+++ b/generated/src/aws-cpp-sdk-gamesparks/include/aws/gamesparks/GameSparksClient.h
@@ -25,6 +25,9 @@ namespace GameSparks
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef GameSparksClientConfiguration ClientConfigurationType;
+      typedef GameSparksEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-glacier/include/aws/glacier/GlacierClient.h
+++ b/generated/src/aws-cpp-sdk-glacier/include/aws/glacier/GlacierClient.h
@@ -50,6 +50,9 @@ namespace Glacier
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef GlacierClientConfiguration ClientConfigurationType;
+      typedef GlacierEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-globalaccelerator/include/aws/globalaccelerator/GlobalAcceleratorClient.h
+++ b/generated/src/aws-cpp-sdk-globalaccelerator/include/aws/globalaccelerator/GlobalAcceleratorClient.h
@@ -76,6 +76,9 @@ namespace GlobalAccelerator
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef GlobalAcceleratorClientConfiguration ClientConfigurationType;
+      typedef GlobalAcceleratorEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-glue/include/aws/glue/GlueClient.h
+++ b/generated/src/aws-cpp-sdk-glue/include/aws/glue/GlueClient.h
@@ -26,6 +26,9 @@ namespace Glue
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef GlueClientConfiguration ClientConfigurationType;
+      typedef GlueEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-grafana/include/aws/grafana/ManagedGrafanaClient.h
+++ b/generated/src/aws-cpp-sdk-grafana/include/aws/grafana/ManagedGrafanaClient.h
@@ -33,6 +33,9 @@ namespace ManagedGrafana
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ManagedGrafanaClientConfiguration ClientConfigurationType;
+      typedef ManagedGrafanaEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-greengrass/include/aws/greengrass/GreengrassClient.h
+++ b/generated/src/aws-cpp-sdk-greengrass/include/aws/greengrass/GreengrassClient.h
@@ -30,6 +30,9 @@ namespace Greengrass
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef GreengrassClientConfiguration ClientConfigurationType;
+      typedef GreengrassEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-greengrassv2/include/aws/greengrassv2/GreengrassV2Client.h
+++ b/generated/src/aws-cpp-sdk-greengrassv2/include/aws/greengrassv2/GreengrassV2Client.h
@@ -38,6 +38,9 @@ namespace GreengrassV2
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef GreengrassV2ClientConfiguration ClientConfigurationType;
+      typedef GreengrassV2EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-groundstation/include/aws/groundstation/GroundStationClient.h
+++ b/generated/src/aws-cpp-sdk-groundstation/include/aws/groundstation/GroundStationClient.h
@@ -29,6 +29,9 @@ namespace GroundStation
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef GroundStationClientConfiguration ClientConfigurationType;
+      typedef GroundStationEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-guardduty/include/aws/guardduty/GuardDutyClient.h
+++ b/generated/src/aws-cpp-sdk-guardduty/include/aws/guardduty/GuardDutyClient.h
@@ -44,6 +44,9 @@ namespace GuardDuty
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef GuardDutyClientConfiguration ClientConfigurationType;
+      typedef GuardDutyEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-health/include/aws/health/HealthClient.h
+++ b/generated/src/aws-cpp-sdk-health/include/aws/health/HealthClient.h
@@ -63,6 +63,9 @@ namespace Health
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef HealthClientConfiguration ClientConfigurationType;
+      typedef HealthEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-healthlake/include/aws/healthlake/HealthLakeClient.h
+++ b/generated/src/aws-cpp-sdk-healthlake/include/aws/healthlake/HealthLakeClient.h
@@ -27,6 +27,9 @@ namespace HealthLake
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef HealthLakeClientConfiguration ClientConfigurationType;
+      typedef HealthLakeEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-honeycode/include/aws/honeycode/HoneycodeClient.h
+++ b/generated/src/aws-cpp-sdk-honeycode/include/aws/honeycode/HoneycodeClient.h
@@ -28,6 +28,9 @@ namespace Honeycode
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef HoneycodeClientConfiguration ClientConfigurationType;
+      typedef HoneycodeEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iam/include/aws/iam/IAMClient.h
+++ b/generated/src/aws-cpp-sdk-iam/include/aws/iam/IAMClient.h
@@ -34,6 +34,9 @@ namespace IAM
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IAMClientConfiguration ClientConfigurationType;
+      typedef IAMEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-identitystore/include/aws/identitystore/IdentityStoreClient.h
+++ b/generated/src/aws-cpp-sdk-identitystore/include/aws/identitystore/IdentityStoreClient.h
@@ -38,6 +38,9 @@ namespace IdentityStore
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IdentityStoreClientConfiguration ClientConfigurationType;
+      typedef IdentityStoreEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-imagebuilder/include/aws/imagebuilder/ImagebuilderClient.h
+++ b/generated/src/aws-cpp-sdk-imagebuilder/include/aws/imagebuilder/ImagebuilderClient.h
@@ -28,6 +28,9 @@ namespace imagebuilder
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ImagebuilderClientConfiguration ClientConfigurationType;
+      typedef ImagebuilderEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-importexport/include/aws/importexport/ImportExportClient.h
+++ b/generated/src/aws-cpp-sdk-importexport/include/aws/importexport/ImportExportClient.h
@@ -31,6 +31,9 @@ namespace ImportExport
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ImportExportClientConfiguration ClientConfigurationType;
+      typedef ImportExportEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-inspector/include/aws/inspector/InspectorClient.h
+++ b/generated/src/aws-cpp-sdk-inspector/include/aws/inspector/InspectorClient.h
@@ -29,6 +29,9 @@ namespace Inspector
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef InspectorClientConfiguration ClientConfigurationType;
+      typedef InspectorEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-inspector2/include/aws/inspector2/Inspector2Client.h
+++ b/generated/src/aws-cpp-sdk-inspector2/include/aws/inspector2/Inspector2Client.h
@@ -27,6 +27,9 @@ namespace Inspector2
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef Inspector2ClientConfiguration ClientConfigurationType;
+      typedef Inspector2EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-internetmonitor/include/aws/internetmonitor/InternetMonitorClient.h
+++ b/generated/src/aws-cpp-sdk-internetmonitor/include/aws/internetmonitor/InternetMonitorClient.h
@@ -50,6 +50,9 @@ namespace InternetMonitor
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef InternetMonitorClientConfiguration ClientConfigurationType;
+      typedef InternetMonitorEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iot-data/include/aws/iot-data/IoTDataPlaneClient.h
+++ b/generated/src/aws-cpp-sdk-iot-data/include/aws/iot-data/IoTDataPlaneClient.h
@@ -36,6 +36,9 @@ namespace IoTDataPlane
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTDataPlaneClientConfiguration ClientConfigurationType;
+      typedef IoTDataPlaneEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iot-jobs-data/include/aws/iot-jobs-data/IoTJobsDataPlaneClient.h
+++ b/generated/src/aws-cpp-sdk-iot-jobs-data/include/aws/iot-jobs-data/IoTJobsDataPlaneClient.h
@@ -37,6 +37,9 @@ namespace IoTJobsDataPlane
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTJobsDataPlaneClientConfiguration ClientConfigurationType;
+      typedef IoTJobsDataPlaneEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iot-roborunner/include/aws/iot-roborunner/IoTRoboRunnerClient.h
+++ b/generated/src/aws-cpp-sdk-iot-roborunner/include/aws/iot-roborunner/IoTRoboRunnerClient.h
@@ -26,6 +26,9 @@ namespace IoTRoboRunner
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTRoboRunnerClientConfiguration ClientConfigurationType;
+      typedef IoTRoboRunnerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iot/include/aws/iot/IoTClient.h
+++ b/generated/src/aws-cpp-sdk-iot/include/aws/iot/IoTClient.h
@@ -44,6 +44,9 @@ namespace IoT
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTClientConfiguration ClientConfigurationType;
+      typedef IoTEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iot1click-devices/include/aws/iot1click-devices/IoT1ClickDevicesServiceClient.h
+++ b/generated/src/aws-cpp-sdk-iot1click-devices/include/aws/iot1click-devices/IoT1ClickDevicesServiceClient.h
@@ -29,6 +29,9 @@ namespace IoT1ClickDevicesService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoT1ClickDevicesServiceClientConfiguration ClientConfigurationType;
+      typedef IoT1ClickDevicesServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iot1click-projects/include/aws/iot1click-projects/IoT1ClickProjectsClient.h
+++ b/generated/src/aws-cpp-sdk-iot1click-projects/include/aws/iot1click-projects/IoT1ClickProjectsClient.h
@@ -25,6 +25,9 @@ namespace IoT1ClickProjects
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoT1ClickProjectsClientConfiguration ClientConfigurationType;
+      typedef IoT1ClickProjectsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iotanalytics/include/aws/iotanalytics/IoTAnalyticsClient.h
+++ b/generated/src/aws-cpp-sdk-iotanalytics/include/aws/iotanalytics/IoTAnalyticsClient.h
@@ -45,6 +45,9 @@ namespace IoTAnalytics
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTAnalyticsClientConfiguration ClientConfigurationType;
+      typedef IoTAnalyticsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iotdeviceadvisor/include/aws/iotdeviceadvisor/IoTDeviceAdvisorClient.h
+++ b/generated/src/aws-cpp-sdk-iotdeviceadvisor/include/aws/iotdeviceadvisor/IoTDeviceAdvisorClient.h
@@ -35,6 +35,9 @@ namespace IoTDeviceAdvisor
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTDeviceAdvisorClientConfiguration ClientConfigurationType;
+      typedef IoTDeviceAdvisorEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iotevents-data/include/aws/iotevents-data/IoTEventsDataClient.h
+++ b/generated/src/aws-cpp-sdk-iotevents-data/include/aws/iotevents-data/IoTEventsDataClient.h
@@ -30,6 +30,9 @@ namespace IoTEventsData
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTEventsDataClientConfiguration ClientConfigurationType;
+      typedef IoTEventsDataEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iotevents/include/aws/iotevents/IoTEventsClient.h
+++ b/generated/src/aws-cpp-sdk-iotevents/include/aws/iotevents/IoTEventsClient.h
@@ -28,6 +28,9 @@ namespace IoTEvents
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTEventsClientConfiguration ClientConfigurationType;
+      typedef IoTEventsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iotfleethub/include/aws/iotfleethub/IoTFleetHubClient.h
+++ b/generated/src/aws-cpp-sdk-iotfleethub/include/aws/iotfleethub/IoTFleetHubClient.h
@@ -28,6 +28,9 @@ namespace IoTFleetHub
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTFleetHubClientConfiguration ClientConfigurationType;
+      typedef IoTFleetHubEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iotfleetwise/include/aws/iotfleetwise/IoTFleetWiseClient.h
+++ b/generated/src/aws-cpp-sdk-iotfleetwise/include/aws/iotfleetwise/IoTFleetWiseClient.h
@@ -33,6 +33,9 @@ namespace IoTFleetWise
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTFleetWiseClientConfiguration ClientConfigurationType;
+      typedef IoTFleetWiseEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iotsecuretunneling/include/aws/iotsecuretunneling/IoTSecureTunnelingClient.h
+++ b/generated/src/aws-cpp-sdk-iotsecuretunneling/include/aws/iotsecuretunneling/IoTSecureTunnelingClient.h
@@ -29,6 +29,9 @@ namespace IoTSecureTunneling
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTSecureTunnelingClientConfiguration ClientConfigurationType;
+      typedef IoTSecureTunnelingEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iotsitewise/include/aws/iotsitewise/IoTSiteWiseClient.h
+++ b/generated/src/aws-cpp-sdk-iotsitewise/include/aws/iotsitewise/IoTSiteWiseClient.h
@@ -33,6 +33,9 @@ namespace IoTSiteWise
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTSiteWiseClientConfiguration ClientConfigurationType;
+      typedef IoTSiteWiseEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iotthingsgraph/include/aws/iotthingsgraph/IoTThingsGraphClient.h
+++ b/generated/src/aws-cpp-sdk-iotthingsgraph/include/aws/iotthingsgraph/IoTThingsGraphClient.h
@@ -33,6 +33,9 @@ namespace IoTThingsGraph
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTThingsGraphClientConfiguration ClientConfigurationType;
+      typedef IoTThingsGraphEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iottwinmaker/include/aws/iottwinmaker/IoTTwinMakerClient.h
+++ b/generated/src/aws-cpp-sdk-iottwinmaker/include/aws/iottwinmaker/IoTTwinMakerClient.h
@@ -30,6 +30,9 @@ namespace IoTTwinMaker
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTTwinMakerClientConfiguration ClientConfigurationType;
+      typedef IoTTwinMakerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-iotwireless/include/aws/iotwireless/IoTWirelessClient.h
+++ b/generated/src/aws-cpp-sdk-iotwireless/include/aws/iotwireless/IoTWirelessClient.h
@@ -37,6 +37,9 @@ namespace IoTWireless
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IoTWirelessClientConfiguration ClientConfigurationType;
+      typedef IoTWirelessEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ivs-realtime/include/aws/ivs-realtime/IvsrealtimeClient.h
+++ b/generated/src/aws-cpp-sdk-ivs-realtime/include/aws/ivs-realtime/IvsrealtimeClient.h
@@ -65,6 +65,9 @@ namespace ivsrealtime
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IvsrealtimeClientConfiguration ClientConfigurationType;
+      typedef IvsrealtimeEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ivs/include/aws/ivs/IVSClient.h
+++ b/generated/src/aws-cpp-sdk-ivs/include/aws/ivs/IVSClient.h
@@ -169,6 +169,9 @@ namespace IVS
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IVSClientConfiguration ClientConfigurationType;
+      typedef IVSEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ivschat/include/aws/ivschat/IvschatClient.h
+++ b/generated/src/aws-cpp-sdk-ivschat/include/aws/ivschat/IvschatClient.h
@@ -134,6 +134,9 @@ namespace ivschat
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef IvschatClientConfiguration ClientConfigurationType;
+      typedef IvschatEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-kafka/include/aws/kafka/KafkaClient.h
+++ b/generated/src/aws-cpp-sdk-kafka/include/aws/kafka/KafkaClient.h
@@ -28,6 +28,9 @@ namespace Kafka
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef KafkaClientConfiguration ClientConfigurationType;
+      typedef KafkaEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-kafkaconnect/include/aws/kafkaconnect/KafkaConnectClient.h
+++ b/generated/src/aws-cpp-sdk-kafkaconnect/include/aws/kafkaconnect/KafkaConnectClient.h
@@ -25,6 +25,9 @@ namespace KafkaConnect
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef KafkaConnectClientConfiguration ClientConfigurationType;
+      typedef KafkaConnectEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-kendra-ranking/include/aws/kendra-ranking/KendraRankingClient.h
+++ b/generated/src/aws-cpp-sdk-kendra-ranking/include/aws/kendra-ranking/KendraRankingClient.h
@@ -26,6 +26,9 @@ namespace KendraRanking
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef KendraRankingClientConfiguration ClientConfigurationType;
+      typedef KendraRankingEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-kendra/include/aws/kendra/KendraClient.h
+++ b/generated/src/aws-cpp-sdk-kendra/include/aws/kendra/KendraClient.h
@@ -25,6 +25,9 @@ namespace kendra
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef KendraClientConfiguration ClientConfigurationType;
+      typedef KendraEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-keyspaces/include/aws/keyspaces/KeyspacesClient.h
+++ b/generated/src/aws-cpp-sdk-keyspaces/include/aws/keyspaces/KeyspacesClient.h
@@ -47,6 +47,9 @@ namespace Keyspaces
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef KeyspacesClientConfiguration ClientConfigurationType;
+      typedef KeyspacesEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-kinesis-video-archived-media/include/aws/kinesis-video-archived-media/KinesisVideoArchivedMediaClient.h
+++ b/generated/src/aws-cpp-sdk-kinesis-video-archived-media/include/aws/kinesis-video-archived-media/KinesisVideoArchivedMediaClient.h
@@ -25,6 +25,9 @@ namespace KinesisVideoArchivedMedia
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef KinesisVideoArchivedMediaClientConfiguration ClientConfigurationType;
+      typedef KinesisVideoArchivedMediaEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-kinesis-video-media/include/aws/kinesis-video-media/KinesisVideoMediaClient.h
+++ b/generated/src/aws-cpp-sdk-kinesis-video-media/include/aws/kinesis-video-media/KinesisVideoMediaClient.h
@@ -25,6 +25,9 @@ namespace KinesisVideoMedia
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef KinesisVideoMediaClientConfiguration ClientConfigurationType;
+      typedef KinesisVideoMediaEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-kinesis-video-signaling/include/aws/kinesis-video-signaling/KinesisVideoSignalingChannelsClient.h
+++ b/generated/src/aws-cpp-sdk-kinesis-video-signaling/include/aws/kinesis-video-signaling/KinesisVideoSignalingChannelsClient.h
@@ -28,6 +28,9 @@ namespace KinesisVideoSignalingChannels
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef KinesisVideoSignalingChannelsClientConfiguration ClientConfigurationType;
+      typedef KinesisVideoSignalingChannelsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-kinesis-video-webrtc-storage/include/aws/kinesis-video-webrtc-storage/KinesisVideoWebRTCStorageClient.h
+++ b/generated/src/aws-cpp-sdk-kinesis-video-webrtc-storage/include/aws/kinesis-video-webrtc-storage/KinesisVideoWebRTCStorageClient.h
@@ -25,6 +25,9 @@ namespace KinesisVideoWebRTCStorage
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef KinesisVideoWebRTCStorageClientConfiguration ClientConfigurationType;
+      typedef KinesisVideoWebRTCStorageEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-kinesis/include/aws/kinesis/KinesisClient.h
+++ b/generated/src/aws-cpp-sdk-kinesis/include/aws/kinesis/KinesisClient.h
@@ -27,6 +27,9 @@ namespace Kinesis
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef KinesisClientConfiguration ClientConfigurationType;
+      typedef KinesisEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-kinesisanalytics/include/aws/kinesisanalytics/KinesisAnalyticsClient.h
+++ b/generated/src/aws-cpp-sdk-kinesisanalytics/include/aws/kinesisanalytics/KinesisAnalyticsClient.h
@@ -32,6 +32,9 @@ namespace KinesisAnalytics
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef KinesisAnalyticsClientConfiguration ClientConfigurationType;
+      typedef KinesisAnalyticsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-kinesisanalyticsv2/include/aws/kinesisanalyticsv2/KinesisAnalyticsV2Client.h
+++ b/generated/src/aws-cpp-sdk-kinesisanalyticsv2/include/aws/kinesisanalyticsv2/KinesisAnalyticsV2Client.h
@@ -29,6 +29,9 @@ namespace KinesisAnalyticsV2
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef KinesisAnalyticsV2ClientConfiguration ClientConfigurationType;
+      typedef KinesisAnalyticsV2EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-kinesisvideo/include/aws/kinesisvideo/KinesisVideoClient.h
+++ b/generated/src/aws-cpp-sdk-kinesisvideo/include/aws/kinesisvideo/KinesisVideoClient.h
@@ -25,6 +25,9 @@ namespace KinesisVideo
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef KinesisVideoClientConfiguration ClientConfigurationType;
+      typedef KinesisVideoEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-kms/include/aws/kms/KMSClient.h
+++ b/generated/src/aws-cpp-sdk-kms/include/aws/kms/KMSClient.h
@@ -86,6 +86,9 @@ namespace KMS
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef KMSClientConfiguration ClientConfigurationType;
+      typedef KMSEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-lakeformation/include/aws/lakeformation/LakeFormationClient.h
+++ b/generated/src/aws-cpp-sdk-lakeformation/include/aws/lakeformation/LakeFormationClient.h
@@ -26,6 +26,9 @@ namespace LakeFormation
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef LakeFormationClientConfiguration ClientConfigurationType;
+      typedef LakeFormationEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-lambda/include/aws/lambda/LambdaClient.h
+++ b/generated/src/aws-cpp-sdk-lambda/include/aws/lambda/LambdaClient.h
@@ -76,6 +76,9 @@ namespace Lambda
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef LambdaClientConfiguration ClientConfigurationType;
+      typedef LambdaEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-lex-models/include/aws/lex-models/LexModelBuildingServiceClient.h
+++ b/generated/src/aws-cpp-sdk-lex-models/include/aws/lex-models/LexModelBuildingServiceClient.h
@@ -28,6 +28,9 @@ namespace LexModelBuildingService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef LexModelBuildingServiceClientConfiguration ClientConfigurationType;
+      typedef LexModelBuildingServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-lex/include/aws/lex/LexRuntimeServiceClient.h
+++ b/generated/src/aws-cpp-sdk-lex/include/aws/lex/LexRuntimeServiceClient.h
@@ -35,6 +35,9 @@ namespace LexRuntimeService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef LexRuntimeServiceClientConfiguration ClientConfigurationType;
+      typedef LexRuntimeServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-lexv2-models/include/aws/lexv2-models/LexModelsV2Client.h
+++ b/generated/src/aws-cpp-sdk-lexv2-models/include/aws/lexv2-models/LexModelsV2Client.h
@@ -25,6 +25,9 @@ namespace LexModelsV2
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef LexModelsV2ClientConfiguration ClientConfigurationType;
+      typedef LexModelsV2EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/LexRuntimeV2Client.h
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/LexRuntimeV2Client.h
@@ -26,6 +26,9 @@ namespace LexRuntimeV2
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef LexRuntimeV2ClientConfiguration ClientConfigurationType;
+      typedef LexRuntimeV2EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-license-manager-linux-subscriptions/include/aws/license-manager-linux-subscriptions/LicenseManagerLinuxSubscriptionsClient.h
+++ b/generated/src/aws-cpp-sdk-license-manager-linux-subscriptions/include/aws/license-manager-linux-subscriptions/LicenseManagerLinuxSubscriptionsClient.h
@@ -26,6 +26,9 @@ namespace LicenseManagerLinuxSubscriptions
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef LicenseManagerLinuxSubscriptionsClientConfiguration ClientConfigurationType;
+      typedef LicenseManagerLinuxSubscriptionsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-license-manager-user-subscriptions/include/aws/license-manager-user-subscriptions/LicenseManagerUserSubscriptionsClient.h
+++ b/generated/src/aws-cpp-sdk-license-manager-user-subscriptions/include/aws/license-manager-user-subscriptions/LicenseManagerUserSubscriptionsClient.h
@@ -26,6 +26,9 @@ namespace LicenseManagerUserSubscriptions
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef LicenseManagerUserSubscriptionsClientConfiguration ClientConfigurationType;
+      typedef LicenseManagerUserSubscriptionsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-license-manager/include/aws/license-manager/LicenseManagerClient.h
+++ b/generated/src/aws-cpp-sdk-license-manager/include/aws/license-manager/LicenseManagerClient.h
@@ -26,6 +26,9 @@ namespace LicenseManager
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef LicenseManagerClientConfiguration ClientConfigurationType;
+      typedef LicenseManagerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-lightsail/include/aws/lightsail/LightsailClient.h
+++ b/generated/src/aws-cpp-sdk-lightsail/include/aws/lightsail/LightsailClient.h
@@ -42,6 +42,9 @@ namespace Lightsail
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef LightsailClientConfiguration ClientConfigurationType;
+      typedef LightsailEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-location/include/aws/location/LocationServiceClient.h
+++ b/generated/src/aws-cpp-sdk-location/include/aws/location/LocationServiceClient.h
@@ -26,6 +26,9 @@ namespace LocationService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef LocationServiceClientConfiguration ClientConfigurationType;
+      typedef LocationServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-logs/include/aws/logs/CloudWatchLogsClient.h
+++ b/generated/src/aws-cpp-sdk-logs/include/aws/logs/CloudWatchLogsClient.h
@@ -49,6 +49,9 @@ namespace CloudWatchLogs
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudWatchLogsClientConfiguration ClientConfigurationType;
+      typedef CloudWatchLogsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-lookoutequipment/include/aws/lookoutequipment/LookoutEquipmentClient.h
+++ b/generated/src/aws-cpp-sdk-lookoutequipment/include/aws/lookoutequipment/LookoutEquipmentClient.h
@@ -27,6 +27,9 @@ namespace LookoutEquipment
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef LookoutEquipmentClientConfiguration ClientConfigurationType;
+      typedef LookoutEquipmentEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-lookoutmetrics/include/aws/lookoutmetrics/LookoutMetricsClient.h
+++ b/generated/src/aws-cpp-sdk-lookoutmetrics/include/aws/lookoutmetrics/LookoutMetricsClient.h
@@ -28,6 +28,9 @@ namespace LookoutMetrics
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef LookoutMetricsClientConfiguration ClientConfigurationType;
+      typedef LookoutMetricsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-lookoutvision/include/aws/lookoutvision/LookoutforVisionClient.h
+++ b/generated/src/aws-cpp-sdk-lookoutvision/include/aws/lookoutvision/LookoutforVisionClient.h
@@ -32,6 +32,9 @@ namespace LookoutforVision
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef LookoutforVisionClientConfiguration ClientConfigurationType;
+      typedef LookoutforVisionEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-m2/include/aws/m2/MainframeModernizationClient.h
+++ b/generated/src/aws-cpp-sdk-m2/include/aws/m2/MainframeModernizationClient.h
@@ -30,6 +30,9 @@ namespace MainframeModernization
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MainframeModernizationClientConfiguration ClientConfigurationType;
+      typedef MainframeModernizationEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-machinelearning/include/aws/machinelearning/MachineLearningClient.h
+++ b/generated/src/aws-cpp-sdk-machinelearning/include/aws/machinelearning/MachineLearningClient.h
@@ -25,6 +25,9 @@ namespace MachineLearning
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MachineLearningClientConfiguration ClientConfigurationType;
+      typedef MachineLearningEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-macie/include/aws/macie/MacieClient.h
+++ b/generated/src/aws-cpp-sdk-macie/include/aws/macie/MacieClient.h
@@ -34,6 +34,9 @@ namespace Macie
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MacieClientConfiguration ClientConfigurationType;
+      typedef MacieEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-macie2/include/aws/macie2/Macie2Client.h
+++ b/generated/src/aws-cpp-sdk-macie2/include/aws/macie2/Macie2Client.h
@@ -25,6 +25,9 @@ namespace Macie2
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef Macie2ClientConfiguration ClientConfigurationType;
+      typedef Macie2EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-managedblockchain/include/aws/managedblockchain/ManagedBlockchainClient.h
+++ b/generated/src/aws-cpp-sdk-managedblockchain/include/aws/managedblockchain/ManagedBlockchainClient.h
@@ -36,6 +36,9 @@ namespace ManagedBlockchain
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ManagedBlockchainClientConfiguration ClientConfigurationType;
+      typedef ManagedBlockchainEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-marketplace-catalog/include/aws/marketplace-catalog/MarketplaceCatalogClient.h
+++ b/generated/src/aws-cpp-sdk-marketplace-catalog/include/aws/marketplace-catalog/MarketplaceCatalogClient.h
@@ -30,6 +30,9 @@ namespace MarketplaceCatalog
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MarketplaceCatalogClientConfiguration ClientConfigurationType;
+      typedef MarketplaceCatalogEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-marketplace-entitlement/include/aws/marketplace-entitlement/MarketplaceEntitlementServiceClient.h
+++ b/generated/src/aws-cpp-sdk-marketplace-entitlement/include/aws/marketplace-entitlement/MarketplaceEntitlementServiceClient.h
@@ -33,6 +33,9 @@ namespace MarketplaceEntitlementService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MarketplaceEntitlementServiceClientConfiguration ClientConfigurationType;
+      typedef MarketplaceEntitlementServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-marketplacecommerceanalytics/include/aws/marketplacecommerceanalytics/MarketplaceCommerceAnalyticsClient.h
+++ b/generated/src/aws-cpp-sdk-marketplacecommerceanalytics/include/aws/marketplacecommerceanalytics/MarketplaceCommerceAnalyticsClient.h
@@ -25,6 +25,9 @@ namespace MarketplaceCommerceAnalytics
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MarketplaceCommerceAnalyticsClientConfiguration ClientConfigurationType;
+      typedef MarketplaceCommerceAnalyticsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-mediaconnect/include/aws/mediaconnect/MediaConnectClient.h
+++ b/generated/src/aws-cpp-sdk-mediaconnect/include/aws/mediaconnect/MediaConnectClient.h
@@ -25,6 +25,9 @@ namespace MediaConnect
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MediaConnectClientConfiguration ClientConfigurationType;
+      typedef MediaConnectEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-mediaconvert/include/aws/mediaconvert/MediaConvertClient.h
+++ b/generated/src/aws-cpp-sdk-mediaconvert/include/aws/mediaconvert/MediaConvertClient.h
@@ -25,6 +25,9 @@ namespace MediaConvert
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MediaConvertClientConfiguration ClientConfigurationType;
+      typedef MediaConvertEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-medialive/include/aws/medialive/MediaLiveClient.h
+++ b/generated/src/aws-cpp-sdk-medialive/include/aws/medialive/MediaLiveClient.h
@@ -25,6 +25,9 @@ namespace MediaLive
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MediaLiveClientConfiguration ClientConfigurationType;
+      typedef MediaLiveEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-mediapackage-vod/include/aws/mediapackage-vod/MediaPackageVodClient.h
+++ b/generated/src/aws-cpp-sdk-mediapackage-vod/include/aws/mediapackage-vod/MediaPackageVodClient.h
@@ -25,6 +25,9 @@ namespace MediaPackageVod
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MediaPackageVodClientConfiguration ClientConfigurationType;
+      typedef MediaPackageVodEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-mediapackage/include/aws/mediapackage/MediaPackageClient.h
+++ b/generated/src/aws-cpp-sdk-mediapackage/include/aws/mediapackage/MediaPackageClient.h
@@ -25,6 +25,9 @@ namespace MediaPackage
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MediaPackageClientConfiguration ClientConfigurationType;
+      typedef MediaPackageEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-mediastore-data/include/aws/mediastore-data/MediaStoreDataClient.h
+++ b/generated/src/aws-cpp-sdk-mediastore-data/include/aws/mediastore-data/MediaStoreDataClient.h
@@ -27,6 +27,9 @@ namespace MediaStoreData
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MediaStoreDataClientConfiguration ClientConfigurationType;
+      typedef MediaStoreDataEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-mediastore/include/aws/mediastore/MediaStoreClient.h
+++ b/generated/src/aws-cpp-sdk-mediastore/include/aws/mediastore/MediaStoreClient.h
@@ -26,6 +26,9 @@ namespace MediaStore
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MediaStoreClientConfiguration ClientConfigurationType;
+      typedef MediaStoreEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-mediatailor/include/aws/mediatailor/MediaTailorClient.h
+++ b/generated/src/aws-cpp-sdk-mediatailor/include/aws/mediatailor/MediaTailorClient.h
@@ -35,6 +35,9 @@ namespace MediaTailor
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MediaTailorClientConfiguration ClientConfigurationType;
+      typedef MediaTailorEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-memorydb/include/aws/memorydb/MemoryDBClient.h
+++ b/generated/src/aws-cpp-sdk-memorydb/include/aws/memorydb/MemoryDBClient.h
@@ -30,6 +30,9 @@ namespace MemoryDB
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MemoryDBClientConfiguration ClientConfigurationType;
+      typedef MemoryDBEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-meteringmarketplace/include/aws/meteringmarketplace/MarketplaceMeteringClient.h
+++ b/generated/src/aws-cpp-sdk-meteringmarketplace/include/aws/meteringmarketplace/MarketplaceMeteringClient.h
@@ -59,6 +59,9 @@ namespace MarketplaceMetering
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MarketplaceMeteringClientConfiguration ClientConfigurationType;
+      typedef MarketplaceMeteringEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-mgn/include/aws/mgn/MgnClient.h
+++ b/generated/src/aws-cpp-sdk-mgn/include/aws/mgn/MgnClient.h
@@ -25,6 +25,9 @@ namespace mgn
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MgnClientConfiguration ClientConfigurationType;
+      typedef MgnEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-migration-hub-refactor-spaces/include/aws/migration-hub-refactor-spaces/MigrationHubRefactorSpacesClient.h
+++ b/generated/src/aws-cpp-sdk-migration-hub-refactor-spaces/include/aws/migration-hub-refactor-spaces/MigrationHubRefactorSpacesClient.h
@@ -37,6 +37,9 @@ namespace MigrationHubRefactorSpaces
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MigrationHubRefactorSpacesClientConfiguration ClientConfigurationType;
+      typedef MigrationHubRefactorSpacesEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-migrationhub-config/include/aws/migrationhub-config/MigrationHubConfigClient.h
+++ b/generated/src/aws-cpp-sdk-migrationhub-config/include/aws/migrationhub-config/MigrationHubConfigClient.h
@@ -36,6 +36,9 @@ namespace MigrationHubConfig
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MigrationHubConfigClientConfiguration ClientConfigurationType;
+      typedef MigrationHubConfigEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-migrationhuborchestrator/include/aws/migrationhuborchestrator/MigrationHubOrchestratorClient.h
+++ b/generated/src/aws-cpp-sdk-migrationhuborchestrator/include/aws/migrationhuborchestrator/MigrationHubOrchestratorClient.h
@@ -29,6 +29,9 @@ namespace MigrationHubOrchestrator
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MigrationHubOrchestratorClientConfiguration ClientConfigurationType;
+      typedef MigrationHubOrchestratorEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-migrationhubstrategy/include/aws/migrationhubstrategy/MigrationHubStrategyRecommendationsClient.h
+++ b/generated/src/aws-cpp-sdk-migrationhubstrategy/include/aws/migrationhubstrategy/MigrationHubStrategyRecommendationsClient.h
@@ -32,6 +32,9 @@ namespace MigrationHubStrategyRecommendations
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MigrationHubStrategyRecommendationsClientConfiguration ClientConfigurationType;
+      typedef MigrationHubStrategyRecommendationsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-mobile/include/aws/mobile/MobileClient.h
+++ b/generated/src/aws-cpp-sdk-mobile/include/aws/mobile/MobileClient.h
@@ -28,6 +28,9 @@ namespace Mobile
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MobileClientConfiguration ClientConfigurationType;
+      typedef MobileEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-monitoring/include/aws/monitoring/CloudWatchClient.h
+++ b/generated/src/aws-cpp-sdk-monitoring/include/aws/monitoring/CloudWatchClient.h
@@ -38,6 +38,9 @@ namespace CloudWatch
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudWatchClientConfiguration ClientConfigurationType;
+      typedef CloudWatchEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-mq/include/aws/mq/MQClient.h
+++ b/generated/src/aws-cpp-sdk-mq/include/aws/mq/MQClient.h
@@ -29,6 +29,9 @@ namespace MQ
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MQClientConfiguration ClientConfigurationType;
+      typedef MQEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-mturk-requester/include/aws/mturk-requester/MTurkClient.h
+++ b/generated/src/aws-cpp-sdk-mturk-requester/include/aws/mturk-requester/MTurkClient.h
@@ -25,6 +25,9 @@ namespace MTurk
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MTurkClientConfiguration ClientConfigurationType;
+      typedef MTurkEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-mwaa/include/aws/mwaa/MWAAClient.h
+++ b/generated/src/aws-cpp-sdk-mwaa/include/aws/mwaa/MWAAClient.h
@@ -59,6 +59,9 @@ namespace MWAA
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef MWAAClientConfiguration ClientConfigurationType;
+      typedef MWAAEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-neptune/include/aws/neptune/NeptuneClient.h
+++ b/generated/src/aws-cpp-sdk-neptune/include/aws/neptune/NeptuneClient.h
@@ -43,6 +43,9 @@ namespace Neptune
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef NeptuneClientConfiguration ClientConfigurationType;
+      typedef NeptuneEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-network-firewall/include/aws/network-firewall/NetworkFirewallClient.h
+++ b/generated/src/aws-cpp-sdk-network-firewall/include/aws/network-firewall/NetworkFirewallClient.h
@@ -75,6 +75,9 @@ namespace NetworkFirewall
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef NetworkFirewallClientConfiguration ClientConfigurationType;
+      typedef NetworkFirewallEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-networkmanager/include/aws/networkmanager/NetworkManagerClient.h
+++ b/generated/src/aws-cpp-sdk-networkmanager/include/aws/networkmanager/NetworkManagerClient.h
@@ -27,6 +27,9 @@ namespace NetworkManager
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef NetworkManagerClientConfiguration ClientConfigurationType;
+      typedef NetworkManagerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-nimble/include/aws/nimble/NimbleStudioClient.h
+++ b/generated/src/aws-cpp-sdk-nimble/include/aws/nimble/NimbleStudioClient.h
@@ -29,6 +29,9 @@ namespace NimbleStudio
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef NimbleStudioClientConfiguration ClientConfigurationType;
+      typedef NimbleStudioEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-oam/include/aws/oam/OAMClient.h
+++ b/generated/src/aws-cpp-sdk-oam/include/aws/oam/OAMClient.h
@@ -39,6 +39,9 @@ namespace OAM
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef OAMClientConfiguration ClientConfigurationType;
+      typedef OAMEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-omics/include/aws/omics/OmicsClient.h
+++ b/generated/src/aws-cpp-sdk-omics/include/aws/omics/OmicsClient.h
@@ -27,6 +27,9 @@ namespace Omics
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef OmicsClientConfiguration ClientConfigurationType;
+      typedef OmicsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-opensearch/include/aws/opensearch/OpenSearchServiceClient.h
+++ b/generated/src/aws-cpp-sdk-opensearch/include/aws/opensearch/OpenSearchServiceClient.h
@@ -37,6 +37,9 @@ namespace OpenSearchService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef OpenSearchServiceClientConfiguration ClientConfigurationType;
+      typedef OpenSearchServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-opensearchserverless/include/aws/opensearchserverless/OpenSearchServerlessClient.h
+++ b/generated/src/aws-cpp-sdk-opensearchserverless/include/aws/opensearchserverless/OpenSearchServerlessClient.h
@@ -34,6 +34,9 @@ namespace OpenSearchServerless
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef OpenSearchServerlessClientConfiguration ClientConfigurationType;
+      typedef OpenSearchServerlessEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-opsworks/include/aws/opsworks/OpsWorksClient.h
+++ b/generated/src/aws-cpp-sdk-opsworks/include/aws/opsworks/OpsWorksClient.h
@@ -76,6 +76,9 @@ namespace OpsWorks
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef OpsWorksClientConfiguration ClientConfigurationType;
+      typedef OpsWorksEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-opsworkscm/include/aws/opsworkscm/OpsWorksCMClient.h
+++ b/generated/src/aws-cpp-sdk-opsworkscm/include/aws/opsworkscm/OpsWorksCMClient.h
@@ -66,6 +66,9 @@ namespace OpsWorksCM
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef OpsWorksCMClientConfiguration ClientConfigurationType;
+      typedef OpsWorksCMEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-organizations/include/aws/organizations/OrganizationsClient.h
+++ b/generated/src/aws-cpp-sdk-organizations/include/aws/organizations/OrganizationsClient.h
@@ -70,6 +70,9 @@ namespace Organizations
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef OrganizationsClientConfiguration ClientConfigurationType;
+      typedef OrganizationsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-outposts/include/aws/outposts/OutpostsClient.h
+++ b/generated/src/aws-cpp-sdk-outposts/include/aws/outposts/OutpostsClient.h
@@ -31,6 +31,9 @@ namespace Outposts
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef OutpostsClientConfiguration ClientConfigurationType;
+      typedef OutpostsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-panorama/include/aws/panorama/PanoramaClient.h
+++ b/generated/src/aws-cpp-sdk-panorama/include/aws/panorama/PanoramaClient.h
@@ -28,6 +28,9 @@ namespace Panorama
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef PanoramaClientConfiguration ClientConfigurationType;
+      typedef PanoramaEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-personalize-events/include/aws/personalize-events/PersonalizeEventsClient.h
+++ b/generated/src/aws-cpp-sdk-personalize-events/include/aws/personalize-events/PersonalizeEventsClient.h
@@ -29,6 +29,9 @@ namespace PersonalizeEvents
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef PersonalizeEventsClientConfiguration ClientConfigurationType;
+      typedef PersonalizeEventsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-personalize-runtime/include/aws/personalize-runtime/PersonalizeRuntimeClient.h
+++ b/generated/src/aws-cpp-sdk-personalize-runtime/include/aws/personalize-runtime/PersonalizeRuntimeClient.h
@@ -25,6 +25,9 @@ namespace PersonalizeRuntime
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef PersonalizeRuntimeClientConfiguration ClientConfigurationType;
+      typedef PersonalizeRuntimeEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-personalize/include/aws/personalize/PersonalizeClient.h
+++ b/generated/src/aws-cpp-sdk-personalize/include/aws/personalize/PersonalizeClient.h
@@ -26,6 +26,9 @@ namespace Personalize
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef PersonalizeClientConfiguration ClientConfigurationType;
+      typedef PersonalizeEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-pi/include/aws/pi/PIClient.h
+++ b/generated/src/aws-cpp-sdk-pi/include/aws/pi/PIClient.h
@@ -47,6 +47,9 @@ namespace PI
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef PIClientConfiguration ClientConfigurationType;
+      typedef PIEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-pinpoint-email/include/aws/pinpoint-email/PinpointEmailClient.h
+++ b/generated/src/aws-cpp-sdk-pinpoint-email/include/aws/pinpoint-email/PinpointEmailClient.h
@@ -58,6 +58,9 @@ namespace PinpointEmail
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef PinpointEmailClientConfiguration ClientConfigurationType;
+      typedef PinpointEmailEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-pinpoint-sms-voice-v2/include/aws/pinpoint-sms-voice-v2/PinpointSMSVoiceV2Client.h
+++ b/generated/src/aws-cpp-sdk-pinpoint-sms-voice-v2/include/aws/pinpoint-sms-voice-v2/PinpointSMSVoiceV2Client.h
@@ -40,6 +40,9 @@ namespace PinpointSMSVoiceV2
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef PinpointSMSVoiceV2ClientConfiguration ClientConfigurationType;
+      typedef PinpointSMSVoiceV2EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-pinpoint/include/aws/pinpoint/PinpointClient.h
+++ b/generated/src/aws-cpp-sdk-pinpoint/include/aws/pinpoint/PinpointClient.h
@@ -25,6 +25,9 @@ namespace Pinpoint
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef PinpointClientConfiguration ClientConfigurationType;
+      typedef PinpointEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-pipes/include/aws/pipes/PipesClient.h
+++ b/generated/src/aws-cpp-sdk-pipes/include/aws/pipes/PipesClient.h
@@ -30,6 +30,9 @@ namespace Pipes
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef PipesClientConfiguration ClientConfigurationType;
+      typedef PipesEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-polly/include/aws/polly/PollyClient.h
+++ b/generated/src/aws-cpp-sdk-polly/include/aws/polly/PollyClient.h
@@ -29,6 +29,9 @@ namespace Polly
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef PollyClientConfiguration ClientConfigurationType;
+      typedef PollyEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-pricing/include/aws/pricing/PricingClient.h
+++ b/generated/src/aws-cpp-sdk-pricing/include/aws/pricing/PricingClient.h
@@ -44,6 +44,9 @@ namespace Pricing
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef PricingClientConfiguration ClientConfigurationType;
+      typedef PricingEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-privatenetworks/include/aws/privatenetworks/PrivateNetworksClient.h
+++ b/generated/src/aws-cpp-sdk-privatenetworks/include/aws/privatenetworks/PrivateNetworksClient.h
@@ -29,6 +29,9 @@ namespace PrivateNetworks
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef PrivateNetworksClientConfiguration ClientConfigurationType;
+      typedef PrivateNetworksEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-proton/include/aws/proton/ProtonClient.h
+++ b/generated/src/aws-cpp-sdk-proton/include/aws/proton/ProtonClient.h
@@ -110,6 +110,9 @@ namespace Proton
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ProtonClientConfiguration ClientConfigurationType;
+      typedef ProtonEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-qldb-session/include/aws/qldb-session/QLDBSessionClient.h
+++ b/generated/src/aws-cpp-sdk-qldb-session/include/aws/qldb-session/QLDBSessionClient.h
@@ -38,6 +38,9 @@ namespace QLDBSession
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef QLDBSessionClientConfiguration ClientConfigurationType;
+      typedef QLDBSessionEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-qldb/include/aws/qldb/QLDBClient.h
+++ b/generated/src/aws-cpp-sdk-qldb/include/aws/qldb/QLDBClient.h
@@ -25,6 +25,9 @@ namespace QLDB
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef QLDBClientConfiguration ClientConfigurationType;
+      typedef QLDBEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-quicksight/include/aws/quicksight/QuickSightClient.h
+++ b/generated/src/aws-cpp-sdk-quicksight/include/aws/quicksight/QuickSightClient.h
@@ -29,6 +29,9 @@ namespace QuickSight
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef QuickSightClientConfiguration ClientConfigurationType;
+      typedef QuickSightEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ram/include/aws/ram/RAMClient.h
+++ b/generated/src/aws-cpp-sdk-ram/include/aws/ram/RAMClient.h
@@ -38,6 +38,9 @@ namespace RAM
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef RAMClientConfiguration ClientConfigurationType;
+      typedef RAMEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-rbin/include/aws/rbin/RecycleBinClient.h
+++ b/generated/src/aws-cpp-sdk-rbin/include/aws/rbin/RecycleBinClient.h
@@ -38,6 +38,9 @@ namespace RecycleBin
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef RecycleBinClientConfiguration ClientConfigurationType;
+      typedef RecycleBinEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-rds-data/include/aws/rds-data/RDSDataServiceClient.h
+++ b/generated/src/aws-cpp-sdk-rds-data/include/aws/rds-data/RDSDataServiceClient.h
@@ -31,6 +31,9 @@ namespace RDSDataService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef RDSDataServiceClientConfiguration ClientConfigurationType;
+      typedef RDSDataServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-rds/include/aws/rds/RDSClient.h
+++ b/generated/src/aws-cpp-sdk-rds/include/aws/rds/RDSClient.h
@@ -62,6 +62,9 @@ namespace Aws
     static const char* SERVICE_NAME;
     static const char* ALLOCATION_TAG;
 
+      typedef RDSClientConfiguration ClientConfigurationType;
+      typedef RDSEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-redshift-data/include/aws/redshift-data/RedshiftDataAPIServiceClient.h
+++ b/generated/src/aws-cpp-sdk-redshift-data/include/aws/redshift-data/RedshiftDataAPIServiceClient.h
@@ -31,6 +31,9 @@ namespace RedshiftDataAPIService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef RedshiftDataAPIServiceClientConfiguration ClientConfigurationType;
+      typedef RedshiftDataAPIServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-redshift-serverless/include/aws/redshift-serverless/RedshiftServerlessClient.h
+++ b/generated/src/aws-cpp-sdk-redshift-serverless/include/aws/redshift-serverless/RedshiftServerlessClient.h
@@ -36,6 +36,9 @@ namespace RedshiftServerless
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef RedshiftServerlessClientConfiguration ClientConfigurationType;
+      typedef RedshiftServerlessEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-redshift/include/aws/redshift/RedshiftClient.h
+++ b/generated/src/aws-cpp-sdk-redshift/include/aws/redshift/RedshiftClient.h
@@ -47,6 +47,9 @@ namespace Redshift
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef RedshiftClientConfiguration ClientConfigurationType;
+      typedef RedshiftEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-rekognition/include/aws/rekognition/RekognitionClient.h
+++ b/generated/src/aws-cpp-sdk-rekognition/include/aws/rekognition/RekognitionClient.h
@@ -158,6 +158,9 @@ namespace Rekognition
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef RekognitionClientConfiguration ClientConfigurationType;
+      typedef RekognitionEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-resiliencehub/include/aws/resiliencehub/ResilienceHubClient.h
+++ b/generated/src/aws-cpp-sdk-resiliencehub/include/aws/resiliencehub/ResilienceHubClient.h
@@ -31,6 +31,9 @@ namespace ResilienceHub
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ResilienceHubClientConfiguration ClientConfigurationType;
+      typedef ResilienceHubEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-resource-explorer-2/include/aws/resource-explorer-2/ResourceExplorer2Client.h
+++ b/generated/src/aws-cpp-sdk-resource-explorer-2/include/aws/resource-explorer-2/ResourceExplorer2Client.h
@@ -53,6 +53,9 @@ namespace ResourceExplorer2
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ResourceExplorer2ClientConfiguration ClientConfigurationType;
+      typedef ResourceExplorer2EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-resource-groups/include/aws/resource-groups/ResourceGroupsClient.h
+++ b/generated/src/aws-cpp-sdk-resource-groups/include/aws/resource-groups/ResourceGroupsClient.h
@@ -49,6 +49,9 @@ namespace ResourceGroups
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ResourceGroupsClientConfiguration ClientConfigurationType;
+      typedef ResourceGroupsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-resourcegroupstaggingapi/include/aws/resourcegroupstaggingapi/ResourceGroupsTaggingAPIClient.h
+++ b/generated/src/aws-cpp-sdk-resourcegroupstaggingapi/include/aws/resourcegroupstaggingapi/ResourceGroupsTaggingAPIClient.h
@@ -25,6 +25,9 @@ namespace ResourceGroupsTaggingAPI
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ResourceGroupsTaggingAPIClientConfiguration ClientConfigurationType;
+      typedef ResourceGroupsTaggingAPIEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-robomaker/include/aws/robomaker/RoboMakerClient.h
+++ b/generated/src/aws-cpp-sdk-robomaker/include/aws/robomaker/RoboMakerClient.h
@@ -25,6 +25,9 @@ namespace RoboMaker
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef RoboMakerClientConfiguration ClientConfigurationType;
+      typedef RoboMakerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-rolesanywhere/include/aws/rolesanywhere/RolesAnywhereClient.h
+++ b/generated/src/aws-cpp-sdk-rolesanywhere/include/aws/rolesanywhere/RolesAnywhereClient.h
@@ -39,6 +39,9 @@ namespace RolesAnywhere
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef RolesAnywhereClientConfiguration ClientConfigurationType;
+      typedef RolesAnywhereEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-route53-recovery-cluster/include/aws/route53-recovery-cluster/Route53RecoveryClusterClient.h
+++ b/generated/src/aws-cpp-sdk-route53-recovery-cluster/include/aws/route53-recovery-cluster/Route53RecoveryClusterClient.h
@@ -67,6 +67,9 @@ namespace Route53RecoveryCluster
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef Route53RecoveryClusterClientConfiguration ClientConfigurationType;
+      typedef Route53RecoveryClusterEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-route53-recovery-control-config/include/aws/route53-recovery-control-config/Route53RecoveryControlConfigClient.h
+++ b/generated/src/aws-cpp-sdk-route53-recovery-control-config/include/aws/route53-recovery-control-config/Route53RecoveryControlConfigClient.h
@@ -26,6 +26,9 @@ namespace Route53RecoveryControlConfig
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef Route53RecoveryControlConfigClientConfiguration ClientConfigurationType;
+      typedef Route53RecoveryControlConfigEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-route53-recovery-readiness/include/aws/route53-recovery-readiness/Route53RecoveryReadinessClient.h
+++ b/generated/src/aws-cpp-sdk-route53-recovery-readiness/include/aws/route53-recovery-readiness/Route53RecoveryReadinessClient.h
@@ -25,6 +25,9 @@ namespace Route53RecoveryReadiness
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef Route53RecoveryReadinessClientConfiguration ClientConfigurationType;
+      typedef Route53RecoveryReadinessEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-route53/include/aws/route53/Route53Client.h
+++ b/generated/src/aws-cpp-sdk-route53/include/aws/route53/Route53Client.h
@@ -36,6 +36,9 @@ namespace Route53
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef Route53ClientConfiguration ClientConfigurationType;
+      typedef Route53EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-route53domains/include/aws/route53domains/Route53DomainsClient.h
+++ b/generated/src/aws-cpp-sdk-route53domains/include/aws/route53domains/Route53DomainsClient.h
@@ -26,6 +26,9 @@ namespace Route53Domains
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef Route53DomainsClientConfiguration ClientConfigurationType;
+      typedef Route53DomainsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-route53resolver/include/aws/route53resolver/Route53ResolverClient.h
+++ b/generated/src/aws-cpp-sdk-route53resolver/include/aws/route53resolver/Route53ResolverClient.h
@@ -53,6 +53,9 @@ namespace Route53Resolver
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef Route53ResolverClientConfiguration ClientConfigurationType;
+      typedef Route53ResolverEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-rum/include/aws/rum/CloudWatchRUMClient.h
+++ b/generated/src/aws-cpp-sdk-rum/include/aws/rum/CloudWatchRUMClient.h
@@ -35,6 +35,9 @@ namespace CloudWatchRUM
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef CloudWatchRUMClientConfiguration ClientConfigurationType;
+      typedef CloudWatchRUMEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
@@ -54,6 +54,9 @@ namespace Aws
         static const char* SERVICE_NAME;
         static const char* ALLOCATION_TAG;
 
+      typedef S3CrtClientConfiguration ClientConfigurationType;
+      typedef S3CrtEndpointProvider EndpointProviderType;
+
 
         /* Legacy constructors due deprecation */
        /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3Client.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3Client.h
@@ -46,6 +46,9 @@ namespace Aws
         static const char* SERVICE_NAME;
         static const char* ALLOCATION_TAG;
 
+      typedef S3ClientConfiguration ClientConfigurationType;
+      typedef S3EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-s3control/include/aws/s3control/S3ControlClient.h
+++ b/generated/src/aws-cpp-sdk-s3control/include/aws/s3control/S3ControlClient.h
@@ -29,6 +29,9 @@ namespace S3Control
         static const char* SERVICE_NAME;
         static const char* ALLOCATION_TAG;
 
+      typedef S3ControlClientConfiguration ClientConfigurationType;
+      typedef S3ControlEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-s3outposts/include/aws/s3outposts/S3OutpostsClient.h
+++ b/generated/src/aws-cpp-sdk-s3outposts/include/aws/s3outposts/S3OutpostsClient.h
@@ -25,6 +25,9 @@ namespace S3Outposts
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef S3OutpostsClientConfiguration ClientConfigurationType;
+      typedef S3OutpostsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sagemaker-a2i-runtime/include/aws/sagemaker-a2i-runtime/AugmentedAIRuntimeClient.h
+++ b/generated/src/aws-cpp-sdk-sagemaker-a2i-runtime/include/aws/sagemaker-a2i-runtime/AugmentedAIRuntimeClient.h
@@ -53,6 +53,9 @@ namespace AugmentedAIRuntime
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AugmentedAIRuntimeClientConfiguration ClientConfigurationType;
+      typedef AugmentedAIRuntimeEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sagemaker-edge/include/aws/sagemaker-edge/SagemakerEdgeManagerClient.h
+++ b/generated/src/aws-cpp-sdk-sagemaker-edge/include/aws/sagemaker-edge/SagemakerEdgeManagerClient.h
@@ -26,6 +26,9 @@ namespace SagemakerEdgeManager
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SagemakerEdgeManagerClientConfiguration ClientConfigurationType;
+      typedef SagemakerEdgeManagerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sagemaker-featurestore-runtime/include/aws/sagemaker-featurestore-runtime/SageMakerFeatureStoreRuntimeClient.h
+++ b/generated/src/aws-cpp-sdk-sagemaker-featurestore-runtime/include/aws/sagemaker-featurestore-runtime/SageMakerFeatureStoreRuntimeClient.h
@@ -37,6 +37,9 @@ namespace SageMakerFeatureStoreRuntime
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SageMakerFeatureStoreRuntimeClientConfiguration ClientConfigurationType;
+      typedef SageMakerFeatureStoreRuntimeEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sagemaker-geospatial/include/aws/sagemaker-geospatial/SageMakerGeospatialClient.h
+++ b/generated/src/aws-cpp-sdk-sagemaker-geospatial/include/aws/sagemaker-geospatial/SageMakerGeospatialClient.h
@@ -25,6 +25,9 @@ namespace SageMakerGeospatial
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SageMakerGeospatialClientConfiguration ClientConfigurationType;
+      typedef SageMakerGeospatialEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sagemaker-metrics/include/aws/sagemaker-metrics/SageMakerMetricsClient.h
+++ b/generated/src/aws-cpp-sdk-sagemaker-metrics/include/aws/sagemaker-metrics/SageMakerMetricsClient.h
@@ -29,6 +29,9 @@ namespace SageMakerMetrics
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SageMakerMetricsClientConfiguration ClientConfigurationType;
+      typedef SageMakerMetricsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sagemaker-runtime/include/aws/sagemaker-runtime/SageMakerRuntimeClient.h
+++ b/generated/src/aws-cpp-sdk-sagemaker-runtime/include/aws/sagemaker-runtime/SageMakerRuntimeClient.h
@@ -25,6 +25,9 @@ namespace SageMakerRuntime
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SageMakerRuntimeClientConfiguration ClientConfigurationType;
+      typedef SageMakerRuntimeEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sagemaker/include/aws/sagemaker/SageMakerClient.h
+++ b/generated/src/aws-cpp-sdk-sagemaker/include/aws/sagemaker/SageMakerClient.h
@@ -30,6 +30,9 @@ namespace SageMaker
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SageMakerClientConfiguration ClientConfigurationType;
+      typedef SageMakerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-savingsplans/include/aws/savingsplans/SavingsPlansClient.h
+++ b/generated/src/aws-cpp-sdk-savingsplans/include/aws/savingsplans/SavingsPlansClient.h
@@ -30,6 +30,9 @@ namespace SavingsPlans
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SavingsPlansClientConfiguration ClientConfigurationType;
+      typedef SavingsPlansEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-scheduler/include/aws/scheduler/SchedulerClient.h
+++ b/generated/src/aws-cpp-sdk-scheduler/include/aws/scheduler/SchedulerClient.h
@@ -30,6 +30,9 @@ namespace Scheduler
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SchedulerClientConfiguration ClientConfigurationType;
+      typedef SchedulerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-schemas/include/aws/schemas/SchemasClient.h
+++ b/generated/src/aws-cpp-sdk-schemas/include/aws/schemas/SchemasClient.h
@@ -25,6 +25,9 @@ namespace Schemas
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SchemasClientConfiguration ClientConfigurationType;
+      typedef SchemasEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sdb/include/aws/sdb/SimpleDBClient.h
+++ b/generated/src/aws-cpp-sdk-sdb/include/aws/sdb/SimpleDBClient.h
@@ -39,6 +39,9 @@ namespace SimpleDB
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SimpleDBClientConfiguration ClientConfigurationType;
+      typedef SimpleDBEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-secretsmanager/include/aws/secretsmanager/SecretsManagerClient.h
+++ b/generated/src/aws-cpp-sdk-secretsmanager/include/aws/secretsmanager/SecretsManagerClient.h
@@ -56,6 +56,9 @@ namespace SecretsManager
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SecretsManagerClientConfiguration ClientConfigurationType;
+      typedef SecretsManagerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-securityhub/include/aws/securityhub/SecurityHubClient.h
+++ b/generated/src/aws-cpp-sdk-securityhub/include/aws/securityhub/SecurityHubClient.h
@@ -56,6 +56,9 @@ namespace SecurityHub
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SecurityHubClientConfiguration ClientConfigurationType;
+      typedef SecurityHubEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-securitylake/include/aws/securitylake/SecurityLakeClient.h
+++ b/generated/src/aws-cpp-sdk-securitylake/include/aws/securitylake/SecurityLakeClient.h
@@ -60,6 +60,9 @@ namespace SecurityLake
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SecurityLakeClientConfiguration ClientConfigurationType;
+      typedef SecurityLakeEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-serverlessrepo/include/aws/serverlessrepo/ServerlessApplicationRepositoryClient.h
+++ b/generated/src/aws-cpp-sdk-serverlessrepo/include/aws/serverlessrepo/ServerlessApplicationRepositoryClient.h
@@ -69,6 +69,9 @@ namespace ServerlessApplicationRepository
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ServerlessApplicationRepositoryClientConfiguration ClientConfigurationType;
+      typedef ServerlessApplicationRepositoryEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-service-quotas/include/aws/service-quotas/ServiceQuotasClient.h
+++ b/generated/src/aws-cpp-sdk-service-quotas/include/aws/service-quotas/ServiceQuotasClient.h
@@ -29,6 +29,9 @@ namespace ServiceQuotas
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ServiceQuotasClientConfiguration ClientConfigurationType;
+      typedef ServiceQuotasEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-servicecatalog-appregistry/include/aws/servicecatalog-appregistry/AppRegistryClient.h
+++ b/generated/src/aws-cpp-sdk-servicecatalog-appregistry/include/aws/servicecatalog-appregistry/AppRegistryClient.h
@@ -28,6 +28,9 @@ namespace AppRegistry
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef AppRegistryClientConfiguration ClientConfigurationType;
+      typedef AppRegistryEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-servicecatalog/include/aws/servicecatalog/ServiceCatalogClient.h
+++ b/generated/src/aws-cpp-sdk-servicecatalog/include/aws/servicecatalog/ServiceCatalogClient.h
@@ -31,6 +31,9 @@ namespace ServiceCatalog
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ServiceCatalogClientConfiguration ClientConfigurationType;
+      typedef ServiceCatalogEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-servicediscovery/include/aws/servicediscovery/ServiceDiscoveryClient.h
+++ b/generated/src/aws-cpp-sdk-servicediscovery/include/aws/servicediscovery/ServiceDiscoveryClient.h
@@ -31,6 +31,9 @@ namespace ServiceDiscovery
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ServiceDiscoveryClientConfiguration ClientConfigurationType;
+      typedef ServiceDiscoveryEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sesv2/include/aws/sesv2/SESV2Client.h
+++ b/generated/src/aws-cpp-sdk-sesv2/include/aws/sesv2/SESV2Client.h
@@ -32,6 +32,9 @@ namespace SESV2
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SESV2ClientConfiguration ClientConfigurationType;
+      typedef SESV2EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-shield/include/aws/shield/ShieldClient.h
+++ b/generated/src/aws-cpp-sdk-shield/include/aws/shield/ShieldClient.h
@@ -31,6 +31,9 @@ namespace Shield
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ShieldClientConfiguration ClientConfigurationType;
+      typedef ShieldEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-signer/include/aws/signer/SignerClient.h
+++ b/generated/src/aws-cpp-sdk-signer/include/aws/signer/SignerClient.h
@@ -41,6 +41,9 @@ namespace signer
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SignerClientConfiguration ClientConfigurationType;
+      typedef SignerEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-simspaceweaver/include/aws/simspaceweaver/SimSpaceWeaverClient.h
+++ b/generated/src/aws-cpp-sdk-simspaceweaver/include/aws/simspaceweaver/SimSpaceWeaverClient.h
@@ -37,6 +37,9 @@ namespace SimSpaceWeaver
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SimSpaceWeaverClientConfiguration ClientConfigurationType;
+      typedef SimSpaceWeaverEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sms-voice/include/aws/sms-voice/PinpointSMSVoiceClient.h
+++ b/generated/src/aws-cpp-sdk-sms-voice/include/aws/sms-voice/PinpointSMSVoiceClient.h
@@ -25,6 +25,9 @@ namespace PinpointSMSVoice
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef PinpointSMSVoiceClientConfiguration ClientConfigurationType;
+      typedef PinpointSMSVoiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sms/include/aws/sms/SMSClient.h
+++ b/generated/src/aws-cpp-sdk-sms/include/aws/sms/SMSClient.h
@@ -37,6 +37,9 @@ namespace SMS
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SMSClientConfiguration ClientConfigurationType;
+      typedef SMSEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-snow-device-management/include/aws/snow-device-management/SnowDeviceManagementClient.h
+++ b/generated/src/aws-cpp-sdk-snow-device-management/include/aws/snow-device-management/SnowDeviceManagementClient.h
@@ -25,6 +25,9 @@ namespace SnowDeviceManagement
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SnowDeviceManagementClientConfiguration ClientConfigurationType;
+      typedef SnowDeviceManagementEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-snowball/include/aws/snowball/SnowballClient.h
+++ b/generated/src/aws-cpp-sdk-snowball/include/aws/snowball/SnowballClient.h
@@ -35,6 +35,9 @@ namespace Snowball
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SnowballClientConfiguration ClientConfigurationType;
+      typedef SnowballEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sns/include/aws/sns/SNSClient.h
+++ b/generated/src/aws-cpp-sdk-sns/include/aws/sns/SNSClient.h
@@ -43,6 +43,9 @@ namespace SNS
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SNSClientConfiguration ClientConfigurationType;
+      typedef SNSEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sqs/include/aws/sqs/SQSClient.h
+++ b/generated/src/aws-cpp-sdk-sqs/include/aws/sqs/SQSClient.h
@@ -50,6 +50,9 @@ namespace SQS
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SQSClientConfiguration ClientConfigurationType;
+      typedef SQSEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ssm-contacts/include/aws/ssm-contacts/SSMContactsClient.h
+++ b/generated/src/aws-cpp-sdk-ssm-contacts/include/aws/ssm-contacts/SSMContactsClient.h
@@ -33,6 +33,9 @@ namespace SSMContacts
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SSMContactsClientConfiguration ClientConfigurationType;
+      typedef SSMContactsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ssm-incidents/include/aws/ssm-incidents/SSMIncidentsClient.h
+++ b/generated/src/aws-cpp-sdk-ssm-incidents/include/aws/ssm-incidents/SSMIncidentsClient.h
@@ -33,6 +33,9 @@ namespace SSMIncidents
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SSMIncidentsClientConfiguration ClientConfigurationType;
+      typedef SSMIncidentsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ssm-sap/include/aws/ssm-sap/SsmSapClient.h
+++ b/generated/src/aws-cpp-sdk-ssm-sap/include/aws/ssm-sap/SsmSapClient.h
@@ -27,6 +27,9 @@ namespace SsmSap
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SsmSapClientConfiguration ClientConfigurationType;
+      typedef SsmSapEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-ssm/include/aws/ssm/SSMClient.h
+++ b/generated/src/aws-cpp-sdk-ssm/include/aws/ssm/SSMClient.h
@@ -50,6 +50,9 @@ namespace SSM
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SSMClientConfiguration ClientConfigurationType;
+      typedef SSMEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sso-admin/include/aws/sso-admin/SSOAdminClient.h
+++ b/generated/src/aws-cpp-sdk-sso-admin/include/aws/sso-admin/SSOAdminClient.h
@@ -50,6 +50,9 @@ namespace SSOAdmin
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SSOAdminClientConfiguration ClientConfigurationType;
+      typedef SSOAdminEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sso-oidc/include/aws/sso-oidc/SSOOIDCClient.h
+++ b/generated/src/aws-cpp-sdk-sso-oidc/include/aws/sso-oidc/SSOOIDCClient.h
@@ -56,6 +56,9 @@ namespace SSOOIDC
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SSOOIDCClientConfiguration ClientConfigurationType;
+      typedef SSOOIDCEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sso/include/aws/sso/SSOClient.h
+++ b/generated/src/aws-cpp-sdk-sso/include/aws/sso/SSOClient.h
@@ -41,6 +41,9 @@ namespace SSO
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SSOClientConfiguration ClientConfigurationType;
+      typedef SSOEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-states/include/aws/states/SFNClient.h
+++ b/generated/src/aws-cpp-sdk-states/include/aws/states/SFNClient.h
@@ -42,6 +42,9 @@ namespace SFN
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SFNClientConfiguration ClientConfigurationType;
+      typedef SFNEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-storagegateway/include/aws/storagegateway/StorageGatewayClient.h
+++ b/generated/src/aws-cpp-sdk-storagegateway/include/aws/storagegateway/StorageGatewayClient.h
@@ -68,6 +68,9 @@ namespace StorageGateway
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef StorageGatewayClientConfiguration ClientConfigurationType;
+      typedef StorageGatewayEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-sts/include/aws/sts/STSClient.h
+++ b/generated/src/aws-cpp-sdk-sts/include/aws/sts/STSClient.h
@@ -32,6 +32,9 @@ namespace STS
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef STSClientConfiguration ClientConfigurationType;
+      typedef STSEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-support-app/include/aws/support-app/SupportAppClient.h
+++ b/generated/src/aws-cpp-sdk-support-app/include/aws/support-app/SupportAppClient.h
@@ -54,6 +54,9 @@ namespace SupportApp
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SupportAppClientConfiguration ClientConfigurationType;
+      typedef SupportAppEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-support/include/aws/support/SupportClient.h
+++ b/generated/src/aws-cpp-sdk-support/include/aws/support/SupportClient.h
@@ -62,6 +62,9 @@ namespace Support
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SupportClientConfiguration ClientConfigurationType;
+      typedef SupportEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-swf/include/aws/swf/SWFClient.h
+++ b/generated/src/aws-cpp-sdk-swf/include/aws/swf/SWFClient.h
@@ -37,6 +37,9 @@ namespace SWF
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SWFClientConfiguration ClientConfigurationType;
+      typedef SWFEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-synthetics/include/aws/synthetics/SyntheticsClient.h
+++ b/generated/src/aws-cpp-sdk-synthetics/include/aws/synthetics/SyntheticsClient.h
@@ -39,6 +39,9 @@ namespace Synthetics
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef SyntheticsClientConfiguration ClientConfigurationType;
+      typedef SyntheticsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-textract/include/aws/textract/TextractClient.h
+++ b/generated/src/aws-cpp-sdk-textract/include/aws/textract/TextractClient.h
@@ -27,6 +27,9 @@ namespace Textract
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef TextractClientConfiguration ClientConfigurationType;
+      typedef TextractEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-timestream-query/include/aws/timestream-query/TimestreamQueryClient.h
+++ b/generated/src/aws-cpp-sdk-timestream-query/include/aws/timestream-query/TimestreamQueryClient.h
@@ -25,6 +25,9 @@ namespace TimestreamQuery
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef TimestreamQueryClientConfiguration ClientConfigurationType;
+      typedef TimestreamQueryEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-timestream-write/include/aws/timestream-write/TimestreamWriteClient.h
+++ b/generated/src/aws-cpp-sdk-timestream-write/include/aws/timestream-write/TimestreamWriteClient.h
@@ -38,6 +38,9 @@ namespace TimestreamWrite
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef TimestreamWriteClientConfiguration ClientConfigurationType;
+      typedef TimestreamWriteEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-tnb/include/aws/tnb/TnbClient.h
+++ b/generated/src/aws-cpp-sdk-tnb/include/aws/tnb/TnbClient.h
@@ -28,6 +28,9 @@ namespace tnb
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef TnbClientConfiguration ClientConfigurationType;
+      typedef TnbEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-transcribe/include/aws/transcribe/TranscribeServiceClient.h
+++ b/generated/src/aws-cpp-sdk-transcribe/include/aws/transcribe/TranscribeServiceClient.h
@@ -34,6 +34,9 @@ namespace TranscribeService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef TranscribeServiceClientConfiguration ClientConfigurationType;
+      typedef TranscribeServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/TranscribeStreamingServiceClient.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/TranscribeStreamingServiceClient.h
@@ -34,6 +34,9 @@ namespace TranscribeStreamingService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef TranscribeStreamingServiceClientConfiguration ClientConfigurationType;
+      typedef TranscribeStreamingServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-translate/include/aws/translate/TranslateClient.h
+++ b/generated/src/aws-cpp-sdk-translate/include/aws/translate/TranslateClient.h
@@ -26,6 +26,9 @@ namespace Translate
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef TranslateClientConfiguration ClientConfigurationType;
+      typedef TranslateEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-voice-id/include/aws/voice-id/VoiceIDClient.h
+++ b/generated/src/aws-cpp-sdk-voice-id/include/aws/voice-id/VoiceIDClient.h
@@ -27,6 +27,9 @@ namespace VoiceID
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef VoiceIDClientConfiguration ClientConfigurationType;
+      typedef VoiceIDEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-vpc-lattice/include/aws/vpc-lattice/VPCLatticeClient.h
+++ b/generated/src/aws-cpp-sdk-vpc-lattice/include/aws/vpc-lattice/VPCLatticeClient.h
@@ -31,6 +31,9 @@ namespace VPCLattice
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef VPCLatticeClientConfiguration ClientConfigurationType;
+      typedef VPCLatticeEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-waf-regional/include/aws/waf-regional/WAFRegionalClient.h
+++ b/generated/src/aws-cpp-sdk-waf-regional/include/aws/waf-regional/WAFRegionalClient.h
@@ -45,6 +45,9 @@ namespace WAFRegional
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef WAFRegionalClientConfiguration ClientConfigurationType;
+      typedef WAFRegionalEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-waf/include/aws/waf/WAFClient.h
+++ b/generated/src/aws-cpp-sdk-waf/include/aws/waf/WAFClient.h
@@ -41,6 +41,9 @@ namespace WAF
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef WAFClientConfiguration ClientConfigurationType;
+      typedef WAFEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-wafv2/include/aws/wafv2/WAFV2Client.h
+++ b/generated/src/aws-cpp-sdk-wafv2/include/aws/wafv2/WAFV2Client.h
@@ -72,6 +72,9 @@ namespace WAFV2
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef WAFV2ClientConfiguration ClientConfigurationType;
+      typedef WAFV2EndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-wellarchitected/include/aws/wellarchitected/WellArchitectedClient.h
+++ b/generated/src/aws-cpp-sdk-wellarchitected/include/aws/wellarchitected/WellArchitectedClient.h
@@ -32,6 +32,9 @@ namespace WellArchitected
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef WellArchitectedClientConfiguration ClientConfigurationType;
+      typedef WellArchitectedEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-wisdom/include/aws/wisdom/ConnectWisdomServiceClient.h
+++ b/generated/src/aws-cpp-sdk-wisdom/include/aws/wisdom/ConnectWisdomServiceClient.h
@@ -29,6 +29,9 @@ namespace ConnectWisdomService
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef ConnectWisdomServiceClientConfiguration ClientConfigurationType;
+      typedef ConnectWisdomServiceEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-workdocs/include/aws/workdocs/WorkDocsClient.h
+++ b/generated/src/aws-cpp-sdk-workdocs/include/aws/workdocs/WorkDocsClient.h
@@ -56,6 +56,9 @@ namespace WorkDocs
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef WorkDocsClientConfiguration ClientConfigurationType;
+      typedef WorkDocsEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-worklink/include/aws/worklink/WorkLinkClient.h
+++ b/generated/src/aws-cpp-sdk-worklink/include/aws/worklink/WorkLinkClient.h
@@ -32,6 +32,9 @@ namespace WorkLink
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef WorkLinkClientConfiguration ClientConfigurationType;
+      typedef WorkLinkEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-workmail/include/aws/workmail/WorkMailClient.h
+++ b/generated/src/aws-cpp-sdk-workmail/include/aws/workmail/WorkMailClient.h
@@ -43,6 +43,9 @@ namespace WorkMail
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef WorkMailClientConfiguration ClientConfigurationType;
+      typedef WorkMailEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-workmailmessageflow/include/aws/workmailmessageflow/WorkMailMessageFlowClient.h
+++ b/generated/src/aws-cpp-sdk-workmailmessageflow/include/aws/workmailmessageflow/WorkMailMessageFlowClient.h
@@ -26,6 +26,9 @@ namespace WorkMailMessageFlow
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef WorkMailMessageFlowClientConfiguration ClientConfigurationType;
+      typedef WorkMailMessageFlowEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-workspaces-web/include/aws/workspaces-web/WorkSpacesWebClient.h
+++ b/generated/src/aws-cpp-sdk-workspaces-web/include/aws/workspaces-web/WorkSpacesWebClient.h
@@ -31,6 +31,9 @@ namespace WorkSpacesWeb
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef WorkSpacesWebClientConfiguration ClientConfigurationType;
+      typedef WorkSpacesWebEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-workspaces/include/aws/workspaces/WorkSpacesClient.h
+++ b/generated/src/aws-cpp-sdk-workspaces/include/aws/workspaces/WorkSpacesClient.h
@@ -47,6 +47,9 @@ namespace WorkSpaces
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef WorkSpacesClientConfiguration ClientConfigurationType;
+      typedef WorkSpacesEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-xray/include/aws/xray/XRayClient.h
+++ b/generated/src/aws-cpp-sdk-xray/include/aws/xray/XRayClient.h
@@ -26,6 +26,9 @@ namespace XRay
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+      typedef XRayClientConfiguration ClientConfigurationType;
+      typedef XRayEndpointProvider EndpointProviderType;
+
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConfigTypeDeclarations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConfigTypeDeclarations.vm
@@ -1,0 +1,8 @@
+#if($serviceModel.endpointRules)
+      typedef ${metadata.classNamePrefix}ClientConfiguration ClientConfigurationType;
+      typedef ${metadata.classNamePrefix}EndpointProvider EndpointProviderType;
+
+#else
+      typedef Aws::${clientConfigurationNamespace}::ClientConfiguration ClientConfigurationType;
+
+#end

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceClientHeader.vm
@@ -32,6 +32,7 @@ namespace ${serviceNamespace}
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+#parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConfigTypeDeclarations.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderOperations.vm")
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/rds/RDSClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/rds/RDSClientHeader.vm
@@ -33,6 +33,7 @@ namespace ${rootNamespace}
     static const char* SERVICE_NAME;
     static const char* ALLOCATION_TAG;
 
+#parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConfigTypeDeclarations.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm")
 
     #if($metadata.protocol == "query")

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
@@ -93,6 +93,7 @@ namespace ${rootNamespace}
         static const char* SERVICE_NAME;
         static const char* ALLOCATION_TAG;
 
+#parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConfigTypeDeclarations.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderOperations.vm")
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3control/S3ControlClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3control/S3ControlClientHeader.vm
@@ -54,6 +54,7 @@ namespace ${metadata.namespace}
         static const char* SERVICE_NAME;
         static const char* ALLOCATION_TAG;
 
+#parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConfigTypeDeclarations.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderOperations.vm")
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlServiceClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlServiceClientHeader.vm
@@ -33,6 +33,7 @@ namespace ${serviceNamespace}
       static const char* SERVICE_NAME;
       static const char* ALLOCATION_TAG;
 
+#parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConfigTypeDeclarations.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm")
 
 #if($metadata.protocol == "query")


### PR DESCRIPTION
*Issue #, if available: #2446 

*Description of changes: Add ClientConfigurationType and EndpointProviderType typedefs to service client classes.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.) (comment: No changes to runtime behavior)
- [X] Checked if this PR is a breaking (APIs have been changed) change. (comment: It does add API though)
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
