### PR TITLE
Encode ARNs in RFC compliant mode

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/endpoint/AWSEndpoint.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/endpoint/AWSEndpoint.h
@@ -44,6 +44,11 @@ namespace Aws
                 m_uri.AddPathSegments(std::forward<T>(pathSegments));
             }
 
+            inline void SetRfc3986Encoded(bool rfcEncoded)
+            {
+                m_uri.SetRfc3986Encoded(rfcEncoded);
+            }
+
             using OptionalError = Crt::Optional<Aws::Client::AWSError<Aws::Client::CoreErrors>>;
             OptionalError AddPrefixIfMissing(const Aws::String& prefix);
 

--- a/src/aws-cpp-sdk-core/include/aws/core/http/URI.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/URI.h
@@ -181,6 +181,16 @@ namespace Aws
             Aws::String GetURIString(bool includeQueryString = true) const;
 
             /**
+            * Returns true if this URI is going to be encoded in Rfc3986 compliant mode
+            */
+            inline bool IsRfc3986Encoded() const { return m_useRfcEncoding; }
+
+            /**
+            * Sets Rfc3986 compliant encoding mode. False (i.e. use legacy encoding with some chars unescaped) is the default.
+            */
+            inline void SetRfc3986Encoded(const bool value) { m_useRfcEncoding = value; }
+
+            /**
              * URLEncodes the path portions of path (doesn't encode the "/" portion)
              * Keeps the first and the last "/".
              */
@@ -189,7 +199,7 @@ namespace Aws
             /**
              * URLEncodes the path portion of the URI according to RFC3986
              */
-            static Aws::String URLEncodePathRFC3986(const Aws::String& path);
+            static Aws::String URLEncodePathRFC3986(const Aws::String& path, bool rfcCompliantEncoding = false);
 
         private:
             void ParseURIParts(const Aws::String& uri);
@@ -205,6 +215,7 @@ namespace Aws
             uint16_t m_port = HTTP_DEFAULT_PORT;
             Aws::Vector<Aws::String> m_pathSegments;
             bool m_pathHasTrailingSlash = false;
+            bool m_useRfcEncoding = false;
             Aws::String m_queryString;
         };
 

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/StringUtils.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/StringUtils.h
@@ -49,6 +49,11 @@ namespace Aws
             */
             static Aws::String URLEncode(const char* unsafe);
 
+            static inline Aws::String URLEncode(const Aws::String& unsafe)
+            {
+              return URLEncode(unsafe.c_str());
+            }
+
             /**
             * Http Clients tend to escape some characters but not all. Escaping all of them causes problems, because the client
             * will also try to escape them.

--- a/src/aws-cpp-sdk-core/source/http/URI.cpp
+++ b/src/aws-cpp-sdk-core/source/http/URI.cpp
@@ -27,10 +27,10 @@ const char* SEPARATOR = "://";
 bool s_compliantRfc3986Encoding = false;
 void SetCompliantRfc3986Encoding(bool compliant) { s_compliantRfc3986Encoding = compliant; }
 
-Aws::String urlEncodeSegment(const Aws::String& segment)
+Aws::String urlEncodeSegment(const Aws::String& segment, bool rfcEncoded = false)
 {
     // consolidates legacy escaping logic into one local method
-    if (s_compliantRfc3986Encoding)
+    if (rfcEncoded || s_compliantRfc3986Encoding)
     {
         return StringUtils::URLEncode(segment.c_str());
     }
@@ -141,7 +141,7 @@ void URI::SetScheme(Scheme value)
     }
 }
 
-Aws::String URI::URLEncodePathRFC3986(const Aws::String& path)
+Aws::String URI::URLEncodePathRFC3986(const Aws::String& path, bool rfcCompliantEncoding)
 {
     if (path.empty())
     {
@@ -155,7 +155,7 @@ Aws::String URI::URLEncodePathRFC3986(const Aws::String& path)
     // escape characters appearing in a URL path according to RFC 3986
     for (const auto& segment : pathParts)
     {
-        ss << '/' << urlEncodeSegment(segment);
+        ss << '/' << urlEncodeSegment(segment, rfcCompliantEncoding);
     }
 
     // if the last character was also a slash, then add that back here.
@@ -237,7 +237,7 @@ Aws::String URI::GetURLEncodedPathRFC3986() const
     // (mostly; there is some non-standards legacy support that can be disabled)
     for (const auto& segment : m_pathSegments)
     {
-        ss << '/' << urlEncodeSegment(segment);
+        ss << '/' << urlEncodeSegment(segment, m_useRfcEncoding);
     }
 
     if (m_pathSegments.empty() || m_pathHasTrailingSlash)

--- a/tests/aws-cpp-sdk-core-tests/http/URITest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/http/URITest.cpp
@@ -286,6 +286,15 @@ TEST_F(URITest, TestParseWithColon)
     EXPECT_EQ(80, complexUri.GetPort());
     EXPECT_STREQ("/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject:1234/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject:Key", complexUri.GetPath().c_str());
     EXPECT_STREQ(strComplexUri, complexUri.GetURIString().c_str());
+
+    URI complexUriCompliant(strComplexUri);
+    complexUriCompliant.SetRfc3986Encoded(true);
+    EXPECT_STREQ("s3.us-east-1.amazonaws.com", complexUriCompliant.GetAuthority().c_str());
+    EXPECT_EQ(80, complexUriCompliant.GetPort());
+    EXPECT_STREQ("/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject:1234/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject:Key",
+                 complexUri.GetPath().c_str());
+    EXPECT_STREQ("http://s3.us-east-1.amazonaws.com/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject%3A1234/awsnativesdkputobjectstestbucket20150702T200059Z/TestObject%3AKey",
+                 complexUriCompliant.GetURIString().c_str());
 }
 
 TEST_F(URITest, TestParseWithColonCompliant)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/UriRequestQueryParams.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/UriRequestQueryParams.vm
@@ -1,4 +1,3 @@
-#if($serviceModel.endpointRules)
 #if(($serviceNamespace == "S3Crt" && $operation.s3CrtEnabled) || $operation.getRequest().getShape().hasEventStreamMembers())
 #set($meterNeeded = true)
 #set($indent = "")
@@ -37,7 +36,6 @@ ${indent}          CoreErrors::ENDPOINT_RESOLUTION_FAILURE, "ENDPOINT_RESOLUTION
 ${indent}      return;
 ${indent}  }
 #end
-#end
 #if($operation.http.requestUri.contains("?"))
 ${indent}  Aws::StringStream ss;
 #end
@@ -54,19 +52,17 @@ ${indent}  Aws::StringStream ss;
 #set($queryStart = true)
 #set($pathAndQuery = $operation.http.splitUriPartIntoPathAndQuery($uriPartString))
 #if(!$pathAndQuery.get(0).isEmpty())
-#if($serviceModel.endpointRules)
-${indent}  endpointResolutionOutcome.GetResult().AddPathSegments("${pathAndQuery.get(0)}");
-#else
-${indent}  uri.AddPathSegments("${pathAndQuery.get(0)}");
+#if($pathAndQuery.get(0).toLowerCase().contains("resourcearn"))
+${indent}  endpointResolutionOutcome.GetResult().SetRfc3986Encoded(true);
 #end
+${indent}  endpointResolutionOutcome.GetResult().AddPathSegments("${pathAndQuery.get(0)}");
 #end
 ${indent}  ss.str("${pathAndQuery.get(1)}");
 #elseif(!$uriPartString.equals("/"))
-#if($serviceModel.endpointRules)
-${indent}  endpointResolutionOutcome.GetResult().AddPathSegments("$uriPartString");
-#else
-${indent}  uri.AddPathSegments("$uriPartString");
+#if($uriPartString.get(0).toLowerCase().contains("resourcearn"))
+${indent}  endpointResolutionOutcome.GetResult().SetRfc3986Encoded(true);
 #end
+${indent}  endpointResolutionOutcome.GetResult().AddPathSegments("$uriPartString");
 #end## ---------------------------- if (request uri contains query) end ------
 #foreach($var in $uriVars)## for (parameter in request uri parameters) -------
 #set($varIndex = $partIndex - 1)
@@ -83,17 +79,12 @@ ${indent}  uri.AddPathSegments("$uriPartString");
 ${indent}  ss << $parameter;
 #else
 #if($greedySyntax)
-#if($serviceModel.endpointRules)
+#if($parameter.toLowerCase().contains("resourcearn"))
+${indent}  endpointResolutionOutcome.GetResult().SetRfc3986Encoded(true);
+#end
 ${indent}  endpointResolutionOutcome.GetResult().AddPathSegments($parameter);
 #else
-${indent}  uri.AddPathSegments($parameter);
-#end
-#else
-#if($serviceModel.endpointRules)
 ${indent}  endpointResolutionOutcome.GetResult().AddPathSegment($parameter);
-#else
-${indent}  uri.AddPathSegment($parameter);
-#end
 #end
 #end
 #if($uriParts.size() > $partIndex)
@@ -102,19 +93,17 @@ ${indent}  uri.AddPathSegment($parameter);
 #set($queryStart = true)
 #set($pathAndQuery = $operation.http.splitUriPartIntoPathAndQuery($uriPartString))
 #if(!$pathAndQuery.get(0).isEmpty())
-#if($serviceModel.endpointRules)
-${indent}  endpointResolutionOutcome.GetResult().AddPathSegments("${pathAndQuery.get(0)}");
-#else
-${indent}  uri.AddPathSegments("${pathAndQuery.get(0)}");
+#if($pathAndQuery.get(0).toLowerCase().contains("resourcearn"))
+${indent}  endpointResolutionOutcome.GetResult().SetRfc3986Encoded(true);
 #end
+${indent}  endpointResolutionOutcome.GetResult().AddPathSegments("${pathAndQuery.get(0)}");
 #end
 ${indent}  ss.str("${pathAndQuery.get(1)}");
 #elseif(!$uriPartString.equals("/"))
-#if($serviceModel.endpointRules)
-${indent}  endpointResolutionOutcome.GetResult().AddPathSegments("$uriPartString");
-#else
-${indent}  uri.AddPathSegments("$uriPartString");
+#if($uriPartString.toLowerCase().contains("resourcearn"))
+${indent}  endpointResolutionOutcome.GetResult().SetRfc3986Encoded(true);
 #end
+${indent}  endpointResolutionOutcome.GetResult().AddPathSegments("$uriPartString");
 #end
 #end
 #end## --------------------- if !skipFirst end ---
@@ -123,9 +112,5 @@ ${indent}  uri.AddPathSegments("$uriPartString");
 #end## --------------------- if uriParts.size() > startIndex end ---
 #end## --------------------- for (parameter in request uri parameters) end ---
 #if($queryStart)
-#if($serviceModel.endpointRules)
 ${indent}  endpointResolutionOutcome.GetResult().SetQueryString(ss.str());
-#else
-${indent}  uri.SetQueryString(ss.str());
-#end
 #end

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/serviceoperations/withoutrequest/OperationOutcome.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/serviceoperations/withoutrequest/OperationOutcome.vm
@@ -1,14 +1,6 @@
 ${operation.name}Outcome ${className}::${operation.name}() const
 {
 AWS_OPERATION_GUARD(${operation.name});
-#if(!$serviceModel.endpointRules)
-  Aws::StringStream ss;
-#if($metadata.hasEndpointTrait)
-  ss << m_baseUri << "${operation.http.requestUri}";
-#else
-  ss << m_uri << "${operation.http.requestUri}";
-#end
-#end
   AWS_OPERATION_CHECK_PTR(m_telemetryProvider, ${operation.name}, CoreErrors, CoreErrors::NOT_INITIALIZED);
   auto tracer = m_telemetryProvider->getTracer(this->GetServiceClientName(), {});
   auto meter = m_telemetryProvider->getMeter(this->GetServiceClientName(), {});
@@ -19,22 +11,17 @@ AWS_OPERATION_GUARD(${operation.name});
   return TracingUtils::MakeCallWithTiming<${operation.name}Outcome>(
     [&]()-> ${operation.name}Outcome {
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/common/EndpointRulesNoRequestUriComputation.vm")
-#if($serviceModel.endpointRules && $operation.http.requestUri && $operation.http.requestUri != "/")
+#if($operation.http.requestUri && $operation.http.requestUri != "/")
+#if($operation.http.requestUri.toLowerCase().contains("resourcearn"))
+      endpointResolutionOutcome.GetResult().SetRfc3986Encoded(true);
+#end
       endpointResolutionOutcome.GetResult().AddPathSegments("${operation.http.requestUri}");
 #end
-#if($serviceModel.endpointRules)
 #if($operation.result && $operation.result.shape.hasStreamMembers())
       return ${operation.name}Outcome(MakeRequestWithUnparsedResponse(endpointResolutionOutcome.GetResult(), Aws::Http::HttpMethod::HTTP_${operation.http.method}, ${operation.signerName}, "${operation.name}"));
 #else
       return ${operation.name}Outcome(MakeRequest(endpointResolutionOutcome.GetResult(), Aws::Http::HttpMethod::HTTP_${operation.http.method}, ${operation.signerName}, "${operation.name}"));
 #end
-#else##-#if($serviceModel.endpointRules)
-#if($operation.result && $operation.result.shape.hasStreamMembers())
-      return ${operation.name}Outcome(MakeRequestWithUnparsedResponse(ss.str(), Aws::Http::HttpMethod::HTTP_${operation.http.method}, ${operation.signerName}, "${operation.name}"));
-#else
-      return ${operation.name}Outcome(MakeRequest(ss.str(), Aws::Http::HttpMethod::HTTP_${operation.http.method}, ${operation.signerName}, "${operation.name}"));
-#end
-#end##-#if($serviceModel.endpointRules)
     },
     TracingUtils::SMITHY_CLIENT_DURATION_METRIC,
     *meter,


### PR DESCRIPTION
*Issue #, if available:*
ARN contains ":" char and this char was not RFC-properly encoded by the SDK.
*Description of changes:*
Encode URIs in RFC-compliant mode if ARN parameter is defined by a model.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
