### PR TITLE
Update CMAKE_PREFIX_PATH to CMAKE_INSTALL_PREFIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ the development efforts by submitting pull requests and sending us feedback and 
   * Amazon Linux
   * Windows
   * Mac
-  
+
 ### Building From Source:
 
 #### To create an **out-of-source build**:
@@ -42,11 +42,12 @@ the development efforts by submitting pull requests and sending us feedback and 
    cd <BUILD_DIR>
    cmake <path-to-root-of-this-source-code> \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DCMAKE_PREFIX_PATH=<path-to-install> \
+    -DCMAKE_INSTALL_PREFIX=<path-to-install> \
     -DBUILD_ONLY="s3"
    cmake --build . --config=Debug
    cmake --install . --config=Debug
    ```
+
    **_NOTE:_** BUILD_ONLY is an optional flag used to list only the services you are using. Building the whole sdk can take a long time. Also check out the list of [CMake parameters](./docs/CMake_Parameters.md)
 
 #### Other Dependencies:


### PR DESCRIPTION
### Description of changes

This fixes what I believe is a small mistake/typo in the README. 

In the CMake configure command, previously `-DCMAKE_PREFIX_PATH` was provided which is used to tell CMake where to look for installed libraries (not where to install the library that will be built). For that, you need to use `-DCMAKE_INSTALL_PREFIX` which I believe it what was intended here.

The flow is usually something like this...

```bash
cd aws-sdk-cpp
cmake -B build -DCMAKE_INSTALL_PREFIX=../aws-demo/install -DBUILD_ONLY="s3"
cmake --build build --target install
cd ../aws-demo
cmake -B build -DCMAKE_PREFIX_PATH=install
cmake --build build
```

There's a chance I've misunderstood and the intention was to find existing libraries, if so please ignore this.

Thanks!

(For reference see the CMake docs [CMAKE_PREFIX_PATH](https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html) and [CMAKE_INSTALL_PREFIX](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html).

#### Check all that applies

- [x] Did a review by yourself.
- [ ] ~~Added proper tests to cover this PR. (If tests are not applicable, explain.)~~
- [ ] ~~Checked if this PR is a breaking (APIs have been changed) change.~~
- [ ] ~~Checked if this PR will _not_ introduce cross-platform inconsistent behavior.~~
- [x] Checked if this PR would require a ReadMe/Wiki update.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
