### PR TITLE
Updates init retry strategy log level

### DIFF
--- a/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
@@ -254,7 +254,7 @@ std::shared_ptr<RetryStrategy> InitRetryStrategy(Aws::String retryMode)
         maxAttempts = static_cast<int>(Aws::Utils::StringUtils::ConvertToInt32(maxAttemptsString.c_str()));
         if (maxAttempts == 0)
         {
-            AWS_LOGSTREAM_WARN(CLIENT_CONFIG_TAG, "Retry Strategy will use the default max attempts.");
+            AWS_LOGSTREAM_INFO(CLIENT_CONFIG_TAG, "Retry Strategy will use the default max attempts.");
             maxAttempts = -1;
         }
     }


### PR DESCRIPTION
*Description of changes:*

The deafult ctor for ClientConfiguration will log a warning statement that default retry count is used, unless a env variable or config file variable is present to update the max retry count. This warning is noise, and should be a info statement. The deafult ctor should not emit warning logging statements for choosing deafults.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
