### PR TITLE
Fix template class instantiation

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/Core_EXPORTS.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/Core_EXPORTS.h
@@ -18,12 +18,15 @@
         #else // AWS_CORE_EXPORTS
             #define  AWS_CORE_API __declspec(dllimport)
         #endif // AWS_CORE_EXPORTS
+        #define AWS_CORE_EXTERN
     #else // USE_IMPORT_EXPORT
         #define AWS_CORE_API
+        #define AWS_CORE_EXTERN extern
     #endif // USE_IMPORT_EXPORT
     #define AWS_CORE_LOCAL
 #else // defined (USE_WINDOWS_DLL_SEMANTICS) || defined (_WIN32)
     #define AWS_CORE_API
+    #define AWS_CORE_EXTERN extern
     #if __GNUC__ >= 4
         #define AWS_CORE_LOCAL __attribute__((visibility("hidden")))
     #else

--- a/src/aws-cpp-sdk-core/include/aws/core/endpoint/DefaultEndpointProvider.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/endpoint/DefaultEndpointProvider.h
@@ -110,7 +110,13 @@ namespace Aws
             BuiltInParametersT m_builtInParameters;
         };
 
-        // Export symbol from the DLL:
-        template class AWS_CORE_API DefaultEndpointProvider<Aws::Client::GenericClientConfiguration</*HasEndpointDiscovery*/ true> >;
+        /**
+         * Export endpoint provider symbols for Windows DLL, otherwise declare as extern
+         */
+        AWS_CORE_EXTERN template class AWS_CORE_API DefaultEndpointProvider<Aws::Client::GenericClientConfiguration<false>,
+            Aws::Endpoint::BuiltInParameters,
+            Aws::Endpoint::ClientContextParameters>;
+        
+        AWS_CORE_EXTERN template class AWS_CORE_API DefaultEndpointProvider<Aws::Client::GenericClientConfiguration<true>>;
     } // namespace Endpoint
 } // namespace Aws

--- a/src/aws-cpp-sdk-core/include/aws/core/endpoint/EndpointProviderBase.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/endpoint/EndpointProviderBase.h
@@ -70,7 +70,9 @@ namespace Aws
             virtual ResolveEndpointOutcome ResolveEndpoint(const EndpointParameters& endpointParameters) const = 0;
         };
 
-        // Export symbol from the DLL:
-        template class AWS_CORE_API EndpointProviderBase<Aws::Client::GenericClientConfiguration</*HasEndpointDiscovery*/ true> >;
+        /**
+         * Export endpoint provider symbols for Windows DLL, otherwise declare as extern
+         */
+        AWS_CORE_EXTERN template class AWS_CORE_API EndpointProviderBase<Aws::Client::GenericClientConfiguration<true>>;
     } // namespace Endpoint
 } // namespace Aws

--- a/src/aws-cpp-sdk-core/source/endpoint/DefaultEndpointProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/endpoint/DefaultEndpointProvider.cpp
@@ -12,12 +12,16 @@ namespace Aws
 namespace Endpoint
 {
 
+#ifndef AWS_CORE_EXPORTS // Except for Windows DLL
 /**
- * Export endpoint provider symbols from DLL
+ * Instantiate endpoint providers
  */
-template class AWS_CORE_API DefaultEndpointProvider<Aws::Client::GenericClientConfiguration<false>,
+template class DefaultEndpointProvider<Aws::Client::GenericClientConfiguration<false>,
             Aws::Endpoint::BuiltInParameters,
             Aws::Endpoint::ClientContextParameters>;
+
+template class DefaultEndpointProvider<Aws::Client::GenericClientConfiguration<true>>;
+#endif
 
 char CharToDec(const char c)
 {

--- a/src/aws-cpp-sdk-core/source/endpoint/EndpointProviderBase.cpp
+++ b/src/aws-cpp-sdk-core/source/endpoint/EndpointProviderBase.cpp
@@ -9,12 +9,15 @@ namespace Aws
 {
 namespace Endpoint
 {
+#ifndef AWS_CORE_EXPORTS // Except for Windows DLL
 /**
- * Export endpoint provider symbols from DLL
+ * Instantiate endpoint providers
  */
-template class AWS_CORE_API EndpointProviderBase<Aws::Client::GenericClientConfiguration<false>,
+template class EndpointProviderBase<Aws::Client::GenericClientConfiguration<false>,
             Aws::Endpoint::BuiltInParameters,
             Aws::Endpoint::ClientContextParameters>;
 
+template class EndpointProviderBase<Aws::Client::GenericClientConfiguration<true>>;
+#endif
 } // namespace Endpoint
 } // namespace Aws

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceExportHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceExportHeader.vm
@@ -21,9 +21,12 @@
         \#else
             $define ${api} __declspec(dllimport)
         #endif /* AWS_${metadata.classNamePrefix.toUpperCase()}_EXPORTS */
+        $define AWS_${metadata.classNamePrefix.toUpperCase()}_EXTERN
     \#else
         $define ${api}
+        $define AWS_${metadata.classNamePrefix.toUpperCase()}_EXTERN extern
     #endif // USE_IMPORT_EXPORT
 \#else // defined (USE_WINDOWS_DLL_SEMANTICS) || defined (WIN32)
     $define ${api}
+    $define AWS_${metadata.classNamePrefix.toUpperCase()}_EXTERN extern
 #endif // defined (USE_WINDOWS_DLL_SEMANTICS) || defined (WIN32)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/endpoint/EndpointProviderHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/endpoint/EndpointProviderHeader.vm
@@ -7,6 +7,7 @@
 #set($epContextClassName = "${metadata.classNamePrefix}ClientContextParameters")
 #set($epBuiltInClassName = "${metadata.classNamePrefix}BuiltInParameters")
 #set($exportMacro = "${CppViewHelper.computeExportValue($metadata.classNamePrefix)}")
+#set($externMacro = "AWS_${metadata.classNamePrefix.toUpperCase()}_EXTERN")
 #pragma once
 \#include <aws/${metadata.projectName}/${metadata.classNamePrefix}_EXPORTS.h>
 #if($serviceModel.metadata.serviceId == "S3" || $serviceModel.metadata.serviceId == "S3 Control")
@@ -101,12 +102,12 @@ using ${metadata.classNamePrefix}DefaultEpProviderBase =
 namespace Endpoint
 {
 /**
- * Export endpoint provider symbols from DLL
+ * Export endpoint provider symbols for Windows DLL, otherwise declare as extern
  */
-template class ${exportMacro}
+${externMacro} template class ${exportMacro}
     Aws::Endpoint::EndpointProviderBase<${serviceNamespace}::Endpoint::${metadata.classNamePrefix}ClientConfiguration, ${serviceNamespace}::Endpoint::${epBuiltInClassName}, ${serviceNamespace}::Endpoint::${epContextClassName}>;
 
-template class ${exportMacro}
+${externMacro} template class ${exportMacro}
     Aws::Endpoint::DefaultEndpointProvider<${serviceNamespace}::Endpoint::${metadata.classNamePrefix}ClientConfiguration, ${serviceNamespace}::Endpoint::${epBuiltInClassName}, ${serviceNamespace}::Endpoint::${epContextClassName}>;
 } // namespace Endpoint
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/endpoint/EndpointProviderSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/endpoint/EndpointProviderSource.vm
@@ -10,6 +10,24 @@
 
 namespace ${rootNamespace}
 {
+#if($serviceModel.metadata.serviceId == "S3" || $serviceModel.metadata.serviceId == "S3 Control" || $serviceModel.clientContextParams)
+#ifndef AWS_${metadata.classNamePrefix.toUpperCase()}_EXPORTS // Except for Windows DLL
+namespace Endpoint
+{
+/**
+ * Instantiate endpoint providers
+ */
+template class Aws::Endpoint::EndpointProviderBase<${serviceNamespace}::Endpoint::${metadata.classNamePrefix}ClientConfiguration,
+    ${serviceNamespace}::Endpoint::${epBuiltInClassName},
+    ${serviceNamespace}::Endpoint::${epContextClassName}>;
+
+template class Aws::Endpoint::DefaultEndpointProvider<${serviceNamespace}::Endpoint::${metadata.classNamePrefix}ClientConfiguration,
+    ${serviceNamespace}::Endpoint::${epBuiltInClassName},
+    ${serviceNamespace}::Endpoint::${epContextClassName}>;
+} // namespace Endpoint
+#endif
+
+#end
 namespace ${serviceNamespace}
 {
 namespace Endpoint


### PR DESCRIPTION
- For Windows DLL, export definition of template class instantiation directly in the header using __declspec(dllexport).
- For other builds (including Windows static lib), declare as extern in the header and define in the cpp.

This change is required to fix 'multiple definition of typeinfo' linker errors seen with some compilers, e.g. GCC for 32-bit armhf arm-linux-gnueabihf-gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1).

*Issue #, if available:*

*Description of changes:*

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [X] Windows
- [X] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
