### PR TITLE
Update EnvironmentAWSCredentialsProvider LogLevel

### DIFF
--- a/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
@@ -83,7 +83,7 @@ AWSCredentials EnvironmentAWSCredentialsProvider::GetAWSCredentials()
         if (!secretKey.empty())
         {
             credentials.SetAWSSecretKey(secretKey);
-            AWS_LOGSTREAM_INFO(ENVIRONMENT_LOG_TAG, "Found secret key");
+            AWS_LOGSTREAM_DEBUG(ENVIRONMENT_LOG_TAG, "Found secret key");
         }
 
         auto sessionToken = Aws::Environment::GetEnv(SESSION_TOKEN_ENV_VAR);
@@ -91,7 +91,7 @@ AWSCredentials EnvironmentAWSCredentialsProvider::GetAWSCredentials()
         if(!sessionToken.empty())
         {
             credentials.SetSessionToken(sessionToken);
-            AWS_LOGSTREAM_INFO(ENVIRONMENT_LOG_TAG, "Found sessionToken");
+            AWS_LOGSTREAM_DEBUG(ENVIRONMENT_LOG_TAG, "Found sessionToken");
         }
     }
 


### PR DESCRIPTION
Addressing issue #2533 
This updates EnvironmentAWSCredentialsProvider LogLevel to be AWS_LOGSTREAM_DEBUG instead of AWS_LOGSTREAM_INFO. 

- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
