### PR TITLE
#2730 Do not overrun put buffer in EventStreamBuf

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
@@ -290,7 +290,12 @@ namespace Aws
             }
 
             // When data is received from the content body of the incoming response, just copy it to the output stream.
+            assert(response);
             response->GetResponseBody().write((const char*)body.ptr, static_cast<long>(body.len));
+            if (response->GetResponseBody().fail()) {
+                const auto& ref = response->GetResponseBody();
+                AWS_LOGSTREAM_ERROR(CRT_HTTP_CLIENT_TAG, "Failed to write " << body.len << " (eof: " << ref.eof() << ", bad: " << ref.bad() << ")");
+            }
 
             if (request->IsEventStreamRequest() && !response->HasHeader(Aws::Http::X_AMZN_ERROR_TYPE))
             {

--- a/src/aws-cpp-sdk-core/source/utils/event/EventStreamBuf.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/event/EventStreamBuf.cpp
@@ -38,12 +38,17 @@ namespace Aws
             {
                 if (pptr() > pbase())
                 {
+                    assert(epptr() >= pptr()); // check that we are in a put area
                     size_t length = static_cast<size_t>(pptr() - pbase());
                     m_decoder.Pump(m_byteBuffer, length);
 
                     if (!m_decoder)
                     {
                         m_err.write(reinterpret_cast<char*>(m_byteBuffer.GetUnderlyingData()), length);
+                        if (m_err.fail()) {
+                            AWS_LOGSTREAM_ERROR("EventStreamBuf",
+                                                "Failed to write " << length << " (eof: " << m_err.eof() << ", bad: " << m_err.bad() << ")");
+                        }
                     }
                     else
                     {
@@ -120,13 +125,25 @@ namespace Aws
 
                 if (m_decoder)
                 {
+                    if (pptr() == epptr()) // always the case by C++ standard, but someone may inherit from this class
+                    {
+                        writeToDecoder();
+                    }
+                    // writeToDecoder had to take some data from the put buffer but failed
+                    if (pptr() == epptr())
+                    {
+                        AWS_LOGSTREAM_ERROR("EventStreamBuf", "Failed to decode EventStream event on char with int value: " << ch);
+                        // let's just reset the put buffer and move on.
+                        setp(pbase(), epptr() - 1);
+                    }
+
+                    // put char to the put area and advance current pptr
                     if (ch != eof)
                     {
                         *pptr() = (char)ch;
                         pbump(1);
                     }
 
-                    writeToDecoder();
                     return ch;
                 }
 


### PR DESCRIPTION
*Issue #, if available:*
#2730
*Description of changes:*

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
