### PR TITLE
Fixes GetLogLevelName for OFF logging level

### DIFF
--- a/src/aws-cpp-sdk-core/source/utils/logging/LogLevel.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/logging/LogLevel.cpp
@@ -34,6 +34,8 @@ Aws::String GetLogLevelName(LogLevel logLevel)
 		return "DEBUG";
 	case LogLevel::Trace:
 		return "TRACE";
+	case LogLevel::Off:
+		return "OFF";
 	default:
 		assert(0);
 		return "";


### PR DESCRIPTION
*Issue #, if available:*

[issues/2436](https://github.com/aws/aws-sdk-cpp/issues/2436)

*Description of changes:*

In the function `GetLogLevelName` we crash on `assert(0)` if we are passed `LogLevel::Off`. This changes the switch statement to return the string "OFF".

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
