### PR TITLE
Fix curl headers when value is absent

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -627,7 +627,11 @@ std::shared_ptr<HttpResponse> CurlHttpClient::MakeRequest(const std::shared_ptr<
     for (auto& requestHeader : requestHeaders)
     {
         headerStream.str("");
-        headerStream << requestHeader.first << ": " << requestHeader.second;
+        if (requestHeader.second.empty()) {
+            headerStream << requestHeader.first << ";";
+        } else {
+            headerStream << requestHeader.first << ": " << requestHeader.second;
+        }
         Aws::String headerString = headerStream.str();
         AWS_LOGSTREAM_TRACE(CURL_HTTP_CLIENT_TAG, headerString);
         headers = curl_slist_append(headers, headerString.c_str());


### PR DESCRIPTION
*Description of changes:*

Right now if a S3 request is made like

```
PutObjectRequest().WithMetadata({{"KeyWithValue", "value"}, {"KeyWithoutValue", ""}});
```

this will result in a curl request with headers like

```
[DEBUG] 2023-11-14 15:37:57.397 CURL [0x1de241b40] (HeaderOut) PUT /test.txt HTTP/1.1
Host: sbiscigl.s3.us-east-1.amazonaws.com
...
x-amz-meta-keywithvalue: value
...
```

without the header without value. after this change it will look like

```
[DEBUG] 2023-11-14 15:42:21.551 CURL [0x1de241b40] (HeaderOut) PUT /test.txt HTTP/1.1
...
x-amz-meta-keywithoutvalue:
x-amz-meta-keywithvalue: value
...
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
