### PR TITLE
add retries on shapless 502 errors

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/http/HttpResponse.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/HttpResponse.h
@@ -116,6 +116,7 @@ namespace Aws
             {
                 case HttpResponseCode::INTERNAL_SERVER_ERROR:
                 case HttpResponseCode::SERVICE_UNAVAILABLE:
+                case HttpResponseCode::BAD_GATEWAY:
                 case HttpResponseCode::TOO_MANY_REQUESTS:
                 case HttpResponseCode::BANDWIDTH_LIMIT_EXCEEDED:
                 case HttpResponseCode::REQUEST_TIMEOUT:


### PR DESCRIPTION
*Description of changes:*

Adds 502 to the list of error codes to retry shapeless errors on to align with the java sdk.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
