### PR TITLE
Crt proxy

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -129,11 +129,11 @@
 #include <aws/crt/Types.h>
 #include <aws/crt/auth/Credentials.h>
 #include <aws/crt/http/HttpRequestResponse.h>
+#include <aws/crt/http/HttpProxyStrategy.h>
 #include <aws/crt/io/Stream.h>
 #include <aws/crt/io/Uri.h>
 #include <aws/http/request_response.h>
 #include <aws/common/string.h>
-#include <aws/crt/http/HttpProxyStrategy.h>
 
 using namespace Aws::Utils;
 

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -133,6 +133,7 @@
 #include <aws/crt/io/Uri.h>
 #include <aws/http/request_response.h>
 #include <aws/common/string.h>
+#include <aws/crt/http/HttpProxyStrategy.h>
 
 using namespace Aws::Utils;
 
@@ -362,6 +363,64 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config,
   else
   {
     s3CrtConfig.tls_connection_options = nullptr;
+  }
+
+  Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
+  aws_http_proxy_options raw_proxy_options;
+
+  if (!config.proxyHost.empty())
+  {
+    if (!config.proxyUserName.empty() || !config.proxyPassword.empty())
+    {
+      Aws::Crt::Http::HttpProxyStrategyBasicAuthConfig basicAuthConfig;
+      basicAuthConfig.ConnectionType = Aws::Crt::Http::AwsHttpProxyConnectionType::Tunneling;
+      basicAuthConfig.Username = config.proxyUserName.c_str();
+      basicAuthConfig.Password = config.proxyPassword.c_str();
+      proxyOptions.ProxyStrategy = Aws::Crt::Http::HttpProxyStrategy::CreateBasicHttpProxyStrategy(basicAuthConfig, Aws::get_aws_allocator());
+    }
+
+    proxyOptions.HostName = config.proxyHost.c_str();
+
+    if (config.proxyPort != 0)
+    {
+      proxyOptions.Port = static_cast<uint16_t>(config.proxyPort);
+    }
+    else
+    {
+      proxyOptions.Port = config.proxyScheme == Scheme::HTTPS ? 443 : 80;
+    }
+
+    if (config.proxyScheme == Scheme::HTTPS)
+    {
+      Crt::Io::TlsContextOptions contextOptions = Crt::Io::TlsContextOptions::InitDefaultClient();
+
+      if (config.proxySSLKeyPassword.empty() && !config.proxySSLCertPath.empty())
+      {
+        const char* certPath = config.proxySSLCertPath.empty() ? nullptr : config.proxySSLCertPath.c_str();
+        const char* certFile = config.proxySSLKeyPath.empty() ? nullptr : config.proxySSLKeyPath.c_str();
+        contextOptions = Crt::Io::TlsContextOptions::InitClientWithMtls(certPath, certFile);
+      }
+      else if (!config.proxySSLKeyPassword.empty())
+      {
+        const char* pkcs12CertFile = config.proxySSLKeyPath.empty() ? nullptr : config.proxySSLKeyPath.c_str();
+        const char* pkcs12Pwd = config.proxySSLKeyPassword.c_str();
+        contextOptions = Crt::Io::TlsContextOptions::InitClientWithMtlsPkcs12(pkcs12CertFile, pkcs12Pwd);
+      }
+
+      if (!config.caFile.empty() || !config.caPath.empty())
+      {
+        const char* caPath = config.caPath.empty() ? nullptr : config.caPath.c_str();
+        const char* caFile = config.caFile.empty() ? nullptr : config.caFile.c_str();
+        contextOptions.OverrideDefaultTrustStore(caPath, caFile);
+      }
+
+      contextOptions.SetVerifyPeer(config.verifySSL);
+      Crt::Io::TlsContext context = Crt::Io::TlsContext(contextOptions, Crt::Io::TlsMode::CLIENT);
+      proxyOptions.TlsOptions = context.NewConnectionOptions();
+    }
+
+    proxyOptions.InitializeRawProxyOptions(raw_proxy_options);
+    s3CrtConfig.proxy_options = &raw_proxy_options;
   }
 
   s3CrtConfig.tls_mode = config.scheme == Aws::Http::Scheme::HTTPS ? AWS_MR_TLS_ENABLED : AWS_MR_TLS_DISABLED;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceHeaders.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceHeaders.vm
@@ -48,6 +48,7 @@
 \#include <aws/crt/Types.h>
 \#include <aws/crt/auth/Credentials.h>
 \#include <aws/crt/http/HttpRequestResponse.h>
+\#include <aws/crt/http/HttpProxyStrategy.h>
 \#include <aws/crt/io/Stream.h>
 \#include <aws/crt/io/Uri.h>
 \#include <aws/http/request_response.h>

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -403,6 +403,64 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
     s3CrtConfig.tls_connection_options = nullptr;
   }
 
+  Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
+  aws_http_proxy_options raw_proxy_options;
+
+  if (!config.proxyHost.empty())
+  {
+    if (!config.proxyUserName.empty() || !config.proxyPassword.empty())
+    {
+      Aws::Crt::Http::HttpProxyStrategyBasicAuthConfig basicAuthConfig;
+      basicAuthConfig.ConnectionType = Aws::Crt::Http::AwsHttpProxyConnectionType::Tunneling;
+      basicAuthConfig.Username = config.proxyUserName.c_str();
+      basicAuthConfig.Password = config.proxyPassword.c_str();
+      proxyOptions.ProxyStrategy = Aws::Crt::Http::HttpProxyStrategy::CreateBasicHttpProxyStrategy(basicAuthConfig, Aws::get_aws_allocator());
+    }
+
+    proxyOptions.HostName = config.proxyHost.c_str();
+
+    if (config.proxyPort != 0)
+    {
+      proxyOptions.Port = static_cast<uint16_t>(config.proxyPort);
+    }
+    else
+    {
+      proxyOptions.Port = config.proxyScheme == Scheme::HTTPS ? 443 : 80;
+    }
+
+    if (config.proxyScheme == Scheme::HTTPS)
+    {
+      Crt::Io::TlsContextOptions contextOptions = Crt::Io::TlsContextOptions::InitDefaultClient();
+
+      if (config.proxySSLKeyPassword.empty() && !config.proxySSLCertPath.empty())
+      {
+        const char* certPath = config.proxySSLCertPath.empty() ? nullptr : config.proxySSLCertPath.c_str();
+        const char* certFile = config.proxySSLKeyPath.empty() ? nullptr : config.proxySSLKeyPath.c_str();
+        contextOptions = Crt::Io::TlsContextOptions::InitClientWithMtls(certPath, certFile);
+      }
+      else if (!config.proxySSLKeyPassword.empty())
+      {
+        const char* pkcs12CertFile = config.proxySSLKeyPath.empty() ? nullptr : config.proxySSLKeyPath.c_str();
+        const char* pkcs12Pwd = config.proxySSLKeyPassword.c_str();
+        contextOptions = Crt::Io::TlsContextOptions::InitClientWithMtlsPkcs12(pkcs12CertFile, pkcs12Pwd);
+      }
+
+      if (!config.caFile.empty() || !config.caPath.empty())
+      {
+        const char* caPath = config.caPath.empty() ? nullptr : config.caPath.c_str();
+        const char* caFile = config.caFile.empty() ? nullptr : config.caFile.c_str();
+        contextOptions.OverrideDefaultTrustStore(caPath, caFile);
+      }
+
+      contextOptions.SetVerifyPeer(config.verifySSL);
+      Crt::Io::TlsContext context = Crt::Io::TlsContext(contextOptions, Crt::Io::TlsMode::CLIENT);
+      proxyOptions.TlsOptions = context.NewConnectionOptions();
+    }
+
+    proxyOptions.InitializeRawProxyOptions(raw_proxy_options);
+    s3CrtConfig.proxy_options = &raw_proxy_options;
+  }
+
   s3CrtConfig.tls_mode = config.scheme == Aws::Http::Scheme::HTTPS ? AWS_MR_TLS_ENABLED : AWS_MR_TLS_DISABLED;
   s3CrtConfig.throughput_target_gbps = config.throughputTargetGbps;
   m_clientShutdownSem = Aws::MakeShared<Threading::Semaphore>(ALLOCATION_TAG, 0, 1);


### PR DESCRIPTION
*Description of changes:*

Based on and cherry picked from [pull/2693](https://github.com/aws/aws-sdk-cpp/pull/2693). I just added code generation to it. from the original PR:

`Pass proxy settings from S3CrtConfig through to the aws_s3_client_config struct for CRT`

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
