### PR TITLE
Add missing lock for a cond var; add one more unit test

### DIFF
--- a/src/aws-cpp-sdk-core/source/utils/logging/DefaultCRTLogSystem.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/logging/DefaultCRTLogSystem.cpp
@@ -71,6 +71,7 @@ namespace Aws
                 m_logsProcessed--;
                 if(m_logsProcessed == 0 && m_stopLogging)
                 {
+                    std::unique_lock<std::mutex> lock(m_stopMutex);
                     m_stopSignal.notify_all();
                 }
             }

--- a/tests/aws-cpp-sdk-core-tests/utils/threading/ReaderWriterLockTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/threading/ReaderWriterLockTest.cpp
@@ -86,3 +86,106 @@ TEST_F(ReaderWriterLockTest, NoReadersMultipleWriters)
 
     ASSERT_EQ(originalLength + THREADS_NUM * ITERATIONS, resource.length());
 }
+
+TEST_F(ReaderWriterLockTest, Explosive)
+{
+    const char sharedBufferOriginal[] = "It's still Day One";
+    char sharedBuffer[] = "It's still Day One";
+    const size_t sharedBufferSz = strlen(sharedBuffer);
+    Aws::Utils::Threading::ReaderWriterLock sharedBufferLock;
+
+    std::atomic<bool> readersRunning;
+    readersRunning.store(true);
+    std::atomic<size_t> readersRunCount;
+    readersRunCount.store(0);
+    auto reader = [&]()
+    {
+        Aws::Utils::Threading::ReaderLockGuard guard(sharedBufferLock);
+
+        readersRunCount++;
+        EXPECT_STREQ(sharedBufferOriginal, sharedBuffer);
+    };
+
+    auto slowWriter = [&]()
+    {
+        Aws::Utils::Threading::WriterLockGuard guard(sharedBufferLock);
+        for(size_t i = 0; i < sharedBufferSz; ++i)
+        {
+            sharedBuffer[i] = 'B';
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+
+        for(size_t i = 0; i < sharedBufferSz; ++i)
+        {
+            sharedBuffer[i] = sharedBufferOriginal[i];
+        }
+    };
+
+    static const size_t READER_COUNT = 8;
+    Aws::Vector<std::future<bool>> readerFutures(READER_COUNT);
+    std::atomic<size_t> readersStarted;
+    readersStarted = 0;
+    for(size_t i = 0; i < READER_COUNT/2; ++i) {
+      readerFutures[i] = std::async(std::launch::async,
+                                    [&]() -> bool {
+                                      readersStarted++;
+                                      while(readersRunning)
+                                      {
+                                        reader();
+                                      }
+                                      return true;
+                                    });
+    }
+
+    while(readersStarted.load() != READER_COUNT/2)
+    {
+        continue;
+    }
+
+    const size_t readersRunCountBeforeWriter = readersRunCount;
+    ASSERT_GE(readersRunCountBeforeWriter, READER_COUNT);
+
+    static const size_t WRITER_COUNT = 3;
+    Aws::Vector<std::future<bool>> writerFutures(WRITER_COUNT);
+    static const size_t WRITERS_REPEAT = 4;
+    for(size_t i = 0; i < WRITER_COUNT; ++i) {
+      writerFutures[i] = std::async(std::launch::async,
+                                    [&]() -> bool {
+                                      for(size_t writeRepeat = 0; writeRepeat < WRITERS_REPEAT; ++writeRepeat)
+                                      {
+                                        slowWriter();
+                                      }
+                                      return true;
+                                    });
+    }
+
+    for(size_t i = READER_COUNT/2; i < READER_COUNT; ++i) {
+      readerFutures[i] = std::async(std::launch::async,
+                                    [&]() -> bool {
+                                      readersStarted++;
+                                      while(readersRunning)
+                                      {
+                                        reader();
+                                      }
+                                      return true;
+                                    });
+    }
+    while(readersStarted.load() != READER_COUNT)
+    {
+        continue;
+    }
+
+    for(size_t i = 0; i < WRITER_COUNT; ++i)
+    {
+        bool success = writerFutures[i].get();
+        ASSERT_TRUE(success);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    readersRunning.store(false);
+
+    for(size_t i = 0; i < READER_COUNT; ++i)
+    {
+        bool success = readerFutures[i].get();
+        ASSERT_TRUE(success);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
conditional variable :: notify all () must be called only under an acquired lock
*Description of changes:*
Add lock
Also add unit test for ReaderWriterLock illustrating it is not broken in a heavy multi-threaded write-read.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
