### PR TITLE
Add github action to prohibit merges during daily release

### DIFF
--- a/.github/workflows/time-blocker.yml
+++ b/.github/workflows/time-blocker.yml
@@ -1,0 +1,16 @@
+name: Block Merge During Daily Release
+on:
+  pull_request:
+    branches: [ main ]
+  merge_group:
+    branches: [ main ]
+jobs:
+  block:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: yykamei/block-merge-based-on-time@v2.1.37
+        with:
+          timezone: "UTC"
+          after: 18:00
+          before: 20:00
+          base-branches: "main"


### PR DESCRIPTION
*Description of changes:*

Adds a github action to block merging during daily releases.

Tested with a test pull request [pull/2510](https://github.com/aws/aws-sdk-cpp/pull/2510)

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
