### PR TITLE
Add cmake arg to disable warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ if (LEGACY_BUILD)
     option(DISABLE_INTERNAL_IMDSV1_CALLS "Disables IMDSv1 internal client calls" OFF)
     option(BUILD_BENCHMARKS "Enables building the benchmark executable" OFF)
     option(BUILD_OPTEL "Enables building the open telemetry implementation of tracing" OFF)
+    option(AWS_SDK_WARNINGS_ARE_ERRORS "Compiler warning is treated as an error. Try turning this off when observing errors on a new or uncommon compiler" ON)
 
     set(AWS_USER_AGENT_CUSTOMIZATION "" CACHE STRING "User agent extension")
     set(AWS_TEST_REGION "US_EAST_1" CACHE STRING "Region to target integration tests against")

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -53,7 +53,10 @@ macro(set_gcc_flags)
 endmacro()
 
 macro(set_gcc_warnings)
-    list(APPEND AWS_COMPILER_WARNINGS "-Wall" "-Werror" "-pedantic" "-Wextra")
+    list(APPEND AWS_COMPILER_WARNINGS "-Wall" "-pedantic" "-Wextra")
+    if(AWS_SDK_WARNINGS_ARE_ERRORS)
+        list(APPEND AWS_COMPILER_WARNINGS "-Werror")
+    endif ()
     if(COMPILER_CLANG)
         if(PLATFORM_ANDROID)
             # when using clang with libc and API lower than 21 we need to include Android support headers and ignore the gnu-include-next warning.
@@ -153,7 +156,7 @@ macro(set_msvc_warnings)
         endif()
 
         # warnings as errors, max warning level (4)
-        if(NOT CMAKE_CXX_FLAGS MATCHES "/WX")
+        if(NOT CMAKE_CXX_FLAGS MATCHES "/WX" AND AWS_SDK_WARNINGS_ARE_ERRORS)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
         endif()
 


### PR DESCRIPTION
*Issue #, if available:*

[issues/2555](https://github.com/aws/aws-sdk-cpp/issues/2555)

*Description of changes:*

Creates a cmake var that will shut off warnings as errors if set. As mentioned in the issue, this will help alleviate pain downstream while fixes are being worked on for new compilers/different compiler versions.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
