### PR TITLE
Add configuration for curl http version

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -7,6 +7,7 @@
 
 #include <aws/core/Core_EXPORTS.h>
 #include <aws/core/http/Scheme.h>
+#include <aws/core/http/Version.h>
 #include <aws/core/Region.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/http/HttpTypes.h>
@@ -294,6 +295,16 @@ namespace Aws
              * Disable all internal IMDS Calls
              */
             bool disableIMDS = false;
+
+            /**
+             * Request HTTP client to use specific http version. Currently supported for
+             * only Curl. More or less is a one to one conversion of the CURLOPT_HTTP_VERSION
+             * configuration option.
+             *
+             * Default to Version 2 TLS which is the default after curl version 7.62.0. Will
+             * fall back to 1.1 if compiled against a earlier version of curl.
+             */
+            Aws::Http::Version version = Http::Version::HTTP_VERSION_2TLS;
 
             /**
              * A helper function to read config value from env variable or aws profile config

--- a/src/aws-cpp-sdk-core/include/aws/core/http/Version.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/Version.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+namespace Aws {
+    namespace Http {
+        /**
+         * Enum to represent version of the http protocol to use
+         */
+        enum class Version {
+            HTTP_VERSION_NONE,
+            HTTP_VERSION_1_0,
+            HTTP_VERSION_1_1,
+            HTTP_VERSION_2_0,
+            HTTP_VERSION_2TLS,
+            HTTP_VERSION_2_PRIOR_KNOWLEDGE,
+            HTTP_VERSION_3,
+            HTTP_VERSION_3ONLY,
+        };
+    }
+}

--- a/src/aws-cpp-sdk-core/include/aws/core/http/curl/CurlHandleContainer.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/curl/CurlHandleContainer.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <aws/core/utils/ResourceManager.h>
+#include <aws/core/http/Version.h>
 
 #include <utility>
 #include <curl/curl.h>
@@ -29,7 +30,8 @@ public:
       * then a small size is best. For async support, a good value would be 6 * number of Processors.   *
       */
     CurlHandleContainer(unsigned maxSize = 50, long httpRequestTimeout = 0, long connectTimeout = 1000, bool tcpKeepAlive = true,
-                        unsigned long tcpKeepAliveIntervalMs = 30000, long lowSpeedTime = 3000, unsigned long lowSpeedLimit = 1);
+                        unsigned long tcpKeepAliveIntervalMs = 30000, long lowSpeedTime = 3000, unsigned long lowSpeedLimit = 1,
+                        Version version = Version::HTTP_VERSION_2TLS);
     ~CurlHandleContainer();
 
     /**
@@ -56,6 +58,7 @@ private:
     CURL* CreateCurlHandleInPool();
     bool CheckAndGrowPool();
     void SetDefaultOptionsOnHandle(CURL* handle);
+    static long ConvertHttpVersion(Version version);
 
     Aws::Utils::ExclusiveOwnershipResourceManager<CURL*> m_handleContainer;
     unsigned m_maxPoolSize;
@@ -67,6 +70,7 @@ private:
     unsigned long m_lowSpeedLimit;
     unsigned m_poolSize;
     std::mutex m_containerLock;
+    Version m_version;
 };
 
 } // namespace Http

--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHandleContainer.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHandleContainer.cpp
@@ -15,9 +15,11 @@ static const char* CURL_HANDLE_CONTAINER_TAG = "CurlHandleContainer";
 
 
 CurlHandleContainer::CurlHandleContainer(unsigned maxSize, long httpRequestTimeout, long connectTimeout, bool enableTcpKeepAlive,
-                                        unsigned long tcpKeepAliveIntervalMs, long lowSpeedTime, unsigned long lowSpeedLimit) :
+                                        unsigned long tcpKeepAliveIntervalMs, long lowSpeedTime, unsigned long lowSpeedLimit,
+                                        Version version) :
                 m_maxPoolSize(maxSize), m_httpRequestTimeout(httpRequestTimeout), m_connectTimeout(connectTimeout), m_enableTcpKeepAlive(enableTcpKeepAlive),
-                m_tcpKeepAliveIntervalMs(tcpKeepAliveIntervalMs), m_lowSpeedTime(lowSpeedTime), m_lowSpeedLimit(lowSpeedLimit), m_poolSize(0)
+                m_tcpKeepAliveIntervalMs(tcpKeepAliveIntervalMs), m_lowSpeedTime(lowSpeedTime), m_lowSpeedLimit(lowSpeedLimit), m_poolSize(0),
+                m_version(version)
 {
     AWS_LOGSTREAM_INFO(CURL_HANDLE_CONTAINER_TAG, "Initializing CurlHandleContainer with size " << maxSize);
 }
@@ -150,7 +152,55 @@ void CurlHandleContainer::SetDefaultOptionsOnHandle(CURL* handle)
     curl_easy_setopt(handle, CURLOPT_TCP_KEEPALIVE, m_enableTcpKeepAlive ? 1L : 0L);
     curl_easy_setopt(handle, CURLOPT_TCP_KEEPINTVL, m_tcpKeepAliveIntervalMs / 1000);
     curl_easy_setopt(handle, CURLOPT_TCP_KEEPIDLE, m_tcpKeepAliveIntervalMs / 1000);
-#ifdef CURL_HAS_H2
-    curl_easy_setopt(handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
+    curl_easy_setopt(handle, CURLOPT_HTTP_VERSION, ConvertHttpVersion(m_version));
+}
+
+long CurlHandleContainer::ConvertHttpVersion(Version version) {
+    if (version == Version::HTTP_VERSION_NONE)
+    {
+        return CURL_HTTP_VERSION_NONE;
+    }
+    else if (version == Version::HTTP_VERSION_1_0)
+    {
+        return CURL_HTTP_VERSION_1_0;
+    }
+    else if (version == Version::HTTP_VERSION_1_1)
+    {
+        return CURL_HTTP_VERSION_1_1;
+    }
+#if LIBCURL_VERSION_NUM >= 0x072100 // 7.33.0
+    else if (version == Version::HTTP_VERSION_2_0)
+    {
+        return CURL_HTTP_VERSION_2_0;
+    }
+#endif
+#if LIBCURL_VERSION_NUM >= 0x072F00 // 7.47.0
+    else if (version == Version::HTTP_VERSION_2TLS)
+    {
+        return CURL_HTTP_VERSION_2TLS;
+    }
+#endif
+#if LIBCURL_VERSION_NUM >= 0x073100 // 7.49.0
+    else if (version == Version::HTTP_VERSION_2_PRIOR_KNOWLEDGE)
+    {
+        return CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE;
+    }
+#endif
+#if LIBCURL_VERSION_NUM >= 0x074200 // 7.66.0
+    else if (version == Version::HTTP_VERSION_3)
+    {
+        return CURL_HTTP_VERSION_3;
+    }
+#endif
+#if LIBCURL_VERSION_NUM >= 0x075800 // 7.88.0
+    else if (version == Version::HTTP_VERSION_3ONLY)
+    {
+        return CURL_HTTP_VERSION_3ONLY;
+    }
+#endif
+#if LIBCURL_VERSION_NUM >= 0x073E00 // 7.62.0
+    return CURL_HTTP_VERSION_2TLS;
+#else
+    return CURL_HTTP_VERSION_1_1;
 #endif
 }

--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -544,7 +544,7 @@ int CurlDebugCallback(CURL *handle, curl_infotype type, char *data, size_t size,
 CurlHttpClient::CurlHttpClient(const ClientConfiguration& clientConfig) :
     Base(),
     m_curlHandleContainer(clientConfig.maxConnections, clientConfig.httpRequestTimeoutMs, clientConfig.connectTimeoutMs, clientConfig.enableTcpKeepAlive,
-                          clientConfig.tcpKeepAliveIntervalMs, clientConfig.requestTimeoutMs, clientConfig.lowSpeedLimit),
+                          clientConfig.tcpKeepAliveIntervalMs, clientConfig.requestTimeoutMs, clientConfig.lowSpeedLimit, clientConfig.version),
     m_isUsingProxy(!clientConfig.proxyHost.empty()), m_proxyUserName(clientConfig.proxyUserName),
     m_proxyPassword(clientConfig.proxyPassword), m_proxyScheme(SchemeMapper::ToString(clientConfig.proxyScheme)), m_proxyHost(clientConfig.proxyHost),
     m_proxySSLCertPath(clientConfig.proxySSLCertPath), m_proxySSLCertType(clientConfig.proxySSLCertType),


### PR DESCRIPTION
*Description of changes:*

Exposes `CURLOPT_HTTP_VERSION` through a common http version interface. Allows user to optionally set the version of the http protocol to use when configuring a client. Is especially useful when wanting to force a h2 connection with `CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE`.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
