### PR TITLE
Fix LoggingTest build on some platforms with some build config

### DIFF
--- a/tests/aws-cpp-sdk-core-tests/utils/logging/LoggingTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/logging/LoggingTest.cpp
@@ -84,6 +84,10 @@ public:
         va_end(tmp_args);
 
         Array<char> outputBuff(requiredLength);
+        if(!outputBuff.GetUnderlyingData() || !outputBuff.GetLength()) {
+            assert(!"Failed to allocate mock outputBuff!");
+            return;
+        }
     #ifdef _WIN32
         vsnprintf_s(outputBuff.GetUnderlyingData(), outputBuff.GetLength(), _TRUNCATE, formatStr, args);
     #else


### PR DESCRIPTION
*Issue #, if available:*
```
LoggingTest.cpp:90:18: error: null destination pointer [-Werror=format-truncation=]
         vsnprintf(outputBuff.GetUnderlyingData(), requiredLength, formatStr, args);
         ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Some gcc versions seem to not like our Aws::Array container.
*Description of changes:*
Add explicit check for pointer to be allocated.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
