### PR TITLE
fix codegen for path prefix

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/Endpoint.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/Endpoint.java
@@ -41,11 +41,15 @@ public class Endpoint {
         String ret = "";
         List<String> parts = getHostPrefixParts();
         List<String> members = getMemberReferences();
-        //  {var1}-{var2}.123.{var3}, with prefix to be "Reqeust"
-        //-> Request.Getvar1() + "-" + Request.Getvar2() + ".123." + Request.Getvar3()
+        //  {var1}-{var2}.123.{var3}, with prefix to be "Request"
+        //-> Request.GetVar1() + "-" + Request.GetVar2() + ".123." + Request.GetVar3()
         for (int i = 0; i < members.size(); i++)
         {
-            ret += "\"" + parts.get(i) + "\" + " + memberPrefix + ".Get" + members.get(i) + "() + ";
+            String member = members.get(i);
+            // Capitalize first letter, we always do it for getters regardless
+            // of casing on the field.
+            member = member.substring(0, 1).toUpperCase() + member.substring(1);
+            ret += "\"" + parts.get(i) + "\" + " + memberPrefix + ".Get" + member + "() + ";
         }
         ret += "\"" + parts.get(parts.size() - 1) + "\"";
 

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/Endpoint.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/Endpoint.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.cpp.CppViewHelper;
+
 @Data
 public class Endpoint {
     private static final Pattern MEMBER_PATTERN = Pattern.compile("\\{[\\w\\d]+\\}");
@@ -45,10 +47,9 @@ public class Endpoint {
         //-> Request.GetVar1() + "-" + Request.GetVar2() + ".123." + Request.GetVar3()
         for (int i = 0; i < members.size(); i++)
         {
-            String member = members.get(i);
             // Capitalize first letter, we always do it for getters regardless
             // of casing on the field.
-            member = member.substring(0, 1).toUpperCase() + member.substring(1);
+            String member = CppViewHelper.capitalizeFirstChar(members.get(i));
             ret += "\"" + parts.get(i) + "\" + " + memberPrefix + ".Get" + member + "() + ";
         }
         ret += "\"" + parts.get(parts.size() - 1) + "\"";

--- a/tools/code-generation/generator/src/test/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/EndpointTest.java
+++ b/tools/code-generation/generator/src/test/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/EndpointTest.java
@@ -18,7 +18,7 @@ public class EndpointTest {
     public void testParseHostPrefixParts() {
         Endpoint endpoint = new Endpoint();
         
-        endpoint.setHostPrefix("abc{var1}-{var2}.{var3}12.3{var4}{var5}");
+        endpoint.setHostPrefix("abc{Var1}-{var2}.{var3}12.3{var4}{var5}");
         List<String> parts = endpoint.getHostPrefixParts();
         assertEquals(6, parts.size());
         assertEquals("abc", parts.get(0));
@@ -30,16 +30,16 @@ public class EndpointTest {
 
         List<String> members = endpoint.getMemberReferences();
         assertEquals(5, members.size());
-        assertEquals("var1", members.get(0));
+        assertEquals("Var1", members.get(0));
         assertEquals("var2", members.get(1));
         assertEquals("var3", members.get(2));
         assertEquals("var4", members.get(3));
         assertEquals("var5", members.get(4));
 
-        String hostPrefix = "\"abc\" + request.Getvar1() + \"-\" + request.Getvar2() + \".\" + request.Getvar3() + \"12.3\" + request.Getvar4() + \"\" + request.Getvar5() + \"\"";
+        String hostPrefix = "\"abc\" + request.GetVar1() + \"-\" + request.GetVar2() + \".\" + request.GetVar3() + \"12.3\" + request.GetVar4() + \"\" + request.GetVar5() + \"\"";
         assertEquals(hostPrefix, endpoint.constructHostPrefixString("request"));
 
-        endpoint.setHostPrefix("{var1}-{var2}.{var3}123{var4}{var5}");
+        endpoint.setHostPrefix("{Var1}-{var2}.{var3}123{var4}{var5}");
         parts = endpoint.getHostPrefixParts();
         assertEquals(6, parts.size());
         assertEquals("", parts.get(0)); // before {var1}
@@ -51,16 +51,16 @@ public class EndpointTest {
 
         members = endpoint.getMemberReferences();
         assertEquals(5, members.size());
-        assertEquals("var1", members.get(0));
+        assertEquals("Var1", members.get(0));
         assertEquals("var2", members.get(1));
         assertEquals("var3", members.get(2));
         assertEquals("var4", members.get(3));
         assertEquals("var5", members.get(4));
 
-        hostPrefix = "\"\" + request.Getvar1() + \"-\" + request.Getvar2() + \".\" + request.Getvar3() + \"123\" + request.Getvar4() + \"\" + request.Getvar5() + \"\"";
+        hostPrefix = "\"\" + request.GetVar1() + \"-\" + request.GetVar2() + \".\" + request.GetVar3() + \"123\" + request.GetVar4() + \"\" + request.GetVar5() + \"\"";
         assertEquals(hostPrefix, endpoint.constructHostPrefixString("request"));
 
-        endpoint.setHostPrefix("{var1}-{var2}.{var3}123{var4}{var5}abc");
+        endpoint.setHostPrefix("{Var1}-{var2}.{var3}123{var4}{var5}abc");
         parts = endpoint.getHostPrefixParts();
         assertEquals(6, parts.size());
         assertEquals("", parts.get(0));
@@ -72,13 +72,13 @@ public class EndpointTest {
 
         members = endpoint.getMemberReferences();
         assertEquals(5, members.size());
-        assertEquals("var1", members.get(0));
+        assertEquals("Var1", members.get(0));
         assertEquals("var2", members.get(1));
         assertEquals("var3", members.get(2));
         assertEquals("var4", members.get(3));
         assertEquals("var5", members.get(4));
 
-        hostPrefix = "\"\" + request.Getvar1() + \"-\" + request.Getvar2() + \".\" + request.Getvar3() + \"123\" + request.Getvar4() + \"\" + request.Getvar5() + \"abc\"";
+        hostPrefix = "\"\" + request.GetVar1() + \"-\" + request.GetVar2() + \".\" + request.GetVar3() + \"123\" + request.GetVar4() + \"\" + request.GetVar5() + \"abc\"";
         assertEquals(hostPrefix, endpoint.constructHostPrefixString("request"));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bug fix: if model has variables lower case, the getters are still generated as starting wih uppercase, ex. for field foo, getter is getFoo. But when parsing prefix for endpoint, we always generate "Get"+<field_name>, which can result in naming mismatch with getter. Fixed it to always uppercase first letter of field.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
