### PR TITLE
Fix codegeneration for query clients

### DIFF
--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/queryxml/QueryRequestSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/queryxml/QueryRequestSource.vm
@@ -199,6 +199,27 @@ void  ${typeInfo.className}::DumpBodyToUrl(Aws::Http::URI& uri ) const
   uri.SetQueryString(SerializePayload());
 }
 #end
+#if($shape.hasHeaderMembers() || $metadata.targetPrefix)
+
+Aws::Http::HeaderValueCollection ${typeInfo.className}::GetRequestSpecificHeaders() const
+{
+  Aws::Http::HeaderValueCollection headers;
+#if($metadata.targetPrefix)
+  headers.insert(Aws::Http::HeaderValuePair("X-Amz-Target", "${metadata.targetPrefix}.${CppViewHelper.computeOperationNameFromInputOutputShape($shape.name)}"));
+#end
+#if($metadata.additionalHeaders)
+#foreach($headerEntry in $metadata.additionalHeaders.entrySet())
+  headers.insert(Aws::Http::HeaderValuePair("${headerEntry.key}", "${headerEntry.value}"));
+#end
+#end
+#foreach($headerEntry in $requestSpecificHeaders.entrySet())
+  headers.emplace(${headerEntry.key}, ${headerEntry.value});
+#end
+#set($useRequiredField = true)
+#parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassHeaderMembersSource.vm")
+  return headers;
+}
+#end
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/common/model/ModelGetEndpointRulesContextParamDefinition.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassChecksumMembers.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassRequiredCompression.vm")


### PR DESCRIPTION
*Description of changes:*

Fixes a issue where if a service had service specific headers and was a query client. We would generate a `GetRequestSpecificHeaders` method definition, without any implementation. We will not regenerate an implementation.
Copies the implementation from [StreamRequestSource.vm](https://github.com/aws/aws-sdk-cpp/blob/main/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/StreamRequestSource.vm#L46-L66)

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
