### PR TITLE
[aws-cpp-sdk-s3]: fix warnings caused by case statement not handled

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/StorageClass.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/StorageClass.cpp
@@ -89,6 +89,8 @@ namespace Aws
         {
           switch(enumValue)
           {
+          case StorageClass::NOT_SET:
+            return {};
           case StorageClass::STANDARD:
             return "STANDARD";
           case StorageClass::REDUCED_REDUNDANCY:

--- a/generated/src/aws-cpp-sdk-s3/source/model/StorageClass.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/StorageClass.cpp
@@ -89,6 +89,8 @@ namespace Aws
         {
           switch(enumValue)
           {
+          case StorageClass::NOT_SET:
+            return {};
           case StorageClass::STANDARD:
             return "STANDARD";
           case StorageClass::REDUCED_REDUNDANCY:


### PR DESCRIPTION
`NOT_SET` is a valid literal, but not handled by the `switch` statement. 

Addresses #2694.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
   See #2694.
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.