### PR TITLE
Add headObjectTemplate to the TransferManagerConfiguration. 

### DIFF
--- a/src/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
+++ b/src/aws-cpp-sdk-transfer/include/aws/transfer/TransferManager.h
@@ -9,6 +9,7 @@
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/PutObjectRequest.h>
 #include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/HeadObjectRequest.h>
 #include <aws/s3/model/CreateMultipartUploadRequest.h>
 #include <aws/s3/model/UploadPartRequest.h>
 #include <aws/s3/model/CompletedPart.h>
@@ -68,6 +69,11 @@ namespace Aws
              * overriding the body stream, bucket, and key. If object metadata is passed through, we will override that as well.
              */
             Aws::S3::Model::GetObjectRequest getObjectTemplate;
+            /**
+             * If you have special arguments you want passed to our head object calls, put them here. We will copy the template for each call
+             * overriding the body stream, bucket, and key. If object metadata is passed through, we will override that as well.
+             */
+            Aws::S3::Model::HeadObjectRequest headObjectTemplate;
             /**
              * If you have special arguments you want passed to our create multipart upload calls, put them here. We will copy the template for each call
              * overriding the body stream, bucket, and key. If object metadata is passed through, we will override that as well.

--- a/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -853,7 +853,7 @@ namespace Aws
             uint64_t bufferSize = m_transferConfig.bufferSize;
             if (!isRetry)
             {
-                Aws::S3::Model::HeadObjectRequest headObjectRequest;
+                auto headObjectRequest = m_transferConfig.headObjectTemplate;
                 headObjectRequest.SetCustomizedAccessLogTag(m_transferConfig.customizedAccessLogTag);
                 headObjectRequest.WithBucket(handle->GetBucketName())
                                  .WithKey(handle->GetKey());


### PR DESCRIPTION
Add headObjectTemplate to the TransferManagerConfiguration. This allows user to pass arguments to Transfer Manager Head object calls.

*Issue #, if available:*  #2640

*Description of changes:*

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
