### PR TITLE
increase cloudwatch integ test timeout

### DIFF
--- a/tests/aws-cpp-sdk-logs-integration-tests/CloudWatchLogsTests.cpp
+++ b/tests/aws-cpp-sdk-logs-integration-tests/CloudWatchLogsTests.cpp
@@ -33,6 +33,7 @@ namespace
     static const char ALLOCATION_TAG[] = "CloudWatchLogsTest";
     static const char BASE_CLOUD_WATCH_LOGS_GROUP[] = "CppSDKIntegrationTestCWLGroup";
     static const char BASE_CLOUD_WATCH_LOGS_STREAM[] = "testLogs";
+    static const int SECONDS_TO_WAIT = 120;
 
     class CloudWatchLogsOperationTest : public ::testing::Test
     {
@@ -116,8 +117,8 @@ namespace
                     .WithLogStreamName(BuildResourceName(BASE_CLOUD_WATCH_LOGS_STREAM))
                     .WithStartFromHead(true);
         size_t eventsCount = 0;
-        int retry = 0;
-        while (retry++ < 10)
+        size_t retry = 0;
+        while (retry < SECONDS_TO_WAIT)
         {
             auto getOutcome = m_client->GetLogEvents(getRequest);
             AWS_ASSERT_SUCCESS(getOutcome);
@@ -135,6 +136,7 @@ namespace
             }
 
             std::this_thread::sleep_for(std::chrono::seconds(1));
+            retry++;
         }
         ASSERT_EQ(6u, eventsCount);
     }


### PR DESCRIPTION
*Description of changes:*

We see failures in cloudwatch tests from time to time, likely due to eventual consistency. We used to wait 10 seconds for all events to arrive. we are now bumping that to two minutes.

*Check all that applies:*
- [x] Did a review by yourself.
- [\x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
