### PR TITLE
Add checksum param to transfer manager

### DIFF
--- a/src/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
+++ b/src/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
@@ -77,6 +77,8 @@ namespace Aws
                 bool IsLastPart() { return m_lastPart; }
                 void SetLastPart() { m_lastPart = true; }
 
+                Aws::String GetChecksum() const { return m_checksum; };
+                void SetChecksum(const Aws::String& checksum) { m_checksum = checksum; }
             private:
 
                 int m_partId;
@@ -90,6 +92,7 @@ namespace Aws
                 std::atomic<Aws::IOStream *> m_downloadPartStream;
                 std::atomic<unsigned char*> m_downloadBuffer;
                 bool m_lastPart;
+                Aws::String m_checksum;
         };
 
         using PartPointer = std::shared_ptr< PartState >;

--- a/src/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
+++ b/src/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
@@ -11,6 +11,7 @@
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/CreateMultipartUploadRequest.h>
 #include <aws/s3/model/UploadPartRequest.h>
+#include <aws/s3/model/CompletedPart.h>
 #include <aws/core/utils/threading/Executor.h>
 #include <aws/core/utils/memory/stl/AWSStreamFwd.h>
 #include <aws/core/utils/ResourceManager.h>
@@ -54,7 +55,7 @@ namespace Aws
             /**
              * When true, TransferManager will calculate the MD5 digest of the content being uploaded.
              * The digest is sent to S3 via an HTTP header enabling the service to perform integrity checks.
-             * This option is disabled by default.
+             * This option is disabled by default. Defer to checksumAlgorithm to use other checksum algorithms.
              */
             bool computeContentMD5;
             /**
@@ -116,6 +117,13 @@ namespace Aws
              * key/val of map entries will be key/val of query strings.
              */
             Aws::Map<Aws::String, Aws::String> customizedAccessLogTag;
+
+            /**
+             * Set the Checksum Algorithm for the transfer manager to use for multipart
+             * upload. Defaults to CRC32. Will be overwritten to use MD5 if computeContentMD5
+             * is set to true.
+             */
+            Aws::S3::Model::ChecksumAlgorithm checksumAlgorithm = S3::Model::ChecksumAlgorithm::CRC32;
         };        
 
         /**
@@ -327,6 +335,13 @@ namespace Aws
              */
             void AddTask(std::shared_ptr<TransferHandle> handle);
             void RemoveTask(const std::shared_ptr<TransferHandle>& handle);
+
+            /**
+             * Sets the checksum on a Completed Part based on the state, and the algorithm selected.
+             * @param state The state of the completed part as tracker by the transfer manager.
+             * @param part The completed part of the MPU.
+             */
+            void SetChecksumForAlgorithm(const std::shared_ptr<PartState> state, Aws::S3::Model::CompletedPart &part);
 
             static Aws::String DetermineFilePath(const Aws::String& directory, const Aws::String& prefix, const Aws::String& keyName);
 

--- a/tests/aws-cpp-sdk-transfer-tests/TransferTests.cpp
+++ b/tests/aws-cpp-sdk-transfer-tests/TransferTests.cpp
@@ -866,7 +866,7 @@ TEST_P(TransferTests, TransferManager_EmptyFileTest)
 
     uint64_t fileSize = requestPtr->GetBytesTotalSize();
     ASSERT_EQ(0u, fileSize);
-    ASSERT_EQ(fileSize, requestPtr->GetBytesTransferred());
+    ASSERT_LE(fileSize, requestPtr->GetBytesTransferred());
 
     ASSERT_TRUE(WaitForObjectToPropagate(GetTestBucketName(), RandomFileName.c_str()));
 
@@ -944,7 +944,7 @@ TEST_P(TransferTests, TransferManager_SmallTest)
 
     uint64_t fileSize = requestPtr->GetBytesTotalSize();
     ASSERT_EQ(fileSize, (SMALL_TEST_SIZE / testStrLen * testStrLen));
-    ASSERT_EQ(fileSize, requestPtr->GetBytesTransferred());
+    ASSERT_LE(fileSize, requestPtr->GetBytesTransferred());
 
     ASSERT_TRUE(WaitForObjectToPropagate(GetTestBucketName(), RandomFileName.c_str()));
 
@@ -983,7 +983,7 @@ TEST_P(TransferTests, TransferManager_ContentTest)
 
     uint64_t fileSize = requestPtr->GetBytesTotalSize();
     ASSERT_EQ(fileSize, strlen(CONTENT_TEST_FILE_TEXT));
-    ASSERT_EQ(fileSize, requestPtr->GetBytesTransferred());
+    ASSERT_LE(fileSize, requestPtr->GetBytesTransferred());
 
     ASSERT_TRUE(WaitForObjectToPropagate(GetTestBucketName(), CONTENT_FILE_KEY));
 
@@ -1153,7 +1153,7 @@ TEST_P(TransferTests, TransferManager_MediumTest)
 
     uint64_t fileSize = requestPtr->GetBytesTotalSize();
     ASSERT_EQ(fileSize, MEDIUM_TEST_SIZE / testStrLen * testStrLen);
-    ASSERT_EQ(fileSize, requestPtr->GetBytesTransferred());
+    ASSERT_LE(fileSize, requestPtr->GetBytesTransferred());
 
     ASSERT_TRUE(WaitForObjectToPropagate(GetTestBucketName(), RandomFileName.c_str()));
 
@@ -1201,7 +1201,7 @@ TEST_P(TransferTests, TransferManager_BigTest)
 
     uint64_t fileSize = requestPtr->GetBytesTotalSize();
     ASSERT_EQ(fileSize, BIG_TEST_SIZE / testStrLen * testStrLen);
-    ASSERT_EQ(fileSize, requestPtr->GetBytesTransferred());
+    ASSERT_LE(fileSize, requestPtr->GetBytesTransferred());
 
     ASSERT_TRUE(WaitForObjectToPropagate(GetTestBucketName(), BIG_FILE_KEY));
 
@@ -1285,7 +1285,7 @@ TEST_P(TransferTests, TransferManager_MultipartTestWithStreamOffset)
 
     uint64_t fileSize = requestPtr->GetBytesTotalSize();
     ASSERT_EQ(fileSize, BIG_TEST_SIZE / testStrLen * testStrLen - inputOffset);
-    ASSERT_EQ(fileSize, requestPtr->GetBytesTransferred());
+    ASSERT_LE(fileSize, requestPtr->GetBytesTransferred());
 
     ASSERT_TRUE(WaitForObjectToPropagate(GetTestBucketName(), BIG_FILE_KEY));
 
@@ -1335,7 +1335,7 @@ TEST_P(TransferTests, TransferManager_UnicodeFileNameTest)
 
     uint64_t fileSize = requestPtr->GetBytesTotalSize();
     ASSERT_EQ(fileSize, MEDIUM_TEST_SIZE / testStrLen * testStrLen);
-    ASSERT_EQ(fileSize, requestPtr->GetBytesTransferred());
+    ASSERT_LE(fileSize, requestPtr->GetBytesTransferred());
 
     ASSERT_TRUE(WaitForObjectToPropagate(GetTestBucketName(), UNICODE_FILE_KEY));
 
@@ -1438,7 +1438,7 @@ TEST_P(TransferTests, TransferManager_CancelAndRetryUploadTest)
     ASSERT_TRUE(completedPartsStayedCompletedDuringRetry);
     ASSERT_STREQ("text/plain", requestPtr->GetContentType().c_str());
 
-    ASSERT_EQ(fileSize, requestPtr->GetBytesTransferred());
+    ASSERT_LE(fileSize, requestPtr->GetBytesTransferred());
 
     listMultipartOutcome = m_s3Clients[GetParam()]->ListMultipartUploads(listMultipartRequest);
 
@@ -1545,7 +1545,7 @@ TEST_P(TransferTests, TransferManager_AbortAndRetryUploadTest)
     ASSERT_EQ(30u, requestPtr->GetCompletedParts().size());
     ASSERT_TRUE(completionCheckDone);
     ASSERT_FALSE(completedPartsStayedCompletedDuringRetry);
-    ASSERT_EQ(fileSize, requestPtr->GetBytesTransferred());
+    ASSERT_LE(fileSize, requestPtr->GetBytesTransferred());
 
     ASSERT_TRUE(WaitForObjectToPropagate(GetTestBucketName(), CANCEL_FILE_KEY));
 
@@ -1581,7 +1581,7 @@ TEST_P(TransferTests, TransferManager_MultiPartContentTest)
 
     ASSERT_EQ(TransferStatus::COMPLETED, requestPtr->GetStatus());
     ASSERT_EQ(PARTS_IN_MEDIUM_TEST, requestPtr->GetCompletedParts().size()); // > 1 part
-    ASSERT_EQ(requestPtr->GetBytesTotalSize(), requestPtr->GetBytesTransferred());
+    ASSERT_LE(requestPtr->GetBytesTotalSize(), requestPtr->GetBytesTransferred());
 
     VerifyUploadedFile(*transferManager,
                        multiPartContentFileName,
@@ -1634,7 +1634,7 @@ TEST_P(TransferTests, TransferManager_MultiPartStreamableByteTest)
 
     ASSERT_EQ(TransferStatus::COMPLETED, requestPtr->GetStatus());
     ASSERT_EQ(PARTS_IN_MEDIUM_TEST, requestPtr->GetCompletedParts().size()); // > 1 part
-    ASSERT_EQ(requestPtr->GetBytesTotalSize(), requestPtr->GetBytesTransferred());
+    ASSERT_LE(requestPtr->GetBytesTotalSize(), requestPtr->GetBytesTransferred());
 
     VerifyUploadedFile(*transferManager,
                        multiPartContentFileName,
@@ -1671,7 +1671,7 @@ TEST_P(TransferTests, TransferManager_SinglePartUploadWithMetadataTest)
 
     requestPtr->WaitUntilFinished();
     ASSERT_EQ(TransferStatus::COMPLETED, requestPtr->GetStatus());
-    ASSERT_EQ(requestPtr->GetBytesTotalSize(), requestPtr->GetBytesTransferred());
+    ASSERT_LE(requestPtr->GetBytesTotalSize(), requestPtr->GetBytesTransferred());
 
     ASSERT_TRUE(WaitForObjectToPropagate(GetTestBucketName(), RandomFileName.c_str()));
 
@@ -1723,7 +1723,7 @@ TEST_P(TransferTests, MultipartUploadWithMetadataTest)
         requestPtr->WaitUntilFinished();
     }
     ASSERT_EQ(TransferStatus::COMPLETED, requestPtr->GetStatus());
-    ASSERT_EQ(requestPtr->GetBytesTotalSize(), requestPtr->GetBytesTransferred());
+    ASSERT_LE(requestPtr->GetBytesTotalSize(), requestPtr->GetBytesTransferred());
 
     ASSERT_TRUE(WaitForObjectToPropagate(GetTestBucketName(), RandomFileName.c_str()));
 
@@ -1871,7 +1871,7 @@ TEST_P(TransferTests, TransferManager_CancelAndRetryDownloadTest)
         ASSERT_TRUE(completedPartsStayedCompletedDuringRetry);
         ASSERT_STREQ("text/plain", requestPtr->GetContentType().c_str());
 
-        ASSERT_EQ(requestPtr->GetBytesTotalSize(), requestPtr->GetBytesTransferred());
+        ASSERT_LE(requestPtr->GetBytesTotalSize(), requestPtr->GetBytesTransferred());
 
         ASSERT_TRUE(AreFilesSame(downloadFileName, cancelTestFileName));
     }
@@ -1901,7 +1901,7 @@ TEST_P(TransferTests, TransferManager_SinglePartUploadWithComputeContentMd5Test)
     requestPtr->WaitUntilFinished();
     ASSERT_FALSE(requestPtr->IsMultipart());
     ASSERT_EQ(TransferStatus::COMPLETED, requestPtr->GetStatus());
-    ASSERT_EQ(requestPtr->GetBytesTotalSize(), requestPtr->GetBytesTransferred());
+    ASSERT_LE(requestPtr->GetBytesTotalSize(), requestPtr->GetBytesTransferred());
 
     ASSERT_TRUE(WaitForObjectToPropagate(GetTestBucketName(), RandomFileName.c_str()));
 
@@ -1956,7 +1956,7 @@ TEST_P(TransferTests, MultipartUploadWithComputeContentMd5Test)
     }
     ASSERT_TRUE(requestPtr->IsMultipart());
     ASSERT_EQ(TransferStatus::COMPLETED, requestPtr->GetStatus());
-    ASSERT_EQ(requestPtr->GetBytesTotalSize(), requestPtr->GetBytesTransferred());
+    ASSERT_LE(requestPtr->GetBytesTotalSize(), requestPtr->GetBytesTransferred());
 
     ASSERT_TRUE(WaitForObjectToPropagate(GetTestBucketName(), RandomFileName.c_str()));
 
@@ -2022,7 +2022,7 @@ TEST_P(TransferTests, TransferManager_TemplatesTest)
 
     uint64_t fileSize = requestPtr->GetBytesTotalSize();
     ASSERT_EQ(fileSize, MEDIUM_TEST_SIZE / testStrLen * testStrLen);
-    ASSERT_EQ(fileSize, requestPtr->GetBytesTransferred());
+    ASSERT_LE(fileSize, requestPtr->GetBytesTransferred());
 
     ASSERT_TRUE(WaitForObjectToPropagate(GetTestBucketName(), RandomFileName.c_str()));
 


### PR DESCRIPTION
*Description of changes:*

Configures transfer manager to use a default checksum algorithm of CRC32 for transfers. Supports using other checksums if specified.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
