### PR TITLE
fix gcc version for smithy attribute

### DIFF
--- a/src/aws-cpp-sdk-core/include/smithy/Smithy_EXPORTS.h
+++ b/src/aws-cpp-sdk-core/include/smithy/Smithy_EXPORTS.h
@@ -24,7 +24,7 @@
         #define SMITHY_API
     #endif // USE_IMPORT_EXPORT
 #else // defined (USE_WINDOWS_DLL_SEMANTICS) || defined (WIN32)
-    #if ((__GNUC__ >= 4) || defined(__clang__)) && defined(USE_IMPORT_EXPORT) && defined(SMITHY_EXPORTS)
+    #if ((__GNUC__ >= 6) || defined(__clang__)) && defined(USE_IMPORT_EXPORT) && defined(SMITHY_EXPORTS)
         #define SMITHY_API __attribute__((visibility("default")))
     #else
         #define SMITHY_API


### PR DESCRIPTION
*Description of changes:*

For the previous change for adding [smithy tracing interfaces](https://github.com/aws/aws-sdk-cpp/commit/30b5e57d19599139db49742c4341d6bb79342a3f) there was a comment to align the visibility of exports with how [crt](https://github.com/awslabs/aws-crt-cpp/blob/main/include/aws/crt/Exports.h#L32-L39) does it. This works for most recent versions of gcc but we have found [a bug in gcc in earlier versions](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=43407) that causes build failures.

```
In file included from aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/tracing/TraceEvent.h:8:0,
                 from aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/tracing/RootTraceProbe.h:8,
                 from aws-sdk-cpp/src/aws-cpp-sdk-core/source/smithy/tracing/RootTraceProbe.cpp:5,
                 from src/aws-cpp-sdk-core/ub_core.cpp:50:
aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/tracing/TraceEventType.h:24:13: error: type attributes ignored after type is already defined [-Werror=attributes]
             };
             ^
In file included from aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/tracing/TraceEvent.h:9:0,
                 from aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/tracing/RootTraceProbe.h:8,
                 from aws-sdk-cpp/src/aws-cpp-sdk-core/source/smithy/tracing/RootTraceProbe.cpp:5,
                 from src/aws-cpp-sdk-core/ub_core.cpp:50:
aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/tracing/TraceEventLevel.h:25:13: error: type attributes ignored after type is already defined [-Werror=attributes]
             };
             ^
In file included from aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/tracing/TraceSpan.h:8:0,
                 from aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/tracing/ScopedTracer.h:7,
                 from aws-sdk-cpp/src/aws-cpp-sdk-core/source/smithy/tracing/ScopedTracer.cpp:5,
                 from src/aws-cpp-sdk-core/ub_core.cpp:51:
aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/tracing/TraceStatType.h:30:13: error: type attributes ignored after type is already defined [-Werror=attributes]
             };
```

from that bug called out in gcc

`Fixed for GCC 6.`

Since this is a new way of limiting visibility in the SDK, bumping the version of gcc required to 6 so that this bug will not effect users using old versions.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
