### PR TITLE
Fix build for disabling IMDSv1

### DIFF
--- a/tests/aws-cpp-sdk-core-tests/aws/auth/AWSHttpResourceClientTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/aws/auth/AWSHttpResourceClientTest.cpp
@@ -647,7 +647,9 @@ namespace
         auto ec2MetadataClient = Aws::MakeShared<Aws::Internal::EC2MetadataClient>(ALLOCATION_TAG, clientConfig);
 
         ASSERT_EQ("", ec2MetadataClient->GetDefaultCredentialsSecurely());
+#if !defined(DISABLE_IMDSV1)
         ASSERT_EQ("", ec2MetadataClient->GetDefaultCredentials());
+#endif
         ASSERT_EQ("", ec2MetadataClient->GetCurrentRegion());
     }
 


### PR DESCRIPTION
*Description of changes:*

The cmake definition `-DDISABLE_IMDSV1` will turn off IMDSv1 code paths at build time. There was a unit test that was added after the fact that checks the constructor argument works to disable IMDS. This unit test will actually test the IMDSv1 api even if it is enabled, causing a build failure. This fixes that intersection.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
