### PR TITLE
Align with other SDKs on IMDSv1 config

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -325,6 +325,11 @@ namespace Aws
             Aws::Http::Version version = Http::Version::HTTP_VERSION_2TLS;
 
             /**
+             * Disable all internal IMDSV1 Calls
+             */
+            bool disableImdsV1 = false;
+
+            /**
              * A helper function to read config value from env variable or aws profile config
              */
             static Aws::String LoadConfigFromEnvOrProfile(const Aws::String& envKey,

--- a/src/aws-cpp-sdk-core/include/aws/core/internal/AWSHttpResourceClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/internal/AWSHttpResourceClient.h
@@ -155,6 +155,7 @@ namespace Aws
             mutable Aws::String m_token;
             mutable bool m_tokenRequired;
             mutable Aws::String m_region;
+            bool m_disableIMDSV1 = false;
         };
 
         void AWS_CORE_API InitEC2MetadataClient();


### PR DESCRIPTION
*Description of changes:*

We previous disabled IMDSv1 fallback via a [cmake parameter](https://github.com/aws/aws-sdk-cpp/commit/3fefb1ce2cac3bd502018587936f3de42389b010). Now that other SDKs also support disabling fallback for V1 we are introducing a common config/env var to disable(i.e. [go](https://github.com/aws/aws-sdk-go-v2/commit/75654bcc726128a4f45f67943a6d3c01f09c8c23#diff-e0272c2b3b8578b2b57ed525b1278ef61a8df0c2bc9809f312dc3b8e167c2baf)). This aligns with them.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
