### PR TITLE
Fix awsmigrationhub build error

### DIFF
--- a/generated/src/aws-cpp-sdk-AWSMigrationHub/CMakeLists.txt
+++ b/generated/src/aws-cpp-sdk-AWSMigrationHub/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_project(aws-cpp-sdk-AWSMigrationHub "C++ SDK for the AWS AWSMigrationHub service" aws-cpp-sdk-core)
+add_project(aws-cpp-sdk-awsmigrationhub "C++ SDK for the AWS AWSMigrationHub service" aws-cpp-sdk-core)
 
 file(GLOB AWS_AWSMIGRATIONHUB_HEADERS
     "include/aws/AWSMigrationHub/*.h"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change project `AWSMigrationHub` name from `aws-cpp-sdk-AWSMigrationHub` to `aws-cpp-sdk-awsmigrationhub`, fix build error:
```
CMake Error at cmake/dependencies.cmake:16 (get_target_property):
  get_target_property() called with non-existent target
  "aws-cpp-sdk-awsmigrationhub".
Call Stack (most recent call first):
  cmake/dependencies.cmake:73 (compute_links)
  cmake/sdks.cmake:288 (sort_links)
  CMakeLists.txt:328 (add_sdks)

CMake Error at cmake/dependencies.cmake:84 (get_target_property):
  get_target_property() called with non-existent target
  "aws-cpp-sdk-awsmigrationhub".
Call Stack (most recent call first):
  cmake/sdks.cmake:288 (sort_links)
  CMakeLists.txt:328 (add_sdks)
```

I'm not sure if the directory name of the project `aws-cpp-sdk-AWSMigrationHub` also needs to be changed to lowercase. Can you help confirm? cc @sdavtaker

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
