### PR TITLE
re-enable more integration tests

### DIFF
--- a/src/aws-cpp-sdk-core/source/endpoint/BuiltInParameters.cpp
+++ b/src/aws-cpp-sdk-core/source/endpoint/BuiltInParameters.cpp
@@ -42,11 +42,11 @@ namespace Endpoint
             static const char* FIPS_SUFFIX = "-fips";
             if (config.region.rfind(FIPS_PREFIX, 0) == 0) {
                 // Backward compatibility layer for code hacking previous SDK version
-                Aws::String regionOverride = config.region.substr(sizeof(FIPS_PREFIX) - 1);
+                Aws::String regionOverride = config.region.substr(strlen(FIPS_PREFIX));
                 forceFIPS = true;
                 SetStringParameter(AWS_REGION, regionOverride);
             } else if (StringEndsWith(config.region, FIPS_SUFFIX)) {
-                Aws::String regionOverride = config.region.substr(0, config.region.size() - sizeof(FIPS_SUFFIX) - 1);
+                Aws::String regionOverride = config.region.substr(0, config.region.size() - strlen(FIPS_SUFFIX));
                 forceFIPS = true;
                 SetStringParameter(AWS_REGION, regionOverride);
             } else {

--- a/tests/aws-cpp-sdk-rds-integration-tests/RDSTest.cpp
+++ b/tests/aws-cpp-sdk-rds-integration-tests/RDSTest.cpp
@@ -138,7 +138,7 @@ namespace
 
         auto copyDBSnapshotOutcome = m_rdsClient.CopyDBSnapshot(copyDBSnapshotRequest);
         ASSERT_FALSE(copyDBSnapshotOutcome.IsSuccess());
-        ASSERT_EQ(RDSErrors::D_B_SNAPSHOT_NOT_FOUND_FAULT, copyDBSnapshotOutcome.GetError().GetErrorType());
+        ASSERT_EQ(RDSErrors::INVALID_PARAMETER_COMBINATION, copyDBSnapshotOutcome.GetError().GetErrorType());
         Aws::String preSignedUrl = ExtractPreSignedUrlFromPayload(TestingMonitoringMetrics::s_lastPayload.c_str());
         QueryStringParameterCollection parameters(URI(preSignedUrl).GetQueryStringParameters());
         ASSERT_NE(parameters.end(), parameters.find("Action"));
@@ -163,7 +163,7 @@ namespace
         copyDBSnapshotRequest.SetPreSignedUrl(TESTING_PRESIGNED_URL);
         copyDBSnapshotOutcome = m_rdsClient.CopyDBSnapshot(copyDBSnapshotRequest);
         ASSERT_FALSE(copyDBSnapshotOutcome.IsSuccess());
-        ASSERT_EQ(RDSErrors::D_B_SNAPSHOT_NOT_FOUND_FAULT, copyDBSnapshotOutcome.GetError().GetErrorType());
+        ASSERT_EQ(RDSErrors::INVALID_PARAMETER_COMBINATION, copyDBSnapshotOutcome.GetError().GetErrorType());
         preSignedUrl = ExtractPreSignedUrlFromPayload(TestingMonitoringMetrics::s_lastPayload.c_str());
         ASSERT_STREQ(TESTING_PRESIGNED_URL, preSignedUrl.c_str());
     }
@@ -269,7 +269,7 @@ namespace
 
         auto createDBClusterOutcome = m_rdsClient.CreateDBCluster(createDBClusterRequest);
         ASSERT_FALSE(createDBClusterOutcome.IsSuccess());
-        ASSERT_EQ(RDSErrors::INVALID_PARAMETER_VALUE, createDBClusterOutcome.GetError().GetErrorType());
+        ASSERT_EQ(RDSErrors::D_B_CLUSTER_NOT_FOUND_FAULT, createDBClusterOutcome.GetError().GetErrorType());
         Aws::String preSignedUrl = ExtractPreSignedUrlFromPayload(TestingMonitoringMetrics::s_lastPayload.c_str());
         QueryStringParameterCollection parameters(URI(preSignedUrl).GetQueryStringParameters());
         ASSERT_NE(parameters.end(), parameters.find("Action"));
@@ -298,7 +298,7 @@ namespace
         createDBClusterRequest.SetPreSignedUrl(TESTING_PRESIGNED_URL);
         createDBClusterOutcome = m_rdsClient.CreateDBCluster(createDBClusterRequest);
         ASSERT_FALSE(createDBClusterOutcome.IsSuccess());
-        ASSERT_EQ(RDSErrors::INVALID_PARAMETER_VALUE, createDBClusterOutcome.GetError().GetErrorType());
+        ASSERT_EQ(RDSErrors::D_B_CLUSTER_NOT_FOUND_FAULT, createDBClusterOutcome.GetError().GetErrorType());
         preSignedUrl = ExtractPreSignedUrlFromPayload(TestingMonitoringMetrics::s_lastPayload.c_str());
         ASSERT_STREQ(TESTING_PRESIGNED_URL, preSignedUrl.c_str());
     }

--- a/tests/aws-cpp-sdk-timestream-query-integration-tests/CMakeLists.txt
+++ b/tests/aws-cpp-sdk-timestream-query-integration-tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_project(aws-cpp-sdk-timestream-query-tests 
+add_project(aws-cpp-sdk-timestream-query-integration-tests
     "Tests for the AWS Timestream-query C++ SDK" 
     aws-cpp-sdk-core 
     aws-cpp-sdk-timestream-query 

--- a/tools/scripts/run_integration_tests.py
+++ b/tools/scripts/run_integration_tests.py
@@ -37,7 +37,7 @@ def main():
         # "aws-cpp-sdk-transcribestreaming-integration-tests", # Temporarily disabled while investigated
         "aws-cpp-sdk-dynamodb-integration-tests",
         "aws-cpp-sdk-sqs-integration-tests",
-        #"aws-cpp-sdk-s3-integration-tests",
+        "aws-cpp-sdk-s3-integration-tests",
         #"aws-cpp-sdk-s3-crt-integration-tests",
         #"aws-cpp-sdk-s3control-integration-tests",
         # "aws-cpp-sdk-lambda-integration-tests",
@@ -48,8 +48,9 @@ def main():
         "aws-cpp-sdk-logs-integration-tests",
         "aws-cpp-sdk-monitoring-integration-tests",
         "aws-cpp-sdk-elasticfilesystem-integration-tests",
-        #"aws-cpp-sdk-rds-integration-tests",
-        "aws-cpp-sdk-ec2-integration-tests"]
+        "aws-cpp-sdk-rds-integration-tests",
+        "aws-cpp-sdk-ec2-integration-tests",
+        "aws-cpp-sdk-timestream-query-integration-tests"]
 
     random.shuffle(test_list)
 


### PR DESCRIPTION
*Description of changes:*

* re-enables s3 integration tests.
 * fixes a problem with fips endpoints from tests.
* re-enables rds tests.
* enables time stream query tests.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
