### PR TITLE
Fix issue 2612

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/ClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/ClientConfiguration.h
@@ -19,7 +19,7 @@ namespace Aws
     {
         struct AWS_S3CRT_API ClientConfiguration : Aws::S3Crt::S3CrtClientConfiguration
         {
-            ClientConfiguration(const Client::DefaultClientConfiguration &configuration = {}) : Aws::S3Crt::S3CrtClientConfiguration(configuration),
+            ClientConfiguration() : Aws::S3Crt::S3CrtClientConfiguration(),
                 partSize(5 * 1024 * 1024),
                 throughputTargetGbps(2.0) {}
 

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/ClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/ClientConfiguration.h
@@ -19,7 +19,7 @@ namespace Aws
     {
         struct AWS_S3CRT_API ClientConfiguration : Aws::S3Crt::S3CrtClientConfiguration
         {
-            ClientConfiguration() : Aws::S3Crt::S3CrtClientConfiguration(),
+            ClientConfiguration(bool shouldDisableIMDS = false) : Aws::S3Crt::S3CrtClientConfiguration(shouldDisableIMDS),
                 partSize(5 * 1024 * 1024),
                 throughputTargetGbps(2.0) {}
 

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/ClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/ClientConfiguration.h
@@ -19,7 +19,7 @@ namespace Aws
     {
         struct AWS_S3CRT_API ClientConfiguration : Aws::S3Crt::S3CrtClientConfiguration
         {
-            ClientConfiguration(bool shouldDisableIMDS = false) : Aws::S3Crt::S3CrtClientConfiguration(shouldDisableIMDS),
+            ClientConfiguration(const Client::DefaultClientConfiguration &configuration = {}) : Aws::S3Crt::S3CrtClientConfiguration(configuration),
                 partSize(5 * 1024 * 1024),
                 throughputTargetGbps(2.0) {}
 

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
@@ -25,7 +25,7 @@ namespace Aws
         {
             using BaseClientConfigClass = Aws::Client::GenericClientConfiguration</*EndpointDiscoverySupported*/true>;
 
-            S3CrtClientConfiguration(const Client::DefaultClientConfiguration &configuration = {});
+            S3CrtClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
 
             /**
             * Create a configuration based on settings in the aws configuration file for the given profile name.

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
@@ -25,7 +25,7 @@ namespace Aws
         {
             using BaseClientConfigClass = Aws::Client::GenericClientConfiguration</*EndpointDiscoverySupported*/true>;
 
-            S3CrtClientConfiguration(bool shouldDisableIMDS = false);
+            S3CrtClientConfiguration(const Client::DefaultClientConfiguration &configuration = {});
 
             /**
             * Create a configuration based on settings in the aws configuration file for the given profile name.

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
@@ -25,7 +25,7 @@ namespace Aws
         {
             using BaseClientConfigClass = Aws::Client::GenericClientConfiguration</*EndpointDiscoverySupported*/true>;
 
-            S3CrtClientConfiguration();
+            S3CrtClientConfiguration(bool shouldDisableIMDS = false);
 
             /**
             * Create a configuration based on settings in the aws configuration file for the given profile name.

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClientConfiguration.cpp
@@ -54,8 +54,8 @@ void S3CrtClientConfiguration::LoadS3CrtSpecificConfig(const Aws::String& inputP
   }
 }
 
-S3CrtClientConfiguration::S3CrtClientConfiguration(bool shouldDisableIMDS = false)
-: BaseClientConfigClass(shouldDisableIMDS)
+S3CrtClientConfiguration::S3CrtClientConfiguration(const Client::DefaultClientConfiguration &configuration)
+: BaseClientConfigClass(configuration)
 {
   LoadS3CrtSpecificConfig(this->profileName);
 }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClientConfiguration.cpp
@@ -54,8 +54,8 @@ void S3CrtClientConfiguration::LoadS3CrtSpecificConfig(const Aws::String& inputP
   }
 }
 
-S3CrtClientConfiguration::S3CrtClientConfiguration()
-: BaseClientConfigClass()
+S3CrtClientConfiguration::S3CrtClientConfiguration(bool shouldDisableIMDS = false)
+: BaseClientConfigClass(shouldDisableIMDS)
 {
   LoadS3CrtSpecificConfig(this->profileName);
 }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClientConfiguration.cpp
@@ -54,7 +54,7 @@ void S3CrtClientConfiguration::LoadS3CrtSpecificConfig(const Aws::String& inputP
   }
 }
 
-S3CrtClientConfiguration::S3CrtClientConfiguration(const Client::DefaultClientConfiguration &configuration)
+S3CrtClientConfiguration::S3CrtClientConfiguration(const Client::ClientConfigurationInitValues &configuration)
 : BaseClientConfigClass(configuration)
 {
   LoadS3CrtSpecificConfig(this->profileName);

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ClientConfiguration.h
@@ -25,7 +25,7 @@ namespace Aws
         {
             using BaseClientConfigClass = Aws::Client::GenericClientConfiguration</*EndpointDiscoverySupported*/true>;
 
-            S3ClientConfiguration();
+            S3ClientConfiguration(const Client::DefaultClientConfiguration &configuration = {});
 
             /**
             * Create a configuration based on settings in the aws configuration file for the given profile name.

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ClientConfiguration.h
@@ -25,7 +25,7 @@ namespace Aws
         {
             using BaseClientConfigClass = Aws::Client::GenericClientConfiguration</*EndpointDiscoverySupported*/true>;
 
-            S3ClientConfiguration(const Client::DefaultClientConfiguration &configuration = {});
+            S3ClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
 
             /**
             * Create a configuration based on settings in the aws configuration file for the given profile name.

--- a/generated/src/aws-cpp-sdk-s3/source/S3ClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3ClientConfiguration.cpp
@@ -54,8 +54,8 @@ void S3ClientConfiguration::LoadS3SpecificConfig(const Aws::String& inputProfile
   }
 }
 
-S3ClientConfiguration::S3ClientConfiguration()
-: BaseClientConfigClass()
+S3ClientConfiguration::S3ClientConfiguration(const Client::DefaultClientConfiguration &configuration)
+: BaseClientConfigClass(configuration)
 {
   LoadS3SpecificConfig(this->profileName);
 }

--- a/generated/src/aws-cpp-sdk-s3/source/S3ClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3ClientConfiguration.cpp
@@ -54,7 +54,7 @@ void S3ClientConfiguration::LoadS3SpecificConfig(const Aws::String& inputProfile
   }
 }
 
-S3ClientConfiguration::S3ClientConfiguration(const Client::DefaultClientConfiguration &configuration)
+S3ClientConfiguration::S3ClientConfiguration(const Client::ClientConfigurationInitValues &configuration)
 : BaseClientConfigClass(configuration)
 {
   LoadS3SpecificConfig(this->profileName);

--- a/generated/src/aws-cpp-sdk-s3control/include/aws/s3control/S3ControlClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3control/include/aws/s3control/S3ControlClientConfiguration.h
@@ -18,7 +18,7 @@ namespace Aws
         {
             using BaseClientConfigClass = Aws::Client::GenericClientConfiguration</*EndpointDiscoverySupported*/true>;
 
-            S3ControlClientConfiguration(const Client::DefaultClientConfiguration &configuration = {});
+            S3ControlClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
 
             /**
             * Create a configuration based on settings in the aws configuration file for the given profile name.

--- a/generated/src/aws-cpp-sdk-s3control/include/aws/s3control/S3ControlClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3control/include/aws/s3control/S3ControlClientConfiguration.h
@@ -18,7 +18,7 @@ namespace Aws
         {
             using BaseClientConfigClass = Aws::Client::GenericClientConfiguration</*EndpointDiscoverySupported*/true>;
 
-            S3ControlClientConfiguration();
+            S3ControlClientConfiguration(const Client::DefaultClientConfiguration &configuration = {});
 
             /**
             * Create a configuration based on settings in the aws configuration file for the given profile name.

--- a/generated/src/aws-cpp-sdk-s3control/source/S3ControlClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/S3ControlClientConfiguration.cpp
@@ -26,8 +26,8 @@ void S3ControlClientConfiguration::LoadS3ControlSpecificConfig(const Aws::String
   }
 }
 
-S3ControlClientConfiguration::S3ControlClientConfiguration()
-: BaseClientConfigClass()
+S3ControlClientConfiguration::S3ControlClientConfiguration(const Client::DefaultClientConfiguration &configuration)
+: BaseClientConfigClass(configuration)
 {
   LoadS3ControlSpecificConfig(this->profileName);
 }

--- a/generated/src/aws-cpp-sdk-s3control/source/S3ControlClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/S3ControlClientConfiguration.cpp
@@ -26,7 +26,7 @@ void S3ControlClientConfiguration::LoadS3ControlSpecificConfig(const Aws::String
   }
 }
 
-S3ControlClientConfiguration::S3ControlClientConfiguration(const Client::DefaultClientConfiguration &configuration)
+S3ControlClientConfiguration::S3ControlClientConfiguration(const Client::ClientConfigurationInitValues &configuration)
 : BaseClientConfigClass(configuration)
 {
   LoadS3ControlSpecificConfig(this->profileName);

--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -60,8 +60,11 @@ namespace Aws
           UseRequestCompression useRequestCompression=UseRequestCompression::ENABLE;
           size_t requestMinCompressionSizeBytes = 10240;
         };
-
-        struct DefaultClientConfiguration {
+         /**
+         * This structure is used to provide initial configuration values to the default ClientConfiguration constructor for the following parameter(s):
+          * - disableIMDS
+         */
+        struct ClientConfigurationInitValues {
             bool shouldDisableIMDS = false;
         };
 
@@ -71,7 +74,11 @@ namespace Aws
          */
         struct AWS_CORE_API ClientConfiguration
         {
-            ClientConfiguration(const DefaultClientConfiguration &configuration = {});
+                /**
+                 * Create a configuration with default settings. By default IMDS calls are enabled.
+                 * @param ClientConfigurationInitValues ClientConfiguration initial customizable values
+                 */
+            ClientConfiguration(const ClientConfigurationInitValues &configuration = {});
 
             /**
              * Create a configuration based on settings in the aws configuration file for the given profile name.

--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -67,7 +67,7 @@ namespace Aws
          */
         struct AWS_CORE_API ClientConfiguration
         {
-            ClientConfiguration();
+            ClientConfiguration(bool shouldDisableIMDS = false);
 
             /**
              * Create a configuration based on settings in the aws configuration file for the given profile name.

--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -61,13 +61,17 @@ namespace Aws
           size_t requestMinCompressionSizeBytes = 10240;
         };
 
+        struct DefaultClientConfiguration {
+            bool shouldDisableIMDS = false;
+        };
+
         /**
          * This mutable structure is used to configure any of the AWS clients.
          * Default values can only be overwritten prior to passing to the client constructors.
          */
         struct AWS_CORE_API ClientConfiguration
         {
-            ClientConfiguration(bool shouldDisableIMDS = false);
+            ClientConfiguration(const DefaultClientConfiguration &configuration = {});
 
             /**
              * Create a configuration based on settings in the aws configuration file for the given profile name.

--- a/src/aws-cpp-sdk-core/include/aws/core/client/GenericClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/GenericClientConfiguration.h
@@ -20,8 +20,8 @@ namespace Aws
         {
             static const bool EndpointDiscoverySupported = HasEndpointDiscovery;
 
-            GenericClientConfiguration()
-              : ClientConfiguration()
+            GenericClientConfiguration(bool shouldDisableIMDS = false)
+              : ClientConfiguration(shouldDisableIMDS)
             {}
 
             /**

--- a/src/aws-cpp-sdk-core/include/aws/core/client/GenericClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/GenericClientConfiguration.h
@@ -20,8 +20,8 @@ namespace Aws
         {
             static const bool EndpointDiscoverySupported = HasEndpointDiscovery;
 
-            GenericClientConfiguration(bool shouldDisableIMDS = false)
-              : ClientConfiguration(shouldDisableIMDS)
+            GenericClientConfiguration(const DefaultClientConfiguration &configuration = {})
+              : ClientConfiguration(configuration)
             {}
 
             /**
@@ -56,7 +56,7 @@ namespace Aws
         {
             static const bool EndpointDiscoverySupported = true;
 
-            GenericClientConfiguration();
+            GenericClientConfiguration(const DefaultClientConfiguration &configuration = {});
             GenericClientConfiguration(const char* profileName, bool shouldDisableIMDS = false);
             explicit GenericClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool shouldDisableIMDS = false);
             GenericClientConfiguration(const ClientConfiguration& config);

--- a/src/aws-cpp-sdk-core/include/aws/core/client/GenericClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/GenericClientConfiguration.h
@@ -20,7 +20,7 @@ namespace Aws
         {
             static const bool EndpointDiscoverySupported = HasEndpointDiscovery;
 
-            GenericClientConfiguration(const DefaultClientConfiguration &configuration = {})
+            GenericClientConfiguration(const ClientConfigurationInitValues &configuration = {})
               : ClientConfiguration(configuration)
             {}
 
@@ -56,7 +56,7 @@ namespace Aws
         {
             static const bool EndpointDiscoverySupported = true;
 
-            GenericClientConfiguration(const DefaultClientConfiguration &configuration = {});
+            GenericClientConfiguration(const ClientConfigurationInitValues &configuration = {});
             GenericClientConfiguration(const char* profileName, bool shouldDisableIMDS = false);
             explicit GenericClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool shouldDisableIMDS = false);
             GenericClientConfiguration(const ClientConfiguration& config);

--- a/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
@@ -139,9 +139,9 @@ void setLegacyClientConfigurationParameters(ClientConfiguration& clientConfig)
     }
 }
 
-ClientConfiguration::ClientConfiguration()
+ClientConfiguration::ClientConfiguration(bool shouldDisableIMDS)
 {
-    this->disableIMDS = false;
+    this->disableIMDS = shouldDisableIMDS;
     setLegacyClientConfigurationParameters(*this);
     retryStrategy = InitRetryStrategy();
 

--- a/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
@@ -139,7 +139,7 @@ void setLegacyClientConfigurationParameters(ClientConfiguration& clientConfig)
     }
 }
 
-ClientConfiguration::ClientConfiguration(const DefaultClientConfiguration &configuration)
+ClientConfiguration::ClientConfiguration(const ClientConfigurationInitValues &configuration)
 {
     this->disableIMDS = configuration.shouldDisableIMDS;
     setLegacyClientConfigurationParameters(*this);

--- a/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
@@ -139,9 +139,9 @@ void setLegacyClientConfigurationParameters(ClientConfiguration& clientConfig)
     }
 }
 
-ClientConfiguration::ClientConfiguration(bool shouldDisableIMDS)
+ClientConfiguration::ClientConfiguration(const DefaultClientConfiguration &configuration)
 {
-    this->disableIMDS = shouldDisableIMDS;
+    this->disableIMDS = configuration.shouldDisableIMDS;
     setLegacyClientConfigurationParameters(*this);
     retryStrategy = InitRetryStrategy();
 

--- a/src/aws-cpp-sdk-core/source/client/GenericClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/GenericClientConfiguration.cpp
@@ -44,7 +44,7 @@ bool IsEndpointDiscoveryEnabled(const Aws::String& endpointOverride, const Aws::
   return enabled;
 }
 
-GenericClientConfiguration<true>::GenericClientConfiguration(bool shouldDisableIMDS)
+GenericClientConfiguration<true>::GenericClientConfiguration(bool shouldDisableIMDS = false)
     : ClientConfiguration(shouldDisableIMDS),
       enableHostPrefixInjection(ClientConfiguration::enableHostPrefixInjection),
       enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
@@ -53,7 +53,7 @@ GenericClientConfiguration<true>::GenericClientConfiguration(bool shouldDisableI
     enableHostPrefixInjection = false; // disabled by default in the SDK
 }
 
-GenericClientConfiguration<true>::GenericClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS)
+GenericClientConfiguration<true>::GenericClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS = false)
     : ClientConfiguration(inputProfileName, shouldDisableIMDS),
       enableHostPrefixInjection(ClientConfiguration::enableHostPrefixInjection),
       enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
@@ -62,7 +62,7 @@ GenericClientConfiguration<true>::GenericClientConfiguration(const char* inputPr
     enableHostPrefixInjection = false; // disabled by default in the SDK
 }
 
-GenericClientConfiguration<true>::GenericClientConfiguration(bool useSmartDefaults, const char* inputDefaultMode, bool shouldDisableIMDS)
+GenericClientConfiguration<true>::GenericClientConfiguration(bool useSmartDefaults, const char* inputDefaultMode, bool shouldDisableIMDS = false)
     : ClientConfiguration(useSmartDefaults, inputDefaultMode, shouldDisableIMDS),
       enableHostPrefixInjection(ClientConfiguration::enableHostPrefixInjection),
       enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)

--- a/src/aws-cpp-sdk-core/source/client/GenericClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/GenericClientConfiguration.cpp
@@ -44,7 +44,7 @@ bool IsEndpointDiscoveryEnabled(const Aws::String& endpointOverride, const Aws::
   return enabled;
 }
 
-GenericClientConfiguration<true>::GenericClientConfiguration(const DefaultClientConfiguration &configuration)
+GenericClientConfiguration<true>::GenericClientConfiguration(const ClientConfigurationInitValues &configuration)
     : ClientConfiguration(configuration),
       enableHostPrefixInjection(ClientConfiguration::enableHostPrefixInjection),
       enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)

--- a/src/aws-cpp-sdk-core/source/client/GenericClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/GenericClientConfiguration.cpp
@@ -44,8 +44,8 @@ bool IsEndpointDiscoveryEnabled(const Aws::String& endpointOverride, const Aws::
   return enabled;
 }
 
-GenericClientConfiguration<true>::GenericClientConfiguration(bool shouldDisableIMDS = false)
-    : ClientConfiguration(shouldDisableIMDS),
+GenericClientConfiguration<true>::GenericClientConfiguration(const DefaultClientConfiguration &configuration)
+    : ClientConfiguration(configuration),
       enableHostPrefixInjection(ClientConfiguration::enableHostPrefixInjection),
       enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
 {
@@ -53,7 +53,7 @@ GenericClientConfiguration<true>::GenericClientConfiguration(bool shouldDisableI
     enableHostPrefixInjection = false; // disabled by default in the SDK
 }
 
-GenericClientConfiguration<true>::GenericClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS = false)
+GenericClientConfiguration<true>::GenericClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS)
     : ClientConfiguration(inputProfileName, shouldDisableIMDS),
       enableHostPrefixInjection(ClientConfiguration::enableHostPrefixInjection),
       enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
@@ -62,7 +62,7 @@ GenericClientConfiguration<true>::GenericClientConfiguration(const char* inputPr
     enableHostPrefixInjection = false; // disabled by default in the SDK
 }
 
-GenericClientConfiguration<true>::GenericClientConfiguration(bool useSmartDefaults, const char* inputDefaultMode, bool shouldDisableIMDS = false)
+GenericClientConfiguration<true>::GenericClientConfiguration(bool useSmartDefaults, const char* inputDefaultMode, bool shouldDisableIMDS)
     : ClientConfiguration(useSmartDefaults, inputDefaultMode, shouldDisableIMDS),
       enableHostPrefixInjection(ClientConfiguration::enableHostPrefixInjection),
       enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)

--- a/src/aws-cpp-sdk-core/source/client/GenericClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/GenericClientConfiguration.cpp
@@ -44,8 +44,8 @@ bool IsEndpointDiscoveryEnabled(const Aws::String& endpointOverride, const Aws::
   return enabled;
 }
 
-GenericClientConfiguration<true>::GenericClientConfiguration()
-    : ClientConfiguration(),
+GenericClientConfiguration<true>::GenericClientConfiguration(bool shouldDisableIMDS)
+    : ClientConfiguration(shouldDisableIMDS),
       enableHostPrefixInjection(ClientConfiguration::enableHostPrefixInjection),
       enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
 {

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationHeader.vm
@@ -34,7 +34,7 @@ namespace ${rootNamespace}
         {
             using BaseClientConfigClass = Aws::Client::GenericClientConfiguration<${EndpointDiscoveryTraitSupported}>;
 
-            ${metadata.classNamePrefix}ClientConfiguration();
+            ${metadata.classNamePrefix}ClientConfiguration(bool shouldDisableIMDS = false);
 
             /**
             * Create a configuration based on settings in the aws configuration file for the given profile name.

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationHeader.vm
@@ -34,7 +34,7 @@ namespace ${rootNamespace}
         {
             using BaseClientConfigClass = Aws::Client::GenericClientConfiguration<${EndpointDiscoveryTraitSupported}>;
 
-            ${metadata.classNamePrefix}ClientConfiguration(bool shouldDisableIMDS = false);
+            ${metadata.classNamePrefix}ClientConfiguration(const Client::DefaultClientConfiguration &configuration = {});
 
             /**
             * Create a configuration based on settings in the aws configuration file for the given profile name.

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationHeader.vm
@@ -34,7 +34,7 @@ namespace ${rootNamespace}
         {
             using BaseClientConfigClass = Aws::Client::GenericClientConfiguration<${EndpointDiscoveryTraitSupported}>;
 
-            ${metadata.classNamePrefix}ClientConfiguration(const Client::DefaultClientConfiguration &configuration = {});
+            ${metadata.classNamePrefix}ClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
 
             /**
             * Create a configuration based on settings in the aws configuration file for the given profile name.

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationSource.vm
@@ -63,19 +63,19 @@ void ${metadata.classNamePrefix}ClientConfiguration::Load${serviceNamespace}Spec
 #end
 }
 
-${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(bool shouldDisableIMDS = false)
-: BaseClientConfigClass(shouldDisableIMDS)
+${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(const Client::DefaultClientConfiguration &configuration)
+: BaseClientConfigClass(configuration)
 {
   Load${serviceNamespace}SpecificConfig(this->profileName);
 }
 
-${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS = false)
+${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS)
 : BaseClientConfigClass(inputProfileName, shouldDisableIMDS)
 {
   Load${serviceNamespace}SpecificConfig(Aws::String(inputProfileName));
 }
 
-${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool shouldDisableIMDS = false)
+${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool shouldDisableIMDS)
 : BaseClientConfigClass(useSmartDefaults, defaultMode, shouldDisableIMDS)
 {
   Load${serviceNamespace}SpecificConfig(this->profileName);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationSource.vm
@@ -63,19 +63,19 @@ void ${metadata.classNamePrefix}ClientConfiguration::Load${serviceNamespace}Spec
 #end
 }
 
-${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration()
-: BaseClientConfigClass()
+${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(bool shouldDisableIMDS = false)
+: BaseClientConfigClass(shouldDisableIMDS)
 {
   Load${serviceNamespace}SpecificConfig(this->profileName);
 }
 
-${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS)
+${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS = false)
 : BaseClientConfigClass(inputProfileName, shouldDisableIMDS)
 {
   Load${serviceNamespace}SpecificConfig(Aws::String(inputProfileName));
 }
 
-${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool shouldDisableIMDS)
+${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool shouldDisableIMDS = false)
 : BaseClientConfigClass(useSmartDefaults, defaultMode, shouldDisableIMDS)
 {
   Load${serviceNamespace}SpecificConfig(this->profileName);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationSource.vm
@@ -63,7 +63,7 @@ void ${metadata.classNamePrefix}ClientConfiguration::Load${serviceNamespace}Spec
 #end
 }
 
-${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(const Client::DefaultClientConfiguration &configuration)
+${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(const Client::ClientConfigurationInitValues &configuration)
 : BaseClientConfigClass(configuration)
 {
   Load${serviceNamespace}SpecificConfig(this->profileName);


### PR DESCRIPTION
Provide shouldDisableIMDS default argument for ClientConfiguration and GenericClientConfiguration constructors


*Issue #, if available:* #2612

*Description of changes:*

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
