### PR TITLE
Allow usage of system default proxy

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -167,6 +167,11 @@ namespace Aws
              * Override the http endpoint used to talk to a service.
              */
             Aws::String endpointOverride;
+
+            /**
+             * Allow HTTP client to discover system proxy setting. Off by default for legacy reasons.
+             */
+            bool allowSystemProxy = false;
             /**
              * If you have users going through a proxy, set the proxy scheme here. Default HTTP
              */

--- a/src/aws-cpp-sdk-core/include/aws/core/http/curl/CurlHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/curl/CurlHttpClient.h
@@ -49,7 +49,8 @@ protected:
 
 private:
     mutable CurlHandleContainer m_curlHandleContainer;
-    bool m_isUsingProxy;
+    bool m_isAllowSystemProxy = false;
+    bool m_isUsingProxy = false;
     Aws::String m_proxyUserName;
     Aws::String m_proxyPassword;
     Aws::String m_proxyScheme;
@@ -59,13 +60,13 @@ private:
     Aws::String m_proxySSLKeyPath;
     Aws::String m_proxySSLKeyType;
     Aws::String m_proxyKeyPasswd;
-    unsigned m_proxyPort;
+    unsigned m_proxyPort = 0;
     Aws::String m_nonProxyHosts;
-    bool m_verifySSL;
+    bool m_verifySSL = true;
     Aws::String m_caPath;
     Aws::String m_caFile;
-    bool m_disableExpectHeader;
-    bool m_allowRedirects;
+    bool m_disableExpectHeader = false;
+    bool m_allowRedirects = false;
     static std::atomic<bool> isInit;
     std::shared_ptr<smithy::components::tracing::TelemetryProvider> m_telemetryProvider;
 };

--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -572,7 +572,7 @@ CurlHttpClient::CurlHttpClient(const ClientConfiguration& clientConfig) :
     Base(),
     m_curlHandleContainer(clientConfig.maxConnections, clientConfig.httpRequestTimeoutMs, clientConfig.connectTimeoutMs, clientConfig.enableTcpKeepAlive,
                           clientConfig.tcpKeepAliveIntervalMs, clientConfig.requestTimeoutMs, clientConfig.lowSpeedLimit, clientConfig.version),
-    m_isUsingProxy(!clientConfig.proxyHost.empty()), m_proxyUserName(clientConfig.proxyUserName),
+    m_isAllowSystemProxy(clientConfig.allowSystemProxy), m_isUsingProxy(!clientConfig.proxyHost.empty()), m_proxyUserName(clientConfig.proxyUserName),
     m_proxyPassword(clientConfig.proxyPassword), m_proxyScheme(SchemeMapper::ToString(clientConfig.proxyScheme)), m_proxyHost(clientConfig.proxyHost),
     m_proxySSLCertPath(clientConfig.proxySSLCertPath), m_proxySSLCertType(clientConfig.proxySSLCertType),
     m_proxySSLKeyPath(clientConfig.proxySSLKeyPath), m_proxySSLKeyType(clientConfig.proxySSLKeyType),
@@ -763,7 +763,10 @@ std::shared_ptr<HttpResponse> CurlHttpClient::MakeRequest(const std::shared_ptr<
         }
         else
         {
-            curl_easy_setopt(connectionHandle, CURLOPT_PROXY, "");
+            if(!m_isAllowSystemProxy)
+            {
+                curl_easy_setopt(connectionHandle, CURLOPT_PROXY, "");
+            }
         }
 
         if (request->GetContentBody())

--- a/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
@@ -51,7 +51,11 @@ WinHttpSyncHttpClient::WinHttpSyncHttpClient(const ClientConfiguration& config) 
     AWS_LOGSTREAM_INFO(GetLogTag(), "Creating http client with user agent " << config.userAgent << " with max connections " << config.maxConnections
         << " request timeout " << config.requestTimeoutMs << ",and connect timeout " << config.connectTimeoutMs);
 
-    DWORD winhttpFlags = WINHTTP_ACCESS_TYPE_NO_PROXY;
+#if defined(WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY)
+    DWORD winhttpFlags = config.allowSystemProxy ? WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY : WINHTTP_ACCESS_TYPE_NO_PROXY;
+#else
+    DWORD winhttpFlags = config.allowSystemProxy ? WINHTTP_ACCESS_TYPE_DEFAULT_PROXY : WINHTTP_ACCESS_TYPE_NO_PROXY;
+#endif
     const char* proxyHosts = nullptr;
     Aws::String strProxyHosts;
 


### PR DESCRIPTION
*Issue #, if available:*
Historically, SDK's http clients disable all system proxy usage
*Description of changes:*
Provide a handle to allow WinHTTP and curl built-in system proxy discovery.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
