### PR TITLE
[Curl Client / Transfer Manager]: add error handling for failing local writes

### DIFF
--- a/src/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
+++ b/src/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
@@ -360,7 +360,11 @@ namespace Aws
 
             const CreateDownloadStreamCallback& GetCreateDownloadStreamFunction() const { return m_createDownloadStreamFn; }
 
-            void WritePartToDownloadStream(Aws::IOStream* partStream, uint64_t writeOffset);
+            /**
+             * Write @partStream to the configured output (f)stream.
+             * Return empty string on success, string with error message on error.
+             */
+            Aws::String WritePartToDownloadStream(Aws::IOStream* partStream, uint64_t writeOffset);
 
             void ApplyDownloadConfiguration(const DownloadConfiguration& downloadConfig);
 

--- a/src/aws-cpp-sdk-transfer/source/transfer/TransferHandle.cpp
+++ b/src/aws-cpp-sdk-transfer/source/transfer/TransferHandle.cpp
@@ -5,6 +5,7 @@
 
 #include <aws/transfer/TransferHandle.h>
 #include <aws/core/utils/logging/LogMacros.h>
+#include <aws/core/utils/memory/stl/SimpleStringStream.h>
 
 #include <cassert>
 
@@ -376,9 +377,10 @@ namespace Aws
             return !m_cancel.load();
         }
 
-        void TransferHandle::WritePartToDownloadStream(Aws::IOStream* partStream, uint64_t writeOffset)
+        Aws::String TransferHandle::WritePartToDownloadStream(Aws::IOStream* partStream, uint64_t writeOffset)
         {
             std::lock_guard<std::mutex> lock(m_downloadStreamLock);
+            Aws::SimpleStringStream ss;
 
             if(m_downloadStream == nullptr)
             {
@@ -388,9 +390,37 @@ namespace Aws
             }
 
             partStream->seekg(0);
+
             m_downloadStream->seekp(m_downloadStreamBaseOffset + writeOffset);
+            if (m_downloadStream->fail())
+            {
+                ss << "Failed to seek to (" << m_downloadStreamBaseOffset << " + " << writeOffset << ")"
+                   << " in '" << m_fileName << "' from " <<  m_bucket << "/" << m_key
+                   << " (eof: " << m_downloadStream->eof()
+                   << ", bad: " << m_downloadStream->bad() << ")";
+                return ss.str();
+            }
+
             (*m_downloadStream) << partStream->rdbuf();
+            if (m_downloadStream->fail())
+            {
+                ss << "Failed to write from " << m_bucket << "/" << m_key
+                   << " to '" <<  m_fileName << "'" << " at " << writeOffset
+                   << " (eof: " << m_downloadStream->eof()
+                   << ", bad: " << m_downloadStream->bad() << ")";
+                return ss.str();
+            }
+
             m_downloadStream->flush();
+            if (m_downloadStream->fail())
+            {
+                ss << "Failed to flush from " << m_bucket << "/" << m_key
+                   << " to '" << m_fileName << "'"
+                   << " (eof: " << m_downloadStream->eof()
+                   << ", bad: " << m_downloadStream->bad() << ")";
+                return ss.str();
+            }
+            return "";
         }
 
         void TransferHandle::ApplyDownloadConfiguration(const DownloadConfiguration& downloadConfig)


### PR DESCRIPTION
When downloading file data via the CurlHTTPClient or the TransferManager, there are no checks for failing local writes.

If a local write fails, it fails silently.

This caused difficult to debug corruption in several of our download applications. If a local disk was close to filling up, some files of the parallel download would be partially written out. Distinguishing partially written/corrupted files from healthy ones took time.

Avoid the problem by checking the stream status, and returning an error if any of the fstream operations fails.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
  Code changes fixed missing error handling. We haven't had issues reported with failing local writes since introducing this change about 2 years ago.
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.