### PR TITLE
Bugfix/0 byte download from s3 using http

### DIFF
--- a/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -758,10 +758,13 @@ namespace Aws
             auto request = m_transferConfig.getObjectTemplate;
             request.SetCustomizedAccessLogTag(m_transferConfig.customizedAccessLogTag);
             request.SetContinueRequestHandler([handle](const Aws::Http::HttpRequest*) { return handle->ShouldContinue(); });
-            request.SetRange(
-                FormatRangeSpecifier(
-                    handle->GetBytesOffset(),
-                    handle->GetBytesOffset() + handle->GetBytesTotalSize() - 1));
+            if (handle->GetBytesTotalSize() != 0)
+            {
+                request.SetRange(
+                    FormatRangeSpecifier(
+                        handle->GetBytesOffset(),
+                        handle->GetBytesOffset() + handle->GetBytesTotalSize() - 1));
+            }
             request.WithBucket(handle->GetBucketName())
                    .WithKey(handle->GetKey());
 


### PR DESCRIPTION
*Issue #, if available:*

This PR fixes an issue similar to #738, but which only appears when using HTTP endpoints. When downloading an empty (0-byte) file from S3 using Transfer API and using HTTP (not HTTPS) endpoints, the download fails with CurlCode 56 (connection reset by peer.) Issue has been present since 1.7.x release series.

The 0-byte file size causes `TransferManager::DoSinglePartDownload` to call `request.SetRange(FormatRangeSpecifier, 0, 0+0-1))`, which results in a malformed `range:` header due to integer underflow. Protection had been added for this underflow issue to some codepaths, but not to this one.

Interestingly, in HTTPS mode, the S3 REST API seems to accept this malformed `range` header without complaint. I have no explanation for the behavior difference between HTTP and HTTPS endpoints, but maybe it has something to do with the way sigv4 signing is forced on with HTTP endpoints.

*Description of changes:*

* Adds integer underflow protection
* To avoid issues like this in the future, I have parameterized the unit tests for `TransferManager` (`TransferTests`) such that they _all_ run in both HTTP and HTTPS mode.
 
The existing `EmptyFileTest` is sufficient to regression-test this issue when it is run against the HTTP endpoint. I have verified that the unit test as currently written in this PR will repro the issue reliably and that my bugfix causes the tests to pass.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
