### PR TITLE
fix s3 copy constructor

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -154,8 +154,8 @@ const char* S3CrtClient::ALLOCATION_TAG = "S3CrtClient";
 S3CrtClient::S3CrtClient(const S3CrtClient &rhs) :
     BASECLASS(rhs.m_clientConfiguration,
         Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
-            Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
-            Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this),
+            rhs.GetCredentialsProvider(),
+            rhs.m_clientConfiguration.identityProviderSupplier(*this),
             SERVICE_NAME,
             Aws::Region::ComputeSignerRegion(rhs.m_clientConfiguration.region),
             rhs.m_clientConfiguration.payloadSigningPolicy,

--- a/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp
@@ -140,7 +140,7 @@ const char* S3Client::ALLOCATION_TAG = "S3Client";
 S3Client::S3Client(const S3Client &rhs) :
     BASECLASS(rhs.m_clientConfiguration,
         Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
-            Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+            rhs.GetCredentialsProvider(),
             rhs.m_clientConfiguration.identityProviderSupplier(*this),
             SERVICE_NAME,
             Aws::Region::ComputeSignerRegion(rhs.m_clientConfiguration.region),

--- a/src/aws-cpp-sdk-core/include/aws/core/auth/signer-provider/AWSAuthSignerProviderBase.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/signer-provider/AWSAuthSignerProviderBase.h
@@ -21,12 +21,14 @@ namespace Aws
     namespace Auth
     {
         class AWSCredentialsProvider;
+        class DefaultAWSCredentialsProviderChain;
 
         class AWS_CORE_API AWSAuthSignerProvider
         {
         public:
             virtual std::shared_ptr<Aws::Client::AWSAuthSigner> GetSigner(const Aws::String& signerName) const = 0;
             virtual void AddSigner(std::shared_ptr<Aws::Client::AWSAuthSigner>& signer) = 0;
+            virtual std::shared_ptr<AWSCredentialsProvider> GetCredentialsProvider() const;
             virtual ~AWSAuthSignerProvider() = default;
         };
     }

--- a/src/aws-cpp-sdk-core/include/aws/core/auth/signer-provider/DefaultAuthSignerProvider.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/signer-provider/DefaultAuthSignerProvider.h
@@ -35,8 +35,10 @@ namespace Aws
             explicit DefaultAuthSignerProvider(const std::shared_ptr<Aws::Client::AWSAuthSigner>& signer);
             void AddSigner(std::shared_ptr<Aws::Client::AWSAuthSigner>& signer) override;
             std::shared_ptr<Aws::Client::AWSAuthSigner> GetSigner(const Aws::String& signerName) const override;
+            std::shared_ptr<AWSCredentialsProvider> GetCredentialsProvider() const override { return m_credentialsProvider; }
         protected:
             Aws::Vector<std::shared_ptr<Aws::Client::AWSAuthSigner>> m_signers;
+            std::shared_ptr<AWSCredentialsProvider> m_credentialsProvider;
         };
     }
 }

--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
@@ -295,6 +295,10 @@ namespace Aws
             Aws::Client::AWSAuthSigner* GetSignerByName(const char* name) const;
 
             friend Aws::Client::AWSAuthSigner* AWSUrlPresigner::GetSignerByName(const char* name) const;
+
+            std::shared_ptr<Auth::AWSCredentialsProvider> GetCredentialsProvider() const {
+                 return m_signerProvider->GetCredentialsProvider();
+            }
         protected:
 
             /**

--- a/src/aws-cpp-sdk-core/source/auth/signer-provider/AWSAuthSignerProviderBase.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/signer-provider/AWSAuthSignerProviderBase.cpp
@@ -1,0 +1,12 @@
+/**
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/core/auth/signer-provider/AWSAuthSignerProviderBase.h>
+#include <aws/core/auth/AWSCredentialsProviderChain.h>
+
+using namespace Aws::Auth;
+
+std::shared_ptr<AWSCredentialsProvider> AWSAuthSignerProvider::GetCredentialsProvider() const {
+  return MakeShared<DefaultAWSCredentialsProviderChain>("AWSAuthSignerProvider");
+}

--- a/src/aws-cpp-sdk-core/source/auth/signer-provider/DefaultAuthSignerProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/signer-provider/DefaultAuthSignerProvider.cpp
@@ -18,7 +18,11 @@ const char CLASS_TAG[] = "AuthSignerProvider";
 using namespace Aws::Auth;
 
 DefaultAuthSignerProvider::DefaultAuthSignerProvider(const std::shared_ptr<AWSCredentialsProvider>& credentialsProvider,
-        const Aws::String& serviceName, const Aws::String& region, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy signingPolicy, bool urlEscapePath)
+        const Aws::String& serviceName,
+        const Aws::String& region,
+        Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy signingPolicy,
+        bool urlEscapePath):
+    m_credentialsProvider(credentialsProvider)
 {
     m_signers.emplace_back(Aws::MakeShared<Aws::Client::AWSAuthV4Signer>(CLASS_TAG, credentialsProvider, serviceName.c_str(), region, signingPolicy, urlEscapePath, AWSSigningAlgorithm::SIGV4));
     m_signers.emplace_back(Aws::MakeShared<Aws::Client::AWSAuthV4Signer>(CLASS_TAG, credentialsProvider, serviceName.c_str(), region, signingPolicy, urlEscapePath, AWSSigningAlgorithm::ASYMMETRIC_SIGV4));

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm
@@ -84,7 +84,7 @@
 ${className}::${className}(const ${className} &rhs) :
     BASECLASS(rhs.m_clientConfiguration,
         Aws::MakeShared<${signerToMake}>(ALLOCATION_TAG,
-            ${defaultCredentialsProviderChainParam},
+            rhs.GetCredentialsProvider(),
             rhs.m_clientConfiguration.identityProviderSupplier(*this),
             SERVICE_NAME,
             Aws::Region::ComputeSignerRegion(rhs.m_clientConfiguration.region),

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -58,8 +58,8 @@
 ${className}::${className}(const ${className} &rhs) :
     BASECLASS(rhs.m_clientConfiguration,
         Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
-            Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
-            Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this),
+            rhs.GetCredentialsProvider(),
+            rhs.m_clientConfiguration.identityProviderSupplier(*this),
             SERVICE_NAME,
             Aws::Region::ComputeSignerRegion(rhs.m_clientConfiguration.region),
             rhs.m_clientConfiguration.payloadSigningPolicy,


### PR DESCRIPTION
*Description of changes:*

There is currently a bug where if you copy construct a S3Client it will use the default credential provider chain instead of a specified credential change. This changes the copy ctor to re-create the signers with previously provided credential provider.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
