### PR TITLE
Add Windows version checking before setting proxy flag

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
@@ -21,6 +21,7 @@
 #include <winhttp.h>
 #include <sstream>
 #include <iostream>
+#include <versionhelpers.h>
 
 using namespace Aws::Client;
 using namespace Aws::Http;
@@ -52,10 +53,16 @@ WinHttpSyncHttpClient::WinHttpSyncHttpClient(const ClientConfiguration& config) 
         << " request timeout " << config.requestTimeoutMs << ",and connect timeout " << config.connectTimeoutMs);
 
 #if defined(WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY)
-    DWORD winhttpFlags = config.allowSystemProxy ? WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY : WINHTTP_ACCESS_TYPE_NO_PROXY;
+    DWORD winhttpFlags;
+    if (config.allowSystemProxy) {
+        winhttpFlags = IsWindows8Point1OrGreater()? WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY : WINHTTP_ACCESS_TYPE_DEFAULT_PROXY;
+    } else {
+        winhttpFlags = WINHTTP_ACCESS_TYPE_NO_PROXY;
+    }
 #else
     DWORD winhttpFlags = config.allowSystemProxy ? WINHTTP_ACCESS_TYPE_DEFAULT_PROXY : WINHTTP_ACCESS_TYPE_NO_PROXY;
 #endif
+
     const char* proxyHosts = nullptr;
     Aws::String strProxyHosts;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The access type passed when opening a WinHTTP-session is set to `WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY` if the application using aws cpp sdk is built with >= Windows 8,1 SDK and have `allowSystemProxy` set to True. As a result, when running the application on Windows version older than 8.1, the WinHTTP-session cannot be successfully initiated. This change adds runtime version checking to determine the proper parameter to use.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
