### PR TITLE
[aws-cpp-sdk-s3-crt] Control memory usage of downloads

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/ClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/ClientConfiguration.h
@@ -41,6 +41,12 @@ namespace Aws
             /* Throughput target in Gbps that we are trying to reach. Normally it's the NIC's throughput */
             double throughputTargetGbps = 2.0;
 
+            /** Control the maximum memory used by downloads.
+             *  When set to a value > 0, the SDK uses flow control to bring the memory usage very close
+             *  to the specified window. Without this cap, memory usage grows proportional to file size.
+             */
+            size_t downloadMemoryUsageWindow = 0;
+
             /* Callback and associated user data for when the client has completed its shutdown process. */
             std::function<void(void*)> clientShutdownCallback;
             void *shutdownCallbackUserData = nullptr;


### PR DESCRIPTION

### Why
The memory usage grows in proportion to the size of the download.

This can be a problem in resource-constrained environments, such as k8s pods; or running out of memory when downloading very large files.

### How
Make use of the flow-control introduced in https://github.com/awslabs/aws-c-s3/pull/213.
This is enabled when the user specifies a `downloadMemoryUsageWindow` (in bytes) greater than 0.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
  Ran experiments that showed that the flow-control window does not increase the download time,
  and that for large files the memory usage (RSS) closely matches the specified window - see comments section.
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.
  It would be good to inform users about this feature, to help them avoid running into issues with larger downloads.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
