### PR TITLE
cache credential chain results

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProviderChain.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProviderChain.h
@@ -46,8 +46,10 @@ namespace Aws
             void AddProvider(const std::shared_ptr<AWSCredentialsProvider>& provider) { m_providerChain.push_back(provider); }
 
 
-        private:            
+        private:
             Aws::Vector<std::shared_ptr<AWSCredentialsProvider> > m_providerChain;
+            std::shared_ptr<AWSCredentialsProvider> m_cachedProvider;
+            mutable Aws::Utils::Threading::ReaderWriterLock m_cachedProviderLock;
         };
 
         /**


### PR DESCRIPTION
*Description of changes:*

Right now by default the credentials provider chain retries each provider in order regardless if one succeeded before. This caches the last known credentials provider to provide credentials. If that cached provider fails to provide credentials it will fallback to the provider chain.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
