### PR TITLE
Add InitAPI call count to workaround multiple init mis-use

### DIFF
--- a/tests/aws-cpp-sdk-core-tests/utils/memory/AwsMemoryManagementTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/memory/AwsMemoryManagementTest.cpp
@@ -40,6 +40,107 @@ TEST(AwsMemoryManagementTest, InitShutdownRepeatable)
     ASSERT_TRUE(memorySystem.IsClean());
 }
 
+TEST(AwsMemoryManagementTest, MultiInit)
+{
+    Aws::SDKOptions options;
+    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Trace;
+    options.httpOptions.installSigPipeHandler = true;
+
+    const uint32_t BUCKET_COUNT = 1024;
+    const uint32_t TRACKER_PER_BLOCK = 128;
+    ExactTestMemorySystem memorySystem(BUCKET_COUNT, TRACKER_PER_BLOCK); \
+    options.memoryManagementOptions.memoryManager = &memorySystem;
+
+    for (size_t ii = 0; ii < 10; ++ii)
+    {
+        Aws::InitAPI(options);
+        for (unsigned jj = 0; jj < 10; ++jj) {
+            AWS_LOG_WARN("AwsMemoryManagementTest", "MultiInit test warn level");
+            AWS_LOGF_TRACE(AWS_LS_COMMON_GENERAL, "AwsMemoryManagementTest::%s test log", "MultiInit");
+        }
+
+        Aws::InitAPI(options);
+        for (unsigned jj = 0; jj < 10; ++jj) {
+            AWS_LOG_WARN("AwsMemoryManagementTest", "MultiInit test warn level");
+            AWS_LOGF_TRACE(AWS_LS_COMMON_GENERAL, "AwsMemoryManagementTest::%s test log", "MultiInit");
+        }
+
+        Aws::ShutdownAPI(options);
+        for (unsigned jj = 0; jj < 10; ++jj) {
+            AWS_LOG_WARN("AwsMemoryManagementTest", "MultiInit after first shutdown test warn level");
+            AWS_LOGF_TRACE(AWS_LS_COMMON_GENERAL, "AwsMemoryManagementTest::%s after first shutdown test log", "MultiInit");
+        }
+        Aws::ShutdownAPI(options);
+    }
+
+    ASSERT_EQ(memorySystem.GetCurrentOutstandingAllocations(), 0ULL);
+    ASSERT_EQ(memorySystem.GetCurrentBytesAllocated(), 0ULL);
+    ASSERT_TRUE(memorySystem.IsClean());
+}
+
+TEST(AwsMemoryManagementTest, MultiInitParallel)
+{
+    Aws::SDKOptions options;
+    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Trace;
+    options.httpOptions.installSigPipeHandler = true;
+
+    const uint32_t BUCKET_COUNT = 1024;
+    const uint32_t TRACKER_PER_BLOCK = 128;
+    ExactTestMemorySystem memorySystem(BUCKET_COUNT, TRACKER_PER_BLOCK); \
+    options.memoryManagementOptions.memoryManager = &memorySystem;
+
+    std::atomic<bool> isRunning;
+    isRunning.store(false);
+    auto InitShutdown = [&]()
+    {
+        while(isRunning)
+        {
+            Aws::ShutdownAPI(options);
+            Aws::InitAPI(options);
+            size_t sleepMs = 0 + std::rand() % ( 200 - 0 ); // random from 0 to 200
+            std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
+            Aws::InitAPI(options);
+            AWS_LOG_FLUSH();
+
+            Aws::ShutdownAPI(options);
+            Aws::ShutdownAPI(options);
+        }
+        return true;
+    };
+
+    auto threadLogger = [&]()
+    {
+      while(isRunning)
+      {
+        AWS_LOG_WARN("AwsMemoryManagementTest", "MultiInitParallel test logging in thread");
+        AWS_LOGF_TRACE(AWS_LS_COMMON_GENERAL, "AwsMemoryManagementTest::%s CRT logging in thread", "MultiInitParallel");
+        AWS_LOG_FLUSH();
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+      }
+      return true;
+    };
+
+    for (size_t ii = 0; ii < 5; ++ii)
+    {
+      isRunning.store(true);
+      std::future<bool> initShutdownFuture = std::async(std::launch::async, InitShutdown);
+
+      std::future<bool> loggerThread1Future = std::async(std::launch::async, threadLogger);
+      std::future<bool> loggerThread2Future = std::async(std::launch::async, threadLogger);
+      size_t sleepMs = 500 + std::rand() % ( 800 - 500 ); // random from 500 to 800
+      std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
+      isRunning.store(false);
+
+      ASSERT_TRUE(initShutdownFuture.get());
+      ASSERT_TRUE(loggerThread1Future.get());
+      ASSERT_TRUE(loggerThread2Future.get());
+    }
+
+    ASSERT_EQ(memorySystem.GetCurrentOutstandingAllocations(), 0ULL);
+    ASSERT_EQ(memorySystem.GetCurrentBytesAllocated(), 0ULL);
+    ASSERT_TRUE(memorySystem.IsClean());
+}
+
 #ifdef USE_AWS_MEMORY_MANAGEMENT
 class TestMemoryManager : public Aws::Utils::Memory::MemorySystemInterface
 {


### PR DESCRIPTION
*Issue #, if available:*
This is a workaround for issues where customer is not able to control underlying libraries using the C++ SDK, such as https://github.com/aws/aws-sdk-cpp/issues/2699
*Description of changes:*
Add reference count on and blocking on mutex on InitAPI-ShutdownAPI methods.
This does not really fix the root architectural issue, but at least it provides a some level of workaround.
All consequent calls to InitAPI only increases the SDK usage count, `options` argument is completely ignored on any subsequent call, and only the last ShutdownAPI will actually shut down the library.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
