### PR TITLE
[aws-cpp-sdk-s3-crt]: use CommonRunTime to support CopyObject

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
@@ -401,11 +401,7 @@ namespace Aws
         /**
          * An Async wrapper for CopyObject that queues the request into a thread executor and triggers associated callback when operation has finished.
          */
-        template<typename CopyObjectRequestT = Model::CopyObjectRequest>
-        void CopyObjectAsync(const CopyObjectRequestT& request, const CopyObjectResponseReceivedHandler& handler, const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context = nullptr) const
-        {
-            return SubmitAsync(&S3CrtClient::CopyObject, request, handler, context);
-        }
+        virtual void CopyObjectAsync(const Model::CopyObjectRequest& request, const CopyObjectResponseReceivedHandler& handler, const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context = nullptr) const;
 
         /**
          * <p>Creates a new S3 bucket. To create a bucket, you must register with Amazon S3
@@ -5579,6 +5575,7 @@ namespace Aws
           const S3CrtClient *s3CrtClient;
           GetObjectResponseReceivedHandler getResponseHandler;
           PutObjectResponseReceivedHandler putResponseHandler;
+          CopyObjectResponseReceivedHandler copyResponseHandler;
           std::shared_ptr<const Aws::Client::AsyncCallerContext> asyncCallerContext;
           const Aws::AmazonWebServiceRequest *originalRequest;
           std::shared_ptr<Aws::Http::HttpRequest> request;

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -705,28 +705,93 @@ CompleteMultipartUploadOutcome S3CrtClient::CompleteMultipartUpload(const Comple
   return CompleteMultipartUploadOutcome(MakeRequest(request, endpointResolutionOutcome.GetResult(), Aws::Http::HttpMethod::HTTP_POST));
 }
 
-CopyObjectOutcome S3CrtClient::CopyObject(const CopyObjectRequest& request) const
+static void CopyObjectRequestShutdownCallback(void *user_data)
 {
-  AWS_OPERATION_CHECK_PTR(m_endpointProvider, CopyObject, CoreErrors, CoreErrors::ENDPOINT_RESOLUTION_FAILURE);
+  auto *userData = static_cast<S3CrtClient::CrtRequestCallbackUserData*>(user_data);
+  S3Crt::Model::CopyObjectOutcome outcome(userData->s3CrtClient->GenerateXmlOutcome(userData->response));
+
+  userData->copyResponseHandler(userData->s3CrtClient, *(reinterpret_cast<const CopyObjectRequest*>(userData->originalRequest)), std::move(outcome), userData->asyncCallerContext);
+  Aws::Delete(userData);
+}
+
+void S3CrtClient::CopyObjectAsync(const Model::CopyObjectRequest& request, const CopyObjectResponseReceivedHandler& handler, const std::shared_ptr<const Aws::Client::AsyncCallerContext>& handlerContext) const
+{
+  if (!m_endpointProvider) {
+    return handler(this, request, CopyObjectOutcome(Aws::Client::AWSError<S3CrtErrors>(S3CrtErrors::INTERNAL_FAILURE, "INTERNAL_FAILURE", "Endpoint provider is not initialized", false)), handlerContext);
+  }
   if (!request.BucketHasBeenSet())
   {
     AWS_LOGSTREAM_ERROR("CopyObject", "Required field: Bucket, is not set");
-    return CopyObjectOutcome(Aws::Client::AWSError<S3CrtErrors>(S3CrtErrors::MISSING_PARAMETER, "MISSING_PARAMETER", "Missing required field [Bucket]", false));
+    return handler(this, request, CopyObjectOutcome(Aws::Client::AWSError<S3CrtErrors>(S3CrtErrors::MISSING_PARAMETER, "MISSING_PARAMETER", "Missing required field [Bucket]", false)), handlerContext);
   }
   if (!request.CopySourceHasBeenSet())
   {
     AWS_LOGSTREAM_ERROR("CopyObject", "Required field: CopySource, is not set");
-    return CopyObjectOutcome(Aws::Client::AWSError<S3CrtErrors>(S3CrtErrors::MISSING_PARAMETER, "MISSING_PARAMETER", "Missing required field [CopySource]", false));
+    return handler(this, request, CopyObjectOutcome(Aws::Client::AWSError<S3CrtErrors>(S3CrtErrors::MISSING_PARAMETER, "MISSING_PARAMETER", "Missing required field [CopySource]", false)), handlerContext);
   }
   if (!request.KeyHasBeenSet())
   {
     AWS_LOGSTREAM_ERROR("CopyObject", "Required field: Key, is not set");
-    return CopyObjectOutcome(Aws::Client::AWSError<S3CrtErrors>(S3CrtErrors::MISSING_PARAMETER, "MISSING_PARAMETER", "Missing required field [Key]", false));
+    return handler(this, request, CopyObjectOutcome(Aws::Client::AWSError<S3CrtErrors>(S3CrtErrors::MISSING_PARAMETER, "MISSING_PARAMETER", "Missing required field [Key]", false)), handlerContext);
   }
+
   ResolveEndpointOutcome endpointResolutionOutcome = m_endpointProvider->ResolveEndpoint(request.GetEndpointContextParams());
-  AWS_OPERATION_CHECK_SUCCESS(endpointResolutionOutcome, CopyObject, CoreErrors, CoreErrors::ENDPOINT_RESOLUTION_FAILURE, endpointResolutionOutcome.GetError().GetMessage());
+  if (!endpointResolutionOutcome.IsSuccess()) {
+    handler(this, request, CopyObjectOutcome(Aws::Client::AWSError<CoreErrors>(
+        CoreErrors::ENDPOINT_RESOLUTION_FAILURE, "ENDPOINT_RESOLUTION_FAILURE", endpointResolutionOutcome.GetError().GetMessage(), false)), handlerContext);
+    return;
+  }
   endpointResolutionOutcome.GetResult().AddPathSegments(request.GetKey());
-  return CopyObjectOutcome(MakeRequest(request, endpointResolutionOutcome.GetResult(), Aws::Http::HttpMethod::HTTP_PUT));
+
+  CrtRequestCallbackUserData *userData = Aws::New<CrtRequestCallbackUserData>(ALLOCATION_TAG);
+  aws_s3_meta_request_options options;
+  AWS_ZERO_STRUCT(options);
+  aws_uri endpoint;
+  AWS_ZERO_STRUCT(endpoint);
+  options.endpoint = &endpoint;
+  std::unique_ptr<aws_uri, void(*)(aws_uri*)> endpointCleanup { options.endpoint, &aws_uri_clean_up };
+
+  userData->copyResponseHandler = handler;
+  userData->asyncCallerContext = handlerContext;
+  InitCommonCrtRequestOption(userData, &options, &request, endpointResolutionOutcome.GetResult().GetURI(), Aws::Http::HttpMethod::HTTP_PUT);
+  options.shutdown_callback = CopyObjectRequestShutdownCallback;
+  options.type = AWS_S3_META_REQUEST_TYPE_COPY_OBJECT;
+
+  struct aws_signing_config_aws signing_config_override = m_s3CrtSigningConfig;
+  if (endpointResolutionOutcome.GetResult().GetAttributes() && endpointResolutionOutcome.GetResult().GetAttributes()->authScheme.GetSigningRegion()) {
+    signing_config_override.region = Aws::Crt::ByteCursorFromCString(endpointResolutionOutcome.GetResult().GetAttributes()->authScheme.GetSigningRegion()->c_str());
+  }
+  if (endpointResolutionOutcome.GetResult().GetAttributes() && endpointResolutionOutcome.GetResult().GetAttributes()->authScheme.GetSigningRegionSet()) {
+    signing_config_override.region = Aws::Crt::ByteCursorFromCString(endpointResolutionOutcome.GetResult().GetAttributes()->authScheme.GetSigningRegionSet()->c_str());
+  }
+  if (endpointResolutionOutcome.GetResult().GetAttributes() && endpointResolutionOutcome.GetResult().GetAttributes()->authScheme.GetSigningName()) {
+    signing_config_override.service = Aws::Crt::ByteCursorFromCString(endpointResolutionOutcome.GetResult().GetAttributes()->authScheme.GetSigningName()->c_str());
+  }
+  options.signing_config = &signing_config_override;
+
+  std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest = userData->request->ToCrtHttpRequest();
+  options.message= crtHttpRequest->GetUnderlyingMessage();
+  userData->crtHttpRequest = crtHttpRequest;
+
+  if (aws_s3_client_make_meta_request(m_s3CrtClient, &options) == nullptr)
+  {
+    return handler(this, request, CopyObjectOutcome(Aws::Client::AWSError<S3CrtErrors>(S3CrtErrors::INTERNAL_FAILURE, "INTERNAL_FAILURE", "Unable to create s3 meta request", false)), handlerContext);
+  }
+}
+
+CopyObjectOutcome S3CrtClient::CopyObject(const CopyObjectRequest& request) const
+{
+  Aws::Utils::Threading::Semaphore sem(0, 1);
+  CopyObjectOutcome res;
+
+  auto handler = CopyObjectResponseReceivedHandler{[&](const S3CrtClient*, const CopyObjectRequest&, CopyObjectOutcome outcome, const std::shared_ptr<const Aws::Client::AsyncCallerContext> &) {
+      res = std::move(outcome);
+      sem.ReleaseAll();
+  }};
+
+  S3CrtClient::CopyObjectAsync(request, handler, nullptr);
+  sem.WaitOne();
+  return res;
 }
 
 CreateBucketOutcome S3CrtClient::CreateBucket(const CreateBucketRequest& request) const


### PR DESCRIPTION
Provide `CopyObject` support based on https://github.com/awslabs/aws-c-s3/pull/284

In contrast to the existing `CopyObject` function, objects larger than 5GB are supported, and multipart copies are automatically handled in parallel.

Resolves #2477.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
   Tested with existing code, using objects of varying sizes (< 5GB, >5GB). 
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.