### PR TITLE
Issue 2568

### DIFF
--- a/src/aws-cpp-sdk-core/source/Globals.cpp
+++ b/src/aws-cpp-sdk-core/source/Globals.cpp
@@ -72,5 +72,6 @@ namespace Aws
     void CleanupEnumOverflowContainer()
     {
         Aws::Delete(g_enumOverflow);
+        g_enumOverflow = nullptr;
     }
 }

--- a/src/aws-cpp-sdk-core/source/utils/component-registry/ComponentRegistry.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/component-registry/ComponentRegistry.cpp
@@ -42,7 +42,6 @@ namespace Aws
             void ShutdownComponentRegistry()
             {
                 std::unique_lock<std::mutex> lock(s_registryMutex);
-                assert(s_registry);
 
                 Aws::Delete(s_registry);
                 s_registry = nullptr;
@@ -80,7 +79,11 @@ namespace Aws
             void TerminateAllComponents()
             {
                 std::unique_lock<std::mutex> lock(s_registryMutex);
-                assert(s_registry);
+
+                if (!s_registry) {
+                    // Registry already shut down -- nothing to do.
+                    return;
+                }
 
                 for(const auto it : *s_registry)
                 {

--- a/tests/aws-cpp-sdk-eventbridge-tests/AwsSdkMisuseTests.cpp
+++ b/tests/aws-cpp-sdk-eventbridge-tests/AwsSdkMisuseTests.cpp
@@ -108,3 +108,18 @@ TEST_F(AwsSdkMisuseTest, MissingCurlyBracesTest)
     ASSERT_FALSE(outcomeAfterShutdown.IsSuccess());
     ASSERT_EQ((Aws::Client::CoreErrors) outcomeAfterShutdown.GetError().GetErrorType(), Aws::Client::CoreErrors::NOT_INITIALIZED);
 }
+
+TEST_F(AwsSdkMisuseTest, MultipleShutdownTest)
+{
+    Aws::SDKOptions options;
+    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Trace;
+
+    Aws::InitAPI(options);
+
+    // Shutdown the API.
+    Aws::ShutdownAPI(options);
+    // Now shut it down a second time. (This call must not crash.)
+    Aws::ShutdownAPI(options);
+    // And one more time, for good measure.
+    Aws::ShutdownAPI(options);
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/issues/2568

*Description of changes:*
    A recent change caused redundant calls to Aws::ShutdownAPI() to crash, with
    SEGV, due to null pointer dereference.
    
This commit fixes this regression and adds a unit test that shows that
    calling Aws::ShutdownAPI() multiple times no longer crashes.
    
Also updates function CleanupEnumOverflowContainer() to prevent a
    double-free on shutdown.


*Check all that applies:*
- [x ] Did a review by yourself.
- [x ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x ] Checked if this PR is a breaking (APIs have been changed) change.
- [x ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
