### PR TITLE
Fix incorrect usage of GetModuleFileNameW win api

### DIFF
--- a/src/aws-cpp-sdk-core/source/platform/windows/FileSystem.cpp
+++ b/src/aws-cpp-sdk-core/source/platform/windows/FileSystem.cpp
@@ -7,6 +7,7 @@
 #include <aws/core/platform/Environment.h>
 #include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/StringUtils.h>
+#include <aws/core/utils/memory/stl/AWSVector.h>
 #include <cassert>
 #include <iostream>
 #include <Userenv.h>
@@ -180,15 +181,15 @@ Aws::String GetHomeDirectory()
 
 Aws::String GetExecutableDirectory()
 {
-    AWS::Vector<wchar_t> buffer(MAX_PATH + 1, NULL);
+    Aws::Vector<wchar_t> buffer(MAX_PATH + 1, NULL);
     DWORD written = GetModuleFileNameW(nullptr, buffer.data(), static_cast<DWORD>(buffer.size()));
 
     if (ERROR_INSUFFICIENT_BUFFER == GetLastError())
     {
-        /* Max unicode path size is 2^15 - 1 + 1 additional byte for null terminator. */
-        const DWORD unicode_max_path = 0x7FFF + 1;
-        buffer.resize(0xFFFF, NULL);
-        written = GetModuleFileNameW(mod, buffer.data(), static_cast<DWORD>(buffer.size()));
+        /* Max unicode path size is 2^15 + 1 additional byte for null terminator. */
+        const DWORD unicode_max_path = 0x8000 + 1;
+        buffer.resize(unicode_max_path, NULL);
+        written = GetModuleFileNameW(nullptr, buffer.data(), static_cast<DWORD>(buffer.size()));
     }
 
     if (written > 0)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://github.com/aws/aws-sdk-cpp/issues/1773

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
