### PR TITLE
Windows GetMessage

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSError.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSError.h
@@ -12,13 +12,6 @@
 #include <aws/core/utils/json/JsonSerializer.h>
 #include <aws/core/utils/StringUtils.h>
 
-// TODO: temporary fix for naming conflicts on Windows.
-#ifdef _WIN32
-#ifdef GetMessage
-#undef GetMessage
-#endif
-#endif
-
 namespace Aws
 {
     namespace Client
@@ -114,7 +107,17 @@ namespace Aws
             /**
              * Gets the error message.
              */
+#ifdef _WIN32
+            #pragma push_macro("GetMessage")
+#undef GetMessage
             inline const Aws::String& GetMessage() const { return m_message; }
+            inline const Aws::String& GetMessageW() const { return GetMessage(); }
+            inline const Aws::String& GetMessageA() const { return GetMessage(); }
+
+#pragma pop_macro("GetMessage")
+#else
+            inline const Aws::String& GetMessage() const { return m_message; }
+#endif //#ifdef _WIN32
             /**
              * Sets the error message
              */

--- a/src/aws-cpp-sdk-s3-encryption/source/s3-encryption/S3EncryptionClient.cpp
+++ b/src/aws-cpp-sdk-s3-encryption/source/s3-encryption/S3EncryptionClient.cpp
@@ -8,9 +8,6 @@
 
 // TODO: temporary fix for naming conflicts on Windows.
 #ifdef _WIN32
-#ifdef GetMessage
-#undef GetMessage
-#endif
 #ifdef GetObject
 #undef GetObject
 #endif

--- a/src/aws-cpp-sdk-s3-encryption/source/s3-encryption/materials/KMSEncryptionMaterials.cpp
+++ b/src/aws-cpp-sdk-s3-encryption/source/s3-encryption/materials/KMSEncryptionMaterials.cpp
@@ -18,13 +18,6 @@ using namespace Aws::KMS::Model;
 using namespace Aws::Client;
 using namespace Aws::S3Encryption;
 
-// TODO: temporary fix for naming conflicts on Windows.
-#ifdef _WIN32
-#ifdef GetMessage
-#undef GetMessage
-#endif
-#endif
-
 namespace Aws
 {
     namespace S3Encryption

--- a/tests/aws-cpp-sdk-core-tests/aws/client/AWSClientTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/aws/client/AWSClientTest.cpp
@@ -23,13 +23,6 @@
 #include <thread>
 #include <aws/core/utils/logging/LogMacros.h>
 
-// TODO: temporary fix for naming conflicts for Windows.
-#ifdef _WIN32
-#ifdef GetMessage
-#undef GetMessage
-#endif
-#endif
-
 using namespace Aws;
 using namespace Aws::Client;
 using namespace Aws::Http;

--- a/tests/aws-cpp-sdk-mediastore-data-integration-tests/MediaStoreDataTest.cpp
+++ b/tests/aws-cpp-sdk-mediastore-data-integration-tests/MediaStoreDataTest.cpp
@@ -40,9 +40,6 @@ using namespace Aws::MediaStoreData::Model;
 
 // TODO: temporary fix for naming conflicts on Windows.
 #ifdef _WIN32
-#ifdef GetMessage
-#undef GetMessage
-#endif
 #ifdef GetObject
 #undef GetObject
 #endif

--- a/tests/testing-resources/include/aws/testing/AwsTestHelpers.h
+++ b/tests/testing-resources/include/aws/testing/AwsTestHelpers.h
@@ -14,10 +14,6 @@
 #include <aws/core/VersionConfig.h>
 #include <aws/core/utils/DateTime.h>
 
-#if defined(GetMessage)
-#undef GetMessage
-#endif
-
 #define AWS_ASSERT_SUCCESS(awsCppSdkOutcome) \
   ASSERT_TRUE(awsCppSdkOutcome.IsSuccess()) << "Error details: " << awsCppSdkOutcome.GetError() \
                                             << "\nNow timestamp: " << Aws::Utils::DateTime::Now().ToGmtString(Aws::Utils::DateFormat::ISO_8601_BASIC)


### PR DESCRIPTION
remove temporary workaround on windows that undefined getmessage to avoid naming conflict

*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/issues/2573

*Description of changes:*

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
