### PR TITLE
Remove empty space before credentials name in saving

### DIFF
--- a/src/aws-cpp-sdk-core/source/config/AWSConfigFileProfileConfigLoader.cpp
+++ b/src/aws-cpp-sdk-core/source/config/AWSConfigFileProfileConfigLoader.cpp
@@ -564,7 +564,7 @@ namespace Aws
 
                     AWS_LOGSTREAM_DEBUG(CONFIG_FILE_LOADER, "Writing profile " << profile.first << " to disk.");
 
-                    outputFile << LEFT_BRACKET << prefix << " " << profile.second.GetName() << RIGHT_BRACKET << std::endl;
+                    outputFile << LEFT_BRACKET << prefix << (m_useProfilePrefix ? " " : "") << profile.second.GetName() << RIGHT_BRACKET << std::endl;
                     const Aws::Auth::AWSCredentials& credentials = profile.second.GetCredentials();
                     if (!credentials.GetAWSAccessKeyId().empty()) {
                         outputFile << ACCESS_KEY_ID_KEY << EQ << credentials.GetAWSAccessKeyId() << std::endl;


### PR DESCRIPTION
*Issue:* https://github.com/aws/aws-sdk-cpp/issues/2650

*Description of changes:*

This PR fixes the issue by checking if `m_useProfilePrefix` is enabled before adding an empty space.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
