### PR TITLE
Add missing definition for GenerateSignature

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/auth/signer/AWSAuthV4Signer.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/signer/AWSAuthV4Signer.h
@@ -184,7 +184,6 @@ namespace Aws
             Aws::String GenerateStringToSign(const Aws::String& dateValue, const Aws::String& simpleDate,
                     const Aws::String& canonicalRequestHash, const Aws::String& region,
                     const Aws::String& serviceName) const;
-            Aws::Utils::ByteBuffer ComputeHash(const Aws::String& secretKey, const Aws::String& simpleDate) const;
             Aws::Utils::ByteBuffer ComputeHash(const Aws::String& secretKey,
                     const Aws::String& simpleDate, const Aws::String& region, const Aws::String& serviceName) const;
             bool SignRequestWithSigV4a(Aws::Http::HttpRequest& request, const char* region, const char* serviceName,

--- a/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
@@ -466,6 +466,17 @@ bool AWSAuthV4Signer::ServiceRequireUnsignedPayload(const Aws::String& serviceNa
     return "s3" == serviceName || "s3-object-lambda" == serviceName;
 }
 
+Aws::String AWSAuthV4Signer::GenerateSignature(const AWSCredentials &credentials,
+    const String &stringToSign,
+    const String &simpleDate) const
+{
+    return GenerateSignature(credentials,
+        stringToSign,
+        simpleDate,
+        GetRegion(),
+        GetServiceName());
+}
+
 Aws::String AWSAuthV4Signer::GenerateSignature(const AWSCredentials& credentials, const Aws::String& stringToSign,
         const Aws::String& simpleDate, const Aws::String& region, const Aws::String& serviceName) const
 {


### PR DESCRIPTION
*Issue #, if available:*

[issues/2599](https://github.com/aws/aws-sdk-cpp/issues/2599)

*Description of changes:*

There was a missing definition for the public function

```
Aws::String GenerateSignature(const Aws::Auth::AWSCredentials& credentials,
  const Aws::String& stringToSign, 
  const Aws::String& simpleDate) const;
```

In the sigv4 signer. This PR adds the implementation and calls the corresponding private method.

We also tidy up and remove another un-implemented private fucntion.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
