### PR TITLE
Avoid concurrent writes in TestingMonitoring

### DIFF
--- a/tests/testing-resources/include/aws/testing/mocks/monitoring/TestingMonitoring.h
+++ b/tests/testing-resources/include/aws/testing/mocks/monitoring/TestingMonitoring.h
@@ -27,6 +27,7 @@ struct TestingMonitoringMetrics
 
 bool TestingMonitoringMetrics::Config::s_enablePayload;
 
+std::mutex s_lastMutex;
 Aws::String TestingMonitoringMetrics::s_lastUriString;
 Aws::String TestingMonitoringMetrics::s_lastSigningRegion;
 Aws::String TestingMonitoringMetrics::s_lastSigningServiceName;
@@ -81,6 +82,8 @@ public:
         AWS_UNREFERENCED_PARAM(serviceName);
         AWS_UNREFERENCED_PARAM(requestName);
         AWS_UNREFERENCED_PARAM(context);
+        std::unique_lock<std::mutex> locker(s_lastMutex);
+
         TestingMonitoringMetrics::s_lastUriString = request->GetUri().GetURIString().c_str();
         TestingMonitoringMetrics::s_lastSigningRegion = request->GetSigningRegion().c_str();
         Aws::Vector<Aws::String> authComponents = request->HasAwsAuthorization() ?
@@ -153,6 +156,7 @@ public:
 private:
     static void Init()
     {
+        std::unique_lock<std::mutex> locker(s_lastMutex);
         TestingMonitoringMetrics::Config::s_enablePayload = false;
 
         TestingMonitoringMetrics::s_lastUriString = "";


### PR DESCRIPTION
*Issue #, if available:*
integration test may get into race condition in a test helper utility
*Description of changes:*
cheap/dirty workaround by adding a mutex.
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
