### PR TITLE
Fix small bug in CRTHttpClient.cpp

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
@@ -58,7 +58,7 @@ protected:
             // kick-in in plenty of time.
             bool retValue = Aws::Crt::Io::StdIOStreamInputStream::ReadImpl(buffer);
             size_t newPos = buffer.len;
-            AWS_ASSERT(newPos >= currentPos && !"the buffer length should not have decreased in value.");
+            AWS_ASSERT(newPos >= currentPos && "the buffer length should not have decreased in value.");
 
             if (retValue && m_isStreaming)
             {


### PR DESCRIPTION
All write operation fail if it's built in debug mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
