### PR TITLE
Fix seg fault(s) in AuthV4Signer, test more combos with checksumming

### DIFF
--- a/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
@@ -233,12 +233,25 @@ bool AWSAuthV4Signer::SignRequest(Aws::Http::HttpRequest& request, const char* r
         payloadHash = ComputePayloadHash(request);
         if (payloadHash.empty())
         {
+            // this indicates a hashing error occurred, which was logged
             return false;
         }
+
         if (request.GetRequestHash().second != nullptr)
         {
             Aws::String checksumHeaderKey = Aws::String("x-amz-checksum-") + request.GetRequestHash().first;
-            Aws::String checksumHeaderValue = HashingUtils::Base64Encode(request.GetRequestHash().second->Calculate(*(request.GetContentBody())).GetResult());
+            Aws::String checksumHeaderValue;
+            if (request.GetRequestHash().first == "sha256") {
+                // we already calculated the payload hash so just reverse the hex string to
+                // a ByteBuffer and Base64Encode it - otherwise we're re-hashing the content
+                checksumHeaderValue = HashingUtils::Base64Encode(HashingUtils::HexDecode(payloadHash));
+            } else {
+                // if it is one of the other hashes, we must be careful if there is no content body
+                auto body = request.GetContentBody();
+                checksumHeaderValue = (body)
+                    ? HashingUtils::Base64Encode(request.GetRequestHash().second->Calculate(*body).GetResult())
+                    : HashingUtils::Base64Encode(request.GetRequestHash().second->Calculate({}).GetResult());
+            }
             request.SetHeaderValue(checksumHeaderKey, checksumHeaderValue);
             request.SetRequestHash("", nullptr);
         }
@@ -254,8 +267,10 @@ bool AWSAuthV4Signer::SignRequest(Aws::Http::HttpRequest& request, const char* r
             request.SetHeaderValue(Http::AWS_TRAILER_HEADER, trailerHeaderValue);
             request.SetTransferEncoding(CHUNKED_VALUE);
             request.SetHeaderValue(Http::CONTENT_ENCODING_HEADER, Http::AWS_CHUNKED_VALUE);
-            request.SetHeaderValue(Http::DECODED_CONTENT_LENGTH_HEADER, request.GetHeaderValue(Http::CONTENT_LENGTH_HEADER));
-            request.DeleteHeader(Http::CONTENT_LENGTH_HEADER);
+            if (request.HasHeader(Http::CONTENT_LENGTH_HEADER)) {
+                request.SetHeaderValue(Http::DECODED_CONTENT_LENGTH_HEADER, request.GetHeaderValue(Http::CONTENT_LENGTH_HEADER));
+                request.DeleteHeader(Http::CONTENT_LENGTH_HEADER);
+            }
         }
     }
 
@@ -509,20 +524,17 @@ Aws::String AWSAuthV4Signer::GenerateSignature(const Aws::String& stringToSign, 
 
 Aws::String AWSAuthV4Signer::ComputePayloadHash(Aws::Http::HttpRequest& request) const
 {
-    if (!request.GetContentBody())
+    const std::shared_ptr<Aws::IOStream>& body = request.GetContentBody();
+    if (!body)
     {
         AWS_LOGSTREAM_DEBUG(v4LogTag, "Using cached empty string sha256 " << EMPTY_STRING_SHA256 << " because payload is empty.");
         return EMPTY_STRING_SHA256;
     }
 
-    //compute hash on payload if it exists.
-    auto hashResult =  m_hash->Calculate(*request.GetContentBody());
-
-    if(request.GetContentBody())
-    {
-        request.GetContentBody()->clear();
-        request.GetContentBody()->seekg(0);
-    }
+    // compute hash on payload if it exists
+    auto hashResult =  m_hash->Calculate(*body);
+    body->clear();      // clears ios_flags
+    body->seekg(0);
 
     if (!hashResult.IsSuccess())
     {
@@ -531,7 +543,6 @@ Aws::String AWSAuthV4Signer::ComputePayloadHash(Aws::Http::HttpRequest& request)
     }
 
     auto sha256Digest = hashResult.GetResult();
-
     Aws::String payloadHash(HashingUtils::HexEncode(sha256Digest));
     AWS_LOGSTREAM_DEBUG(v4LogTag, "Calculated sha256 " << payloadHash << " for payload.");
     return payloadHash;


### PR DESCRIPTION
*Issue #, if available:*

V1183021468

*Description of changes:*

I observed a null pointer dereference in the following conditions:

1. Calling PutObject with no body (zero length object).
2. Setting the checksum algorithm to SHA256 (though likely any will do).
3. Providing a pre-calculated checksum (though likely any matching (2) will do).
4. Using payload signatures.

In multiple places, SDK code checks to see if the Content-Body is a nullptr before using it, but in AWSAuthV4Signer::SignRequest it was not doing so.

A second bug was observed when not using payload signatures, only when the scheme is HTTP.   In this case the code assumed it was okay to call GetHeaderValue on Content-Length before checking if the header exists (it is not okay to do so).  This was identified by the more rigorous testing.

Added a matrix test to verify more code paths in AWSAuthV4Signer and fixed the two seg faults in the area.  The assumptions checked during testing should be scrutinized.

Tested this live against s3 and s3express endpoints using a workload that generates zero-length objects.

*Check all that applies:*
- [X] Did a review by yourself: Yes
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.): Yes
- [X] Checked if this PR is a breaking (APIs have been changed) change: No
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior: No
- [X] Checked if this PR would require a ReadMe/Wiki update: No

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
