### PR TITLE
Stop using `stdext::checked_array_iterator`.

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/Array.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/Array.h
@@ -54,11 +54,7 @@ namespace Aws
                 {
                     m_data.reset(Aws::NewArray<T>(m_size, ARRAY_ALLOCATION_TAG));
 
-#ifdef _WIN32
-                    std::copy(arrayToCopy, arrayToCopy + arraySize, stdext::checked_array_iterator< T * >(m_data.get(), m_size));
-#else
                     std::copy(arrayToCopy, arrayToCopy + arraySize, m_data.get());
-#endif // MSVC
                 }
             }
 
@@ -82,11 +78,7 @@ namespace Aws
                     if(arr->m_size > 0 && arr->m_data)
                     {
                         size_t arraySize = arr->m_size;
-#ifdef _WIN32
-                        std::copy(arr->m_data.get(), arr->m_data.get() + arraySize, stdext::checked_array_iterator< T * >(m_data.get() + location, m_size));
-#else
                         std::copy(arr->m_data.get(), arr->m_data.get() + arraySize, m_data.get() + location);
-#endif // MSVC
                         location += arraySize;
                     }
                 }
@@ -101,11 +93,7 @@ namespace Aws
                 {
                     m_data.reset(Aws::NewArray<T>(m_size, ARRAY_ALLOCATION_TAG));
 
-#ifdef _WIN32
-                    std::copy(other.m_data.get(), other.m_data.get() + other.m_size, stdext::checked_array_iterator< T * >(m_data.get(), m_size));
-#else
                     std::copy(other.m_data.get(), other.m_data.get() + other.m_size, m_data.get());
-#endif // MSVC
                 }
             }
 
@@ -134,11 +122,7 @@ namespace Aws
                 {
                     m_data.reset(Aws::NewArray<T>(m_size, ARRAY_ALLOCATION_TAG));
 
-#ifdef _WIN32
-                    std::copy(other.m_data.get(), other.m_data.get() + other.m_size, stdext::checked_array_iterator< T * >(m_data.get(), m_size));
-#else
                     std::copy(other.m_data.get(), other.m_data.get() + other.m_size, m_data.get());
-#endif // MSVC
                 }
 
                 return *this;


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
`stdext::checked_array_iterator` will be deprecated in Visual Studio 17.8 (microsoft/STL#3818), does not exist in MinGW, and the uses of it in the SDK would never fail either way.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.) - The change is trivial and only removes code
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [X] Other Platforms (MinGW)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.