### PR TITLE
Pass S3 SSE Customer Algorithm and Key in TM

### DIFF
--- a/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -679,6 +679,12 @@ namespace Aws
                         .WithKey(handle->GetKey())
                         .WithUploadId(handle->GetMultiPartId())
                         .WithMultipartUpload(completedUpload);
+                    if (m_transferConfig.uploadPartTemplate.SSECustomerAlgorithmHasBeenSet())
+                    {
+                        completeMultipartUploadRequest.WithSSECustomerAlgorithm(m_transferConfig.uploadPartTemplate.GetSSECustomerAlgorithm())
+                                                      .WithSSECustomerKey(m_transferConfig.uploadPartTemplate.GetSSECustomerKey())
+                                                      .WithSSECustomerKeyMD5(m_transferConfig.uploadPartTemplate.GetSSECustomerKeyMD5());
+                    }
 
                     auto completeUploadOutcome = m_transferConfig.s3Client->CompleteMultipartUpload(completeMultipartUploadRequest);
 
@@ -975,6 +981,12 @@ namespace Aws
                     if(handle->GetVersionId().size() > 0)
                     {
                         getObjectRangeRequest.SetVersionId(handle->GetVersionId());
+                    }
+                    if (m_transferConfig.getObjectTemplate.SSECustomerAlgorithmHasBeenSet())
+                    {
+                        getObjectRangeRequest.WithSSECustomerAlgorithm(m_transferConfig.getObjectTemplate.GetSSECustomerAlgorithm())
+                                             .WithSSECustomerKey(m_transferConfig.getObjectTemplate.GetSSECustomerKey())
+                                             .WithSSECustomerKeyMD5(m_transferConfig.getObjectTemplate.GetSSECustomerKeyMD5());
                     }
 
                     auto self = shared_from_this(); // keep transfer manager alive until all callbacks are finished.


### PR DESCRIPTION
*Issue #, if available:*
Updating the SDK to conform to S3 specification:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html

similar issue:
https://github.com/aws/aws-sdk-java/issues/3001
*Description of changes:*
Take SSE-C values set by customer and pass them to completeMultipartUploadRequest and getObjectRangeRequest.
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
