### PR TITLE
Generate presigned URL for CopySnapshot

### DIFF
--- a/generated/src/aws-cpp-sdk-ec2/source/model/CopySnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-ec2/source/model/CopySnapshotRequest.cpp
@@ -40,11 +40,6 @@ Aws::String CopySnapshotRequest::SerializePayload() const
     ss << "DestinationOutpostArn=" << StringUtils::URLEncode(m_destinationOutpostArn.c_str()) << "&";
   }
 
-  if(m_destinationRegionHasBeenSet)
-  {
-    ss << "DestinationRegion=" << StringUtils::URLEncode(m_destinationRegion.c_str()) << "&";
-  }
-
   if(m_encryptedHasBeenSet)
   {
     ss << "Encrypted=" << std::boolalpha << m_encrypted << "&";

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/ec2/Ec2CppClientGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/ec2/Ec2CppClientGenerator.java
@@ -8,17 +8,25 @@ package com.amazonaws.util.awsclientgenerator.generators.cpp.ec2;
 import com.amazonaws.util.awsclientgenerator.domainmodels.SdkFileEntry;
 import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.*;
 import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.Error;
+import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.cpp.CppViewHelper;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.QueryCppClientGenerator;
+import com.google.common.collect.ImmutableSet;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-public class Ec2CppClientGenerator extends QueryCppClientGenerator{
+public class Ec2CppClientGenerator extends QueryCppClientGenerator {
+
+    private static final Set<String> OPS_WITH_PRESIGNED_URLS = ImmutableSet.of(
+            "CopySnapshot"
+    );
 
     public Ec2CppClientGenerator() throws Exception {
         super();
@@ -669,7 +677,7 @@ public class Ec2CppClientGenerator extends QueryCppClientGenerator{
         final Error securityGroupsPerInterfaceLimitExceeded = new Error();
         securityGroupsPerInterfaceLimitExceeded.setName("SecurityGroupsPerInterfaceLimitExceeded");
         securityGroupsPerInterfaceLimitExceeded.setText("SecurityGroupsPerInterfaceLimitExceeded");
-        serviceErrors.add(securityGroupsPerInterfaceLimitExceeded);        
+        serviceErrors.add(securityGroupsPerInterfaceLimitExceeded);
         final Error snapshotLimitExceeded = new Error();
         snapshotLimitExceeded.setName("SnapshotLimitExceeded");
         snapshotLimitExceeded.setText("SnapshotLimitExceeded");
@@ -742,6 +750,17 @@ public class Ec2CppClientGenerator extends QueryCppClientGenerator{
         vpnGatewayLimitExceeded.setName("VpnGatewayLimitExceeded");
         vpnGatewayLimitExceeded.setText("VpnGatewayLimitExceeded");
         serviceErrors.add(vpnGatewayLimitExceeded);
+
+        // Add customization for operations with presigned URLs
+        serviceModel.getMetadata().setHasPreSignedUrl(true);
+
+        serviceModel.getOperations().values().stream()
+                .filter(operationEntry -> OPS_WITH_PRESIGNED_URLS.contains(operationEntry.getName()))
+                .forEach(operationEntry -> {
+                    operationEntry.setHasPreSignedUrl(true);
+                    operationEntry.getRequest().getShape().setHasPreSignedUrl(true);
+                });
+
         return super.generateSourceFiles(serviceModel);
     }
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientOperationEndpointPrepareCommonBody.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientOperationEndpointPrepareCommonBody.vm
@@ -190,9 +190,16 @@
 #end
 #end
 #end
+#if($serviceModel.metadata.serviceId == "EC2")
+#set($presignSpelling = "PresignedUrl")
+#set($shouldGenerateUrl = "request.SourceRegionHasBeenSet()")
+#else
+#set($presignSpelling = "PreSignedUrl")
+#set($shouldGenerateUrl = "request.SourceRegionHasBeenSet() && !request.${presignSpelling}HasBeenSet()")
+#end
 #if($operation.hasPreSignedUrl)
   ${operation.request.shape.name} newRequest = request;
-  if (request.SourceRegionHasBeenSet() && !request.PreSignedUrlHasBeenSet())
+  if (${shouldGenerateUrl})
   {
     Aws::Endpoint::EndpointParameters endpointParameters;
 #if($operation.staticContextParams)
@@ -203,17 +210,17 @@
     endpointParameters.emplace_back(Aws::Endpoint::EndpointParameter("Region", request.GetSourceRegion()));
     ResolveEndpointOutcome presignedEndpointResolutionOutcome = m_endpointProvider->ResolveEndpoint(endpointParameters);
     AWS_OPERATION_CHECK_SUCCESS(presignedEndpointResolutionOutcome, ${operation.name}, CoreErrors, CoreErrors::ENDPOINT_RESOLUTION_FAILURE, presignedEndpointResolutionOutcome.GetError().GetMessage());
-    newRequest.SetPreSignedUrl(GeneratePresignedUrl(request, presignedEndpointResolutionOutcome.GetResult().GetURI(),
+    newRequest.Set${presignSpelling}(GeneratePresignedUrl(request, presignedEndpointResolutionOutcome.GetResult().GetURI(),
                                                     Aws::Http::HttpMethod::HTTP_GET, request.GetSourceRegion().c_str(),
                                                     {{ "DestinationRegion", m_region }}, 3600));
   }
 #end##-#if($operation.hasPreSignedUrl)
 #else##-#if($serviceModel.endpointRules)
   ${operation.request.shape.name} newRequest = request;
-  if (request.SourceRegionHasBeenSet() && !request.PreSignedUrlHasBeenSet())
+  if (${shouldGenerateUrl})
   {
     Aws::Http::URI sourceUri(m_configScheme + "://" + ${metadata.classNamePrefix}Endpoint::ForRegion(request.GetSourceRegion(), m_useDualStack));
-    newRequest.SetPreSignedUrl(GeneratePresignedUrl(request, sourceUri, Aws::Http::HttpMethod::HTTP_GET, request.GetSourceRegion().c_str(), {{ "DestinationRegion", m_region }}, 3600));
+    newRequest.Set${presignSpelling}(GeneratePresignedUrl(request, sourceUri, Aws::Http::HttpMethod::HTTP_GET, request.GetSourceRegion().c_str(), {{ "DestinationRegion", m_region }}, 3600));
   }
 #end##-#if($serviceModel.endpointRules)
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientOperationEndpointDiscoveryWithRules.vm")

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/queryxml/QueryRequestSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/queryxml/QueryRequestSource.vm
@@ -33,7 +33,9 @@ Aws::String ${typeInfo.className}::SerializePayload() const
 #set($memberVarName = $CppViewHelper.computeMemberVariableName($member.key))
 #set($varName = $CppViewHelper.computeVariableName($member.key))
 #set($spaces = '')
-#if(!$member.value.usedForPayload || ($shape.hasPreSignedUrl && $member.key.equals("SourceRegion")))
+#if(!$member.value.usedForPayload ||
+    ($shape.hasPreSignedUrl && $member.key.equals("SourceRegion") && ${serviceNamespace} != "EC2") ||
+    ($shape.hasPreSignedUrl && $member.key.equals("DestinationRegion") && ${serviceNamespace} == "EC2"))
 #set($shouldSkipSerialize = true)
 #else
 #set($shouldSkipSerialize = false)


### PR DESCRIPTION
*Description of changes:*

Updates CopySnapshot in EC2 to generate the presigned URL required by EC2 for this call. This brings the C++ in line with other AWS SDKs that do this.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

I ran manual tests by copying snapshots in a aws account under different criteria.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
