### PR TITLE
Control memory usage of downloads (including code-gen changes)

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/ClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/ClientConfiguration.h
@@ -41,6 +41,12 @@ namespace Aws
             /* Throughput target in Gbps that we are trying to reach. Normally it's the NIC's throughput */
             double throughputTargetGbps = 2.0;
 
+            /** Control the maximum memory used by downloads.
+             *  When set to a value > 0, the SDK uses flow control to bring the memory usage very close
+             *  to the specified window. Without this cap, memory usage grows proportional to file size.
+             */
+            size_t downloadMemoryUsageWindow = 0;
+
             /* Callback and associated user data for when the client has completed its shutdown process. */
             std::function<void(void*)> clientShutdownCallback;
             void *shutdownCallbackUserData = nullptr;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtClientConfig.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtClientConfig.vm
@@ -41,6 +41,12 @@ namespace ${rootNamespace}
             /* Throughput target in Gbps that we are trying to reach. Normally it's the NIC's throughput */
             double throughputTargetGbps = 2.0;
 
+            /** Control the maximum memory used by downloads.
+             *  When set to a value > 0, the SDK uses flow control to bring the memory usage very close
+             *  to the specified window. Without this cap, memory usage grows proportional to file size.
+             */
+            size_t downloadMemoryUsageWindow = 0;
+
             /* Callback and associated user data for when the client has completed its shutdown process. */
             std::function<void(void*)> clientShutdownCallback;
             void *shutdownCallbackUserData = nullptr;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -244,6 +244,10 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
   s3CrtConfig.region = Aws::Crt::ByteCursorFromCString(config.region.c_str());
   s3CrtConfig.connect_timeout_ms = config.connectTimeoutMs;
 
+  // Download flow-control configuration:
+  s3CrtConfig.enable_read_backpressure = (config.downloadMemoryUsageWindow > 0);
+  s3CrtConfig.initial_read_window = config.downloadMemoryUsageWindow;
+
   aws_s3_tcp_keep_alive_options tcp_keep_alive_options;
   if (config.enableTcpKeepAlive) {
     uint16_t configKeepAliveS = static_cast<uint16_t>(std::min(static_cast<unsigned long>(std::numeric_limits<uint16_t>::max()), config.tcpKeepAliveIntervalMs / 1000ul));

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
@@ -19,7 +19,6 @@ static int S3CrtRequestHeadersCallback(struct aws_s3_meta_request *meta_request,
 
 static int S3CrtRequestGetBodyCallback(struct aws_s3_meta_request *meta_request, const struct aws_byte_cursor *body, uint64_t range_start, void *user_data)
 {
-  AWS_UNREFERENCED_PARAM(meta_request);
   AWS_UNREFERENCED_PARAM(range_start);
 
   auto *userData = static_cast<S3CrtClient::CrtRequestCallbackUserData*>(user_data);
@@ -30,6 +29,9 @@ static int S3CrtRequestGetBodyCallback(struct aws_s3_meta_request *meta_request,
   {
     bodyStream.flush();
   }
+
+  // Replenish flow-control window (no-op if enable_read_backpressure is not set):
+  aws_s3_meta_request_increment_read_window(meta_request, body->len);
 
   // data sent handler and continuation handler will be supported later when aws_c_s3 support it.
   auto& receivedHandler = userData->request->GetDataReceivedEventHandler();


### PR DESCRIPTION
Thanks @grrtrr. Original [PR](https://github.com/aws/aws-sdk-cpp/pull/2474)

### Why
The memory usage grows in proportion to the size of the download.

This can be a problem in resource-constrained environments, such as k8s pods; or running out of memory when downloading very large files.

### How
Make use of the flow-control introduced in https://github.com/awslabs/aws-c-s3/pull/213.
This is enabled when the user specifies a `downloadMemoryUsageWindow` (in bytes) greater than 0.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
  Ran experiments that showed that the flow-control window does not increase the download time,
  and that for large files the memory usage (RSS) closely matches the specified window - see comments section.
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.
  It would be good to inform users about this feature, to help them avoid running into issues with larger downloads.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [X] Windows
- [ ] Android
- [X] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


## Affect of flow control when downloading a large (4.8GiB) file

The following are the averages of 3 runs each for downloading a 4.8GiB file, using various flow-control windows.

|Window |Runtime|Memory Usage (RSS)|
|------------|-----------|-----------------------------|
|No Flow Control|10.25s|3.53 GiB|
|80 MiB|15.91s|0.09 GiB|
|160 MiB|12.10s|0.17 GiB|
|320 MiB|10.45s|0.33 GiB|
|640 MiB|10.28s|0.64 GiB|
|1200 MiB|9.98s|1.19 GiB|
|1600 MiB|9.92s|1.57 GiB|
|2000 MiB|9.92s|1.94 GiB|
|2400 MiB|10.34s|4.02 GiB|
|3200 MiB|9.90s|4.02 GiB|
|4000 MiB|9.65s|3.29 GiB|
|4800 MiB|9.57s|0.70 GiB|
|5000 MiB|10.01s|0.91 GiB|

_Observations_:
- _Smaller windows_: Up to 2000 MiB, the memory usage is tightly controlled by the window size parameter.
- _Large windows_: 
  - Above 2400MiB (50% of file size), the usage exceeds the window.
  - Closer to the actual file size (4000/4800/5000 MiB), the _actual usage_ is less than the window size.
- _Once the flow-control window is above 7% of the file size (320MiB) or larger, there is no noticeable slow-down._

## Performance of a 640 MiB flow-control window on smaller files

The next tests evaluated whether turning on the flow-control window has any negative side effects on the performance of smaller downloads.

Again this is showing the averages of 3 runs each, using a fixed flow-control download window of 640MiB.

|File size|Runtime without|Runtime with|Memory without|Memory with|
|------------|---------------------|------------------|---------------------|-----------------|
|1 MiB|1.07s|1.10s|20.94 MiB|20.96 MiB|
|2 MiB|1.04s|1.04s|22.09 MiB|21.99 MiB|
|4 MiB|1.04s|1.04s|23.93 MiB|23.99 MiB|
|8 MiB|1.04s|1.04s|27.96 MiB|27.92 MiB|
|16 MiB|1.04s|1.04s|36.01 MiB|35.95 MiB|
|32 MiB|1.04s|1.04s|36.23 MiB|36.14 MiB|
|64 MiB|1.04s|1.04s|64.61 MiB|68.53 MiB|
|128 MiB|1.04s|1.04s|126.36 MiB|133.12 MiB|
|256 MiB|1.04s|1.04s|241.62 MiB|237.45 MiB|
|512 MiB|2.37s|2.04s|451.28 MiB|430.10 MiB|
|1024 MiB|3.04s|3.04s|975.38 MiB|577.57 MiB|
|1536 MiB|3.07s|3.04s|1450.26 MiB|647.14 MiB|
|2048 MiB|4.04s|4.04s|1856.66 MiB|657.86 MiB|

_Observations_:
 * _There is no noticeable slow-down when using flow-control._
 * Up to the window size (1 ... 512 MiB) the large window has no affect on memory usage.
 * Once the file size exceeds the window (1024/1536/2048 MiB), the flow-control window caps the memory usage.