### PR TITLE
Request member collision

### DIFF
--- a/generated/src/aws-cpp-sdk-accessanalyzer/source/model/GetGeneratedPolicyResult.cpp
+++ b/generated/src/aws-cpp-sdk-accessanalyzer/source/model/GetGeneratedPolicyResult.cpp
@@ -35,9 +35,9 @@ GetGeneratedPolicyResult& GetGeneratedPolicyResult::operator =(const Aws::Amazon
 
   }
 
-  if(jsonValue.ValueExists("GeneratedPolicyResults"))
+  if(jsonValue.ValueExists("generatedPolicyResult"))
   {
-    m_generatedPolicyResults = jsonValue.GetObject("GeneratedPolicyResults");
+    m_generatedPolicyResults = jsonValue.GetObject("generatedPolicyResult");
 
   }
 

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
@@ -800,7 +800,9 @@ public class C2jModelToGeneratorModelTransformer {
             shapes.remove(originalShapeName);
         }
         if (!Objects.equals(originalMemberKey, newMemberKey)) {
-            parentShape.getMembers().put(newMemberKey, parentShape.getMembers().get(originalMemberKey));
+            final ShapeMember member = parentShape.getMembers().get(originalMemberKey);
+            member.setLocationName(originalMemberKey);
+            parentShape.getMembers().put(newMemberKey, member);
             parentShape.RemoveMember(originalMemberKey);
         }
         if (isPayload)


### PR DESCRIPTION
*Description of changes:*

Duplicate of a existing PR with a bug fix on top. [Original PR](https://github.com/aws/aws-sdk-cpp/pull/2786)

From the original PR

> We do this beacuse the C++ SDK has a design flaw: Model fields and request fields are mixed
in a single object. Practically this means that if a request has a field called headers, the SDK will
generate a method called GetHeaders, which clashes with the GetHeaders method to get access to the
HTTP request headers.
This method will substitute headers for headerValues so we end up with a GetHeaderValues
method. This is still going to be confusing for the end user but it's the best I can think of right now.

From that PR we had a conversation and noticed serveral things. First we changed the PR to capture more member values that might collide on request objects, and realized that [api gateway has a entire custom generator](https://github.com/aws/aws-sdk-cpp/blob/main/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/apigateway/APIGatewayRestJsonCppClientGenerator.java#L24-L58) to get around what the issue was. So making a general case can remove this customization in the future and prevent further customizations.

This also revealed a current bug where location name was not getting set correctly for the renaming of shapes in json services, that revealed deserialization of `GetGeneratedPolicyResult.cpp` was actually broken because of the rename.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
