### PR TITLE
re-add sqs customization that was dropped in json migration

### DIFF
--- a/generated/src/aws-cpp-sdk-sqs/include/aws/sqs/model/QueueAttributeName.h
+++ b/generated/src/aws-cpp-sdk-sqs/include/aws/sqs/model/QueueAttributeName.h
@@ -37,7 +37,11 @@ namespace Model
     DeduplicationScope,
     FifoThroughputLimit,
     RedriveAllowPolicy,
-    SqsManagedSseEnabled
+    SqsManagedSseEnabled,
+    SentTimestamp,
+    ApproximateFirstReceiveTimestamp,
+    ApproximateReceiveCount,
+    SenderId
   };
 
 namespace QueueAttributeNameMapper

--- a/generated/src/aws-cpp-sdk-sqs/source/model/QueueAttributeName.cpp
+++ b/generated/src/aws-cpp-sdk-sqs/source/model/QueueAttributeName.cpp
@@ -42,6 +42,10 @@ namespace Aws
         static const int FifoThroughputLimit_HASH = HashingUtils::HashString("FifoThroughputLimit");
         static const int RedriveAllowPolicy_HASH = HashingUtils::HashString("RedriveAllowPolicy");
         static const int SqsManagedSseEnabled_HASH = HashingUtils::HashString("SqsManagedSseEnabled");
+        static const int SentTimestamp_HASH = HashingUtils::HashString("SentTimestamp");
+        static const int ApproximateFirstReceiveTimestamp_HASH = HashingUtils::HashString("ApproximateFirstReceiveTimestamp");
+        static const int ApproximateReceiveCount_HASH = HashingUtils::HashString("ApproximateReceiveCount");
+        static const int SenderId_HASH = HashingUtils::HashString("SenderId");
 
 
         QueueAttributeName GetQueueAttributeNameForName(const Aws::String& name)
@@ -135,6 +139,22 @@ namespace Aws
           {
             return QueueAttributeName::SqsManagedSseEnabled;
           }
+          else if (hashCode == SentTimestamp_HASH)
+          {
+            return QueueAttributeName::SentTimestamp;
+          }
+          else if (hashCode == ApproximateFirstReceiveTimestamp_HASH)
+          {
+            return QueueAttributeName::ApproximateFirstReceiveTimestamp;
+          }
+          else if (hashCode == ApproximateReceiveCount_HASH)
+          {
+            return QueueAttributeName::ApproximateReceiveCount;
+          }
+          else if (hashCode == SenderId_HASH)
+          {
+            return QueueAttributeName::SenderId;
+          }
           EnumParseOverflowContainer* overflowContainer = Aws::GetEnumOverflowContainer();
           if(overflowContainer)
           {
@@ -195,6 +215,14 @@ namespace Aws
             return "RedriveAllowPolicy";
           case QueueAttributeName::SqsManagedSseEnabled:
             return "SqsManagedSseEnabled";
+          case QueueAttributeName::SentTimestamp:
+            return "SentTimestamp";
+          case QueueAttributeName::ApproximateFirstReceiveTimestamp:
+            return "ApproximateFirstReceiveTimestamp";
+          case QueueAttributeName::ApproximateReceiveCount:
+            return "ApproximateReceiveCount";
+          case QueueAttributeName::SenderId:
+            return "SenderId";
           default:
             EnumParseOverflowContainer* overflowContainer = Aws::GetEnumOverflowContainer();
             if(overflowContainer)

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/config/ServiceGeneratorConfig.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/config/ServiceGeneratorConfig.java
@@ -25,6 +25,7 @@ import com.amazonaws.util.awsclientgenerator.generators.cpp.polly.PollyCppClient
 import com.amazonaws.util.awsclientgenerator.generators.cpp.rds.RDSCppClientGenerator;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.s3.S3RestXmlCppClientGenerator;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.s3control.S3ControlRestXmlCppClientGenerator;
+import com.amazonaws.util.awsclientgenerator.generators.cpp.sqs.SQSJsonCppClientGenerator;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.sqs.SQSQueryXmlCppClientGenerator;
 
 import java.util.HashMap;
@@ -52,6 +53,7 @@ public class ServiceGeneratorConfig {
             SPEC_OVERRIDE_MAPPING.put("cpp-glacier-rest-json", new GlacierRestJsonCppClientGenerator());
             SPEC_OVERRIDE_MAPPING.put("cpp-lambda-rest-json", new LambdaRestJsonCppClientGenerator());
             SPEC_OVERRIDE_MAPPING.put("cpp-sqs-query", new SQSQueryXmlCppClientGenerator());
+            SPEC_OVERRIDE_MAPPING.put("cpp-sqs-json", new SQSJsonCppClientGenerator());
             SPEC_OVERRIDE_MAPPING.put("cpp-s3-rest-xml", new S3RestXmlCppClientGenerator());
             SPEC_OVERRIDE_MAPPING.put("cpp-s3-crt-rest-xml", new S3RestXmlCppClientGenerator());
             SPEC_OVERRIDE_MAPPING.put("cpp-s3control-rest-xml", new S3ControlRestXmlCppClientGenerator());

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/sqs/SQSJsonCppClientGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/sqs/SQSJsonCppClientGenerator.java
@@ -1,0 +1,31 @@
+package com.amazonaws.util.awsclientgenerator.generators.cpp.sqs;
+
+import com.amazonaws.util.awsclientgenerator.domainmodels.SdkFileEntry;
+import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.ServiceModel;
+import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.Shape;
+import com.amazonaws.util.awsclientgenerator.generators.cpp.JsonCppClientGenerator;
+
+public class SQSJsonCppClientGenerator extends JsonCppClientGenerator {
+
+    public SQSJsonCppClientGenerator() throws Exception {
+        super();
+    }
+
+    @Override
+    public SdkFileEntry[] generateSourceFiles(ServiceModel serviceModel) throws Exception {
+        Shape queueAttributeNameShape = serviceModel.getShapes().get("QueueAttributeName");
+
+        /*
+         * Add missing unmodeled queue attribute shapes that were already present
+         * in a customization for the QueryXML client generation.
+         */
+        if(queueAttributeNameShape != null) {
+            queueAttributeNameShape.getEnumValues().add("SentTimestamp");
+            queueAttributeNameShape.getEnumValues().add("ApproximateFirstReceiveTimestamp");
+            queueAttributeNameShape.getEnumValues().add("ApproximateReceiveCount");
+            queueAttributeNameShape.getEnumValues().add("SenderId");
+        }
+
+        return super.generateSourceFiles(serviceModel);
+    }
+}


### PR DESCRIPTION
*Description of changes:*

In the json protocol migration for SQS we missed moving over a customization that was present in the old [XML generator](https://github.com/aws/aws-sdk-cpp/commit/376755b0ade8c49e14eaff83ab5a438e7a5efc3f) that caused some [unmodeled enum values to be dropped](https://github.com/aws/aws-sdk-cpp/commit/0655398d886fc7ccbcbff37376b92fc0fbe1b9ce#diff-66e1474b8d5b6f7687e846bc369e3f52cc8556fc2b916bbb8722a7ce47632403L139-L157) causing a backwards incompatible change. This adds the enum members back

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
