### PR TITLE
Handle Operation<Request>/<Result> possible type name conflicts

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
@@ -110,6 +110,13 @@ public class C2jModelToGeneratorModelTransformer {
             "GeneratedPolicyResult"
     );
 
+    private static List<String> SHAPE_SDK_RESULT_SUFFIX = ImmutableList.of(
+            "Result", "SdkResult", "CppSdkResult"
+    );
+    private static List<String> SHAPE_SDK_REQUEST_SUFFIX = ImmutableList.of(
+            "Request", "SdkRequest", "CppSdkRequest"
+    );
+
     public C2jModelToGeneratorModelTransformer(C2jServiceModel c2jServiceModel, boolean standalone) {
         this.c2jServiceModel = c2jServiceModel;
         this.standalone = standalone;
@@ -548,8 +555,8 @@ public class C2jModelToGeneratorModelTransformer {
 
         // input
         if (c2jOperation.getInput() != null) {
-            String requestName = c2jOperation.getName() + "Request";
-            Shape requestShape = renameShape(shapes.get(c2jOperation.getInput().getShape()), requestName);
+            Shape requestShape = renameShape(shapes.get(c2jOperation.getInput().getShape()), c2jOperation.getName(), SHAPE_SDK_REQUEST_SUFFIX);
+
             requestShape.setRequest(true);
             requestShape.setReferenced(true);
             requestShape.getReferencedBy().add(c2jOperation.getName());
@@ -562,7 +569,7 @@ public class C2jModelToGeneratorModelTransformer {
             }
             if(requestShape.getLocationName() != null && requestShape.getLocationName().length() > 0 &&
                     (requestShape.getPayload() == null || requestShape.getPayload().length() == 0) ) {
-                requestShape.setPayload(requestName);
+                requestShape.setPayload(requestShape.getName());
             }
 
             requestShape.setSignBody(true);
@@ -597,8 +604,8 @@ public class C2jModelToGeneratorModelTransformer {
 
         // output
         if (c2jOperation.getOutput() != null) {
-            String resultName = c2jOperation.getName() + "Result";
-            Shape resultShape = renameShape(shapes.get(c2jOperation.getOutput().getShape()), resultName);
+            Shape resultShape = renameShape(shapes.get(c2jOperation.getOutput().getShape()), c2jOperation.getName(), SHAPE_SDK_RESULT_SUFFIX);
+
             resultShape.setResult(true);
             resultShape.setReferenced(true);
             resultShape.getReferencedBy().add(c2jOperation.getName());
@@ -651,44 +658,52 @@ public class C2jModelToGeneratorModelTransformer {
         return operation;
     }
 
-    Shape renameShape(Shape shape, String name) {
-        if (shape.getName().equals(name)) {
-            return shape;
-        }
+    Shape renameShape(Shape shape, String baseName, List<String> suffixOptions) {
+        String newName = null;
+        Iterator<String> suffixIt = suffixOptions.iterator();
+        while (suffixIt.hasNext()) {
+            newName = baseName + suffixIt.next();
 
-        // Detect any conflicts with shape name defined by service team, need to rename it if so.
-        Optional<String> conflicted = shapes.keySet().stream()
-                .filter(shapeName -> name.equals(shapeName) ||
-                        (shape.getMembers().keySet().stream().anyMatch(memberName -> memberName.equals(shapeName) ||
-                         shape.getMembers().values().stream().anyMatch(shapeMember -> LEGACY_RENAMED_APIS.contains(shapeMember.getShape().getName()))) &&
-                                        (name.equals("Get" + shapeName) || name.equals("Set" + shapeName)))).findFirst();
-        if (conflicted.isPresent()) {
-            String originalShapeName = conflicted.get();
-            String newShapeName = "";
-            switch(originalShapeName) {
-                case "CopyObjectResult":
+            if (shape.getName().equals(newName)) {
+                return shape;
+            }
+
+            // Detect any conflicts with shape name defined by service team, need to rename it if so.
+            String finalNewName = newName;
+            Optional<String> conflicted = shapes.keySet().stream()
+                    .filter(shapeName -> finalNewName.equals(shapeName) ||
+                            (shape.getMembers().keySet().stream().anyMatch(memberName -> memberName.equals(shapeName) ||
+                                    shape.getMembers().values().stream().anyMatch(shapeMember -> LEGACY_RENAMED_APIS.contains(shapeMember.getShape().getName()))) &&
+                                    (finalNewName.equals("Get" + shapeName) || finalNewName.equals("Set" + shapeName)))).findFirst();
+            if (!conflicted.isPresent()) {
+                break;
+            } else {
+                String originalShapeName = conflicted.get();
+                String newShapeName = "";
+                if (originalShapeName.equals("CopyObjectResult")) {
                     newShapeName = "CopyObjectResultDetails";
                     renameShapeMember(shape, "CopyObjectResult", originalShapeName, newShapeName, newShapeName, true);
                     break;
-                case "BatchUpdateScheduleResult":
+                } else if (originalShapeName.equals("BatchUpdateScheduleResult")) {
                     shapes.remove(originalShapeName);
                     break;
-                case "GeneratedPolicyResult":
+                } else if (originalShapeName.equals("GeneratedPolicyResult")) {
                     newShapeName = "GeneratedPolicyResults";
                     renameShapeMember(shape, "generatedPolicyResult", originalShapeName, newShapeName, newShapeName, false);
                     break;
-                case "SearchResult":
+                } else if (originalShapeName.equals("SearchResult")) {
                     newShapeName = "SearchResultDetails";
                     renameShapeMember(shape, "results", originalShapeName, "results", newShapeName, true);
                     break;
-                default:
-                    throw new RuntimeException("Unhandled shape name conflict: " + name);
+                }
+                if (!suffixIt.hasNext())
+                    throw new RuntimeException("Unhandled shape name conflict: " + newName);
             }
         }
 
         Shape cloned = cloneShape(shape);
-        cloned.setName(name);
-        shapes.put(name, cloned);
+        cloned.setName(newName);
+        shapes.put(newName, cloned);
         return cloned;
     }
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/RequestHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/RequestHeader.vm
@@ -137,7 +137,7 @@ namespace Model
     /**
      * Underlying Event Stream Handler which is used to define callback functions.
      */
-    inline ${operation.name}Request& WithEventStreamHandler(const ${operation.name}Handler& value) { SetEventStreamHandler(value); return *this; }
+    inline ${operation.request.shape.name}& WithEventStreamHandler(const ${operation.name}Handler& value) { SetEventStreamHandler(value); return *this; }
 
 #end
 #if($operation.requestCompressionRequired)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
@@ -203,11 +203,11 @@ static void ${operation.name}RequestShutdownCallback(void *user_data)
 #end
 #if($operation.request)
 #if($operation.name == "PutObject")
-  userData->putResponseHandler(userData->s3CrtClient, *(reinterpret_cast<const ${operation.name}Request*>(userData->originalRequest)), std::move(outcome), userData->asyncCallerContext);
+  userData->putResponseHandler(userData->s3CrtClient, *(reinterpret_cast<const ${operation.request.shape.name}*>(userData->originalRequest)), std::move(outcome), userData->asyncCallerContext);
 #elseif($operation.name == "GetObject")
-  userData->getResponseHandler(userData->s3CrtClient, *(reinterpret_cast<const ${operation.name}Request*>(userData->originalRequest)), std::move(outcome), userData->asyncCallerContext);
+  userData->getResponseHandler(userData->s3CrtClient, *(reinterpret_cast<const ${operation.request.shape.name}*>(userData->originalRequest)), std::move(outcome), userData->asyncCallerContext);
 #elseif($operation.name == "CopyObject")
-  userData->copyResponseHandler(userData->s3CrtClient, *(reinterpret_cast<const ${operation.name}Request*>(userData->originalRequest)), std::move(outcome), userData->asyncCallerContext);
+  userData->copyResponseHandler(userData->s3CrtClient, *(reinterpret_cast<const ${operation.request.shape.name}*>(userData->originalRequest)), std::move(outcome), userData->asyncCallerContext);
 #end
 #else
   (*handler)(userData->s3CrtClient, outcome, userData->userCallbackContext);
@@ -290,7 +290,7 @@ void ${className}::${operation.name}Async(${constText}${operation.request.shape.
 #else
   InitCommonCrtRequestOption(userData, &options, &request, uri, Aws::Http::HttpMethod::HTTP_${operation.http.method});
 #end
-  options.shutdown_callback = ${operation.name}RequestShutdownCallback;
+  options.shutdown_callback = ${operation.request.shape.name}ShutdownCallback;
 #if($operation.name == "PutObject")
   options.type = AWS_S3_META_REQUEST_TYPE_PUT_OBJECT;
 #elseif($operation.name == "GetObject")


### PR DESCRIPTION
Handle Operation<Request>/<Result> possible type name conflict at a higher abstraction level

*Issue #, if available:*
Service teams can use <OperationName>Result shape name.
*Description of changes:*
Instead of handling conflict case-by-case - just change the suffix.
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
