### PR TITLE
Check for null doc before embedded error

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/CompleteMultipartUploadRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/CompleteMultipartUploadRequest.cpp
@@ -49,7 +49,7 @@ bool CompleteMultipartUploadRequest::HasEmbeddedError(Aws::IOStream &body,
     return false;
   }
 
-  if (doc.GetRootElement().GetName() == "Error") {
+  if (!doc.GetRootElement().IsNull() && doc.GetRootElement().GetName() == Aws::String("Error")) {
     body.seekg(readPointer);
     return true;
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/CopyObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/CopyObjectRequest.cpp
@@ -86,7 +86,7 @@ bool CopyObjectRequest::HasEmbeddedError(Aws::IOStream &body,
     return false;
   }
 
-  if (doc.GetRootElement().GetName() == "Error") {
+  if (!doc.GetRootElement().IsNull() && doc.GetRootElement().GetName() == Aws::String("Error")) {
     body.seekg(readPointer);
     return true;
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/UploadPartCopyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/UploadPartCopyRequest.cpp
@@ -56,7 +56,7 @@ bool UploadPartCopyRequest::HasEmbeddedError(Aws::IOStream &body,
     return false;
   }
 
-  if (doc.GetRootElement().GetName() == "Error") {
+  if (!doc.GetRootElement().IsNull() && doc.GetRootElement().GetName() == Aws::String("Error")) {
     body.seekg(readPointer);
     return true;
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/CompleteMultipartUploadRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/CompleteMultipartUploadRequest.cpp
@@ -49,7 +49,7 @@ bool CompleteMultipartUploadRequest::HasEmbeddedError(Aws::IOStream &body,
     return false;
   }
 
-  if (doc.GetRootElement().GetName() == "Error") {
+  if (!doc.GetRootElement().IsNull() && doc.GetRootElement().GetName() == Aws::String("Error")) {
     body.seekg(readPointer);
     return true;
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/CopyObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/CopyObjectRequest.cpp
@@ -86,7 +86,7 @@ bool CopyObjectRequest::HasEmbeddedError(Aws::IOStream &body,
     return false;
   }
 
-  if (doc.GetRootElement().GetName() == "Error") {
+  if (!doc.GetRootElement().IsNull() && doc.GetRootElement().GetName() == Aws::String("Error")) {
     body.seekg(readPointer);
     return true;
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/UploadPartCopyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/UploadPartCopyRequest.cpp
@@ -56,7 +56,7 @@ bool UploadPartCopyRequest::HasEmbeddedError(Aws::IOStream &body,
     return false;
   }
 
-  if (doc.GetRootElement().GetName() == "Error") {
+  if (!doc.GetRootElement().IsNull() && doc.GetRootElement().GetName() == Aws::String("Error")) {
     body.seekg(readPointer);
     return true;
   }

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlRequestSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlRequestSource.vm
@@ -48,7 +48,7 @@ bool ${typeInfo.className}::HasEmbeddedError(Aws::IOStream &body,
     return false;
   }
 
-  if (doc.GetRootElement().GetName() == "Error") {
+  if (!doc.GetRootElement().IsNull() && doc.GetRootElement().GetName() == Aws::String("Error")) {
     body.seekg(readPointer);
     return true;
   }


### PR DESCRIPTION
*Description of changes:*

There was reports of segfault errors when checking for embedded errors in CompleteMultipartUpload. This is likely from the change we made to check for [these embedded errors](https://github.com/aws/aws-sdk-cpp/issues/658). Looking at the stack trace provided to us

```
Data fault address (nil)
frame[1]: /lib64/libpthread.so.0
frame[2]: /usr/local/lib64/libaws-cpp-sdk-core.so(External::tinyxmlXML::NodeValue)
frame[3]: /usr/local/lib64/libaws-cpp-sdk-core.so(Aws::Utils::XmlXmlNode::GetName)
frame[4]: /usr/local/lib64/libaws-cpp-sdk-s3.so(Aws::Model::CompleteMultipartUploadReques::tHasEmbeddedError::basic_string::char_traits::Crt::StlAllocator
```

There is two changes we should be making:
* check that the root node is non null before checking for error in the root node.
* compare to Aws::String not std::string from message.

this updates both of those.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
