### PR TITLE
Fix Windows clang-cl build

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinHttpConnectionPoolMgr.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinHttpConnectionPoolMgr.h
@@ -34,7 +34,7 @@ namespace Aws
             /**
              * Gets the log tag to use for logging in the base class.
              */
-            const char* GetLogTag() const { return "WinHttpConnectionPoolMgr"; }
+            const char* GetLogTag() const override { return "WinHttpConnectionPoolMgr"; }
 
         private:
             virtual void DoCloseHandle(void* handle) const override;

--- a/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinSyncHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinSyncHttpClient.h
@@ -7,7 +7,7 @@
 
 #include <aws/core/Core_EXPORTS.h>
 
-#include <aws/core/utils/memory/stl/AwsStringStream.h>
+#include <aws/core/utils/memory/stl/AWSStringStream.h>
 #include <aws/core/auth/AWSAuthSigner.h>
 #include <aws/core/http/HttpClient.h>
 #include <aws/core/http/standard/StandardHttpResponse.h>

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/crypto/bcrypt/CryptoImpl.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/crypto/bcrypt/CryptoImpl.h
@@ -209,7 +209,7 @@ namespace Aws
                 /**
                 * Initialize with key and initializationVector, set tag for decryption of authenticated modes  (move the buffers)
                 */
-                BCryptSymmetricCipher(CryptoBuffer&& key, CryptoBuffer&& initializationVector, CryptoBuffer&& tag = std::move(CryptoBuffer(0)));
+                BCryptSymmetricCipher(CryptoBuffer&& key, CryptoBuffer&& initializationVector, CryptoBuffer&& tag = CryptoBuffer(0));
 
                 BCryptSymmetricCipher(const BCryptSymmetricCipher&) = delete;
                 BCryptSymmetricCipher& operator=(const BCryptSymmetricCipher&) = delete;

--- a/src/aws-cpp-sdk-core/include/smithy/tracing/TraceSpan.h
+++ b/src/aws-cpp-sdk-core/include/smithy/tracing/TraceSpan.h
@@ -16,7 +16,7 @@ namespace smithy {
             /**
              * Status of the span.
              */
-            enum class SMITHY_API TraceSpanStatus {
+            enum class TraceSpanStatus {
                 UNSET,
                 OK,
                 ERROR,

--- a/src/aws-cpp-sdk-core/include/smithy/tracing/Tracer.h
+++ b/src/aws-cpp-sdk-core/include/smithy/tracing/Tracer.h
@@ -14,7 +14,7 @@ namespace smithy {
             /**
              * The kind of span being created.
              */
-            enum class SMITHY_API SpanKind {
+            enum class SpanKind {
                 INTERNAL,
                 CLIENT,
                 SERVER,

--- a/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
@@ -5,7 +5,7 @@
 
 #include <aws/core/http/windows/WinHttpSyncHttpClient.h>
 
-#include <aws/core/Http/HttpRequest.h>
+#include <aws/core/http/HttpRequest.h>
 #include <aws/core/http/standard/StandardHttpResponse.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/logging/LogMacros.h>
@@ -27,8 +27,6 @@ using namespace Aws::Http;
 using namespace Aws::Http::Standard;
 using namespace Aws::Utils;
 using namespace Aws::Utils::Logging;
-
-static const uint32_t HTTP_REQUEST_WRITE_BUFFER_LENGTH = 8192;
 
 static void WinHttpEnableHttp2(void* handle)
 {

--- a/src/aws-cpp-sdk-core/source/http/windows/WinINetSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinINetSyncHttpClient.cpp
@@ -5,7 +5,7 @@
 
 #include <aws/core/http/windows/WinINetSyncHttpClient.h>
 
-#include <aws/core/Http/HttpRequest.h>
+#include <aws/core/http/HttpRequest.h>
 #include <aws/core/http/standard/StandardHttpResponse.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/logging/LogMacros.h>
@@ -26,8 +26,6 @@ using namespace Aws::Http;
 using namespace Aws::Http::Standard;
 using namespace Aws::Utils;
 using namespace Aws::Utils::Logging;
-
-static const uint32_t HTTP_REQUEST_WRITE_BUFFER_LENGTH = 8192;
 
 static void WinINetEnableHttp2(void* handle)
 {

--- a/src/aws-cpp-sdk-core/source/http/windows/WinSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinSyncHttpClient.cpp
@@ -4,7 +4,7 @@
  */
 
 #include <aws/core/http/windows/WinSyncHttpClient.h>
-#include <aws/core/Http/HttpRequest.h>
+#include <aws/core/http/HttpRequest.h>
 #include <aws/core/http/standard/StandardHttpResponse.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/HashingUtils.h>
@@ -27,7 +27,6 @@ using namespace Aws::Utils;
 using namespace Aws::Utils::Logging;
 
 static const uint32_t HTTP_REQUEST_WRITE_BUFFER_LENGTH = 8192;
-static const char CLASS_TAG[] = "WinSyncHttpClient";
 
 WinSyncHttpClient::~WinSyncHttpClient()
 {
@@ -349,7 +348,7 @@ std::shared_ptr<HttpResponse> WinSyncHttpClient::MakeRequest(const std::shared_p
         }
     }
 
-    if (!success && !IsRequestProcessingEnabled() || !ContinueRequest(*request))
+    if ((!success && !IsRequestProcessingEnabled()) || !ContinueRequest(*request))
     {
         response->SetClientErrorType(CoreErrors::USER_CANCELLED);
         response->SetClientErrorMessage("Request processing disabled or continuation cancelled by user's continuation handler.");

--- a/src/aws-cpp-sdk-core/source/utils/crypto/bcrypt/CryptoImpl.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/crypto/bcrypt/CryptoImpl.cpp
@@ -932,7 +932,6 @@ namespace Aws
                 {
                     return CryptoBuffer();
                 }
-                size_t bytesWritten = 0;
                 Aws::Vector<ByteBuffer*> finalBufferSet(0);
 
                 CryptoBuffer bufferToEncrypt;
@@ -984,7 +983,6 @@ namespace Aws
                         *newBuffer = slicedBuffers[i] ^ encryptedText;
                         finalBufferSet[i] = newBuffer;
                         m_workingIv = IncrementCTRCounter(m_workingIv, 1);
-                        bytesWritten += static_cast<size_t>(lengthWritten);
                     }
                     else
                     {


### PR DESCRIPTION
*Description of changes:*
Fix Visual Studio 'C++ clang tools for Windows' build, a.k.a. `clang-cl`.

Tested using Visual Studio 2022 (17.6.3) with 'C++ clang tools for Windows (15.0.1)' using the following commands:
```
cmake .. -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Debug -T ClangCL
msbuild ALL_BUILD.vcxproj /p:Configuration=Debug
```

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
