### PR TITLE
Issue 2744: fix liveness / performance bug in PooledThreadExecutor

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/threading/Executor.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/threading/Executor.h
@@ -9,7 +9,7 @@
 #include <aws/core/utils/memory/stl/AWSQueue.h>
 #include <aws/core/utils/memory/stl/AWSVector.h>
 #include <aws/core/utils/memory/stl/AWSMap.h>
-#include <aws/core/utils/threading/Semaphore.h>
+#include <condition_variable>
 #include <functional>
 #include <future>
 #include <mutex>
@@ -105,7 +105,7 @@ namespace Aws
             private:
                 Aws::Queue<std::function<void()>*> m_tasks;
                 std::mutex m_queueLock;
-                Aws::Utils::Threading::Semaphore m_sync;
+                std::condition_variable m_sync;
                 Aws::Vector<ThreadTask*> m_threadTaskHandles;
                 size_t m_poolSize;
                 OverflowPolicy m_overflowPolicy;


### PR DESCRIPTION
*Issue #, if available:* 2744

*Description of changes:* Ensures that `ThreadTask` holds the `PooledThreadExecutor`'s mutex between when it sees that the `m_executor` does not have any tasks, and when it waits on the condition variable.

Since AWS Semaphore does not take a mutex as parameter, replaces use of `Semaphore` with `std::condition_variable` here.

*Check all that applies:*
- [ x ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ x ] Checked if this PR is a breaking (APIs have been changed) change.
- [ x ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ x ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ x ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
