### PR TITLE
Fix gcc warnings for crt http client

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
@@ -317,8 +317,8 @@ namespace Aws
             for (size_t i = 0; i < headersCount; ++i)
             {
                 const Crt::Http::HttpHeader* header = &headersArray[i];
-                Aws::String headerNameStr((const char* const)header->name.ptr, header->name.len);
-                Aws::String headerValueStr((const char* const)header->value.ptr, header->value.len);
+                Aws::String headerNameStr((const char*)header->name.ptr, header->name.len);
+                Aws::String headerValueStr((const char*)header->value.ptr, header->value.len);
                 AWS_LOGSTREAM_TRACE(CRT_HTTP_CLIENT_TAG, headerNameStr << ": " << headerValueStr);
                 response->AddHeader(headerNameStr, std::move(headerValueStr));
             }


### PR DESCRIPTION
*Description of changes:*

When building against AL2023 and using the CRT http client we see the warning as error

```

aws-sdk-cpp/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp:320:43: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
  320 |                 Aws::String headerNameStr((const char* const)header->name.ptr, header->name.len);
      |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
aws-sdk-cpp/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp:321:44: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
  321 |                 Aws::String headerValueStr((const char* const)header->value.ptr, header->value.len);
      |        
```

Which shoes that we are casting header->value.ptr to `const * const` when it should only be `const *`

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
