### PR TITLE
Remove exact message check in integ tests

### DIFF
--- a/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
@@ -2155,13 +2155,11 @@ namespace
         listObjectsOutcome = s3ClientWithDualStack.ListObjects(listObjectsRequest);
         ASSERT_FALSE(listObjectsOutcome.IsSuccess());
         ASSERT_EQ(HttpResponseCode::REQUEST_NOT_MADE, listObjectsOutcome.GetError().GetResponseCode());
-        ASSERT_EQ("Host override cannot be combined with Dualstack, FIPS, or S3 Accelerate", listObjectsOutcome.GetError().GetMessage());
 
         listObjectsRequest.SetBucket("arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint");
         listObjectsOutcome = s3ClientWithDualStack.ListObjects(listObjectsRequest);
         ASSERT_FALSE(listObjectsOutcome.IsSuccess());
         ASSERT_EQ(HttpResponseCode::REQUEST_NOT_MADE, listObjectsOutcome.GetError().GetResponseCode());
-        ASSERT_EQ("S3 Outposts does not support Dual-stack", listObjectsOutcome.GetError().GetMessage());
     }
 
     TEST_F(BucketAndObjectOperationTest, TestS3AccessPointARN)


### PR DESCRIPTION
*Issue #, if available:*
Some other things may change the exact message
*Description of changes:*
Remove the exact string check in the negative test.
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
