### PR TITLE
Add ABI version mismatch warning in InitAPI

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/Aws.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/Aws.h
@@ -242,6 +242,13 @@ namespace Aws
          * Basic usage can be found in aws-cpp-sdk-core-tests/monitoring/MonitoringTest.cpp
          */
         MonitoringOptions monitoringOptions;
+
+        struct SDKVersion
+        {
+            unsigned char major = AWS_SDK_VERSION_MAJOR;
+            unsigned char minor = AWS_SDK_VERSION_MINOR;
+            unsigned short patch = AWS_SDK_VERSION_PATCH;
+        } sdkVersion;
     };
 
     /*

--- a/src/aws-cpp-sdk-core/source/Aws.cpp
+++ b/src/aws-cpp-sdk-core/source/Aws.cpp
@@ -153,6 +153,21 @@ namespace Aws
         Aws::Internal::InitEC2MetadataClient();
         Aws::Monitoring::InitMonitoring(options.monitoringOptions.customizedMonitoringFactory_create_fn);
         Aws::Utils::ComponentRegistry::InitComponentRegistry();
+
+        if(options.sdkVersion.major != AWS_SDK_VERSION_MAJOR ||
+            options.sdkVersion.minor != AWS_SDK_VERSION_MINOR ||
+            options.sdkVersion.patch != AWS_SDK_VERSION_PATCH)
+        {
+            AWS_LOGSTREAM_ERROR(ALLOCATION_TAG, "AWS-SDK-CPP version mismatch detected.");
+            AWS_LOGSTREAM_INFO(ALLOCATION_TAG, "Initialized AWS-SDK-CPP with version "
+              << AWS_SDK_VERSION_MAJOR << "." << AWS_SDK_VERSION_MINOR << "." << AWS_SDK_VERSION_PATCH << "; "
+              << "However, the caller application had been built for AWS-SDK-CPP version "
+              << (int) options.sdkVersion.major << "."
+              << (int) options.sdkVersion.minor << "."
+              << (int) options.sdkVersion.patch << "; "
+              << "ABI is not guaranteed, please don't mix different versions of built libraries "
+              << "and different versions of headers and corresponding built libraries.");
+        }
     }
 
     void ShutdownAPI(const SDKOptions& options)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a warning to InitAPI if API version mismatch is detected:
grep -air "Aws_Init_Cleanup" aws_sdk*.log
When it matches:
```
[INFO] 2023-09-20 21:36:16.513 Aws_Init_Cleanup [139749740966656] Initiate AWS SDK for C++ with Version:1.11.169
```

When app is built with SDK version before this change added (a memory overrun has happened):
```
[INFO] 2023-09-20 21:38:46.310 Aws_Init_Cleanup [140058908148480] Initiate AWS SDK for C++ with Version:1.11.169
[ERROR] 2023-09-20 21:38:46.330 Aws_Init_Cleanup [140058908148480] AWS-SDK-CPP version mismatch detected.
[INFO] 2023-09-20 21:38:46.330 Aws_Init_Cleanup [140058908148480] Initialized AWS-SDK-CPP with version 1.11.169; However, the caller application had been built for AWS-SDK-CPP version 144.31.20534; ABI is not guaranteed, please don't mix different versions of built libraries and different versions of headers and corresponding built libraries.
```

When app is built with this change within SDK but different version loaded:
```
[INFO] 2023-09-20 21:35:38.994 Aws_Init_Cleanup [139965597451008] Initiate AWS SDK for C++ with Version:1.11.169
[ERROR] 2023-09-20 21:35:39.013 Aws_Init_Cleanup [139965597451008] AWS-SDK-CPP version mismatch detected.
[INFO] 2023-09-20 21:35:39.013 Aws_Init_Cleanup [139965597451008] Initialized AWS-SDK-CPP with version 1.11.169; However, the caller application had been built for AWS-SDK-CPP version 1.11.168; ABI is not guaranteed, please don't mix different versions of built libraries and different versions of headers and corresponding built libraries.
```
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
