### PR TITLE
Remove large intermediate built files on windows build

### DIFF
--- a/tools/scripts/build-tests/build-windows-default.ps1
+++ b/tools/scripts/build-tests/build-windows-default.ps1
@@ -13,3 +13,6 @@ cd "${PREFIX_DIR}/win-build"
 &'C:\\Program Files\\CMake\\bin\\cmake.exe' ../aws-sdk-cpp -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}/win-install"
 &'C:\\Program Files\\CMake\\bin\\cmake.exe' --build . -j 8
 &'C:\\Program Files\\CMake\\bin\\cmake.exe' --build . --target install
+&cmd.exe /c "del /s /q *.pdb"
+&cmd.exe /c "del /s /q *.ilk"
+&cmd.exe /c "del /s /q *.obj"


### PR DESCRIPTION
*Issue #, if available:*
n/a
*Description of changes:*
remove 
.pdb - debug symbols
.ilk - incremental linker info
.obj - intermediate object files
All of them are not used after the build is complete.
Changes built artifacts zip size from ~2.7Gb to ~0.6Gb; also changes CI build artifacts upload time from ~1500s to 900s.
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
