### PR TITLE
CSS for docs update to use div and span layout not table

### DIFF
--- a/docs/doxygen/static/aws-cpp-sdk.css
+++ b/docs/doxygen/static/aws-cpp-sdk.css
@@ -15,4 +15,36 @@
     }
 }
 
+div.memberdecls div[class^='memitem']{
+    transition: none;
+    padding-top: var(--spacing-small);
+    padding-bottom: var(--spacing-small);
+    border-top: 1px solid var(--separator-color);
+    border-bottom: 1px solid var(--separator-color);
+    background-color: var(--fragment-background);
+}
+
+div.memberdecls .memItemLeft,
+div.memberdecls .memItemRight,
+div.memberdecls .memTemplItemLeft,
+div.memberdecls .memTemplItemRight,
+div.memberdecls .memTemplParams {
+    transition: none;
+    padding-top: var(--spacing-small);
+    padding-bottom: var(--spacing-small);
+    background-color: var(--fragment-background);
+}
+
+span.memSeparator {
+    border-color: var(--separator-color);
+}
+
+div.memberdecls .memSeparator {
+    background: var(--page-background-color);
+    height: var(--spacing-large);
+    display:inline-block;
+    border: 0;
+    transition: none;
+}
+
 


### PR DESCRIPTION
*Issue #, if available:*
our local fork of doxygen has started to emit div span elements not tables
https://github.com/doxygen/doxygen/commit/07ca5382ee4e381ebf27248d2c9373262093442f
*Description of changes:*
amend CSS to improve look of the docs.
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
