### PR TITLE
Add missing include for a library version check

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/Aws.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/Aws.h
@@ -12,6 +12,7 @@
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/monitoring/MonitoringManager.h>
 #include <aws/core/Core_EXPORTS.h>
+#include <aws/core/VersionConfig.h>
 #include <aws/crt/io/Bootstrap.h>
 #include <aws/crt/io/TlsOptions.h>
 


### PR DESCRIPTION
*Issue #, if available:*
```
C:\install-path\aws-cpp-sdk-all\include\aws/core/Aws.h(248,35): error C2065: 
'AWS_SDK_VERSION_MAJOR': undeclared identifier [C:\userApp\src\build\userApp.vcxproj]
```
these macro definitions used in Aws.h added in https://github.com/aws/aws-sdk-cpp/pull/2677 are in fact added by cmake and in some cases can be missing.
*Description of changes:*
Add `#include <aws/core/VersionConfig.h>`
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
