### PR TITLE
Serialize Query String with multiple values

### DIFF
--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/AddQueryStringParametersToRequest.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/AddQueryStringParametersToRequest.vm
@@ -21,9 +21,18 @@ void ${typeInfo.className}::AddQueryStringParameters(URI& uri) const
 #elseif($memberEntry.value.shape.map)
     ${spaces}for(auto& item : ${memberVarName})
     ${spaces}{
+#if(!$memberEntry.value.shape.mapValue.shape.list)
     ${spaces}  ss << item.second;
     ${spaces}  uri.AddQueryStringParameter(item.first.c_str(), ss.str());
     ${spaces}  ss.str("");
+#else##URL query Key has multiple values, multiply key per https://smithy.io/2.0/spec/http-bindings.html#id9
+    ${spaces}  for(auto& innerItem : item.second)
+    ${spaces}  {
+    ${spaces}    ss << innerItem;
+    ${spaces}    uri.AddQueryStringParameter(item.first.c_str(), ss.str());
+    ${spaces}    ss.str("");
+    ${spaces}  }
+#end##if(!$memberEntry.value.shape.map.mapValue.shape.list)
     ${spaces}}
 #elseif($memberEntry.value.shape.list)
     ${spaces}for(const auto& item : $memberVarName)


### PR DESCRIPTION
*Issue #, if available:*
n/a
*Description of changes:*
https://smithy.io/2.0/spec/http-bindings.html#id9
>[List](https://smithy.io/2.0/spec/aggregate-types.html#list) members are serialized by adding multiple query string parameters to the query string using the same name. For example, given a member bound to foo that targets a list of strings with a value of ["a", "b"], the value is serialized in the query string as foo=a&foo=b.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
