### PR TITLE
Compute if shapes contain each other through their all ancestors too

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/Shape.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/Shape.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -219,23 +220,68 @@ public class Shape {
       return "null";
     }
 
+    private Set<String> getAllChildrenShapeNames() {
+        Set<String> collected = new HashSet<String>();
+
+        if (members == null || members.isEmpty()) {
+            return collected;
+        }
+
+        collected.addAll(members.values().parallelStream()
+                .map(value -> value.getShape())
+                .map(memberShape -> memberShape.isList() ? memberShape.getListMember().getShape() : memberShape) //if references through a list container
+                .map(memberShape -> memberShape.getName())
+                .collect(Collectors.toSet()));
+
+        Map<String, Shape> toVisit = new HashMap<>(); // map to avoid Shape hashing quirks
+        toVisit.putAll(members.values().parallelStream()
+               .map(ShapeMember::getShape)
+               .collect(Collectors.toMap(shape -> shape.getName(), shape->shape, (shape1, shape2) -> shape1)));
+
+        while(!toVisit.isEmpty())
+        {
+            Shape visited = toVisit.entrySet().iterator().next().getValue();
+
+            if (visited.members != null && !visited.members.isEmpty()) {
+
+                Map<String, Shape> children = visited.members.values().parallelStream()
+                        .map(value -> value.getShape())
+                        .filter(shape -> !collected.contains(shape.getName()))
+                        .map(memberShape -> memberShape.isList() ? memberShape.getListMember().getShape() : memberShape) //if references through a list container
+                        .collect(Collectors.toMap(
+                                shape -> shape.getName(), shape -> shape,
+                                (shape1, shape2) -> shape1));
+
+                collected.addAll(children.keySet());
+                toVisit.putAll(children);
+            }
+            toVisit.remove(visited.getName());
+        }
+
+        return collected;
+    }
+
+    private Set<String> thisAndAllChildrenShapeNamesMemoized;
+    private Set<String> getThisAndAllChildrenShapeNames() {
+        if (thisAndAllChildrenShapeNamesMemoized != null && !thisAndAllChildrenShapeNamesMemoized.isEmpty()) {
+            // this method is called for at least shape count ^ 2 times
+            return thisAndAllChildrenShapeNamesMemoized;
+        }
+        Set<String> shapes = getAllChildrenShapeNames();
+
+        thisAndAllChildrenShapeNamesMemoized = shapes;
+        thisAndAllChildrenShapeNamesMemoized.add(getName());
+        return thisAndAllChildrenShapeNamesMemoized;
+    }
+
     // Some shapes are mutually referenced with each other, e.g. Statement and NotStatement in wafv2.
     public boolean isMutuallyReferencedWith(Shape otherShape) {
         if (otherShape == null || otherShape.members == null || members == null || !isStructure() || !otherShape.isStructure() || name.equals(otherShape.getName())) return false;
 
-        // Get this and other member type names, if member is a list then get underlying type in this list
-        Set<String> thisMemberShapeNames = members.values().parallelStream()
-                .map(value -> value.getShape())
-                .map(memberShape -> memberShape.isList() ? memberShape.getListMember().getShape() : memberShape) //if references through a list container
-                .map(memberShape -> memberShape.getName())
-                .collect(Collectors.toSet());
-        Set<String> otherMemberShapeNames = otherShape.getMembers().values().parallelStream()
-                .map(value -> value.getShape())
-                .map(memberShape -> memberShape.isList() ? memberShape.getListMember().getShape() : memberShape)
-                .map(memberShape -> memberShape.getName())
-                .collect(Collectors.toSet());
+        Set<String> thisShapes = this.getThisAndAllChildrenShapeNames();
+        Set<String> otherShapes = otherShape.getThisAndAllChildrenShapeNames();
 
-        return thisMemberShapeNames.contains(otherShape.getName()) && otherMemberShapeNames.contains(this.getName());
+        return thisShapes.contains(otherShape.getName()) && otherShapes.contains(this.getName());
     }
 
     public boolean hasContextParam() {


### PR DESCRIPTION
*Issue #, if available:*
n/a
*Description of changes:*
Current check for "mutually referenced" does not go beyond first level of shape composition, so use BFS to collect all and set intersection.

Also, memoize the result of shape names collection as this method is called quite many times.

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
