### PR TITLE
Disable dynamic content on doxygen docs, do not embed svgs

### DIFF
--- a/docs/doxygen/config/Doxyfile-prj.cfg
+++ b/docs/doxygen/config/Doxyfile-prj.cfg
@@ -83,6 +83,7 @@ GRAPHICAL_HIERARCHY    = NO
 # Disable JS dynamic content as it is incompatible with accessibility requirements
 HTML_DYNAMIC_MENUS     = NO
 HTML_DYNAMIC_SECTIONS  = NO
+HTML_DYNAMIC_TUMBLERS  = NO
 
 # Markdown to not generate empty drop-down arrows
 TOC_INCLUDE_HEADINGS   = 0


### PR DESCRIPTION
*Issue #, if available:*
Links on embedded SVGs are not clickable: https://sdk.amazonaws.com/cpp/api/LATEST/aws-cpp-sdk-s3/html/class_aws_1_1_s3_1_1_s3_client.html
*Description of changes:*
Disable hide-show on inherited sections; do not embed svgs.
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
