### PR TITLE
Fix gcc 12 uninitialized warning

### DIFF
--- a/tests/aws-cpp-sdk-core-tests/utils/CacheTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/CacheTest.cpp
@@ -81,7 +81,7 @@ TEST_F(CacheTests, TestPutWithSameKey)
     cache.Put("one", 1.0f, std::chrono::minutes(5));
     cache.Put("one", 1.1f, std::chrono::seconds(1));
 
-    float out;
+    float out = 0.0f;
     ASSERT_TRUE(cache.Get("one", out));
     ASSERT_EQ(1.1f, out);
 


### PR DESCRIPTION
*Description of changes:*

The sdk fails to build with warnings as errors on gcc12

```
build/gcc-12.3.0/include/c++/12.3.0/ostream:228:25: error: 'out' may be used uninitialized [-Werror=maybe-uninitialized]
  228 |         return _M_insert(static_cast<double>(__f));
      |                ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
aws-sdk-cpp/tests/aws-cpp-sdk-core-tests/utils/CacheTest.cpp: In member function 'virtual void CacheTests_TestPutWithSameKey_Test::TestBody()':
aws-sdk-cpp/tests/aws-cpp-sdk-core-tests/utils/CacheTest.cpp:84:11: note: 'out' was declared here
   84 |     float out;
      |           ^~~
```

This initializes the variable to 0.0 to fix this warning.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
