### PR TITLE
Add SDKOption for default Credentials Provider Chain

### DIFF
--- a/generated/src/aws-cpp-sdk-AWSMigrationHub/source/MigrationHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-AWSMigrationHub/source/MigrationHubClient.cpp
@@ -59,7 +59,7 @@ MigrationHubClient::MigrationHubClient(const MigrationHub::MigrationHubClientCon
                                        std::shared_ptr<MigrationHubEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubErrorMarshaller>(ALLOCATION_TAG)),
@@ -106,7 +106,7 @@ MigrationHubClient::MigrationHubClient(const std::shared_ptr<AWSCredentialsProvi
   MigrationHubClient::MigrationHubClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-accessanalyzer/source/AccessAnalyzerClient.cpp
+++ b/generated/src/aws-cpp-sdk-accessanalyzer/source/AccessAnalyzerClient.cpp
@@ -74,7 +74,7 @@ AccessAnalyzerClient::AccessAnalyzerClient(const AccessAnalyzer::AccessAnalyzerC
                                            std::shared_ptr<AccessAnalyzerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AccessAnalyzerErrorMarshaller>(ALLOCATION_TAG)),
@@ -121,7 +121,7 @@ AccessAnalyzerClient::AccessAnalyzerClient(const std::shared_ptr<AWSCredentialsP
   AccessAnalyzerClient::AccessAnalyzerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AccessAnalyzerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-account/source/AccountClient.cpp
+++ b/generated/src/aws-cpp-sdk-account/source/AccountClient.cpp
@@ -51,7 +51,7 @@ AccountClient::AccountClient(const Account::AccountClientConfiguration& clientCo
                              std::shared_ptr<AccountEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AccountErrorMarshaller>(ALLOCATION_TAG)),
@@ -98,7 +98,7 @@ AccountClient::AccountClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   AccountClient::AccountClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AccountErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-acm-pca/source/ACMPCAClient.cpp
+++ b/generated/src/aws-cpp-sdk-acm-pca/source/ACMPCAClient.cpp
@@ -65,7 +65,7 @@ ACMPCAClient::ACMPCAClient(const ACMPCA::ACMPCAClientConfiguration& clientConfig
                            std::shared_ptr<ACMPCAEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ACMPCAErrorMarshaller>(ALLOCATION_TAG)),
@@ -112,7 +112,7 @@ ACMPCAClient::ACMPCAClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   ACMPCAClient::ACMPCAClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ACMPCAErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-acm/source/ACMClient.cpp
+++ b/generated/src/aws-cpp-sdk-acm/source/ACMClient.cpp
@@ -57,7 +57,7 @@ ACMClient::ACMClient(const ACM::ACMClientConfiguration& clientConfiguration,
                      std::shared_ptr<ACMEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ACMErrorMarshaller>(ALLOCATION_TAG)),
@@ -104,7 +104,7 @@ ACMClient::ACMClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   ACMClient::ACMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ACMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-alexaforbusiness/source/AlexaForBusinessClient.cpp
+++ b/generated/src/aws-cpp-sdk-alexaforbusiness/source/AlexaForBusinessClient.cpp
@@ -43,7 +43,7 @@ AlexaForBusinessClient::AlexaForBusinessClient(const AlexaForBusiness::AlexaForB
                                                std::shared_ptr<AlexaForBusinessEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AlexaForBusinessErrorMarshaller>(ALLOCATION_TAG)),
@@ -90,7 +90,7 @@ AlexaForBusinessClient::AlexaForBusinessClient(const std::shared_ptr<AWSCredenti
   AlexaForBusinessClient::AlexaForBusinessClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AlexaForBusinessErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-amp/source/PrometheusServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-amp/source/PrometheusServiceClient.cpp
@@ -68,7 +68,7 @@ PrometheusServiceClient::PrometheusServiceClient(const PrometheusService::Promet
                                                  std::shared_ptr<PrometheusServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PrometheusServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -115,7 +115,7 @@ PrometheusServiceClient::PrometheusServiceClient(const std::shared_ptr<AWSCreden
   PrometheusServiceClient::PrometheusServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PrometheusServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-amplify/source/AmplifyClient.cpp
+++ b/generated/src/aws-cpp-sdk-amplify/source/AmplifyClient.cpp
@@ -79,7 +79,7 @@ AmplifyClient::AmplifyClient(const Amplify::AmplifyClientConfiguration& clientCo
                              std::shared_ptr<AmplifyEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AmplifyErrorMarshaller>(ALLOCATION_TAG)),
@@ -126,7 +126,7 @@ AmplifyClient::AmplifyClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   AmplifyClient::AmplifyClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AmplifyErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-amplifybackend/source/AmplifyBackendClient.cpp
+++ b/generated/src/aws-cpp-sdk-amplifybackend/source/AmplifyBackendClient.cpp
@@ -73,7 +73,7 @@ AmplifyBackendClient::AmplifyBackendClient(const AmplifyBackend::AmplifyBackendC
                                            std::shared_ptr<AmplifyBackendEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AmplifyBackendErrorMarshaller>(ALLOCATION_TAG)),
@@ -120,7 +120,7 @@ AmplifyBackendClient::AmplifyBackendClient(const std::shared_ptr<AWSCredentialsP
   AmplifyBackendClient::AmplifyBackendClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AmplifyBackendErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-amplifyuibuilder/source/AmplifyUIBuilderClient.cpp
+++ b/generated/src/aws-cpp-sdk-amplifyuibuilder/source/AmplifyUIBuilderClient.cpp
@@ -67,7 +67,7 @@ AmplifyUIBuilderClient::AmplifyUIBuilderClient(const AmplifyUIBuilder::AmplifyUI
                                                std::shared_ptr<AmplifyUIBuilderEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AmplifyUIBuilderErrorMarshaller>(ALLOCATION_TAG)),
@@ -114,7 +114,7 @@ AmplifyUIBuilderClient::AmplifyUIBuilderClient(const std::shared_ptr<AWSCredenti
   AmplifyUIBuilderClient::AmplifyUIBuilderClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AmplifyUIBuilderErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-apigateway/source/APIGatewayClient.cpp
+++ b/generated/src/aws-cpp-sdk-apigateway/source/APIGatewayClient.cpp
@@ -162,7 +162,7 @@ APIGatewayClient::APIGatewayClient(const APIGateway::APIGatewayClientConfigurati
                                    std::shared_ptr<APIGatewayEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<APIGatewayErrorMarshaller>(ALLOCATION_TAG)),
@@ -209,7 +209,7 @@ APIGatewayClient::APIGatewayClient(const std::shared_ptr<AWSCredentialsProvider>
   APIGatewayClient::APIGatewayClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<APIGatewayErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-apigatewaymanagementapi/source/ApiGatewayManagementApiClient.cpp
+++ b/generated/src/aws-cpp-sdk-apigatewaymanagementapi/source/ApiGatewayManagementApiClient.cpp
@@ -45,7 +45,7 @@ ApiGatewayManagementApiClient::ApiGatewayManagementApiClient(const ApiGatewayMan
                                                              std::shared_ptr<ApiGatewayManagementApiEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApiGatewayManagementApiErrorMarshaller>(ALLOCATION_TAG)),
@@ -92,7 +92,7 @@ ApiGatewayManagementApiClient::ApiGatewayManagementApiClient(const std::shared_p
   ApiGatewayManagementApiClient::ApiGatewayManagementApiClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApiGatewayManagementApiErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-apigatewayv2/source/ApiGatewayV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-apigatewayv2/source/ApiGatewayV2Client.cpp
@@ -114,7 +114,7 @@ ApiGatewayV2Client::ApiGatewayV2Client(const ApiGatewayV2::ApiGatewayV2ClientCon
                                        std::shared_ptr<ApiGatewayV2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApiGatewayV2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -161,7 +161,7 @@ ApiGatewayV2Client::ApiGatewayV2Client(const std::shared_ptr<AWSCredentialsProvi
   ApiGatewayV2Client::ApiGatewayV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApiGatewayV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appconfig/source/AppConfigClient.cpp
+++ b/generated/src/aws-cpp-sdk-appconfig/source/AppConfigClient.cpp
@@ -84,7 +84,7 @@ AppConfigClient::AppConfigClient(const AppConfig::AppConfigClientConfiguration& 
                                  std::shared_ptr<AppConfigEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppConfigErrorMarshaller>(ALLOCATION_TAG)),
@@ -131,7 +131,7 @@ AppConfigClient::AppConfigClient(const std::shared_ptr<AWSCredentialsProvider>& 
   AppConfigClient::AppConfigClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppConfigErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appconfigdata/source/AppConfigDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-appconfigdata/source/AppConfigDataClient.cpp
@@ -44,7 +44,7 @@ AppConfigDataClient::AppConfigDataClient(const AppConfigData::AppConfigDataClien
                                          std::shared_ptr<AppConfigDataEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppConfigDataErrorMarshaller>(ALLOCATION_TAG)),
@@ -91,7 +91,7 @@ AppConfigDataClient::AppConfigDataClient(const std::shared_ptr<AWSCredentialsPro
   AppConfigDataClient::AppConfigDataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppConfigDataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appfabric/source/AppFabricClient.cpp
+++ b/generated/src/aws-cpp-sdk-appfabric/source/AppFabricClient.cpp
@@ -68,7 +68,7 @@ AppFabricClient::AppFabricClient(const AppFabric::AppFabricClientConfiguration& 
                                  std::shared_ptr<AppFabricEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppFabricErrorMarshaller>(ALLOCATION_TAG)),
@@ -115,7 +115,7 @@ AppFabricClient::AppFabricClient(const std::shared_ptr<AWSCredentialsProvider>& 
   AppFabricClient::AppFabricClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppFabricErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appflow/source/AppflowClient.cpp
+++ b/generated/src/aws-cpp-sdk-appflow/source/AppflowClient.cpp
@@ -67,7 +67,7 @@ AppflowClient::AppflowClient(const Appflow::AppflowClientConfiguration& clientCo
                              std::shared_ptr<AppflowEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppflowErrorMarshaller>(ALLOCATION_TAG)),
@@ -114,7 +114,7 @@ AppflowClient::AppflowClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   AppflowClient::AppflowClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppflowErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appintegrations/source/AppIntegrationsServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-appintegrations/source/AppIntegrationsServiceClient.cpp
@@ -63,7 +63,7 @@ AppIntegrationsServiceClient::AppIntegrationsServiceClient(const AppIntegrations
                                                            std::shared_ptr<AppIntegrationsServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppIntegrationsServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -110,7 +110,7 @@ AppIntegrationsServiceClient::AppIntegrationsServiceClient(const std::shared_ptr
   AppIntegrationsServiceClient::AppIntegrationsServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppIntegrationsServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-application-autoscaling/source/ApplicationAutoScalingClient.cpp
+++ b/generated/src/aws-cpp-sdk-application-autoscaling/source/ApplicationAutoScalingClient.cpp
@@ -55,7 +55,7 @@ ApplicationAutoScalingClient::ApplicationAutoScalingClient(const ApplicationAuto
                                                            std::shared_ptr<ApplicationAutoScalingEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApplicationAutoScalingErrorMarshaller>(ALLOCATION_TAG)),
@@ -102,7 +102,7 @@ ApplicationAutoScalingClient::ApplicationAutoScalingClient(const std::shared_ptr
   ApplicationAutoScalingClient::ApplicationAutoScalingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApplicationAutoScalingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-application-insights/source/ApplicationInsightsClient.cpp
+++ b/generated/src/aws-cpp-sdk-application-insights/source/ApplicationInsightsClient.cpp
@@ -75,7 +75,7 @@ ApplicationInsightsClient::ApplicationInsightsClient(const ApplicationInsights::
                                                      std::shared_ptr<ApplicationInsightsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApplicationInsightsErrorMarshaller>(ALLOCATION_TAG)),
@@ -122,7 +122,7 @@ ApplicationInsightsClient::ApplicationInsightsClient(const std::shared_ptr<AWSCr
   ApplicationInsightsClient::ApplicationInsightsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApplicationInsightsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-applicationcostprofiler/source/ApplicationCostProfilerClient.cpp
+++ b/generated/src/aws-cpp-sdk-applicationcostprofiler/source/ApplicationCostProfilerClient.cpp
@@ -48,7 +48,7 @@ ApplicationCostProfilerClient::ApplicationCostProfilerClient(const ApplicationCo
                                                              std::shared_ptr<ApplicationCostProfilerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApplicationCostProfilerErrorMarshaller>(ALLOCATION_TAG)),
@@ -95,7 +95,7 @@ ApplicationCostProfilerClient::ApplicationCostProfilerClient(const std::shared_p
   ApplicationCostProfilerClient::ApplicationCostProfilerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApplicationCostProfilerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appmesh/source/AppMeshClient.cpp
+++ b/generated/src/aws-cpp-sdk-appmesh/source/AppMeshClient.cpp
@@ -80,7 +80,7 @@ AppMeshClient::AppMeshClient(const AppMesh::AppMeshClientConfiguration& clientCo
                              std::shared_ptr<AppMeshEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppMeshErrorMarshaller>(ALLOCATION_TAG)),
@@ -127,7 +127,7 @@ AppMeshClient::AppMeshClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   AppMeshClient::AppMeshClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppMeshErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-apprunner/source/AppRunnerClient.cpp
+++ b/generated/src/aws-cpp-sdk-apprunner/source/AppRunnerClient.cpp
@@ -79,7 +79,7 @@ AppRunnerClient::AppRunnerClient(const AppRunner::AppRunnerClientConfiguration& 
                                  std::shared_ptr<AppRunnerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppRunnerErrorMarshaller>(ALLOCATION_TAG)),
@@ -126,7 +126,7 @@ AppRunnerClient::AppRunnerClient(const std::shared_ptr<AWSCredentialsProvider>& 
   AppRunnerClient::AppRunnerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppRunnerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appstream/source/AppStreamClient.cpp
+++ b/generated/src/aws-cpp-sdk-appstream/source/AppStreamClient.cpp
@@ -117,7 +117,7 @@ AppStreamClient::AppStreamClient(const AppStream::AppStreamClientConfiguration& 
                                  std::shared_ptr<AppStreamEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppStreamErrorMarshaller>(ALLOCATION_TAG)),
@@ -164,7 +164,7 @@ AppStreamClient::AppStreamClient(const std::shared_ptr<AWSCredentialsProvider>& 
   AppStreamClient::AppStreamClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppStreamErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appsync/source/AppSyncClient.cpp
+++ b/generated/src/aws-cpp-sdk-appsync/source/AppSyncClient.cpp
@@ -104,7 +104,7 @@ AppSyncClient::AppSyncClient(const AppSync::AppSyncClientConfiguration& clientCo
                              std::shared_ptr<AppSyncEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppSyncErrorMarshaller>(ALLOCATION_TAG)),
@@ -151,7 +151,7 @@ AppSyncClient::AppSyncClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   AppSyncClient::AppSyncClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppSyncErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-arc-zonal-shift/source/ARCZonalShiftClient.cpp
+++ b/generated/src/aws-cpp-sdk-arc-zonal-shift/source/ARCZonalShiftClient.cpp
@@ -53,7 +53,7 @@ ARCZonalShiftClient::ARCZonalShiftClient(const ARCZonalShift::ARCZonalShiftClien
                                          std::shared_ptr<ARCZonalShiftEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ARCZonalShiftErrorMarshaller>(ALLOCATION_TAG)),
@@ -100,7 +100,7 @@ ARCZonalShiftClient::ARCZonalShiftClient(const std::shared_ptr<AWSCredentialsPro
   ARCZonalShiftClient::ARCZonalShiftClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ARCZonalShiftErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-athena/source/AthenaClient.cpp
+++ b/generated/src/aws-cpp-sdk-athena/source/AthenaClient.cpp
@@ -110,7 +110,7 @@ AthenaClient::AthenaClient(const Athena::AthenaClientConfiguration& clientConfig
                            std::shared_ptr<AthenaEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AthenaErrorMarshaller>(ALLOCATION_TAG)),
@@ -157,7 +157,7 @@ AthenaClient::AthenaClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   AthenaClient::AthenaClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AthenaErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-auditmanager/source/AuditManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-auditmanager/source/AuditManagerClient.cpp
@@ -104,7 +104,7 @@ AuditManagerClient::AuditManagerClient(const AuditManager::AuditManagerClientCon
                                        std::shared_ptr<AuditManagerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AuditManagerErrorMarshaller>(ALLOCATION_TAG)),
@@ -151,7 +151,7 @@ AuditManagerClient::AuditManagerClient(const std::shared_ptr<AWSCredentialsProvi
   AuditManagerClient::AuditManagerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AuditManagerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-autoscaling-plans/source/AutoScalingPlansClient.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling-plans/source/AutoScalingPlansClient.cpp
@@ -48,7 +48,7 @@ AutoScalingPlansClient::AutoScalingPlansClient(const AutoScalingPlans::AutoScali
                                                std::shared_ptr<AutoScalingPlansEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AutoScalingPlansErrorMarshaller>(ALLOCATION_TAG)),
@@ -95,7 +95,7 @@ AutoScalingPlansClient::AutoScalingPlansClient(const std::shared_ptr<AWSCredenti
   AutoScalingPlansClient::AutoScalingPlansClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AutoScalingPlansErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-autoscaling/source/AutoScalingClient.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/AutoScalingClient.cpp
@@ -108,7 +108,7 @@ AutoScalingClient::AutoScalingClient(const AutoScaling::AutoScalingClientConfigu
                                      std::shared_ptr<AutoScalingEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AutoScalingErrorMarshaller>(ALLOCATION_TAG)),
@@ -155,7 +155,7 @@ AutoScalingClient::AutoScalingClient(const std::shared_ptr<AWSCredentialsProvide
   AutoScalingClient::AutoScalingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AutoScalingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-awstransfer/source/TransferClient.cpp
+++ b/generated/src/aws-cpp-sdk-awstransfer/source/TransferClient.cpp
@@ -101,7 +101,7 @@ TransferClient::TransferClient(const Transfer::TransferClientConfiguration& clie
                                std::shared_ptr<TransferEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TransferErrorMarshaller>(ALLOCATION_TAG)),
@@ -148,7 +148,7 @@ TransferClient::TransferClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   TransferClient::TransferClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TransferErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-b2bi/source/B2BIClient.cpp
+++ b/generated/src/aws-cpp-sdk-b2bi/source/B2BIClient.cpp
@@ -69,7 +69,7 @@ B2BIClient::B2BIClient(const B2BI::B2BIClientConfiguration& clientConfiguration,
                        std::shared_ptr<B2BIEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<B2BIErrorMarshaller>(ALLOCATION_TAG)),
@@ -116,7 +116,7 @@ B2BIClient::B2BIClient(const std::shared_ptr<AWSCredentialsProvider>& credential
   B2BIClient::B2BIClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<B2BIErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-backup-gateway/source/BackupGatewayClient.cpp
+++ b/generated/src/aws-cpp-sdk-backup-gateway/source/BackupGatewayClient.cpp
@@ -67,7 +67,7 @@ BackupGatewayClient::BackupGatewayClient(const BackupGateway::BackupGatewayClien
                                          std::shared_ptr<BackupGatewayEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BackupGatewayErrorMarshaller>(ALLOCATION_TAG)),
@@ -114,7 +114,7 @@ BackupGatewayClient::BackupGatewayClient(const std::shared_ptr<AWSCredentialsPro
   BackupGatewayClient::BackupGatewayClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BackupGatewayErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-backup/source/BackupClient.cpp
+++ b/generated/src/aws-cpp-sdk-backup/source/BackupClient.cpp
@@ -133,7 +133,7 @@ BackupClient::BackupClient(const Backup::BackupClientConfiguration& clientConfig
                            std::shared_ptr<BackupEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BackupErrorMarshaller>(ALLOCATION_TAG)),
@@ -180,7 +180,7 @@ BackupClient::BackupClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   BackupClient::BackupClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BackupErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-backupstorage/source/BackupStorageClient.cpp
+++ b/generated/src/aws-cpp-sdk-backupstorage/source/BackupStorageClient.cpp
@@ -51,7 +51,7 @@ BackupStorageClient::BackupStorageClient(const BackupStorage::BackupStorageClien
                                          std::shared_ptr<BackupStorageEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BackupStorageErrorMarshaller>(ALLOCATION_TAG)),
@@ -98,7 +98,7 @@ BackupStorageClient::BackupStorageClient(const std::shared_ptr<AWSCredentialsPro
   BackupStorageClient::BackupStorageClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BackupStorageErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-batch/source/BatchClient.cpp
+++ b/generated/src/aws-cpp-sdk-batch/source/BatchClient.cpp
@@ -66,7 +66,7 @@ BatchClient::BatchClient(const Batch::BatchClientConfiguration& clientConfigurat
                          std::shared_ptr<BatchEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BatchErrorMarshaller>(ALLOCATION_TAG)),
@@ -113,7 +113,7 @@ BatchClient::BatchClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   BatchClient::BatchClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BatchErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bcm-data-exports/source/BCMDataExportsClient.cpp
+++ b/generated/src/aws-cpp-sdk-bcm-data-exports/source/BCMDataExportsClient.cpp
@@ -54,7 +54,7 @@ BCMDataExportsClient::BCMDataExportsClient(const BCMDataExports::BCMDataExportsC
                                            std::shared_ptr<BCMDataExportsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BCMDataExportsErrorMarshaller>(ALLOCATION_TAG)),
@@ -101,7 +101,7 @@ BCMDataExportsClient::BCMDataExportsClient(const std::shared_ptr<AWSCredentialsP
   BCMDataExportsClient::BCMDataExportsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BCMDataExportsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bedrock-agent-runtime/source/BedrockAgentRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-agent-runtime/source/BedrockAgentRuntimeClient.cpp
@@ -46,7 +46,7 @@ BedrockAgentRuntimeClient::BedrockAgentRuntimeClient(const BedrockAgentRuntime::
                                                      std::shared_ptr<BedrockAgentRuntimeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockAgentRuntimeErrorMarshaller>(ALLOCATION_TAG)),
@@ -93,7 +93,7 @@ BedrockAgentRuntimeClient::BedrockAgentRuntimeClient(const std::shared_ptr<AWSCr
   BedrockAgentRuntimeClient::BedrockAgentRuntimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockAgentRuntimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bedrock-agent/source/BedrockAgentClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-agent/source/BedrockAgentClient.cpp
@@ -82,7 +82,7 @@ BedrockAgentClient::BedrockAgentClient(const BedrockAgent::BedrockAgentClientCon
                                        std::shared_ptr<BedrockAgentEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockAgentErrorMarshaller>(ALLOCATION_TAG)),
@@ -129,7 +129,7 @@ BedrockAgentClient::BedrockAgentClient(const std::shared_ptr<AWSCredentialsProvi
   BedrockAgentClient::BedrockAgentClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockAgentErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/source/BedrockRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/source/BedrockRuntimeClient.cpp
@@ -45,7 +45,7 @@ BedrockRuntimeClient::BedrockRuntimeClient(const BedrockRuntime::BedrockRuntimeC
                                            std::shared_ptr<BedrockRuntimeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockRuntimeErrorMarshaller>(ALLOCATION_TAG)),
@@ -92,7 +92,7 @@ BedrockRuntimeClient::BedrockRuntimeClient(const std::shared_ptr<AWSCredentialsP
   BedrockRuntimeClient::BedrockRuntimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockRuntimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bedrock/source/BedrockClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock/source/BedrockClient.cpp
@@ -62,7 +62,7 @@ BedrockClient::BedrockClient(const Bedrock::BedrockClientConfiguration& clientCo
                              std::shared_ptr<BedrockEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockErrorMarshaller>(ALLOCATION_TAG)),
@@ -109,7 +109,7 @@ BedrockClient::BedrockClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   BedrockClient::BedrockClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-billingconductor/source/BillingConductorClient.cpp
+++ b/generated/src/aws-cpp-sdk-billingconductor/source/BillingConductorClient.cpp
@@ -74,7 +74,7 @@ BillingConductorClient::BillingConductorClient(const BillingConductor::BillingCo
                                                std::shared_ptr<BillingConductorEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BillingConductorErrorMarshaller>(ALLOCATION_TAG)),
@@ -121,7 +121,7 @@ BillingConductorClient::BillingConductorClient(const std::shared_ptr<AWSCredenti
   BillingConductorClient::BillingConductorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BillingConductorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-braket/source/BraketClient.cpp
+++ b/generated/src/aws-cpp-sdk-braket/source/BraketClient.cpp
@@ -55,7 +55,7 @@ BraketClient::BraketClient(const Braket::BraketClientConfiguration& clientConfig
                            std::shared_ptr<BraketEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BraketErrorMarshaller>(ALLOCATION_TAG)),
@@ -102,7 +102,7 @@ BraketClient::BraketClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   BraketClient::BraketClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BraketErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-budgets/source/BudgetsClient.cpp
+++ b/generated/src/aws-cpp-sdk-budgets/source/BudgetsClient.cpp
@@ -65,7 +65,7 @@ BudgetsClient::BudgetsClient(const Budgets::BudgetsClientConfiguration& clientCo
                              std::shared_ptr<BudgetsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BudgetsErrorMarshaller>(ALLOCATION_TAG)),
@@ -112,7 +112,7 @@ BudgetsClient::BudgetsClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   BudgetsClient::BudgetsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BudgetsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ce/source/CostExplorerClient.cpp
+++ b/generated/src/aws-cpp-sdk-ce/source/CostExplorerClient.cpp
@@ -80,7 +80,7 @@ CostExplorerClient::CostExplorerClient(const CostExplorer::CostExplorerClientCon
                                        std::shared_ptr<CostExplorerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CostExplorerErrorMarshaller>(ALLOCATION_TAG)),
@@ -127,7 +127,7 @@ CostExplorerClient::CostExplorerClient(const std::shared_ptr<AWSCredentialsProvi
   CostExplorerClient::CostExplorerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CostExplorerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-chime-sdk-identity/source/ChimeSDKIdentityClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-identity/source/ChimeSDKIdentityClient.cpp
@@ -72,7 +72,7 @@ ChimeSDKIdentityClient::ChimeSDKIdentityClient(const ChimeSDKIdentity::ChimeSDKI
                                                std::shared_ptr<ChimeSDKIdentityEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKIdentityErrorMarshaller>(ALLOCATION_TAG)),
@@ -119,7 +119,7 @@ ChimeSDKIdentityClient::ChimeSDKIdentityClient(const std::shared_ptr<AWSCredenti
   ChimeSDKIdentityClient::ChimeSDKIdentityClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKIdentityErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-chime-sdk-media-pipelines/source/ChimeSDKMediaPipelinesClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-media-pipelines/source/ChimeSDKMediaPipelinesClient.cpp
@@ -73,7 +73,7 @@ ChimeSDKMediaPipelinesClient::ChimeSDKMediaPipelinesClient(const ChimeSDKMediaPi
                                                            std::shared_ptr<ChimeSDKMediaPipelinesEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKMediaPipelinesErrorMarshaller>(ALLOCATION_TAG)),
@@ -120,7 +120,7 @@ ChimeSDKMediaPipelinesClient::ChimeSDKMediaPipelinesClient(const std::shared_ptr
   ChimeSDKMediaPipelinesClient::ChimeSDKMediaPipelinesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKMediaPipelinesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-chime-sdk-meetings/source/ChimeSDKMeetingsClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-meetings/source/ChimeSDKMeetingsClient.cpp
@@ -58,7 +58,7 @@ ChimeSDKMeetingsClient::ChimeSDKMeetingsClient(const ChimeSDKMeetings::ChimeSDKM
                                                std::shared_ptr<ChimeSDKMeetingsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKMeetingsErrorMarshaller>(ALLOCATION_TAG)),
@@ -105,7 +105,7 @@ ChimeSDKMeetingsClient::ChimeSDKMeetingsClient(const std::shared_ptr<AWSCredenti
   ChimeSDKMeetingsClient::ChimeSDKMeetingsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKMeetingsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-chime-sdk-messaging/source/ChimeSDKMessagingClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-messaging/source/ChimeSDKMessagingClient.cpp
@@ -93,7 +93,7 @@ ChimeSDKMessagingClient::ChimeSDKMessagingClient(const ChimeSDKMessaging::ChimeS
                                                  std::shared_ptr<ChimeSDKMessagingEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKMessagingErrorMarshaller>(ALLOCATION_TAG)),
@@ -140,7 +140,7 @@ ChimeSDKMessagingClient::ChimeSDKMessagingClient(const std::shared_ptr<AWSCreden
   ChimeSDKMessagingClient::ChimeSDKMessagingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKMessagingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-chime-sdk-voice/source/ChimeSDKVoiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-voice/source/ChimeSDKVoiceClient.cpp
@@ -135,7 +135,7 @@ ChimeSDKVoiceClient::ChimeSDKVoiceClient(const ChimeSDKVoice::ChimeSDKVoiceClien
                                          std::shared_ptr<ChimeSDKVoiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKVoiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -182,7 +182,7 @@ ChimeSDKVoiceClient::ChimeSDKVoiceClient(const std::shared_ptr<AWSCredentialsPro
   ChimeSDKVoiceClient::ChimeSDKVoiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKVoiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-chime/source/ChimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime/source/ChimeClient.cpp
@@ -104,7 +104,7 @@ ChimeClient::ChimeClient(const Chime::ChimeClientConfiguration& clientConfigurat
                          std::shared_ptr<ChimeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeErrorMarshaller>(ALLOCATION_TAG)),
@@ -151,7 +151,7 @@ ChimeClient::ChimeClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   ChimeClient::ChimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cleanrooms/source/CleanRoomsClient.cpp
+++ b/generated/src/aws-cpp-sdk-cleanrooms/source/CleanRoomsClient.cpp
@@ -104,7 +104,7 @@ CleanRoomsClient::CleanRoomsClient(const CleanRooms::CleanRoomsClientConfigurati
                                    std::shared_ptr<CleanRoomsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CleanRoomsErrorMarshaller>(ALLOCATION_TAG)),
@@ -151,7 +151,7 @@ CleanRoomsClient::CleanRoomsClient(const std::shared_ptr<AWSCredentialsProvider>
   CleanRoomsClient::CleanRoomsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CleanRoomsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cleanroomsml/source/CleanRoomsMLClient.cpp
+++ b/generated/src/aws-cpp-sdk-cleanroomsml/source/CleanRoomsMLClient.cpp
@@ -67,7 +67,7 @@ CleanRoomsMLClient::CleanRoomsMLClient(const CleanRoomsML::CleanRoomsMLClientCon
                                        std::shared_ptr<CleanRoomsMLEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CleanRoomsMLErrorMarshaller>(ALLOCATION_TAG)),
@@ -114,7 +114,7 @@ CleanRoomsMLClient::CleanRoomsMLClient(const std::shared_ptr<AWSCredentialsProvi
   CleanRoomsMLClient::CleanRoomsMLClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CleanRoomsMLErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloud9/source/Cloud9Client.cpp
+++ b/generated/src/aws-cpp-sdk-cloud9/source/Cloud9Client.cpp
@@ -55,7 +55,7 @@ Cloud9Client::Cloud9Client(const Cloud9::Cloud9ClientConfiguration& clientConfig
                            std::shared_ptr<Cloud9EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Cloud9ErrorMarshaller>(ALLOCATION_TAG)),
@@ -102,7 +102,7 @@ Cloud9Client::Cloud9Client(const std::shared_ptr<AWSCredentialsProvider>& creden
   Cloud9Client::Cloud9Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Cloud9ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudcontrol/source/CloudControlApiClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudcontrol/source/CloudControlApiClient.cpp
@@ -50,7 +50,7 @@ CloudControlApiClient::CloudControlApiClient(const CloudControlApi::CloudControl
                                              std::shared_ptr<CloudControlApiEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudControlApiErrorMarshaller>(ALLOCATION_TAG)),
@@ -97,7 +97,7 @@ CloudControlApiClient::CloudControlApiClient(const std::shared_ptr<AWSCredential
   CloudControlApiClient::CloudControlApiClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudControlApiErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-clouddirectory/source/CloudDirectoryClient.cpp
+++ b/generated/src/aws-cpp-sdk-clouddirectory/source/CloudDirectoryClient.cpp
@@ -108,7 +108,7 @@ CloudDirectoryClient::CloudDirectoryClient(const CloudDirectory::CloudDirectoryC
                                            std::shared_ptr<CloudDirectoryEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudDirectoryErrorMarshaller>(ALLOCATION_TAG)),
@@ -155,7 +155,7 @@ CloudDirectoryClient::CloudDirectoryClient(const std::shared_ptr<AWSCredentialsP
   CloudDirectoryClient::CloudDirectoryClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudDirectoryErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudformation/source/CloudFormationClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/CloudFormationClient.cpp
@@ -113,7 +113,7 @@ CloudFormationClient::CloudFormationClient(const CloudFormation::CloudFormationC
                                            std::shared_ptr<CloudFormationEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudFormationErrorMarshaller>(ALLOCATION_TAG)),
@@ -160,7 +160,7 @@ CloudFormationClient::CloudFormationClient(const std::shared_ptr<AWSCredentialsP
   CloudFormationClient::CloudFormationClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudFormationErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudfront-keyvaluestore/source/CloudFrontKeyValueStoreClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront-keyvaluestore/source/CloudFrontKeyValueStoreClient.cpp
@@ -48,7 +48,7 @@ CloudFrontKeyValueStoreClient::CloudFrontKeyValueStoreClient(const CloudFrontKey
                                                              std::shared_ptr<CloudFrontKeyValueStoreEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudFrontKeyValueStoreErrorMarshaller>(ALLOCATION_TAG)),
@@ -95,7 +95,7 @@ CloudFrontKeyValueStoreClient::CloudFrontKeyValueStoreClient(const std::shared_p
   CloudFrontKeyValueStoreClient::CloudFrontKeyValueStoreClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudFrontKeyValueStoreErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudfront/source/CloudFrontClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/CloudFrontClient.cpp
@@ -154,7 +154,7 @@ CloudFrontClient::CloudFrontClient(const CloudFront::CloudFrontClientConfigurati
                                    std::shared_ptr<CloudFrontEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudFrontErrorMarshaller>(ALLOCATION_TAG)),
@@ -201,7 +201,7 @@ CloudFrontClient::CloudFrontClient(const std::shared_ptr<AWSCredentialsProvider>
   CloudFrontClient::CloudFrontClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudFrontErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudhsm/source/CloudHSMClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudhsm/source/CloudHSMClient.cpp
@@ -42,7 +42,7 @@ CloudHSMClient::CloudHSMClient(const CloudHSM::CloudHSMClientConfiguration& clie
                                std::shared_ptr<CloudHSMEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudHSMErrorMarshaller>(ALLOCATION_TAG)),
@@ -89,7 +89,7 @@ CloudHSMClient::CloudHSMClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   CloudHSMClient::CloudHSMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudHSMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudhsmv2/source/CloudHSMV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-cloudhsmv2/source/CloudHSMV2Client.cpp
@@ -57,7 +57,7 @@ CloudHSMV2Client::CloudHSMV2Client(const CloudHSMV2::CloudHSMV2ClientConfigurati
                                    std::shared_ptr<CloudHSMV2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudHSMV2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -104,7 +104,7 @@ CloudHSMV2Client::CloudHSMV2Client(const std::shared_ptr<AWSCredentialsProvider>
   CloudHSMV2Client::CloudHSMV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudHSMV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudsearch/source/CloudSearchClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudsearch/source/CloudSearchClient.cpp
@@ -69,7 +69,7 @@ CloudSearchClient::CloudSearchClient(const CloudSearch::CloudSearchClientConfigu
                                      std::shared_ptr<CloudSearchEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudSearchErrorMarshaller>(ALLOCATION_TAG)),
@@ -116,7 +116,7 @@ CloudSearchClient::CloudSearchClient(const std::shared_ptr<AWSCredentialsProvide
   CloudSearchClient::CloudSearchClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudSearchErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudsearchdomain/source/CloudSearchDomainClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudsearchdomain/source/CloudSearchDomainClient.cpp
@@ -45,7 +45,7 @@ CloudSearchDomainClient::CloudSearchDomainClient(const CloudSearchDomain::CloudS
                                                  std::shared_ptr<CloudSearchDomainEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudSearchDomainErrorMarshaller>(ALLOCATION_TAG)),
@@ -92,7 +92,7 @@ CloudSearchDomainClient::CloudSearchDomainClient(const std::shared_ptr<AWSCreden
   CloudSearchDomainClient::CloudSearchDomainClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudSearchDomainErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudtrail-data/source/CloudTrailDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudtrail-data/source/CloudTrailDataClient.cpp
@@ -43,7 +43,7 @@ CloudTrailDataClient::CloudTrailDataClient(const CloudTrailData::CloudTrailDataC
                                            std::shared_ptr<CloudTrailDataEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudTrailDataErrorMarshaller>(ALLOCATION_TAG)),
@@ -90,7 +90,7 @@ CloudTrailDataClient::CloudTrailDataClient(const std::shared_ptr<AWSCredentialsP
   CloudTrailDataClient::CloudTrailDataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudTrailDataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudtrail/source/CloudTrailClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudtrail/source/CloudTrailClient.cpp
@@ -90,7 +90,7 @@ CloudTrailClient::CloudTrailClient(const CloudTrail::CloudTrailClientConfigurati
                                    std::shared_ptr<CloudTrailEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudTrailErrorMarshaller>(ALLOCATION_TAG)),
@@ -137,7 +137,7 @@ CloudTrailClient::CloudTrailClient(const std::shared_ptr<AWSCredentialsProvider>
   CloudTrailClient::CloudTrailClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudTrailErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codeartifact/source/CodeArtifactClient.cpp
+++ b/generated/src/aws-cpp-sdk-codeartifact/source/CodeArtifactClient.cpp
@@ -80,7 +80,7 @@ CodeArtifactClient::CodeArtifactClient(const CodeArtifact::CodeArtifactClientCon
                                        std::shared_ptr<CodeArtifactEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeArtifactErrorMarshaller>(ALLOCATION_TAG)),
@@ -127,7 +127,7 @@ CodeArtifactClient::CodeArtifactClient(const std::shared_ptr<AWSCredentialsProvi
   CodeArtifactClient::CodeArtifactClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeArtifactErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codebuild/source/CodeBuildClient.cpp
+++ b/generated/src/aws-cpp-sdk-codebuild/source/CodeBuildClient.cpp
@@ -87,7 +87,7 @@ CodeBuildClient::CodeBuildClient(const CodeBuild::CodeBuildClientConfiguration& 
                                  std::shared_ptr<CodeBuildEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeBuildErrorMarshaller>(ALLOCATION_TAG)),
@@ -134,7 +134,7 @@ CodeBuildClient::CodeBuildClient(const std::shared_ptr<AWSCredentialsProvider>& 
   CodeBuildClient::CodeBuildClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeBuildErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codecommit/source/CodeCommitClient.cpp
+++ b/generated/src/aws-cpp-sdk-codecommit/source/CodeCommitClient.cpp
@@ -121,7 +121,7 @@ CodeCommitClient::CodeCommitClient(const CodeCommit::CodeCommitClientConfigurati
                                    std::shared_ptr<CodeCommitEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeCommitErrorMarshaller>(ALLOCATION_TAG)),
@@ -168,7 +168,7 @@ CodeCommitClient::CodeCommitClient(const std::shared_ptr<AWSCredentialsProvider>
   CodeCommitClient::CodeCommitClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeCommitErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codedeploy/source/CodeDeployClient.cpp
+++ b/generated/src/aws-cpp-sdk-codedeploy/source/CodeDeployClient.cpp
@@ -85,7 +85,7 @@ CodeDeployClient::CodeDeployClient(const CodeDeploy::CodeDeployClientConfigurati
                                    std::shared_ptr<CodeDeployEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeDeployErrorMarshaller>(ALLOCATION_TAG)),
@@ -132,7 +132,7 @@ CodeDeployClient::CodeDeployClient(const std::shared_ptr<AWSCredentialsProvider>
   CodeDeployClient::CodeDeployClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeDeployErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codeguru-reviewer/source/CodeGuruReviewerClient.cpp
+++ b/generated/src/aws-cpp-sdk-codeguru-reviewer/source/CodeGuruReviewerClient.cpp
@@ -56,7 +56,7 @@ CodeGuruReviewerClient::CodeGuruReviewerClient(const CodeGuruReviewer::CodeGuruR
                                                std::shared_ptr<CodeGuruReviewerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeGuruReviewerErrorMarshaller>(ALLOCATION_TAG)),
@@ -103,7 +103,7 @@ CodeGuruReviewerClient::CodeGuruReviewerClient(const std::shared_ptr<AWSCredenti
   CodeGuruReviewerClient::CodeGuruReviewerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeGuruReviewerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codeguru-security/source/CodeGuruSecurityClient.cpp
+++ b/generated/src/aws-cpp-sdk-codeguru-security/source/CodeGuruSecurityClient.cpp
@@ -55,7 +55,7 @@ CodeGuruSecurityClient::CodeGuruSecurityClient(const CodeGuruSecurity::CodeGuruS
                                                std::shared_ptr<CodeGuruSecurityEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeGuruSecurityErrorMarshaller>(ALLOCATION_TAG)),
@@ -102,7 +102,7 @@ CodeGuruSecurityClient::CodeGuruSecurityClient(const std::shared_ptr<AWSCredenti
   CodeGuruSecurityClient::CodeGuruSecurityClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeGuruSecurityErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codeguruprofiler/source/CodeGuruProfilerClient.cpp
+++ b/generated/src/aws-cpp-sdk-codeguruprofiler/source/CodeGuruProfilerClient.cpp
@@ -65,7 +65,7 @@ CodeGuruProfilerClient::CodeGuruProfilerClient(const CodeGuruProfiler::CodeGuruP
                                                std::shared_ptr<CodeGuruProfilerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeGuruProfilerErrorMarshaller>(ALLOCATION_TAG)),
@@ -112,7 +112,7 @@ CodeGuruProfilerClient::CodeGuruProfilerClient(const std::shared_ptr<AWSCredenti
   CodeGuruProfilerClient::CodeGuruProfilerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeGuruProfilerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codepipeline/source/CodePipelineClient.cpp
+++ b/generated/src/aws-cpp-sdk-codepipeline/source/CodePipelineClient.cpp
@@ -81,7 +81,7 @@ CodePipelineClient::CodePipelineClient(const CodePipeline::CodePipelineClientCon
                                        std::shared_ptr<CodePipelineEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodePipelineErrorMarshaller>(ALLOCATION_TAG)),
@@ -128,7 +128,7 @@ CodePipelineClient::CodePipelineClient(const std::shared_ptr<AWSCredentialsProvi
   CodePipelineClient::CodePipelineClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodePipelineErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codestar-connections/source/CodeStarconnectionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-codestar-connections/source/CodeStarconnectionsClient.cpp
@@ -69,7 +69,7 @@ CodeStarconnectionsClient::CodeStarconnectionsClient(const CodeStarconnections::
                                                      std::shared_ptr<CodeStarconnectionsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeStarconnectionsErrorMarshaller>(ALLOCATION_TAG)),
@@ -116,7 +116,7 @@ CodeStarconnectionsClient::CodeStarconnectionsClient(const std::shared_ptr<AWSCr
   CodeStarconnectionsClient::CodeStarconnectionsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeStarconnectionsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codestar-notifications/source/CodeStarNotificationsClient.cpp
+++ b/generated/src/aws-cpp-sdk-codestar-notifications/source/CodeStarNotificationsClient.cpp
@@ -55,7 +55,7 @@ CodeStarNotificationsClient::CodeStarNotificationsClient(const CodeStarNotificat
                                                          std::shared_ptr<CodeStarNotificationsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeStarNotificationsErrorMarshaller>(ALLOCATION_TAG)),
@@ -102,7 +102,7 @@ CodeStarNotificationsClient::CodeStarNotificationsClient(const std::shared_ptr<A
   CodeStarNotificationsClient::CodeStarNotificationsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeStarNotificationsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codestar/source/CodeStarClient.cpp
+++ b/generated/src/aws-cpp-sdk-codestar/source/CodeStarClient.cpp
@@ -60,7 +60,7 @@ CodeStarClient::CodeStarClient(const CodeStar::CodeStarClientConfiguration& clie
                                std::shared_ptr<CodeStarEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeStarErrorMarshaller>(ALLOCATION_TAG)),
@@ -107,7 +107,7 @@ CodeStarClient::CodeStarClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   CodeStarClient::CodeStarClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeStarErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cognito-identity/source/CognitoIdentityClient.cpp
+++ b/generated/src/aws-cpp-sdk-cognito-identity/source/CognitoIdentityClient.cpp
@@ -65,7 +65,7 @@ CognitoIdentityClient::CognitoIdentityClient(const CognitoIdentity::CognitoIdent
                                              std::shared_ptr<CognitoIdentityEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CognitoIdentityErrorMarshaller>(ALLOCATION_TAG)),
@@ -112,7 +112,7 @@ CognitoIdentityClient::CognitoIdentityClient(const std::shared_ptr<AWSCredential
   CognitoIdentityClient::CognitoIdentityClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CognitoIdentityErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cognito-idp/source/CognitoIdentityProviderClient.cpp
+++ b/generated/src/aws-cpp-sdk-cognito-idp/source/CognitoIdentityProviderClient.cpp
@@ -145,7 +145,7 @@ CognitoIdentityProviderClient::CognitoIdentityProviderClient(const CognitoIdenti
                                                              std::shared_ptr<CognitoIdentityProviderEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CognitoIdentityProviderErrorMarshaller>(ALLOCATION_TAG)),
@@ -192,7 +192,7 @@ CognitoIdentityProviderClient::CognitoIdentityProviderClient(const std::shared_p
   CognitoIdentityProviderClient::CognitoIdentityProviderClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CognitoIdentityProviderErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cognito-sync/source/CognitoSyncClient.cpp
+++ b/generated/src/aws-cpp-sdk-cognito-sync/source/CognitoSyncClient.cpp
@@ -59,7 +59,7 @@ CognitoSyncClient::CognitoSyncClient(const CognitoSync::CognitoSyncClientConfigu
                                      std::shared_ptr<CognitoSyncEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CognitoSyncErrorMarshaller>(ALLOCATION_TAG)),
@@ -106,7 +106,7 @@ CognitoSyncClient::CognitoSyncClient(const std::shared_ptr<AWSCredentialsProvide
   CognitoSyncClient::CognitoSyncClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CognitoSyncErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-comprehend/source/ComprehendClient.cpp
+++ b/generated/src/aws-cpp-sdk-comprehend/source/ComprehendClient.cpp
@@ -127,7 +127,7 @@ ComprehendClient::ComprehendClient(const Comprehend::ComprehendClientConfigurati
                                    std::shared_ptr<ComprehendEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ComprehendErrorMarshaller>(ALLOCATION_TAG)),
@@ -174,7 +174,7 @@ ComprehendClient::ComprehendClient(const std::shared_ptr<AWSCredentialsProvider>
   ComprehendClient::ComprehendClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ComprehendErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-comprehendmedical/source/ComprehendMedicalClient.cpp
+++ b/generated/src/aws-cpp-sdk-comprehendmedical/source/ComprehendMedicalClient.cpp
@@ -67,7 +67,7 @@ ComprehendMedicalClient::ComprehendMedicalClient(const ComprehendMedical::Compre
                                                  std::shared_ptr<ComprehendMedicalEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ComprehendMedicalErrorMarshaller>(ALLOCATION_TAG)),
@@ -114,7 +114,7 @@ ComprehendMedicalClient::ComprehendMedicalClient(const std::shared_ptr<AWSCreden
   ComprehendMedicalClient::ComprehendMedicalClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ComprehendMedicalErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-compute-optimizer/source/ComputeOptimizerClient.cpp
+++ b/generated/src/aws-cpp-sdk-compute-optimizer/source/ComputeOptimizerClient.cpp
@@ -65,7 +65,7 @@ ComputeOptimizerClient::ComputeOptimizerClient(const ComputeOptimizer::ComputeOp
                                                std::shared_ptr<ComputeOptimizerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ComputeOptimizerErrorMarshaller>(ALLOCATION_TAG)),
@@ -112,7 +112,7 @@ ComputeOptimizerClient::ComputeOptimizerClient(const std::shared_ptr<AWSCredenti
   ComputeOptimizerClient::ComputeOptimizerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ComputeOptimizerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-config/source/ConfigServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-config/source/ConfigServiceClient.cpp
@@ -134,7 +134,7 @@ ConfigServiceClient::ConfigServiceClient(const ConfigService::ConfigServiceClien
                                          std::shared_ptr<ConfigServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConfigServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -181,7 +181,7 @@ ConfigServiceClient::ConfigServiceClient(const std::shared_ptr<AWSCredentialsPro
   ConfigServiceClient::ConfigServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConfigServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-connect-contact-lens/source/ConnectContactLensClient.cpp
+++ b/generated/src/aws-cpp-sdk-connect-contact-lens/source/ConnectContactLensClient.cpp
@@ -43,7 +43,7 @@ ConnectContactLensClient::ConnectContactLensClient(const ConnectContactLens::Con
                                                    std::shared_ptr<ConnectContactLensEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectContactLensErrorMarshaller>(ALLOCATION_TAG)),
@@ -90,7 +90,7 @@ ConnectContactLensClient::ConnectContactLensClient(const std::shared_ptr<AWSCred
   ConnectContactLensClient::ConnectContactLensClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectContactLensErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-connect/source/ConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-connect/source/ConnectClient.cpp
@@ -142,7 +142,7 @@ ConnectClient::ConnectClient(const Connect::ConnectClientConfiguration& clientCo
                              std::shared_ptr<ConnectEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectErrorMarshaller>(ALLOCATION_TAG)),
@@ -189,7 +189,7 @@ ConnectClient::ConnectClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   ConnectClient::ConnectClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-connectcampaigns/source/ConnectCampaignsClient.cpp
+++ b/generated/src/aws-cpp-sdk-connectcampaigns/source/ConnectCampaignsClient.cpp
@@ -64,7 +64,7 @@ ConnectCampaignsClient::ConnectCampaignsClient(const ConnectCampaigns::ConnectCa
                                                std::shared_ptr<ConnectCampaignsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectCampaignsErrorMarshaller>(ALLOCATION_TAG)),
@@ -111,7 +111,7 @@ ConnectCampaignsClient::ConnectCampaignsClient(const std::shared_ptr<AWSCredenti
   ConnectCampaignsClient::ConnectCampaignsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectCampaignsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-connectcases/source/ConnectCasesClient.cpp
+++ b/generated/src/aws-cpp-sdk-connectcases/source/ConnectCasesClient.cpp
@@ -72,7 +72,7 @@ ConnectCasesClient::ConnectCasesClient(const ConnectCases::ConnectCasesClientCon
                                        std::shared_ptr<ConnectCasesEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectCasesErrorMarshaller>(ALLOCATION_TAG)),
@@ -119,7 +119,7 @@ ConnectCasesClient::ConnectCasesClient(const std::shared_ptr<AWSCredentialsProvi
   ConnectCasesClient::ConnectCasesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectCasesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-connectparticipant/source/ConnectParticipantClient.cpp
+++ b/generated/src/aws-cpp-sdk-connectparticipant/source/ConnectParticipantClient.cpp
@@ -51,7 +51,7 @@ ConnectParticipantClient::ConnectParticipantClient(const ConnectParticipant::Con
                                                    std::shared_ptr<ConnectParticipantEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectParticipantErrorMarshaller>(ALLOCATION_TAG)),
@@ -98,7 +98,7 @@ ConnectParticipantClient::ConnectParticipantClient(const std::shared_ptr<AWSCred
   ConnectParticipantClient::ConnectParticipantClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectParticipantErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-controltower/source/ControlTowerClient.cpp
+++ b/generated/src/aws-cpp-sdk-controltower/source/ControlTowerClient.cpp
@@ -58,7 +58,7 @@ ControlTowerClient::ControlTowerClient(const ControlTower::ControlTowerClientCon
                                        std::shared_ptr<ControlTowerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ControlTowerErrorMarshaller>(ALLOCATION_TAG)),
@@ -105,7 +105,7 @@ ControlTowerClient::ControlTowerClient(const std::shared_ptr<AWSCredentialsProvi
   ControlTowerClient::ControlTowerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ControlTowerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cost-optimization-hub/source/CostOptimizationHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-cost-optimization-hub/source/CostOptimizationHubClient.cpp
@@ -49,7 +49,7 @@ CostOptimizationHubClient::CostOptimizationHubClient(const CostOptimizationHub::
                                                      std::shared_ptr<CostOptimizationHubEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CostOptimizationHubErrorMarshaller>(ALLOCATION_TAG)),
@@ -96,7 +96,7 @@ CostOptimizationHubClient::CostOptimizationHubClient(const std::shared_ptr<AWSCr
   CostOptimizationHubClient::CostOptimizationHubClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CostOptimizationHubErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cur/source/CostandUsageReportServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-cur/source/CostandUsageReportServiceClient.cpp
@@ -49,7 +49,7 @@ CostandUsageReportServiceClient::CostandUsageReportServiceClient(const CostandUs
                                                                  std::shared_ptr<CostandUsageReportServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CostandUsageReportServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -96,7 +96,7 @@ CostandUsageReportServiceClient::CostandUsageReportServiceClient(const std::shar
   CostandUsageReportServiceClient::CostandUsageReportServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CostandUsageReportServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-customer-profiles/source/CustomerProfilesClient.cpp
+++ b/generated/src/aws-cpp-sdk-customer-profiles/source/CustomerProfilesClient.cpp
@@ -94,7 +94,7 @@ CustomerProfilesClient::CustomerProfilesClient(const CustomerProfiles::CustomerP
                                                std::shared_ptr<CustomerProfilesEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CustomerProfilesErrorMarshaller>(ALLOCATION_TAG)),
@@ -141,7 +141,7 @@ CustomerProfilesClient::CustomerProfilesClient(const std::shared_ptr<AWSCredenti
   CustomerProfilesClient::CustomerProfilesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CustomerProfilesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-databrew/source/GlueDataBrewClient.cpp
+++ b/generated/src/aws-cpp-sdk-databrew/source/GlueDataBrewClient.cpp
@@ -86,7 +86,7 @@ GlueDataBrewClient::GlueDataBrewClient(const GlueDataBrew::GlueDataBrewClientCon
                                        std::shared_ptr<GlueDataBrewEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GlueDataBrewErrorMarshaller>(ALLOCATION_TAG)),
@@ -133,7 +133,7 @@ GlueDataBrewClient::GlueDataBrewClient(const std::shared_ptr<AWSCredentialsProvi
   GlueDataBrewClient::GlueDataBrewClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GlueDataBrewErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-dataexchange/source/DataExchangeClient.cpp
+++ b/generated/src/aws-cpp-sdk-dataexchange/source/DataExchangeClient.cpp
@@ -72,7 +72,7 @@ DataExchangeClient::DataExchangeClient(const DataExchange::DataExchangeClientCon
                                        std::shared_ptr<DataExchangeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DataExchangeErrorMarshaller>(ALLOCATION_TAG)),
@@ -119,7 +119,7 @@ DataExchangeClient::DataExchangeClient(const std::shared_ptr<AWSCredentialsProvi
   DataExchangeClient::DataExchangeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DataExchangeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-datapipeline/source/DataPipelineClient.cpp
+++ b/generated/src/aws-cpp-sdk-datapipeline/source/DataPipelineClient.cpp
@@ -61,7 +61,7 @@ DataPipelineClient::DataPipelineClient(const DataPipeline::DataPipelineClientCon
                                        std::shared_ptr<DataPipelineEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DataPipelineErrorMarshaller>(ALLOCATION_TAG)),
@@ -108,7 +108,7 @@ DataPipelineClient::DataPipelineClient(const std::shared_ptr<AWSCredentialsProvi
   DataPipelineClient::DataPipelineClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DataPipelineErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-datasync/source/DataSyncClient.cpp
+++ b/generated/src/aws-cpp-sdk-datasync/source/DataSyncClient.cpp
@@ -102,7 +102,7 @@ DataSyncClient::DataSyncClient(const DataSync::DataSyncClientConfiguration& clie
                                std::shared_ptr<DataSyncEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DataSyncErrorMarshaller>(ALLOCATION_TAG)),
@@ -149,7 +149,7 @@ DataSyncClient::DataSyncClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   DataSyncClient::DataSyncClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DataSyncErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-datazone/source/DataZoneClient.cpp
+++ b/generated/src/aws-cpp-sdk-datazone/source/DataZoneClient.cpp
@@ -141,7 +141,7 @@ DataZoneClient::DataZoneClient(const DataZone::DataZoneClientConfiguration& clie
                                std::shared_ptr<DataZoneEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DataZoneErrorMarshaller>(ALLOCATION_TAG)),
@@ -188,7 +188,7 @@ DataZoneClient::DataZoneClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   DataZoneClient::DataZoneClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DataZoneErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-dax/source/DAXClient.cpp
+++ b/generated/src/aws-cpp-sdk-dax/source/DAXClient.cpp
@@ -63,7 +63,7 @@ DAXClient::DAXClient(const DAX::DAXClientConfiguration& clientConfiguration,
                      std::shared_ptr<DAXEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DAXErrorMarshaller>(ALLOCATION_TAG)),
@@ -110,7 +110,7 @@ DAXClient::DAXClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   DAXClient::DAXClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DAXErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-detective/source/DetectiveClient.cpp
+++ b/generated/src/aws-cpp-sdk-detective/source/DetectiveClient.cpp
@@ -71,7 +71,7 @@ DetectiveClient::DetectiveClient(const Detective::DetectiveClientConfiguration& 
                                  std::shared_ptr<DetectiveEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DetectiveErrorMarshaller>(ALLOCATION_TAG)),
@@ -118,7 +118,7 @@ DetectiveClient::DetectiveClient(const std::shared_ptr<AWSCredentialsProvider>& 
   DetectiveClient::DetectiveClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DetectiveErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-devicefarm/source/DeviceFarmClient.cpp
+++ b/generated/src/aws-cpp-sdk-devicefarm/source/DeviceFarmClient.cpp
@@ -119,7 +119,7 @@ DeviceFarmClient::DeviceFarmClient(const DeviceFarm::DeviceFarmClientConfigurati
                                    std::shared_ptr<DeviceFarmEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DeviceFarmErrorMarshaller>(ALLOCATION_TAG)),
@@ -166,7 +166,7 @@ DeviceFarmClient::DeviceFarmClient(const std::shared_ptr<AWSCredentialsProvider>
   DeviceFarmClient::DeviceFarmClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DeviceFarmErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-devops-guru/source/DevOpsGuruClient.cpp
+++ b/generated/src/aws-cpp-sdk-devops-guru/source/DevOpsGuruClient.cpp
@@ -73,7 +73,7 @@ DevOpsGuruClient::DevOpsGuruClient(const DevOpsGuru::DevOpsGuruClientConfigurati
                                    std::shared_ptr<DevOpsGuruEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DevOpsGuruErrorMarshaller>(ALLOCATION_TAG)),
@@ -120,7 +120,7 @@ DevOpsGuruClient::DevOpsGuruClient(const std::shared_ptr<AWSCredentialsProvider>
   DevOpsGuruClient::DevOpsGuruClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DevOpsGuruErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-directconnect/source/DirectConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-directconnect/source/DirectConnectClient.cpp
@@ -101,7 +101,7 @@ DirectConnectClient::DirectConnectClient(const DirectConnect::DirectConnectClien
                                          std::shared_ptr<DirectConnectEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DirectConnectErrorMarshaller>(ALLOCATION_TAG)),
@@ -148,7 +148,7 @@ DirectConnectClient::DirectConnectClient(const std::shared_ptr<AWSCredentialsPro
   DirectConnectClient::DirectConnectClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DirectConnectErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-discovery/source/ApplicationDiscoveryServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-discovery/source/ApplicationDiscoveryServiceClient.cpp
@@ -68,7 +68,7 @@ ApplicationDiscoveryServiceClient::ApplicationDiscoveryServiceClient(const Appli
                                                                      std::shared_ptr<ApplicationDiscoveryServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApplicationDiscoveryServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -115,7 +115,7 @@ ApplicationDiscoveryServiceClient::ApplicationDiscoveryServiceClient(const std::
   ApplicationDiscoveryServiceClient::ApplicationDiscoveryServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApplicationDiscoveryServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-dlm/source/DLMClient.cpp
+++ b/generated/src/aws-cpp-sdk-dlm/source/DLMClient.cpp
@@ -50,7 +50,7 @@ DLMClient::DLMClient(const DLM::DLMClientConfiguration& clientConfiguration,
                      std::shared_ptr<DLMEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DLMErrorMarshaller>(ALLOCATION_TAG)),
@@ -97,7 +97,7 @@ DLMClient::DLMClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   DLMClient::DLMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DLMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-dms/source/DatabaseMigrationServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-dms/source/DatabaseMigrationServiceClient.cpp
@@ -148,7 +148,7 @@ DatabaseMigrationServiceClient::DatabaseMigrationServiceClient(const DatabaseMig
                                                                std::shared_ptr<DatabaseMigrationServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DatabaseMigrationServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -195,7 +195,7 @@ DatabaseMigrationServiceClient::DatabaseMigrationServiceClient(const std::shared
   DatabaseMigrationServiceClient::DatabaseMigrationServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DatabaseMigrationServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-docdb-elastic/source/DocDBElasticClient.cpp
+++ b/generated/src/aws-cpp-sdk-docdb-elastic/source/DocDBElasticClient.cpp
@@ -55,7 +55,7 @@ DocDBElasticClient::DocDBElasticClient(const DocDBElastic::DocDBElasticClientCon
                                        std::shared_ptr<DocDBElasticEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DocDBElasticErrorMarshaller>(ALLOCATION_TAG)),
@@ -102,7 +102,7 @@ DocDBElasticClient::DocDBElasticClient(const std::shared_ptr<AWSCredentialsProvi
   DocDBElasticClient::DocDBElasticClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DocDBElasticErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-docdb/source/DocDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/DocDBClient.cpp
@@ -96,7 +96,7 @@ DocDBClient::DocDBClient(const DocDB::DocDBClientConfiguration& clientConfigurat
                          std::shared_ptr<DocDBEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DocDBErrorMarshaller>(ALLOCATION_TAG)),
@@ -143,7 +143,7 @@ DocDBClient::DocDBClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   DocDBClient::DocDBClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DocDBErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-drs/source/DrsClient.cpp
+++ b/generated/src/aws-cpp-sdk-drs/source/DrsClient.cpp
@@ -91,7 +91,7 @@ DrsClient::DrsClient(const drs::DrsClientConfiguration& clientConfiguration,
                      std::shared_ptr<DrsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DrsErrorMarshaller>(ALLOCATION_TAG)),
@@ -138,7 +138,7 @@ DrsClient::DrsClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   DrsClient::DrsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DrsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ds/source/DirectoryServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-ds/source/DirectoryServiceClient.cpp
@@ -109,7 +109,7 @@ DirectoryServiceClient::DirectoryServiceClient(const DirectoryService::Directory
                                                std::shared_ptr<DirectoryServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DirectoryServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -156,7 +156,7 @@ DirectoryServiceClient::DirectoryServiceClient(const std::shared_ptr<AWSCredenti
   DirectoryServiceClient::DirectoryServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DirectoryServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClient.cpp
@@ -96,7 +96,7 @@ DynamoDBClient::DynamoDBClient(const DynamoDB::DynamoDBClientConfiguration& clie
                                std::shared_ptr<DynamoDBEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DynamoDBErrorMarshaller>(ALLOCATION_TAG)),
@@ -143,7 +143,7 @@ DynamoDBClient::DynamoDBClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   DynamoDBClient::DynamoDBClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DynamoDBErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-dynamodbstreams/source/DynamoDBStreamsClient.cpp
+++ b/generated/src/aws-cpp-sdk-dynamodbstreams/source/DynamoDBStreamsClient.cpp
@@ -46,7 +46,7 @@ DynamoDBStreamsClient::DynamoDBStreamsClient(const DynamoDBStreams::DynamoDBStre
                                              std::shared_ptr<DynamoDBStreamsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DynamoDBStreamsErrorMarshaller>(ALLOCATION_TAG)),
@@ -93,7 +93,7 @@ DynamoDBStreamsClient::DynamoDBStreamsClient(const std::shared_ptr<AWSCredential
   DynamoDBStreamsClient::DynamoDBStreamsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DynamoDBStreamsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ebs/source/EBSClient.cpp
+++ b/generated/src/aws-cpp-sdk-ebs/source/EBSClient.cpp
@@ -48,7 +48,7 @@ EBSClient::EBSClient(const EBS::EBSClientConfiguration& clientConfiguration,
                      std::shared_ptr<EBSEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EBSErrorMarshaller>(ALLOCATION_TAG)),
@@ -95,7 +95,7 @@ EBSClient::EBSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   EBSClient::EBSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EBSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ec2-instance-connect/source/EC2InstanceConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-ec2-instance-connect/source/EC2InstanceConnectClient.cpp
@@ -44,7 +44,7 @@ EC2InstanceConnectClient::EC2InstanceConnectClient(const EC2InstanceConnect::EC2
                                                    std::shared_ptr<EC2InstanceConnectEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EC2InstanceConnectErrorMarshaller>(ALLOCATION_TAG)),
@@ -91,7 +91,7 @@ EC2InstanceConnectClient::EC2InstanceConnectClient(const std::shared_ptr<AWSCred
   EC2InstanceConnectClient::EC2InstanceConnectClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EC2InstanceConnectErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ec2/source/EC2Client.cpp
+++ b/generated/src/aws-cpp-sdk-ec2/source/EC2Client.cpp
@@ -143,7 +143,7 @@ EC2Client::EC2Client(const EC2::EC2ClientConfiguration& clientConfiguration,
                      std::shared_ptr<EC2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EC2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -190,7 +190,7 @@ EC2Client::EC2Client(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   EC2Client::EC2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EC2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ecr-public/source/ECRPublicClient.cpp
+++ b/generated/src/aws-cpp-sdk-ecr-public/source/ECRPublicClient.cpp
@@ -65,7 +65,7 @@ ECRPublicClient::ECRPublicClient(const ECRPublic::ECRPublicClientConfiguration& 
                                  std::shared_ptr<ECRPublicEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ECRPublicErrorMarshaller>(ALLOCATION_TAG)),
@@ -112,7 +112,7 @@ ECRPublicClient::ECRPublicClient(const std::shared_ptr<AWSCredentialsProvider>& 
   ECRPublicClient::ECRPublicClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ECRPublicErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ecr/source/ECRClient.cpp
+++ b/generated/src/aws-cpp-sdk-ecr/source/ECRClient.cpp
@@ -85,7 +85,7 @@ ECRClient::ECRClient(const ECR::ECRClientConfiguration& clientConfiguration,
                      std::shared_ptr<ECREndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ECRErrorMarshaller>(ALLOCATION_TAG)),
@@ -132,7 +132,7 @@ ECRClient::ECRClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   ECRClient::ECRClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ECRErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ecs/source/ECSClient.cpp
+++ b/generated/src/aws-cpp-sdk-ecs/source/ECSClient.cpp
@@ -98,7 +98,7 @@ ECSClient::ECSClient(const ECS::ECSClientConfiguration& clientConfiguration,
                      std::shared_ptr<ECSEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ECSErrorMarshaller>(ALLOCATION_TAG)),
@@ -145,7 +145,7 @@ ECSClient::ECSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   ECSClient::ECSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ECSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-eks-auth/source/EKSAuthClient.cpp
+++ b/generated/src/aws-cpp-sdk-eks-auth/source/EKSAuthClient.cpp
@@ -43,7 +43,7 @@ EKSAuthClient::EKSAuthClient(const EKSAuth::EKSAuthClientConfiguration& clientCo
                              std::shared_ptr<EKSAuthEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EKSAuthErrorMarshaller>(ALLOCATION_TAG)),
@@ -90,7 +90,7 @@ EKSAuthClient::EKSAuthClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   EKSAuthClient::EKSAuthClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EKSAuthErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-eks/source/EKSClient.cpp
+++ b/generated/src/aws-cpp-sdk-eks/source/EKSClient.cpp
@@ -98,7 +98,7 @@ EKSClient::EKSClient(const EKS::EKSClientConfiguration& clientConfiguration,
                      std::shared_ptr<EKSEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EKSErrorMarshaller>(ALLOCATION_TAG)),
@@ -145,7 +145,7 @@ EKSClient::EKSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   EKSClient::EKSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EKSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elastic-inference/source/ElasticInferenceClient.cpp
+++ b/generated/src/aws-cpp-sdk-elastic-inference/source/ElasticInferenceClient.cpp
@@ -48,7 +48,7 @@ ElasticInferenceClient::ElasticInferenceClient(const ElasticInference::ElasticIn
                                                std::shared_ptr<ElasticInferenceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticInferenceErrorMarshaller>(ALLOCATION_TAG)),
@@ -95,7 +95,7 @@ ElasticInferenceClient::ElasticInferenceClient(const std::shared_ptr<AWSCredenti
   ElasticInferenceClient::ElasticInferenceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticInferenceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elasticache/source/ElastiCacheClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/ElastiCacheClient.cpp
@@ -118,7 +118,7 @@ ElastiCacheClient::ElastiCacheClient(const ElastiCache::ElastiCacheClientConfigu
                                      std::shared_ptr<ElastiCacheEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElastiCacheErrorMarshaller>(ALLOCATION_TAG)),
@@ -165,7 +165,7 @@ ElastiCacheClient::ElastiCacheClient(const std::shared_ptr<AWSCredentialsProvide
   ElastiCacheClient::ElastiCacheClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElastiCacheErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/ElasticBeanstalkClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/ElasticBeanstalkClient.cpp
@@ -90,7 +90,7 @@ ElasticBeanstalkClient::ElasticBeanstalkClient(const ElasticBeanstalk::ElasticBe
                                                std::shared_ptr<ElasticBeanstalkEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticBeanstalkErrorMarshaller>(ALLOCATION_TAG)),
@@ -137,7 +137,7 @@ ElasticBeanstalkClient::ElasticBeanstalkClient(const std::shared_ptr<AWSCredenti
   ElasticBeanstalkClient::ElasticBeanstalkClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticBeanstalkErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elasticfilesystem/source/EFSClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticfilesystem/source/EFSClient.cpp
@@ -70,7 +70,7 @@ EFSClient::EFSClient(const EFS::EFSClientConfiguration& clientConfiguration,
                      std::shared_ptr<EFSEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EFSErrorMarshaller>(ALLOCATION_TAG)),
@@ -117,7 +117,7 @@ EFSClient::EFSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   EFSClient::EFSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EFSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/ElasticLoadBalancingClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/ElasticLoadBalancingClient.cpp
@@ -72,7 +72,7 @@ ElasticLoadBalancingClient::ElasticLoadBalancingClient(const ElasticLoadBalancin
                                                        std::shared_ptr<ElasticLoadBalancingEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticLoadBalancingErrorMarshaller>(ALLOCATION_TAG)),
@@ -119,7 +119,7 @@ ElasticLoadBalancingClient::ElasticLoadBalancingClient(const std::shared_ptr<AWS
   ElasticLoadBalancingClient::ElasticLoadBalancingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticLoadBalancingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/ElasticLoadBalancingv2Client.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/ElasticLoadBalancingv2Client.cpp
@@ -87,7 +87,7 @@ ElasticLoadBalancingv2Client::ElasticLoadBalancingv2Client(const ElasticLoadBala
                                                            std::shared_ptr<ElasticLoadBalancingv2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticLoadBalancingv2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -134,7 +134,7 @@ ElasticLoadBalancingv2Client::ElasticLoadBalancingv2Client(const std::shared_ptr
   ElasticLoadBalancingv2Client::ElasticLoadBalancingv2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticLoadBalancingv2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elasticmapreduce/source/EMRClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticmapreduce/source/EMRClient.cpp
@@ -96,7 +96,7 @@ EMRClient::EMRClient(const EMR::EMRClientConfiguration& clientConfiguration,
                      std::shared_ptr<EMREndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EMRErrorMarshaller>(ALLOCATION_TAG)),
@@ -143,7 +143,7 @@ EMRClient::EMRClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   EMRClient::EMRClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EMRErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elastictranscoder/source/ElasticTranscoderClient.cpp
+++ b/generated/src/aws-cpp-sdk-elastictranscoder/source/ElasticTranscoderClient.cpp
@@ -58,7 +58,7 @@ ElasticTranscoderClient::ElasticTranscoderClient(const ElasticTranscoder::Elasti
                                                  std::shared_ptr<ElasticTranscoderEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticTranscoderErrorMarshaller>(ALLOCATION_TAG)),
@@ -105,7 +105,7 @@ ElasticTranscoderClient::ElasticTranscoderClient(const std::shared_ptr<AWSCreden
   ElasticTranscoderClient::ElasticTranscoderClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticTranscoderErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-email/source/SESClient.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/SESClient.cpp
@@ -114,7 +114,7 @@ SESClient::SESClient(const SES::SESClientConfiguration& clientConfiguration,
                      std::shared_ptr<SESEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SESErrorMarshaller>(ALLOCATION_TAG)),
@@ -161,7 +161,7 @@ SESClient::SESClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SESClient::SESClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SESErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-emr-containers/source/EMRContainersClient.cpp
+++ b/generated/src/aws-cpp-sdk-emr-containers/source/EMRContainersClient.cpp
@@ -62,7 +62,7 @@ EMRContainersClient::EMRContainersClient(const EMRContainers::EMRContainersClien
                                          std::shared_ptr<EMRContainersEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EMRContainersErrorMarshaller>(ALLOCATION_TAG)),
@@ -109,7 +109,7 @@ EMRContainersClient::EMRContainersClient(const std::shared_ptr<AWSCredentialsPro
   EMRContainersClient::EMRContainersClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EMRContainersErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-emr-serverless/source/EMRServerlessClient.cpp
+++ b/generated/src/aws-cpp-sdk-emr-serverless/source/EMRServerlessClient.cpp
@@ -57,7 +57,7 @@ EMRServerlessClient::EMRServerlessClient(const EMRServerless::EMRServerlessClien
                                          std::shared_ptr<EMRServerlessEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EMRServerlessErrorMarshaller>(ALLOCATION_TAG)),
@@ -104,7 +104,7 @@ EMRServerlessClient::EMRServerlessClient(const std::shared_ptr<AWSCredentialsPro
   EMRServerlessClient::EMRServerlessClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EMRServerlessErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-entityresolution/source/EntityResolutionClient.cpp
+++ b/generated/src/aws-cpp-sdk-entityresolution/source/EntityResolutionClient.cpp
@@ -69,7 +69,7 @@ EntityResolutionClient::EntityResolutionClient(const EntityResolution::EntityRes
                                                std::shared_ptr<EntityResolutionEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EntityResolutionErrorMarshaller>(ALLOCATION_TAG)),
@@ -116,7 +116,7 @@ EntityResolutionClient::EntityResolutionClient(const std::shared_ptr<AWSCredenti
   EntityResolutionClient::EntityResolutionClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EntityResolutionErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-es/source/ElasticsearchServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-es/source/ElasticsearchServiceClient.cpp
@@ -92,7 +92,7 @@ ElasticsearchServiceClient::ElasticsearchServiceClient(const ElasticsearchServic
                                                        std::shared_ptr<ElasticsearchServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticsearchServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -139,7 +139,7 @@ ElasticsearchServiceClient::ElasticsearchServiceClient(const std::shared_ptr<AWS
   ElasticsearchServiceClient::ElasticsearchServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticsearchServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-eventbridge/source/EventBridgeClient.cpp
+++ b/generated/src/aws-cpp-sdk-eventbridge/source/EventBridgeClient.cpp
@@ -98,7 +98,7 @@ EventBridgeClient::EventBridgeClient(const EventBridge::EventBridgeClientConfigu
                                      std::shared_ptr<EventBridgeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EventBridgeErrorMarshaller>(ALLOCATION_TAG)),
@@ -145,7 +145,7 @@ EventBridgeClient::EventBridgeClient(const std::shared_ptr<AWSCredentialsProvide
   EventBridgeClient::EventBridgeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EventBridgeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-events/source/CloudWatchEventsClient.cpp
+++ b/generated/src/aws-cpp-sdk-events/source/CloudWatchEventsClient.cpp
@@ -93,7 +93,7 @@ CloudWatchEventsClient::CloudWatchEventsClient(const CloudWatchEvents::CloudWatc
                                                std::shared_ptr<CloudWatchEventsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchEventsErrorMarshaller>(ALLOCATION_TAG)),
@@ -140,7 +140,7 @@ CloudWatchEventsClient::CloudWatchEventsClient(const std::shared_ptr<AWSCredenti
   CloudWatchEventsClient::CloudWatchEventsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchEventsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-evidently/source/CloudWatchEvidentlyClient.cpp
+++ b/generated/src/aws-cpp-sdk-evidently/source/CloudWatchEvidentlyClient.cpp
@@ -80,7 +80,7 @@ CloudWatchEvidentlyClient::CloudWatchEvidentlyClient(const CloudWatchEvidently::
                                                      std::shared_ptr<CloudWatchEvidentlyEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchEvidentlyErrorMarshaller>(ALLOCATION_TAG)),
@@ -127,7 +127,7 @@ CloudWatchEvidentlyClient::CloudWatchEvidentlyClient(const std::shared_ptr<AWSCr
   CloudWatchEvidentlyClient::CloudWatchEvidentlyClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchEvidentlyErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-finspace-data/source/FinSpaceDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-finspace-data/source/FinSpaceDataClient.cpp
@@ -42,7 +42,7 @@ FinSpaceDataClient::FinSpaceDataClient(const FinSpaceData::FinSpaceDataClientCon
                                        std::shared_ptr<FinSpaceDataEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FinSpaceDataErrorMarshaller>(ALLOCATION_TAG)),
@@ -89,7 +89,7 @@ FinSpaceDataClient::FinSpaceDataClient(const std::shared_ptr<AWSCredentialsProvi
   FinSpaceDataClient::FinSpaceDataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FinSpaceDataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-finspace/source/FinspaceClient.cpp
+++ b/generated/src/aws-cpp-sdk-finspace/source/FinspaceClient.cpp
@@ -86,7 +86,7 @@ FinspaceClient::FinspaceClient(const finspace::FinspaceClientConfiguration& clie
                                std::shared_ptr<FinspaceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FinspaceErrorMarshaller>(ALLOCATION_TAG)),
@@ -133,7 +133,7 @@ FinspaceClient::FinspaceClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   FinspaceClient::FinspaceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FinspaceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-firehose/source/FirehoseClient.cpp
+++ b/generated/src/aws-cpp-sdk-firehose/source/FirehoseClient.cpp
@@ -54,7 +54,7 @@ FirehoseClient::FirehoseClient(const Firehose::FirehoseClientConfiguration& clie
                                std::shared_ptr<FirehoseEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FirehoseErrorMarshaller>(ALLOCATION_TAG)),
@@ -101,7 +101,7 @@ FirehoseClient::FirehoseClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   FirehoseClient::FirehoseClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FirehoseErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-fis/source/FISClient.cpp
+++ b/generated/src/aws-cpp-sdk-fis/source/FISClient.cpp
@@ -66,7 +66,7 @@ FISClient::FISClient(const FIS::FISClientConfiguration& clientConfiguration,
                      std::shared_ptr<FISEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FISErrorMarshaller>(ALLOCATION_TAG)),
@@ -113,7 +113,7 @@ FISClient::FISClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   FISClient::FISClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FISErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-fms/source/FMSClient.cpp
+++ b/generated/src/aws-cpp-sdk-fms/source/FMSClient.cpp
@@ -84,7 +84,7 @@ FMSClient::FMSClient(const FMS::FMSClientConfiguration& clientConfiguration,
                      std::shared_ptr<FMSEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FMSErrorMarshaller>(ALLOCATION_TAG)),
@@ -131,7 +131,7 @@ FMSClient::FMSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   FMSClient::FMSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FMSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-forecast/source/ForecastServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-forecast/source/ForecastServiceClient.cpp
@@ -105,7 +105,7 @@ ForecastServiceClient::ForecastServiceClient(const ForecastService::ForecastServ
                                              std::shared_ptr<ForecastServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ForecastServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -152,7 +152,7 @@ ForecastServiceClient::ForecastServiceClient(const std::shared_ptr<AWSCredential
   ForecastServiceClient::ForecastServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ForecastServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-forecastquery/source/ForecastQueryServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-forecastquery/source/ForecastQueryServiceClient.cpp
@@ -44,7 +44,7 @@ ForecastQueryServiceClient::ForecastQueryServiceClient(const ForecastQueryServic
                                                        std::shared_ptr<ForecastQueryServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ForecastQueryServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -91,7 +91,7 @@ ForecastQueryServiceClient::ForecastQueryServiceClient(const std::shared_ptr<AWS
   ForecastQueryServiceClient::ForecastQueryServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ForecastQueryServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-frauddetector/source/FraudDetectorClient.cpp
+++ b/generated/src/aws-cpp-sdk-frauddetector/source/FraudDetectorClient.cpp
@@ -115,7 +115,7 @@ FraudDetectorClient::FraudDetectorClient(const FraudDetector::FraudDetectorClien
                                          std::shared_ptr<FraudDetectorEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FraudDetectorErrorMarshaller>(ALLOCATION_TAG)),
@@ -162,7 +162,7 @@ FraudDetectorClient::FraudDetectorClient(const std::shared_ptr<AWSCredentialsPro
   FraudDetectorClient::FraudDetectorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FraudDetectorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-freetier/source/FreeTierClient.cpp
+++ b/generated/src/aws-cpp-sdk-freetier/source/FreeTierClient.cpp
@@ -43,7 +43,7 @@ FreeTierClient::FreeTierClient(const FreeTier::FreeTierClientConfiguration& clie
                                std::shared_ptr<FreeTierEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FreeTierErrorMarshaller>(ALLOCATION_TAG)),
@@ -90,7 +90,7 @@ FreeTierClient::FreeTierClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   FreeTierClient::FreeTierClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FreeTierErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-fsx/source/FSxClient.cpp
+++ b/generated/src/aws-cpp-sdk-fsx/source/FSxClient.cpp
@@ -87,7 +87,7 @@ FSxClient::FSxClient(const FSx::FSxClientConfiguration& clientConfiguration,
                      std::shared_ptr<FSxEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FSxErrorMarshaller>(ALLOCATION_TAG)),
@@ -134,7 +134,7 @@ FSxClient::FSxClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   FSxClient::FSxClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FSxErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-gamelift/source/GameLiftClient.cpp
+++ b/generated/src/aws-cpp-sdk-gamelift/source/GameLiftClient.cpp
@@ -146,7 +146,7 @@ GameLiftClient::GameLiftClient(const GameLift::GameLiftClientConfiguration& clie
                                std::shared_ptr<GameLiftEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GameLiftErrorMarshaller>(ALLOCATION_TAG)),
@@ -193,7 +193,7 @@ GameLiftClient::GameLiftClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   GameLiftClient::GameLiftClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GameLiftErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-glacier/source/GlacierClient.cpp
+++ b/generated/src/aws-cpp-sdk-glacier/source/GlacierClient.cpp
@@ -75,7 +75,7 @@ GlacierClient::GlacierClient(const Glacier::GlacierClientConfiguration& clientCo
                              std::shared_ptr<GlacierEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GlacierErrorMarshaller>(ALLOCATION_TAG)),
@@ -122,7 +122,7 @@ GlacierClient::GlacierClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   GlacierClient::GlacierClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GlacierErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-globalaccelerator/source/GlobalAcceleratorClient.cpp
+++ b/generated/src/aws-cpp-sdk-globalaccelerator/source/GlobalAcceleratorClient.cpp
@@ -98,7 +98,7 @@ GlobalAcceleratorClient::GlobalAcceleratorClient(const GlobalAccelerator::Global
                                                  std::shared_ptr<GlobalAcceleratorEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GlobalAcceleratorErrorMarshaller>(ALLOCATION_TAG)),
@@ -145,7 +145,7 @@ GlobalAcceleratorClient::GlobalAcceleratorClient(const std::shared_ptr<AWSCreden
   GlobalAcceleratorClient::GlobalAcceleratorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GlobalAcceleratorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-glue/source/GlueClient.cpp
+++ b/generated/src/aws-cpp-sdk-glue/source/GlueClient.cpp
@@ -142,7 +142,7 @@ GlueClient::GlueClient(const Glue::GlueClientConfiguration& clientConfiguration,
                        std::shared_ptr<GlueEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GlueErrorMarshaller>(ALLOCATION_TAG)),
@@ -189,7 +189,7 @@ GlueClient::GlueClient(const std::shared_ptr<AWSCredentialsProvider>& credential
   GlueClient::GlueClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GlueErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-grafana/source/ManagedGrafanaClient.cpp
+++ b/generated/src/aws-cpp-sdk-grafana/source/ManagedGrafanaClient.cpp
@@ -61,7 +61,7 @@ ManagedGrafanaClient::ManagedGrafanaClient(const ManagedGrafana::ManagedGrafanaC
                                            std::shared_ptr<ManagedGrafanaEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ManagedGrafanaErrorMarshaller>(ALLOCATION_TAG)),
@@ -108,7 +108,7 @@ ManagedGrafanaClient::ManagedGrafanaClient(const std::shared_ptr<AWSCredentialsP
   ManagedGrafanaClient::ManagedGrafanaClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ManagedGrafanaErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-greengrass/source/GreengrassClient.cpp
+++ b/generated/src/aws-cpp-sdk-greengrass/source/GreengrassClient.cpp
@@ -134,7 +134,7 @@ GreengrassClient::GreengrassClient(const Greengrass::GreengrassClientConfigurati
                                    std::shared_ptr<GreengrassEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GreengrassErrorMarshaller>(ALLOCATION_TAG)),
@@ -181,7 +181,7 @@ GreengrassClient::GreengrassClient(const std::shared_ptr<AWSCredentialsProvider>
   GreengrassClient::GreengrassClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GreengrassErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-greengrassv2/source/GreengrassV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-greengrassv2/source/GreengrassV2Client.cpp
@@ -71,7 +71,7 @@ GreengrassV2Client::GreengrassV2Client(const GreengrassV2::GreengrassV2ClientCon
                                        std::shared_ptr<GreengrassV2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GreengrassV2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -118,7 +118,7 @@ GreengrassV2Client::GreengrassV2Client(const std::shared_ptr<AWSCredentialsProvi
   GreengrassV2Client::GreengrassV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GreengrassV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-groundstation/source/GroundStationClient.cpp
+++ b/generated/src/aws-cpp-sdk-groundstation/source/GroundStationClient.cpp
@@ -75,7 +75,7 @@ GroundStationClient::GroundStationClient(const GroundStation::GroundStationClien
                                          std::shared_ptr<GroundStationEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GroundStationErrorMarshaller>(ALLOCATION_TAG)),
@@ -122,7 +122,7 @@ GroundStationClient::GroundStationClient(const std::shared_ptr<AWSCredentialsPro
   GroundStationClient::GroundStationClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GroundStationErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-guardduty/source/GuardDutyClient.cpp
+++ b/generated/src/aws-cpp-sdk-guardduty/source/GuardDutyClient.cpp
@@ -108,7 +108,7 @@ GuardDutyClient::GuardDutyClient(const GuardDuty::GuardDutyClientConfiguration& 
                                  std::shared_ptr<GuardDutyEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GuardDutyErrorMarshaller>(ALLOCATION_TAG)),
@@ -155,7 +155,7 @@ GuardDutyClient::GuardDutyClient(const std::shared_ptr<AWSCredentialsProvider>& 
   GuardDutyClient::GuardDutyClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GuardDutyErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-health/source/HealthClient.cpp
+++ b/generated/src/aws-cpp-sdk-health/source/HealthClient.cpp
@@ -56,7 +56,7 @@ HealthClient::HealthClient(const Health::HealthClientConfiguration& clientConfig
                            std::shared_ptr<HealthEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<HealthErrorMarshaller>(ALLOCATION_TAG)),
@@ -103,7 +103,7 @@ HealthClient::HealthClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   HealthClient::HealthClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<HealthErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-healthlake/source/HealthLakeClient.cpp
+++ b/generated/src/aws-cpp-sdk-healthlake/source/HealthLakeClient.cpp
@@ -55,7 +55,7 @@ HealthLakeClient::HealthLakeClient(const HealthLake::HealthLakeClientConfigurati
                                    std::shared_ptr<HealthLakeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<HealthLakeErrorMarshaller>(ALLOCATION_TAG)),
@@ -102,7 +102,7 @@ HealthLakeClient::HealthLakeClient(const std::shared_ptr<AWSCredentialsProvider>
   HealthLakeClient::HealthLakeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<HealthLakeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-honeycode/source/HoneycodeClient.cpp
+++ b/generated/src/aws-cpp-sdk-honeycode/source/HoneycodeClient.cpp
@@ -57,7 +57,7 @@ HoneycodeClient::HoneycodeClient(const Honeycode::HoneycodeClientConfiguration& 
                                  std::shared_ptr<HoneycodeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<HoneycodeErrorMarshaller>(ALLOCATION_TAG)),
@@ -104,7 +104,7 @@ HoneycodeClient::HoneycodeClient(const std::shared_ptr<AWSCredentialsProvider>& 
   HoneycodeClient::HoneycodeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<HoneycodeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iam/source/IAMClient.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/IAMClient.cpp
@@ -202,7 +202,7 @@ IAMClient::IAMClient(const IAM::IAMClientConfiguration& clientConfiguration,
                      std::shared_ptr<IAMEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IAMErrorMarshaller>(ALLOCATION_TAG)),
@@ -249,7 +249,7 @@ IAMClient::IAMClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   IAMClient::IAMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IAMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-identitystore/source/IdentityStoreClient.cpp
+++ b/generated/src/aws-cpp-sdk-identitystore/source/IdentityStoreClient.cpp
@@ -61,7 +61,7 @@ IdentityStoreClient::IdentityStoreClient(const IdentityStore::IdentityStoreClien
                                          std::shared_ptr<IdentityStoreEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IdentityStoreErrorMarshaller>(ALLOCATION_TAG)),
@@ -108,7 +108,7 @@ IdentityStoreClient::IdentityStoreClient(const std::shared_ptr<AWSCredentialsPro
   IdentityStoreClient::IdentityStoreClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IdentityStoreErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-imagebuilder/source/ImagebuilderClient.cpp
+++ b/generated/src/aws-cpp-sdk-imagebuilder/source/ImagebuilderClient.cpp
@@ -115,7 +115,7 @@ ImagebuilderClient::ImagebuilderClient(const imagebuilder::ImagebuilderClientCon
                                        std::shared_ptr<ImagebuilderEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ImagebuilderErrorMarshaller>(ALLOCATION_TAG)),
@@ -162,7 +162,7 @@ ImagebuilderClient::ImagebuilderClient(const std::shared_ptr<AWSCredentialsProvi
   ImagebuilderClient::ImagebuilderClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ImagebuilderErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-importexport/source/ImportExportClient.cpp
+++ b/generated/src/aws-cpp-sdk-importexport/source/ImportExportClient.cpp
@@ -49,7 +49,7 @@ ImportExportClient::ImportExportClient(const ImportExport::ImportExportClientCon
                                        std::shared_ptr<ImportExportEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ImportExportErrorMarshaller>(ALLOCATION_TAG)),
@@ -96,7 +96,7 @@ ImportExportClient::ImportExportClient(const std::shared_ptr<AWSCredentialsProvi
   ImportExportClient::ImportExportClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ImportExportErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-inspector-scan/source/InspectorscanClient.cpp
+++ b/generated/src/aws-cpp-sdk-inspector-scan/source/InspectorscanClient.cpp
@@ -43,7 +43,7 @@ InspectorscanClient::InspectorscanClient(const inspectorscan::InspectorscanClien
                                          std::shared_ptr<InspectorscanEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<InspectorscanErrorMarshaller>(ALLOCATION_TAG)),
@@ -90,7 +90,7 @@ InspectorscanClient::InspectorscanClient(const std::shared_ptr<AWSCredentialsPro
   InspectorscanClient::InspectorscanClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<InspectorscanErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-inspector/source/InspectorClient.cpp
+++ b/generated/src/aws-cpp-sdk-inspector/source/InspectorClient.cpp
@@ -79,7 +79,7 @@ InspectorClient::InspectorClient(const Inspector::InspectorClientConfiguration& 
                                  std::shared_ptr<InspectorEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<InspectorErrorMarshaller>(ALLOCATION_TAG)),
@@ -126,7 +126,7 @@ InspectorClient::InspectorClient(const std::shared_ptr<AWSCredentialsProvider>& 
   InspectorClient::InspectorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<InspectorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-inspector2/source/Inspector2Client.cpp
+++ b/generated/src/aws-cpp-sdk-inspector2/source/Inspector2Client.cpp
@@ -88,7 +88,7 @@ Inspector2Client::Inspector2Client(const Inspector2::Inspector2ClientConfigurati
                                    std::shared_ptr<Inspector2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Inspector2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -135,7 +135,7 @@ Inspector2Client::Inspector2Client(const std::shared_ptr<AWSCredentialsProvider>
   Inspector2Client::Inspector2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Inspector2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-internetmonitor/source/InternetMonitorClient.cpp
+++ b/generated/src/aws-cpp-sdk-internetmonitor/source/InternetMonitorClient.cpp
@@ -56,7 +56,7 @@ InternetMonitorClient::InternetMonitorClient(const InternetMonitor::InternetMoni
                                              std::shared_ptr<InternetMonitorEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<InternetMonitorErrorMarshaller>(ALLOCATION_TAG)),
@@ -103,7 +103,7 @@ InternetMonitorClient::InternetMonitorClient(const std::shared_ptr<AWSCredential
   InternetMonitorClient::InternetMonitorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<InternetMonitorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iot-data/source/IoTDataPlaneClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot-data/source/IoTDataPlaneClient.cpp
@@ -49,7 +49,7 @@ IoTDataPlaneClient::IoTDataPlaneClient(const IoTDataPlane::IoTDataPlaneClientCon
                                        std::shared_ptr<IoTDataPlaneEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTDataPlaneErrorMarshaller>(ALLOCATION_TAG)),
@@ -96,7 +96,7 @@ IoTDataPlaneClient::IoTDataPlaneClient(const std::shared_ptr<AWSCredentialsProvi
   IoTDataPlaneClient::IoTDataPlaneClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTDataPlaneErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iot-jobs-data/source/IoTJobsDataPlaneClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot-jobs-data/source/IoTJobsDataPlaneClient.cpp
@@ -46,7 +46,7 @@ IoTJobsDataPlaneClient::IoTJobsDataPlaneClient(const IoTJobsDataPlane::IoTJobsDa
                                                std::shared_ptr<IoTJobsDataPlaneEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTJobsDataPlaneErrorMarshaller>(ALLOCATION_TAG)),
@@ -93,7 +93,7 @@ IoTJobsDataPlaneClient::IoTJobsDataPlaneClient(const std::shared_ptr<AWSCredenti
   IoTJobsDataPlaneClient::IoTJobsDataPlaneClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTJobsDataPlaneErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iot-roborunner/source/IoTRoboRunnerClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot-roborunner/source/IoTRoboRunnerClient.cpp
@@ -62,7 +62,7 @@ IoTRoboRunnerClient::IoTRoboRunnerClient(const IoTRoboRunner::IoTRoboRunnerClien
                                          std::shared_ptr<IoTRoboRunnerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTRoboRunnerErrorMarshaller>(ALLOCATION_TAG)),
@@ -109,7 +109,7 @@ IoTRoboRunnerClient::IoTRoboRunnerClient(const std::shared_ptr<AWSCredentialsPro
   IoTRoboRunnerClient::IoTRoboRunnerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTRoboRunnerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iot/source/IoTClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot/source/IoTClient.cpp
@@ -142,7 +142,7 @@ IoTClient::IoTClient(const IoT::IoTClientConfiguration& clientConfiguration,
                      std::shared_ptr<IoTEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTErrorMarshaller>(ALLOCATION_TAG)),
@@ -189,7 +189,7 @@ IoTClient::IoTClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   IoTClient::IoTClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iot1click-devices/source/IoT1ClickDevicesServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot1click-devices/source/IoT1ClickDevicesServiceClient.cpp
@@ -55,7 +55,7 @@ IoT1ClickDevicesServiceClient::IoT1ClickDevicesServiceClient(const IoT1ClickDevi
                                                              std::shared_ptr<IoT1ClickDevicesServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoT1ClickDevicesServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -102,7 +102,7 @@ IoT1ClickDevicesServiceClient::IoT1ClickDevicesServiceClient(const std::shared_p
   IoT1ClickDevicesServiceClient::IoT1ClickDevicesServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoT1ClickDevicesServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iot1click-projects/source/IoT1ClickProjectsClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot1click-projects/source/IoT1ClickProjectsClient.cpp
@@ -58,7 +58,7 @@ IoT1ClickProjectsClient::IoT1ClickProjectsClient(const IoT1ClickProjects::IoT1Cl
                                                  std::shared_ptr<IoT1ClickProjectsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoT1ClickProjectsErrorMarshaller>(ALLOCATION_TAG)),
@@ -105,7 +105,7 @@ IoT1ClickProjectsClient::IoT1ClickProjectsClient(const std::shared_ptr<AWSCreden
   IoT1ClickProjectsClient::IoT1ClickProjectsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoT1ClickProjectsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotanalytics/source/IoTAnalyticsClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotanalytics/source/IoTAnalyticsClient.cpp
@@ -76,7 +76,7 @@ IoTAnalyticsClient::IoTAnalyticsClient(const IoTAnalytics::IoTAnalyticsClientCon
                                        std::shared_ptr<IoTAnalyticsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTAnalyticsErrorMarshaller>(ALLOCATION_TAG)),
@@ -123,7 +123,7 @@ IoTAnalyticsClient::IoTAnalyticsClient(const std::shared_ptr<AWSCredentialsProvi
   IoTAnalyticsClient::IoTAnalyticsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTAnalyticsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotdeviceadvisor/source/IoTDeviceAdvisorClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotdeviceadvisor/source/IoTDeviceAdvisorClient.cpp
@@ -56,7 +56,7 @@ IoTDeviceAdvisorClient::IoTDeviceAdvisorClient(const IoTDeviceAdvisor::IoTDevice
                                                std::shared_ptr<IoTDeviceAdvisorEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTDeviceAdvisorErrorMarshaller>(ALLOCATION_TAG)),
@@ -103,7 +103,7 @@ IoTDeviceAdvisorClient::IoTDeviceAdvisorClient(const std::shared_ptr<AWSCredenti
   IoTDeviceAdvisorClient::IoTDeviceAdvisorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTDeviceAdvisorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotevents-data/source/IoTEventsDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotevents-data/source/IoTEventsDataClient.cpp
@@ -54,7 +54,7 @@ IoTEventsDataClient::IoTEventsDataClient(const IoTEventsData::IoTEventsDataClien
                                          std::shared_ptr<IoTEventsDataEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTEventsDataErrorMarshaller>(ALLOCATION_TAG)),
@@ -101,7 +101,7 @@ IoTEventsDataClient::IoTEventsDataClient(const std::shared_ptr<AWSCredentialsPro
   IoTEventsDataClient::IoTEventsDataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTEventsDataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotevents/source/IoTEventsClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotevents/source/IoTEventsClient.cpp
@@ -68,7 +68,7 @@ IoTEventsClient::IoTEventsClient(const IoTEvents::IoTEventsClientConfiguration& 
                                  std::shared_ptr<IoTEventsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTEventsErrorMarshaller>(ALLOCATION_TAG)),
@@ -115,7 +115,7 @@ IoTEventsClient::IoTEventsClient(const std::shared_ptr<AWSCredentialsProvider>& 
   IoTEventsClient::IoTEventsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTEventsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotfleethub/source/IoTFleetHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotfleethub/source/IoTFleetHubClient.cpp
@@ -50,7 +50,7 @@ IoTFleetHubClient::IoTFleetHubClient(const IoTFleetHub::IoTFleetHubClientConfigu
                                      std::shared_ptr<IoTFleetHubEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTFleetHubErrorMarshaller>(ALLOCATION_TAG)),
@@ -97,7 +97,7 @@ IoTFleetHubClient::IoTFleetHubClient(const std::shared_ptr<AWSCredentialsProvide
   IoTFleetHubClient::IoTFleetHubClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTFleetHubErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotfleetwise/source/IoTFleetWiseClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotfleetwise/source/IoTFleetWiseClient.cpp
@@ -94,7 +94,7 @@ IoTFleetWiseClient::IoTFleetWiseClient(const IoTFleetWise::IoTFleetWiseClientCon
                                        std::shared_ptr<IoTFleetWiseEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTFleetWiseErrorMarshaller>(ALLOCATION_TAG)),
@@ -141,7 +141,7 @@ IoTFleetWiseClient::IoTFleetWiseClient(const std::shared_ptr<AWSCredentialsProvi
   IoTFleetWiseClient::IoTFleetWiseClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTFleetWiseErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotsecuretunneling/source/IoTSecureTunnelingClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotsecuretunneling/source/IoTSecureTunnelingClient.cpp
@@ -50,7 +50,7 @@ IoTSecureTunnelingClient::IoTSecureTunnelingClient(const IoTSecureTunneling::IoT
                                                    std::shared_ptr<IoTSecureTunnelingEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTSecureTunnelingErrorMarshaller>(ALLOCATION_TAG)),
@@ -97,7 +97,7 @@ IoTSecureTunnelingClient::IoTSecureTunnelingClient(const std::shared_ptr<AWSCred
   IoTSecureTunnelingClient::IoTSecureTunnelingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTSecureTunnelingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotsitewise/source/IoTSiteWiseClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotsitewise/source/IoTSiteWiseClient.cpp
@@ -126,7 +126,7 @@ IoTSiteWiseClient::IoTSiteWiseClient(const IoTSiteWise::IoTSiteWiseClientConfigu
                                      std::shared_ptr<IoTSiteWiseEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTSiteWiseErrorMarshaller>(ALLOCATION_TAG)),
@@ -173,7 +173,7 @@ IoTSiteWiseClient::IoTSiteWiseClient(const std::shared_ptr<AWSCredentialsProvide
   IoTSiteWiseClient::IoTSiteWiseClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTSiteWiseErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotthingsgraph/source/IoTThingsGraphClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotthingsgraph/source/IoTThingsGraphClient.cpp
@@ -42,7 +42,7 @@ IoTThingsGraphClient::IoTThingsGraphClient(const IoTThingsGraph::IoTThingsGraphC
                                            std::shared_ptr<IoTThingsGraphEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTThingsGraphErrorMarshaller>(ALLOCATION_TAG)),
@@ -89,7 +89,7 @@ IoTThingsGraphClient::IoTThingsGraphClient(const std::shared_ptr<AWSCredentialsP
   IoTThingsGraphClient::IoTThingsGraphClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTThingsGraphErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iottwinmaker/source/IoTTwinMakerClient.cpp
+++ b/generated/src/aws-cpp-sdk-iottwinmaker/source/IoTTwinMakerClient.cpp
@@ -82,7 +82,7 @@ IoTTwinMakerClient::IoTTwinMakerClient(const IoTTwinMaker::IoTTwinMakerClientCon
                                        std::shared_ptr<IoTTwinMakerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTTwinMakerErrorMarshaller>(ALLOCATION_TAG)),
@@ -129,7 +129,7 @@ IoTTwinMakerClient::IoTTwinMakerClient(const std::shared_ptr<AWSCredentialsProvi
   IoTTwinMakerClient::IoTTwinMakerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTTwinMakerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotwireless/source/IoTWirelessClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotwireless/source/IoTWirelessClient.cpp
@@ -146,7 +146,7 @@ IoTWirelessClient::IoTWirelessClient(const IoTWireless::IoTWirelessClientConfigu
                                      std::shared_ptr<IoTWirelessEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTWirelessErrorMarshaller>(ALLOCATION_TAG)),
@@ -193,7 +193,7 @@ IoTWirelessClient::IoTWirelessClient(const std::shared_ptr<AWSCredentialsProvide
   IoTWirelessClient::IoTWirelessClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTWirelessErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ivs-realtime/source/IvsrealtimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-ivs-realtime/source/IvsrealtimeClient.cpp
@@ -69,7 +69,7 @@ IvsrealtimeClient::IvsrealtimeClient(const ivsrealtime::IvsrealtimeClientConfigu
                                      std::shared_ptr<IvsrealtimeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IvsrealtimeErrorMarshaller>(ALLOCATION_TAG)),
@@ -116,7 +116,7 @@ IvsrealtimeClient::IvsrealtimeClient(const std::shared_ptr<AWSCredentialsProvide
   IvsrealtimeClient::IvsrealtimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IvsrealtimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ivs/source/IVSClient.cpp
+++ b/generated/src/aws-cpp-sdk-ivs/source/IVSClient.cpp
@@ -72,7 +72,7 @@ IVSClient::IVSClient(const IVS::IVSClientConfiguration& clientConfiguration,
                      std::shared_ptr<IVSEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IVSErrorMarshaller>(ALLOCATION_TAG)),
@@ -119,7 +119,7 @@ IVSClient::IVSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   IVSClient::IVSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IVSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ivschat/source/IvschatClient.cpp
+++ b/generated/src/aws-cpp-sdk-ivschat/source/IvschatClient.cpp
@@ -59,7 +59,7 @@ IvschatClient::IvschatClient(const ivschat::IvschatClientConfiguration& clientCo
                              std::shared_ptr<IvschatEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IvschatErrorMarshaller>(ALLOCATION_TAG)),
@@ -106,7 +106,7 @@ IvschatClient::IvschatClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   IvschatClient::IvschatClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IvschatErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kafka/source/KafkaClient.cpp
+++ b/generated/src/aws-cpp-sdk-kafka/source/KafkaClient.cpp
@@ -94,7 +94,7 @@ KafkaClient::KafkaClient(const Kafka::KafkaClientConfiguration& clientConfigurat
                          std::shared_ptr<KafkaEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KafkaErrorMarshaller>(ALLOCATION_TAG)),
@@ -141,7 +141,7 @@ KafkaClient::KafkaClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   KafkaClient::KafkaClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KafkaErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kafkaconnect/source/KafkaConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-kafkaconnect/source/KafkaConnectClient.cpp
@@ -54,7 +54,7 @@ KafkaConnectClient::KafkaConnectClient(const KafkaConnect::KafkaConnectClientCon
                                        std::shared_ptr<KafkaConnectEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KafkaConnectErrorMarshaller>(ALLOCATION_TAG)),
@@ -101,7 +101,7 @@ KafkaConnectClient::KafkaConnectClient(const std::shared_ptr<AWSCredentialsProvi
   KafkaConnectClient::KafkaConnectClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KafkaConnectErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kendra-ranking/source/KendraRankingClient.cpp
+++ b/generated/src/aws-cpp-sdk-kendra-ranking/source/KendraRankingClient.cpp
@@ -51,7 +51,7 @@ KendraRankingClient::KendraRankingClient(const KendraRanking::KendraRankingClien
                                          std::shared_ptr<KendraRankingEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KendraRankingErrorMarshaller>(ALLOCATION_TAG)),
@@ -98,7 +98,7 @@ KendraRankingClient::KendraRankingClient(const std::shared_ptr<AWSCredentialsPro
   KendraRankingClient::KendraRankingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KendraRankingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kendra/source/KendraClient.cpp
+++ b/generated/src/aws-cpp-sdk-kendra/source/KendraClient.cpp
@@ -108,7 +108,7 @@ KendraClient::KendraClient(const kendra::KendraClientConfiguration& clientConfig
                            std::shared_ptr<KendraEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KendraErrorMarshaller>(ALLOCATION_TAG)),
@@ -155,7 +155,7 @@ KendraClient::KendraClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   KendraClient::KendraClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KendraErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-keyspaces/source/KeyspacesClient.cpp
+++ b/generated/src/aws-cpp-sdk-keyspaces/source/KeyspacesClient.cpp
@@ -55,7 +55,7 @@ KeyspacesClient::KeyspacesClient(const Keyspaces::KeyspacesClientConfiguration& 
                                  std::shared_ptr<KeyspacesEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KeyspacesErrorMarshaller>(ALLOCATION_TAG)),
@@ -102,7 +102,7 @@ KeyspacesClient::KeyspacesClient(const std::shared_ptr<AWSCredentialsProvider>& 
   KeyspacesClient::KeyspacesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KeyspacesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesis-video-archived-media/source/KinesisVideoArchivedMediaClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis-video-archived-media/source/KinesisVideoArchivedMediaClient.cpp
@@ -48,7 +48,7 @@ KinesisVideoArchivedMediaClient::KinesisVideoArchivedMediaClient(const KinesisVi
                                                                  std::shared_ptr<KinesisVideoArchivedMediaEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoArchivedMediaErrorMarshaller>(ALLOCATION_TAG)),
@@ -95,7 +95,7 @@ KinesisVideoArchivedMediaClient::KinesisVideoArchivedMediaClient(const std::shar
   KinesisVideoArchivedMediaClient::KinesisVideoArchivedMediaClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoArchivedMediaErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesis-video-media/source/KinesisVideoMediaClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis-video-media/source/KinesisVideoMediaClient.cpp
@@ -43,7 +43,7 @@ KinesisVideoMediaClient::KinesisVideoMediaClient(const KinesisVideoMedia::Kinesi
                                                  std::shared_ptr<KinesisVideoMediaEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoMediaErrorMarshaller>(ALLOCATION_TAG)),
@@ -90,7 +90,7 @@ KinesisVideoMediaClient::KinesisVideoMediaClient(const std::shared_ptr<AWSCreden
   KinesisVideoMediaClient::KinesisVideoMediaClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoMediaErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesis-video-signaling/source/KinesisVideoSignalingChannelsClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis-video-signaling/source/KinesisVideoSignalingChannelsClient.cpp
@@ -44,7 +44,7 @@ KinesisVideoSignalingChannelsClient::KinesisVideoSignalingChannelsClient(const K
                                                                          std::shared_ptr<KinesisVideoSignalingChannelsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoSignalingChannelsErrorMarshaller>(ALLOCATION_TAG)),
@@ -91,7 +91,7 @@ KinesisVideoSignalingChannelsClient::KinesisVideoSignalingChannelsClient(const s
   KinesisVideoSignalingChannelsClient::KinesisVideoSignalingChannelsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoSignalingChannelsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesis-video-webrtc-storage/source/KinesisVideoWebRTCStorageClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis-video-webrtc-storage/source/KinesisVideoWebRTCStorageClient.cpp
@@ -43,7 +43,7 @@ KinesisVideoWebRTCStorageClient::KinesisVideoWebRTCStorageClient(const KinesisVi
                                                                  std::shared_ptr<KinesisVideoWebRTCStorageEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoWebRTCStorageErrorMarshaller>(ALLOCATION_TAG)),
@@ -90,7 +90,7 @@ KinesisVideoWebRTCStorageClient::KinesisVideoWebRTCStorageClient(const std::shar
   KinesisVideoWebRTCStorageClient::KinesisVideoWebRTCStorageClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoWebRTCStorageErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesis/source/KinesisClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis/source/KinesisClient.cpp
@@ -75,7 +75,7 @@ KinesisClient::KinesisClient(const Kinesis::KinesisClientConfiguration& clientCo
                              std::shared_ptr<KinesisEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisErrorMarshaller>(ALLOCATION_TAG)),
@@ -122,7 +122,7 @@ KinesisClient::KinesisClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   KinesisClient::KinesisClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesisanalytics/source/KinesisAnalyticsClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesisanalytics/source/KinesisAnalyticsClient.cpp
@@ -62,7 +62,7 @@ KinesisAnalyticsClient::KinesisAnalyticsClient(const KinesisAnalytics::KinesisAn
                                                std::shared_ptr<KinesisAnalyticsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisAnalyticsErrorMarshaller>(ALLOCATION_TAG)),
@@ -109,7 +109,7 @@ KinesisAnalyticsClient::KinesisAnalyticsClient(const std::shared_ptr<AWSCredenti
   KinesisAnalyticsClient::KinesisAnalyticsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisAnalyticsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesisanalyticsv2/source/KinesisAnalyticsV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-kinesisanalyticsv2/source/KinesisAnalyticsV2Client.cpp
@@ -73,7 +73,7 @@ KinesisAnalyticsV2Client::KinesisAnalyticsV2Client(const KinesisAnalyticsV2::Kin
                                                    std::shared_ptr<KinesisAnalyticsV2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisAnalyticsV2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -120,7 +120,7 @@ KinesisAnalyticsV2Client::KinesisAnalyticsV2Client(const std::shared_ptr<AWSCred
   KinesisAnalyticsV2Client::KinesisAnalyticsV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisAnalyticsV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesisvideo/source/KinesisVideoClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesisvideo/source/KinesisVideoClient.cpp
@@ -72,7 +72,7 @@ KinesisVideoClient::KinesisVideoClient(const KinesisVideo::KinesisVideoClientCon
                                        std::shared_ptr<KinesisVideoEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoErrorMarshaller>(ALLOCATION_TAG)),
@@ -119,7 +119,7 @@ KinesisVideoClient::KinesisVideoClient(const std::shared_ptr<AWSCredentialsProvi
   KinesisVideoClient::KinesisVideoClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kms/source/KMSClient.cpp
+++ b/generated/src/aws-cpp-sdk-kms/source/KMSClient.cpp
@@ -92,7 +92,7 @@ KMSClient::KMSClient(const KMS::KMSClientConfiguration& clientConfiguration,
                      std::shared_ptr<KMSEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KMSErrorMarshaller>(ALLOCATION_TAG)),
@@ -139,7 +139,7 @@ KMSClient::KMSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   KMSClient::KMSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KMSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lakeformation/source/LakeFormationClient.cpp
+++ b/generated/src/aws-cpp-sdk-lakeformation/source/LakeFormationClient.cpp
@@ -96,7 +96,7 @@ LakeFormationClient::LakeFormationClient(const LakeFormation::LakeFormationClien
                                          std::shared_ptr<LakeFormationEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LakeFormationErrorMarshaller>(ALLOCATION_TAG)),
@@ -143,7 +143,7 @@ LakeFormationClient::LakeFormationClient(const std::shared_ptr<AWSCredentialsPro
   LakeFormationClient::LakeFormationClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LakeFormationErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lambda/source/LambdaClient.cpp
+++ b/generated/src/aws-cpp-sdk-lambda/source/LambdaClient.cpp
@@ -108,7 +108,7 @@ LambdaClient::LambdaClient(const Lambda::LambdaClientConfiguration& clientConfig
                            std::shared_ptr<LambdaEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LambdaErrorMarshaller>(ALLOCATION_TAG)),
@@ -155,7 +155,7 @@ LambdaClient::LambdaClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   LambdaClient::LambdaClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LambdaErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-launch-wizard/source/LaunchWizardClient.cpp
+++ b/generated/src/aws-cpp-sdk-launch-wizard/source/LaunchWizardClient.cpp
@@ -50,7 +50,7 @@ LaunchWizardClient::LaunchWizardClient(const LaunchWizard::LaunchWizardClientCon
                                        std::shared_ptr<LaunchWizardEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LaunchWizardErrorMarshaller>(ALLOCATION_TAG)),
@@ -97,7 +97,7 @@ LaunchWizardClient::LaunchWizardClient(const std::shared_ptr<AWSCredentialsProvi
   LaunchWizardClient::LaunchWizardClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LaunchWizardErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lex-models/source/LexModelBuildingServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-lex-models/source/LexModelBuildingServiceClient.cpp
@@ -84,7 +84,7 @@ LexModelBuildingServiceClient::LexModelBuildingServiceClient(const LexModelBuild
                                                              std::shared_ptr<LexModelBuildingServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LexModelBuildingServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -131,7 +131,7 @@ LexModelBuildingServiceClient::LexModelBuildingServiceClient(const std::shared_p
   LexModelBuildingServiceClient::LexModelBuildingServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LexModelBuildingServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lex/source/LexRuntimeServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-lex/source/LexRuntimeServiceClient.cpp
@@ -47,7 +47,7 @@ LexRuntimeServiceClient::LexRuntimeServiceClient(const LexRuntimeService::LexRun
                                                  std::shared_ptr<LexRuntimeServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LexRuntimeServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -94,7 +94,7 @@ LexRuntimeServiceClient::LexRuntimeServiceClient(const std::shared_ptr<AWSCreden
   LexRuntimeServiceClient::LexRuntimeServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LexRuntimeServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lexv2-models/source/LexModelsV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-lexv2-models/source/LexModelsV2Client.cpp
@@ -138,7 +138,7 @@ LexModelsV2Client::LexModelsV2Client(const LexModelsV2::LexModelsV2ClientConfigu
                                      std::shared_ptr<LexModelsV2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LexModelsV2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -185,7 +185,7 @@ LexModelsV2Client::LexModelsV2Client(const std::shared_ptr<AWSCredentialsProvide
   LexModelsV2Client::LexModelsV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LexModelsV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/source/LexRuntimeV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/source/LexRuntimeV2Client.cpp
@@ -49,7 +49,7 @@ LexRuntimeV2Client::LexRuntimeV2Client(const LexRuntimeV2::LexRuntimeV2ClientCon
                                        std::shared_ptr<LexRuntimeV2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LexRuntimeV2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -96,7 +96,7 @@ LexRuntimeV2Client::LexRuntimeV2Client(const std::shared_ptr<AWSCredentialsProvi
   LexRuntimeV2Client::LexRuntimeV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LexRuntimeV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-license-manager-linux-subscriptions/source/LicenseManagerLinuxSubscriptionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-license-manager-linux-subscriptions/source/LicenseManagerLinuxSubscriptionsClient.cpp
@@ -46,7 +46,7 @@ LicenseManagerLinuxSubscriptionsClient::LicenseManagerLinuxSubscriptionsClient(c
                                                                                std::shared_ptr<LicenseManagerLinuxSubscriptionsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LicenseManagerLinuxSubscriptionsErrorMarshaller>(ALLOCATION_TAG)),
@@ -93,7 +93,7 @@ LicenseManagerLinuxSubscriptionsClient::LicenseManagerLinuxSubscriptionsClient(c
   LicenseManagerLinuxSubscriptionsClient::LicenseManagerLinuxSubscriptionsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LicenseManagerLinuxSubscriptionsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-license-manager-user-subscriptions/source/LicenseManagerUserSubscriptionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-license-manager-user-subscriptions/source/LicenseManagerUserSubscriptionsClient.cpp
@@ -53,7 +53,7 @@ LicenseManagerUserSubscriptionsClient::LicenseManagerUserSubscriptionsClient(con
                                                                              std::shared_ptr<LicenseManagerUserSubscriptionsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LicenseManagerUserSubscriptionsErrorMarshaller>(ALLOCATION_TAG)),
@@ -100,7 +100,7 @@ LicenseManagerUserSubscriptionsClient::LicenseManagerUserSubscriptionsClient(con
   LicenseManagerUserSubscriptionsClient::LicenseManagerUserSubscriptionsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LicenseManagerUserSubscriptionsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-license-manager/source/LicenseManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-license-manager/source/LicenseManagerClient.cpp
@@ -92,7 +92,7 @@ LicenseManagerClient::LicenseManagerClient(const LicenseManager::LicenseManagerC
                                            std::shared_ptr<LicenseManagerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LicenseManagerErrorMarshaller>(ALLOCATION_TAG)),
@@ -139,7 +139,7 @@ LicenseManagerClient::LicenseManagerClient(const std::shared_ptr<AWSCredentialsP
   LicenseManagerClient::LicenseManagerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LicenseManagerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lightsail/source/LightsailClient.cpp
+++ b/generated/src/aws-cpp-sdk-lightsail/source/LightsailClient.cpp
@@ -203,7 +203,7 @@ LightsailClient::LightsailClient(const Lightsail::LightsailClientConfiguration& 
                                  std::shared_ptr<LightsailEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LightsailErrorMarshaller>(ALLOCATION_TAG)),
@@ -250,7 +250,7 @@ LightsailClient::LightsailClient(const std::shared_ptr<AWSCredentialsProvider>& 
   LightsailClient::LightsailClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LightsailErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-location/source/LocationServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-location/source/LocationServiceClient.cpp
@@ -100,7 +100,7 @@ LocationServiceClient::LocationServiceClient(const LocationService::LocationServ
                                              std::shared_ptr<LocationServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LocationServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -147,7 +147,7 @@ LocationServiceClient::LocationServiceClient(const std::shared_ptr<AWSCredential
   LocationServiceClient::LocationServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LocationServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-logs/source/CloudWatchLogsClient.cpp
+++ b/generated/src/aws-cpp-sdk-logs/source/CloudWatchLogsClient.cpp
@@ -114,7 +114,7 @@ CloudWatchLogsClient::CloudWatchLogsClient(const CloudWatchLogs::CloudWatchLogsC
                                            std::shared_ptr<CloudWatchLogsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchLogsErrorMarshaller>(ALLOCATION_TAG)),
@@ -161,7 +161,7 @@ CloudWatchLogsClient::CloudWatchLogsClient(const std::shared_ptr<AWSCredentialsP
   CloudWatchLogsClient::CloudWatchLogsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchLogsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lookoutequipment/source/LookoutEquipmentClient.cpp
+++ b/generated/src/aws-cpp-sdk-lookoutequipment/source/LookoutEquipmentClient.cpp
@@ -91,7 +91,7 @@ LookoutEquipmentClient::LookoutEquipmentClient(const LookoutEquipment::LookoutEq
                                                std::shared_ptr<LookoutEquipmentEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LookoutEquipmentErrorMarshaller>(ALLOCATION_TAG)),
@@ -138,7 +138,7 @@ LookoutEquipmentClient::LookoutEquipmentClient(const std::shared_ptr<AWSCredenti
   LookoutEquipmentClient::LookoutEquipmentClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LookoutEquipmentErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lookoutmetrics/source/LookoutMetricsClient.cpp
+++ b/generated/src/aws-cpp-sdk-lookoutmetrics/source/LookoutMetricsClient.cpp
@@ -72,7 +72,7 @@ LookoutMetricsClient::LookoutMetricsClient(const LookoutMetrics::LookoutMetricsC
                                            std::shared_ptr<LookoutMetricsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LookoutMetricsErrorMarshaller>(ALLOCATION_TAG)),
@@ -119,7 +119,7 @@ LookoutMetricsClient::LookoutMetricsClient(const std::shared_ptr<AWSCredentialsP
   LookoutMetricsClient::LookoutMetricsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LookoutMetricsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lookoutvision/source/LookoutforVisionClient.cpp
+++ b/generated/src/aws-cpp-sdk-lookoutvision/source/LookoutforVisionClient.cpp
@@ -64,7 +64,7 @@ LookoutforVisionClient::LookoutforVisionClient(const LookoutforVision::Lookoutfo
                                                std::shared_ptr<LookoutforVisionEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LookoutforVisionErrorMarshaller>(ALLOCATION_TAG)),
@@ -111,7 +111,7 @@ LookoutforVisionClient::LookoutforVisionClient(const std::shared_ptr<AWSCredenti
   LookoutforVisionClient::LookoutforVisionClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LookoutforVisionErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-m2/source/MainframeModernizationClient.cpp
+++ b/generated/src/aws-cpp-sdk-m2/source/MainframeModernizationClient.cpp
@@ -75,7 +75,7 @@ MainframeModernizationClient::MainframeModernizationClient(const MainframeModern
                                                            std::shared_ptr<MainframeModernizationEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MainframeModernizationErrorMarshaller>(ALLOCATION_TAG)),
@@ -122,7 +122,7 @@ MainframeModernizationClient::MainframeModernizationClient(const std::shared_ptr
   MainframeModernizationClient::MainframeModernizationClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MainframeModernizationErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-machinelearning/source/MachineLearningClient.cpp
+++ b/generated/src/aws-cpp-sdk-machinelearning/source/MachineLearningClient.cpp
@@ -70,7 +70,7 @@ MachineLearningClient::MachineLearningClient(const MachineLearning::MachineLearn
                                              std::shared_ptr<MachineLearningEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MachineLearningErrorMarshaller>(ALLOCATION_TAG)),
@@ -117,7 +117,7 @@ MachineLearningClient::MachineLearningClient(const std::shared_ptr<AWSCredential
   MachineLearningClient::MachineLearningClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MachineLearningErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-macie2/source/Macie2Client.cpp
+++ b/generated/src/aws-cpp-sdk-macie2/source/Macie2Client.cpp
@@ -121,7 +121,7 @@ Macie2Client::Macie2Client(const Macie2::Macie2ClientConfiguration& clientConfig
                            std::shared_ptr<Macie2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Macie2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -168,7 +168,7 @@ Macie2Client::Macie2Client(const std::shared_ptr<AWSCredentialsProvider>& creden
   Macie2Client::Macie2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Macie2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-managedblockchain-query/source/ManagedBlockchainQueryClient.cpp
+++ b/generated/src/aws-cpp-sdk-managedblockchain-query/source/ManagedBlockchainQueryClient.cpp
@@ -50,7 +50,7 @@ ManagedBlockchainQueryClient::ManagedBlockchainQueryClient(const ManagedBlockcha
                                                            std::shared_ptr<ManagedBlockchainQueryEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ManagedBlockchainQueryErrorMarshaller>(ALLOCATION_TAG)),
@@ -97,7 +97,7 @@ ManagedBlockchainQueryClient::ManagedBlockchainQueryClient(const std::shared_ptr
   ManagedBlockchainQueryClient::ManagedBlockchainQueryClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ManagedBlockchainQueryErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-managedblockchain/source/ManagedBlockchainClient.cpp
+++ b/generated/src/aws-cpp-sdk-managedblockchain/source/ManagedBlockchainClient.cpp
@@ -69,7 +69,7 @@ ManagedBlockchainClient::ManagedBlockchainClient(const ManagedBlockchain::Manage
                                                  std::shared_ptr<ManagedBlockchainEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ManagedBlockchainErrorMarshaller>(ALLOCATION_TAG)),
@@ -116,7 +116,7 @@ ManagedBlockchainClient::ManagedBlockchainClient(const std::shared_ptr<AWSCreden
   ManagedBlockchainClient::ManagedBlockchainClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ManagedBlockchainErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-marketplace-agreement/source/AgreementServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplace-agreement/source/AgreementServiceClient.cpp
@@ -45,7 +45,7 @@ AgreementServiceClient::AgreementServiceClient(const AgreementService::Agreement
                                                std::shared_ptr<AgreementServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AgreementServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -92,7 +92,7 @@ AgreementServiceClient::AgreementServiceClient(const std::shared_ptr<AWSCredenti
   AgreementServiceClient::AgreementServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AgreementServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-marketplace-catalog/source/MarketplaceCatalogClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplace-catalog/source/MarketplaceCatalogClient.cpp
@@ -55,7 +55,7 @@ MarketplaceCatalogClient::MarketplaceCatalogClient(const MarketplaceCatalog::Mar
                                                    std::shared_ptr<MarketplaceCatalogEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceCatalogErrorMarshaller>(ALLOCATION_TAG)),
@@ -102,7 +102,7 @@ MarketplaceCatalogClient::MarketplaceCatalogClient(const std::shared_ptr<AWSCred
   MarketplaceCatalogClient::MarketplaceCatalogClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceCatalogErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-marketplace-deployment/source/MarketplaceDeploymentClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplace-deployment/source/MarketplaceDeploymentClient.cpp
@@ -46,7 +46,7 @@ MarketplaceDeploymentClient::MarketplaceDeploymentClient(const MarketplaceDeploy
                                                          std::shared_ptr<MarketplaceDeploymentEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceDeploymentErrorMarshaller>(ALLOCATION_TAG)),
@@ -93,7 +93,7 @@ MarketplaceDeploymentClient::MarketplaceDeploymentClient(const std::shared_ptr<A
   MarketplaceDeploymentClient::MarketplaceDeploymentClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceDeploymentErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-marketplace-entitlement/source/MarketplaceEntitlementServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplace-entitlement/source/MarketplaceEntitlementServiceClient.cpp
@@ -43,7 +43,7 @@ MarketplaceEntitlementServiceClient::MarketplaceEntitlementServiceClient(const M
                                                                          std::shared_ptr<MarketplaceEntitlementServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceEntitlementServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -90,7 +90,7 @@ MarketplaceEntitlementServiceClient::MarketplaceEntitlementServiceClient(const s
   MarketplaceEntitlementServiceClient::MarketplaceEntitlementServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceEntitlementServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-marketplacecommerceanalytics/source/MarketplaceCommerceAnalyticsClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplacecommerceanalytics/source/MarketplaceCommerceAnalyticsClient.cpp
@@ -43,7 +43,7 @@ MarketplaceCommerceAnalyticsClient::MarketplaceCommerceAnalyticsClient(const Mar
                                                                        std::shared_ptr<MarketplaceCommerceAnalyticsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceCommerceAnalyticsErrorMarshaller>(ALLOCATION_TAG)),
@@ -90,7 +90,7 @@ MarketplaceCommerceAnalyticsClient::MarketplaceCommerceAnalyticsClient(const std
   MarketplaceCommerceAnalyticsClient::MarketplaceCommerceAnalyticsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceCommerceAnalyticsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediaconnect/source/MediaConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediaconnect/source/MediaConnectClient.cpp
@@ -93,7 +93,7 @@ MediaConnectClient::MediaConnectClient(const MediaConnect::MediaConnectClientCon
                                        std::shared_ptr<MediaConnectEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaConnectErrorMarshaller>(ALLOCATION_TAG)),
@@ -140,7 +140,7 @@ MediaConnectClient::MediaConnectClient(const std::shared_ptr<AWSCredentialsProvi
   MediaConnectClient::MediaConnectClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaConnectErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediaconvert/source/MediaConvertClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediaconvert/source/MediaConvertClient.cpp
@@ -70,7 +70,7 @@ MediaConvertClient::MediaConvertClient(const MediaConvert::MediaConvertClientCon
                                        std::shared_ptr<MediaConvertEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaConvertErrorMarshaller>(ALLOCATION_TAG)),
@@ -117,7 +117,7 @@ MediaConvertClient::MediaConvertClient(const std::shared_ptr<AWSCredentialsProvi
   MediaConvertClient::MediaConvertClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaConvertErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-medialive/source/MediaLiveClient.cpp
+++ b/generated/src/aws-cpp-sdk-medialive/source/MediaLiveClient.cpp
@@ -106,7 +106,7 @@ MediaLiveClient::MediaLiveClient(const MediaLive::MediaLiveClientConfiguration& 
                                  std::shared_ptr<MediaLiveEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaLiveErrorMarshaller>(ALLOCATION_TAG)),
@@ -153,7 +153,7 @@ MediaLiveClient::MediaLiveClient(const std::shared_ptr<AWSCredentialsProvider>& 
   MediaLiveClient::MediaLiveClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaLiveErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediapackage-vod/source/MediaPackageVodClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediapackage-vod/source/MediaPackageVodClient.cpp
@@ -59,7 +59,7 @@ MediaPackageVodClient::MediaPackageVodClient(const MediaPackageVod::MediaPackage
                                              std::shared_ptr<MediaPackageVodEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaPackageVodErrorMarshaller>(ALLOCATION_TAG)),
@@ -106,7 +106,7 @@ MediaPackageVodClient::MediaPackageVodClient(const std::shared_ptr<AWSCredential
   MediaPackageVodClient::MediaPackageVodClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaPackageVodErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediapackage/source/MediaPackageClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediapackage/source/MediaPackageClient.cpp
@@ -60,7 +60,7 @@ MediaPackageClient::MediaPackageClient(const MediaPackage::MediaPackageClientCon
                                        std::shared_ptr<MediaPackageEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaPackageErrorMarshaller>(ALLOCATION_TAG)),
@@ -107,7 +107,7 @@ MediaPackageClient::MediaPackageClient(const std::shared_ptr<AWSCredentialsProvi
   MediaPackageClient::MediaPackageClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaPackageErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediapackagev2/source/Mediapackagev2Client.cpp
+++ b/generated/src/aws-cpp-sdk-mediapackagev2/source/Mediapackagev2Client.cpp
@@ -66,7 +66,7 @@ Mediapackagev2Client::Mediapackagev2Client(const mediapackagev2::Mediapackagev2C
                                            std::shared_ptr<Mediapackagev2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Mediapackagev2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -113,7 +113,7 @@ Mediapackagev2Client::Mediapackagev2Client(const std::shared_ptr<AWSCredentialsP
   Mediapackagev2Client::Mediapackagev2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Mediapackagev2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediastore-data/source/MediaStoreDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediastore-data/source/MediaStoreDataClient.cpp
@@ -47,7 +47,7 @@ MediaStoreDataClient::MediaStoreDataClient(const MediaStoreData::MediaStoreDataC
                                            std::shared_ptr<MediaStoreDataEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaStoreDataErrorMarshaller>(ALLOCATION_TAG)),
@@ -94,7 +94,7 @@ MediaStoreDataClient::MediaStoreDataClient(const std::shared_ptr<AWSCredentialsP
   MediaStoreDataClient::MediaStoreDataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaStoreDataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediastore/source/MediaStoreClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediastore/source/MediaStoreClient.cpp
@@ -63,7 +63,7 @@ MediaStoreClient::MediaStoreClient(const MediaStore::MediaStoreClientConfigurati
                                    std::shared_ptr<MediaStoreEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaStoreErrorMarshaller>(ALLOCATION_TAG)),
@@ -110,7 +110,7 @@ MediaStoreClient::MediaStoreClient(const std::shared_ptr<AWSCredentialsProvider>
   MediaStoreClient::MediaStoreClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaStoreErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediatailor/source/MediaTailorClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediatailor/source/MediaTailorClient.cpp
@@ -86,7 +86,7 @@ MediaTailorClient::MediaTailorClient(const MediaTailor::MediaTailorClientConfigu
                                      std::shared_ptr<MediaTailorEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaTailorErrorMarshaller>(ALLOCATION_TAG)),
@@ -133,7 +133,7 @@ MediaTailorClient::MediaTailorClient(const std::shared_ptr<AWSCredentialsProvide
   MediaTailorClient::MediaTailorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaTailorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-medical-imaging/source/MedicalImagingClient.cpp
+++ b/generated/src/aws-cpp-sdk-medical-imaging/source/MedicalImagingClient.cpp
@@ -60,7 +60,7 @@ MedicalImagingClient::MedicalImagingClient(const MedicalImaging::MedicalImagingC
                                            std::shared_ptr<MedicalImagingEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MedicalImagingErrorMarshaller>(ALLOCATION_TAG)),
@@ -107,7 +107,7 @@ MedicalImagingClient::MedicalImagingClient(const std::shared_ptr<AWSCredentialsP
   MedicalImagingClient::MedicalImagingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MedicalImagingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-memorydb/source/MemoryDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-memorydb/source/MemoryDBClient.cpp
@@ -80,7 +80,7 @@ MemoryDBClient::MemoryDBClient(const MemoryDB::MemoryDBClientConfiguration& clie
                                std::shared_ptr<MemoryDBEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MemoryDBErrorMarshaller>(ALLOCATION_TAG)),
@@ -127,7 +127,7 @@ MemoryDBClient::MemoryDBClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   MemoryDBClient::MemoryDBClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MemoryDBErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-meteringmarketplace/source/MarketplaceMeteringClient.cpp
+++ b/generated/src/aws-cpp-sdk-meteringmarketplace/source/MarketplaceMeteringClient.cpp
@@ -46,7 +46,7 @@ MarketplaceMeteringClient::MarketplaceMeteringClient(const MarketplaceMetering::
                                                      std::shared_ptr<MarketplaceMeteringEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceMeteringErrorMarshaller>(ALLOCATION_TAG)),
@@ -93,7 +93,7 @@ MarketplaceMeteringClient::MarketplaceMeteringClient(const std::shared_ptr<AWSCr
   MarketplaceMeteringClient::MarketplaceMeteringClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceMeteringErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mgn/source/MgnClient.cpp
+++ b/generated/src/aws-cpp-sdk-mgn/source/MgnClient.cpp
@@ -112,7 +112,7 @@ MgnClient::MgnClient(const mgn::MgnClientConfiguration& clientConfiguration,
                      std::shared_ptr<MgnEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MgnErrorMarshaller>(ALLOCATION_TAG)),
@@ -159,7 +159,7 @@ MgnClient::MgnClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   MgnClient::MgnClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MgnErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-migration-hub-refactor-spaces/source/MigrationHubRefactorSpacesClient.cpp
+++ b/generated/src/aws-cpp-sdk-migration-hub-refactor-spaces/source/MigrationHubRefactorSpacesClient.cpp
@@ -66,7 +66,7 @@ MigrationHubRefactorSpacesClient::MigrationHubRefactorSpacesClient(const Migrati
                                                                    std::shared_ptr<MigrationHubRefactorSpacesEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubRefactorSpacesErrorMarshaller>(ALLOCATION_TAG)),
@@ -113,7 +113,7 @@ MigrationHubRefactorSpacesClient::MigrationHubRefactorSpacesClient(const std::sh
   MigrationHubRefactorSpacesClient::MigrationHubRefactorSpacesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubRefactorSpacesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-migrationhub-config/source/MigrationHubConfigClient.cpp
+++ b/generated/src/aws-cpp-sdk-migrationhub-config/source/MigrationHubConfigClient.cpp
@@ -46,7 +46,7 @@ MigrationHubConfigClient::MigrationHubConfigClient(const MigrationHubConfig::Mig
                                                    std::shared_ptr<MigrationHubConfigEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubConfigErrorMarshaller>(ALLOCATION_TAG)),
@@ -93,7 +93,7 @@ MigrationHubConfigClient::MigrationHubConfigClient(const std::shared_ptr<AWSCred
   MigrationHubConfigClient::MigrationHubConfigClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubConfigErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-migrationhuborchestrator/source/MigrationHubOrchestratorClient.cpp
+++ b/generated/src/aws-cpp-sdk-migrationhuborchestrator/source/MigrationHubOrchestratorClient.cpp
@@ -70,7 +70,7 @@ MigrationHubOrchestratorClient::MigrationHubOrchestratorClient(const MigrationHu
                                                                std::shared_ptr<MigrationHubOrchestratorEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubOrchestratorErrorMarshaller>(ALLOCATION_TAG)),
@@ -117,7 +117,7 @@ MigrationHubOrchestratorClient::MigrationHubOrchestratorClient(const std::shared
   MigrationHubOrchestratorClient::MigrationHubOrchestratorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubOrchestratorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-migrationhubstrategy/source/MigrationHubStrategyRecommendationsClient.cpp
+++ b/generated/src/aws-cpp-sdk-migrationhubstrategy/source/MigrationHubStrategyRecommendationsClient.cpp
@@ -64,7 +64,7 @@ MigrationHubStrategyRecommendationsClient::MigrationHubStrategyRecommendationsCl
                                                                                      std::shared_ptr<MigrationHubStrategyRecommendationsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubStrategyRecommendationsErrorMarshaller>(ALLOCATION_TAG)),
@@ -111,7 +111,7 @@ MigrationHubStrategyRecommendationsClient::MigrationHubStrategyRecommendationsCl
   MigrationHubStrategyRecommendationsClient::MigrationHubStrategyRecommendationsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubStrategyRecommendationsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mobile/source/MobileClient.cpp
+++ b/generated/src/aws-cpp-sdk-mobile/source/MobileClient.cpp
@@ -51,7 +51,7 @@ MobileClient::MobileClient(const Mobile::MobileClientConfiguration& clientConfig
                            std::shared_ptr<MobileEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MobileErrorMarshaller>(ALLOCATION_TAG)),
@@ -98,7 +98,7 @@ MobileClient::MobileClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   MobileClient::MobileClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MobileErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-monitoring/source/CloudWatchClient.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/CloudWatchClient.cpp
@@ -81,7 +81,7 @@ CloudWatchClient::CloudWatchClient(const CloudWatch::CloudWatchClientConfigurati
                                    std::shared_ptr<CloudWatchEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchErrorMarshaller>(ALLOCATION_TAG)),
@@ -128,7 +128,7 @@ CloudWatchClient::CloudWatchClient(const std::shared_ptr<AWSCredentialsProvider>
   CloudWatchClient::CloudWatchClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mq/source/MQClient.cpp
+++ b/generated/src/aws-cpp-sdk-mq/source/MQClient.cpp
@@ -65,7 +65,7 @@ MQClient::MQClient(const MQ::MQClientConfiguration& clientConfiguration,
                    std::shared_ptr<MQEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MQErrorMarshaller>(ALLOCATION_TAG)),
@@ -112,7 +112,7 @@ MQClient::MQClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsPro
   MQClient::MQClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MQErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mturk-requester/source/MTurkClient.cpp
+++ b/generated/src/aws-cpp-sdk-mturk-requester/source/MTurkClient.cpp
@@ -81,7 +81,7 @@ MTurkClient::MTurkClient(const MTurk::MTurkClientConfiguration& clientConfigurat
                          std::shared_ptr<MTurkEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MTurkErrorMarshaller>(ALLOCATION_TAG)),
@@ -128,7 +128,7 @@ MTurkClient::MTurkClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   MTurkClient::MTurkClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MTurkErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mwaa/source/MWAAClient.cpp
+++ b/generated/src/aws-cpp-sdk-mwaa/source/MWAAClient.cpp
@@ -52,7 +52,7 @@ MWAAClient::MWAAClient(const MWAA::MWAAClientConfiguration& clientConfiguration,
                        std::shared_ptr<MWAAEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MWAAErrorMarshaller>(ALLOCATION_TAG)),
@@ -99,7 +99,7 @@ MWAAClient::MWAAClient(const std::shared_ptr<AWSCredentialsProvider>& credential
   MWAAClient::MWAAClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MWAAErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-neptune-graph/source/NeptuneGraphClient.cpp
+++ b/generated/src/aws-cpp-sdk-neptune-graph/source/NeptuneGraphClient.cpp
@@ -64,7 +64,7 @@ NeptuneGraphClient::NeptuneGraphClient(const NeptuneGraph::NeptuneGraphClientCon
                                        std::shared_ptr<NeptuneGraphEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NeptuneGraphErrorMarshaller>(ALLOCATION_TAG)),
@@ -111,7 +111,7 @@ NeptuneGraphClient::NeptuneGraphClient(const std::shared_ptr<AWSCredentialsProvi
   NeptuneGraphClient::NeptuneGraphClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NeptuneGraphErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-neptune/source/NeptuneClient.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/NeptuneClient.cpp
@@ -112,7 +112,7 @@ NeptuneClient::NeptuneClient(const Neptune::NeptuneClientConfiguration& clientCo
                              std::shared_ptr<NeptuneEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NeptuneErrorMarshaller>(ALLOCATION_TAG)),
@@ -159,7 +159,7 @@ NeptuneClient::NeptuneClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   NeptuneClient::NeptuneClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NeptuneErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-neptunedata/source/NeptunedataClient.cpp
+++ b/generated/src/aws-cpp-sdk-neptunedata/source/NeptunedataClient.cpp
@@ -85,7 +85,7 @@ NeptunedataClient::NeptunedataClient(const neptunedata::NeptunedataClientConfigu
                                      std::shared_ptr<NeptunedataEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NeptunedataErrorMarshaller>(ALLOCATION_TAG)),
@@ -132,7 +132,7 @@ NeptunedataClient::NeptunedataClient(const std::shared_ptr<AWSCredentialsProvide
   NeptunedataClient::NeptunedataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NeptunedataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-network-firewall/source/NetworkFirewallClient.cpp
+++ b/generated/src/aws-cpp-sdk-network-firewall/source/NetworkFirewallClient.cpp
@@ -78,7 +78,7 @@ NetworkFirewallClient::NetworkFirewallClient(const NetworkFirewall::NetworkFirew
                                              std::shared_ptr<NetworkFirewallEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NetworkFirewallErrorMarshaller>(ALLOCATION_TAG)),
@@ -125,7 +125,7 @@ NetworkFirewallClient::NetworkFirewallClient(const std::shared_ptr<AWSCredential
   NetworkFirewallClient::NetworkFirewallClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NetworkFirewallErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-networkmanager/source/NetworkManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-networkmanager/source/NetworkManagerClient.cpp
@@ -127,7 +127,7 @@ NetworkManagerClient::NetworkManagerClient(const NetworkManager::NetworkManagerC
                                            std::shared_ptr<NetworkManagerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NetworkManagerErrorMarshaller>(ALLOCATION_TAG)),
@@ -174,7 +174,7 @@ NetworkManagerClient::NetworkManagerClient(const std::shared_ptr<AWSCredentialsP
   NetworkManagerClient::NetworkManagerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NetworkManagerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-networkmonitor/source/NetworkMonitorClient.cpp
+++ b/generated/src/aws-cpp-sdk-networkmonitor/source/NetworkMonitorClient.cpp
@@ -54,7 +54,7 @@ NetworkMonitorClient::NetworkMonitorClient(const NetworkMonitor::NetworkMonitorC
                                            std::shared_ptr<NetworkMonitorEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NetworkMonitorErrorMarshaller>(ALLOCATION_TAG)),
@@ -101,7 +101,7 @@ NetworkMonitorClient::NetworkMonitorClient(const std::shared_ptr<AWSCredentialsP
   NetworkMonitorClient::NetworkMonitorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NetworkMonitorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-nimble/source/NimbleStudioClient.cpp
+++ b/generated/src/aws-cpp-sdk-nimble/source/NimbleStudioClient.cpp
@@ -91,7 +91,7 @@ NimbleStudioClient::NimbleStudioClient(const NimbleStudio::NimbleStudioClientCon
                                        std::shared_ptr<NimbleStudioEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NimbleStudioErrorMarshaller>(ALLOCATION_TAG)),
@@ -138,7 +138,7 @@ NimbleStudioClient::NimbleStudioClient(const std::shared_ptr<AWSCredentialsProvi
   NimbleStudioClient::NimbleStudioClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NimbleStudioErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-oam/source/OAMClient.cpp
+++ b/generated/src/aws-cpp-sdk-oam/source/OAMClient.cpp
@@ -57,7 +57,7 @@ OAMClient::OAMClient(const OAM::OAMClientConfiguration& clientConfiguration,
                      std::shared_ptr<OAMEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OAMErrorMarshaller>(ALLOCATION_TAG)),
@@ -104,7 +104,7 @@ OAMClient::OAMClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   OAMClient::OAMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OAMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-omics/source/OmicsClient.cpp
+++ b/generated/src/aws-cpp-sdk-omics/source/OmicsClient.cpp
@@ -124,7 +124,7 @@ OmicsClient::OmicsClient(const Omics::OmicsClientConfiguration& clientConfigurat
                          std::shared_ptr<OmicsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OmicsErrorMarshaller>(ALLOCATION_TAG)),
@@ -171,7 +171,7 @@ OmicsClient::OmicsClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   OmicsClient::OmicsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OmicsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-opensearch/source/OpenSearchServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-opensearch/source/OpenSearchServiceClient.cpp
@@ -104,7 +104,7 @@ OpenSearchServiceClient::OpenSearchServiceClient(const OpenSearchService::OpenSe
                                                  std::shared_ptr<OpenSearchServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OpenSearchServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -151,7 +151,7 @@ OpenSearchServiceClient::OpenSearchServiceClient(const std::shared_ptr<AWSCreden
   OpenSearchServiceClient::OpenSearchServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OpenSearchServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-opensearchserverless/source/OpenSearchServerlessClient.cpp
+++ b/generated/src/aws-cpp-sdk-opensearchserverless/source/OpenSearchServerlessClient.cpp
@@ -79,7 +79,7 @@ OpenSearchServerlessClient::OpenSearchServerlessClient(const OpenSearchServerles
                                                        std::shared_ptr<OpenSearchServerlessEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OpenSearchServerlessErrorMarshaller>(ALLOCATION_TAG)),
@@ -126,7 +126,7 @@ OpenSearchServerlessClient::OpenSearchServerlessClient(const std::shared_ptr<AWS
   OpenSearchServerlessClient::OpenSearchServerlessClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OpenSearchServerlessErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-opsworks/source/OpsWorksClient.cpp
+++ b/generated/src/aws-cpp-sdk-opsworks/source/OpsWorksClient.cpp
@@ -116,7 +116,7 @@ OpsWorksClient::OpsWorksClient(const OpsWorks::OpsWorksClientConfiguration& clie
                                std::shared_ptr<OpsWorksEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OpsWorksErrorMarshaller>(ALLOCATION_TAG)),
@@ -163,7 +163,7 @@ OpsWorksClient::OpsWorksClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   OpsWorksClient::OpsWorksClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OpsWorksErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-opsworkscm/source/OpsWorksCMClient.cpp
+++ b/generated/src/aws-cpp-sdk-opsworkscm/source/OpsWorksCMClient.cpp
@@ -61,7 +61,7 @@ OpsWorksCMClient::OpsWorksCMClient(const OpsWorksCM::OpsWorksCMClientConfigurati
                                    std::shared_ptr<OpsWorksCMEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OpsWorksCMErrorMarshaller>(ALLOCATION_TAG)),
@@ -108,7 +108,7 @@ OpsWorksCMClient::OpsWorksCMClient(const std::shared_ptr<AWSCredentialsProvider>
   OpsWorksCMClient::OpsWorksCMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OpsWorksCMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-organizations/source/OrganizationsClient.cpp
+++ b/generated/src/aws-cpp-sdk-organizations/source/OrganizationsClient.cpp
@@ -97,7 +97,7 @@ OrganizationsClient::OrganizationsClient(const Organizations::OrganizationsClien
                                          std::shared_ptr<OrganizationsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OrganizationsErrorMarshaller>(ALLOCATION_TAG)),
@@ -144,7 +144,7 @@ OrganizationsClient::OrganizationsClient(const std::shared_ptr<AWSCredentialsPro
   OrganizationsClient::OrganizationsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OrganizationsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-osis/source/OSISClient.cpp
+++ b/generated/src/aws-cpp-sdk-osis/source/OSISClient.cpp
@@ -56,7 +56,7 @@ OSISClient::OSISClient(const OSIS::OSISClientConfiguration& clientConfiguration,
                        std::shared_ptr<OSISEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OSISErrorMarshaller>(ALLOCATION_TAG)),
@@ -103,7 +103,7 @@ OSISClient::OSISClient(const std::shared_ptr<AWSCredentialsProvider>& credential
   OSISClient::OSISClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OSISErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-outposts/source/OutpostsClient.cpp
+++ b/generated/src/aws-cpp-sdk-outposts/source/OutpostsClient.cpp
@@ -68,7 +68,7 @@ OutpostsClient::OutpostsClient(const Outposts::OutpostsClientConfiguration& clie
                                std::shared_ptr<OutpostsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OutpostsErrorMarshaller>(ALLOCATION_TAG)),
@@ -115,7 +115,7 @@ OutpostsClient::OutpostsClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   OutpostsClient::OutpostsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OutpostsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-panorama/source/PanoramaClient.cpp
+++ b/generated/src/aws-cpp-sdk-panorama/source/PanoramaClient.cpp
@@ -76,7 +76,7 @@ PanoramaClient::PanoramaClient(const Panorama::PanoramaClientConfiguration& clie
                                std::shared_ptr<PanoramaEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PanoramaErrorMarshaller>(ALLOCATION_TAG)),
@@ -123,7 +123,7 @@ PanoramaClient::PanoramaClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   PanoramaClient::PanoramaClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PanoramaErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-payment-cryptography-data/source/PaymentCryptographyDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-payment-cryptography-data/source/PaymentCryptographyDataClient.cpp
@@ -53,7 +53,7 @@ PaymentCryptographyDataClient::PaymentCryptographyDataClient(const PaymentCrypto
                                                              std::shared_ptr<PaymentCryptographyDataEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PaymentCryptographyDataErrorMarshaller>(ALLOCATION_TAG)),
@@ -100,7 +100,7 @@ PaymentCryptographyDataClient::PaymentCryptographyDataClient(const std::shared_p
   PaymentCryptographyDataClient::PaymentCryptographyDataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PaymentCryptographyDataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-payment-cryptography/source/PaymentCryptographyClient.cpp
+++ b/generated/src/aws-cpp-sdk-payment-cryptography/source/PaymentCryptographyClient.cpp
@@ -62,7 +62,7 @@ PaymentCryptographyClient::PaymentCryptographyClient(const PaymentCryptography::
                                                      std::shared_ptr<PaymentCryptographyEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PaymentCryptographyErrorMarshaller>(ALLOCATION_TAG)),
@@ -109,7 +109,7 @@ PaymentCryptographyClient::PaymentCryptographyClient(const std::shared_ptr<AWSCr
   PaymentCryptographyClient::PaymentCryptographyClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PaymentCryptographyErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pca-connector-ad/source/PcaConnectorAdClient.cpp
+++ b/generated/src/aws-cpp-sdk-pca-connector-ad/source/PcaConnectorAdClient.cpp
@@ -67,7 +67,7 @@ PcaConnectorAdClient::PcaConnectorAdClient(const PcaConnectorAd::PcaConnectorAdC
                                            std::shared_ptr<PcaConnectorAdEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PcaConnectorAdErrorMarshaller>(ALLOCATION_TAG)),
@@ -114,7 +114,7 @@ PcaConnectorAdClient::PcaConnectorAdClient(const std::shared_ptr<AWSCredentialsP
   PcaConnectorAdClient::PcaConnectorAdClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PcaConnectorAdErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-personalize-events/source/PersonalizeEventsClient.cpp
+++ b/generated/src/aws-cpp-sdk-personalize-events/source/PersonalizeEventsClient.cpp
@@ -47,7 +47,7 @@ PersonalizeEventsClient::PersonalizeEventsClient(const PersonalizeEvents::Person
                                                  std::shared_ptr<PersonalizeEventsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PersonalizeEventsErrorMarshaller>(ALLOCATION_TAG)),
@@ -94,7 +94,7 @@ PersonalizeEventsClient::PersonalizeEventsClient(const std::shared_ptr<AWSCreden
   PersonalizeEventsClient::PersonalizeEventsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PersonalizeEventsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-personalize-runtime/source/PersonalizeRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-personalize-runtime/source/PersonalizeRuntimeClient.cpp
@@ -45,7 +45,7 @@ PersonalizeRuntimeClient::PersonalizeRuntimeClient(const PersonalizeRuntime::Per
                                                    std::shared_ptr<PersonalizeRuntimeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PersonalizeRuntimeErrorMarshaller>(ALLOCATION_TAG)),
@@ -92,7 +92,7 @@ PersonalizeRuntimeClient::PersonalizeRuntimeClient(const std::shared_ptr<AWSCred
   PersonalizeRuntimeClient::PersonalizeRuntimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PersonalizeRuntimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-personalize/source/PersonalizeClient.cpp
+++ b/generated/src/aws-cpp-sdk-personalize/source/PersonalizeClient.cpp
@@ -109,7 +109,7 @@ PersonalizeClient::PersonalizeClient(const Personalize::PersonalizeClientConfigu
                                      std::shared_ptr<PersonalizeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PersonalizeErrorMarshaller>(ALLOCATION_TAG)),
@@ -156,7 +156,7 @@ PersonalizeClient::PersonalizeClient(const std::shared_ptr<AWSCredentialsProvide
   PersonalizeClient::PersonalizeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PersonalizeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pi/source/PIClient.cpp
+++ b/generated/src/aws-cpp-sdk-pi/source/PIClient.cpp
@@ -55,7 +55,7 @@ PIClient::PIClient(const PI::PIClientConfiguration& clientConfiguration,
                    std::shared_ptr<PIEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PIErrorMarshaller>(ALLOCATION_TAG)),
@@ -102,7 +102,7 @@ PIClient::PIClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsPro
   PIClient::PIClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PIErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pinpoint-email/source/PinpointEmailClient.cpp
+++ b/generated/src/aws-cpp-sdk-pinpoint-email/source/PinpointEmailClient.cpp
@@ -84,7 +84,7 @@ PinpointEmailClient::PinpointEmailClient(const PinpointEmail::PinpointEmailClien
                                          std::shared_ptr<PinpointEmailEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PinpointEmailErrorMarshaller>(ALLOCATION_TAG)),
@@ -131,7 +131,7 @@ PinpointEmailClient::PinpointEmailClient(const std::shared_ptr<AWSCredentialsPro
   PinpointEmailClient::PinpointEmailClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PinpointEmailErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pinpoint-sms-voice-v2/source/PinpointSMSVoiceV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-pinpoint-sms-voice-v2/source/PinpointSMSVoiceV2Client.cpp
@@ -111,7 +111,7 @@ PinpointSMSVoiceV2Client::PinpointSMSVoiceV2Client(const PinpointSMSVoiceV2::Pin
                                                    std::shared_ptr<PinpointSMSVoiceV2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PinpointSMSVoiceV2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -158,7 +158,7 @@ PinpointSMSVoiceV2Client::PinpointSMSVoiceV2Client(const std::shared_ptr<AWSCred
   PinpointSMSVoiceV2Client::PinpointSMSVoiceV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PinpointSMSVoiceV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pinpoint/source/PinpointClient.cpp
+++ b/generated/src/aws-cpp-sdk-pinpoint/source/PinpointClient.cpp
@@ -164,7 +164,7 @@ PinpointClient::PinpointClient(const Pinpoint::PinpointClientConfiguration& clie
                                std::shared_ptr<PinpointEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PinpointErrorMarshaller>(ALLOCATION_TAG)),
@@ -211,7 +211,7 @@ PinpointClient::PinpointClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   PinpointClient::PinpointClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PinpointErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pipes/source/PipesClient.cpp
+++ b/generated/src/aws-cpp-sdk-pipes/source/PipesClient.cpp
@@ -52,7 +52,7 @@ PipesClient::PipesClient(const Pipes::PipesClientConfiguration& clientConfigurat
                          std::shared_ptr<PipesEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PipesErrorMarshaller>(ALLOCATION_TAG)),
@@ -99,7 +99,7 @@ PipesClient::PipesClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   PipesClient::PipesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PipesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-polly/source/PollyClient.cpp
+++ b/generated/src/aws-cpp-sdk-polly/source/PollyClient.cpp
@@ -51,7 +51,7 @@ PollyClient::PollyClient(const Polly::PollyClientConfiguration& clientConfigurat
                          std::shared_ptr<PollyEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PollyErrorMarshaller>(ALLOCATION_TAG)),
@@ -98,7 +98,7 @@ PollyClient::PollyClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   PollyClient::PollyClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PollyErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pricing/source/PricingClient.cpp
+++ b/generated/src/aws-cpp-sdk-pricing/source/PricingClient.cpp
@@ -47,7 +47,7 @@ PricingClient::PricingClient(const Pricing::PricingClientConfiguration& clientCo
                              std::shared_ptr<PricingEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PricingErrorMarshaller>(ALLOCATION_TAG)),
@@ -94,7 +94,7 @@ PricingClient::PricingClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   PricingClient::PricingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PricingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-privatenetworks/source/PrivateNetworksClient.cpp
+++ b/generated/src/aws-cpp-sdk-privatenetworks/source/PrivateNetworksClient.cpp
@@ -68,7 +68,7 @@ PrivateNetworksClient::PrivateNetworksClient(const PrivateNetworks::PrivateNetwo
                                              std::shared_ptr<PrivateNetworksEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PrivateNetworksErrorMarshaller>(ALLOCATION_TAG)),
@@ -115,7 +115,7 @@ PrivateNetworksClient::PrivateNetworksClient(const std::shared_ptr<AWSCredential
   PrivateNetworksClient::PrivateNetworksClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PrivateNetworksErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-proton/source/ProtonClient.cpp
+++ b/generated/src/aws-cpp-sdk-proton/source/ProtonClient.cpp
@@ -129,7 +129,7 @@ ProtonClient::ProtonClient(const Proton::ProtonClientConfiguration& clientConfig
                            std::shared_ptr<ProtonEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ProtonErrorMarshaller>(ALLOCATION_TAG)),
@@ -176,7 +176,7 @@ ProtonClient::ProtonClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   ProtonClient::ProtonClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ProtonErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-qbusiness/source/QBusinessClient.cpp
+++ b/generated/src/aws-cpp-sdk-qbusiness/source/QBusinessClient.cpp
@@ -97,7 +97,7 @@ QBusinessClient::QBusinessClient(const QBusiness::QBusinessClientConfiguration& 
                                  std::shared_ptr<QBusinessEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QBusinessErrorMarshaller>(ALLOCATION_TAG)),
@@ -144,7 +144,7 @@ QBusinessClient::QBusinessClient(const std::shared_ptr<AWSCredentialsProvider>& 
   QBusinessClient::QBusinessClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QBusinessErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-qconnect/source/QConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-qconnect/source/QConnectClient.cpp
@@ -82,7 +82,7 @@ QConnectClient::QConnectClient(const QConnect::QConnectClientConfiguration& clie
                                std::shared_ptr<QConnectEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QConnectErrorMarshaller>(ALLOCATION_TAG)),
@@ -129,7 +129,7 @@ QConnectClient::QConnectClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   QConnectClient::QConnectClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QConnectErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-qldb-session/source/QLDBSessionClient.cpp
+++ b/generated/src/aws-cpp-sdk-qldb-session/source/QLDBSessionClient.cpp
@@ -43,7 +43,7 @@ QLDBSessionClient::QLDBSessionClient(const QLDBSession::QLDBSessionClientConfigu
                                      std::shared_ptr<QLDBSessionEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QLDBSessionErrorMarshaller>(ALLOCATION_TAG)),
@@ -90,7 +90,7 @@ QLDBSessionClient::QLDBSessionClient(const std::shared_ptr<AWSCredentialsProvide
   QLDBSessionClient::QLDBSessionClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QLDBSessionErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-qldb/source/QLDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-qldb/source/QLDBClient.cpp
@@ -62,7 +62,7 @@ QLDBClient::QLDBClient(const QLDB::QLDBClientConfiguration& clientConfiguration,
                        std::shared_ptr<QLDBEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QLDBErrorMarshaller>(ALLOCATION_TAG)),
@@ -109,7 +109,7 @@ QLDBClient::QLDBClient(const std::shared_ptr<AWSCredentialsProvider>& credential
   QLDBClient::QLDBClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QLDBErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-quicksight/source/QuickSightClient.cpp
+++ b/generated/src/aws-cpp-sdk-quicksight/source/QuickSightClient.cpp
@@ -213,7 +213,7 @@ QuickSightClient::QuickSightClient(const QuickSight::QuickSightClientConfigurati
                                    std::shared_ptr<QuickSightEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QuickSightErrorMarshaller>(ALLOCATION_TAG)),
@@ -260,7 +260,7 @@ QuickSightClient::QuickSightClient(const std::shared_ptr<AWSCredentialsProvider>
   QuickSightClient::QuickSightClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QuickSightErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ram/source/RAMClient.cpp
+++ b/generated/src/aws-cpp-sdk-ram/source/RAMClient.cpp
@@ -76,7 +76,7 @@ RAMClient::RAMClient(const RAM::RAMClientConfiguration& clientConfiguration,
                      std::shared_ptr<RAMEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RAMErrorMarshaller>(ALLOCATION_TAG)),
@@ -123,7 +123,7 @@ RAMClient::RAMClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   RAMClient::RAMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RAMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-rbin/source/RecycleBinClient.cpp
+++ b/generated/src/aws-cpp-sdk-rbin/source/RecycleBinClient.cpp
@@ -52,7 +52,7 @@ RecycleBinClient::RecycleBinClient(const RecycleBin::RecycleBinClientConfigurati
                                    std::shared_ptr<RecycleBinEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RecycleBinErrorMarshaller>(ALLOCATION_TAG)),
@@ -99,7 +99,7 @@ RecycleBinClient::RecycleBinClient(const std::shared_ptr<AWSCredentialsProvider>
   RecycleBinClient::RecycleBinClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RecycleBinErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-rds-data/source/RDSDataServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-rds-data/source/RDSDataServiceClient.cpp
@@ -47,7 +47,7 @@ RDSDataServiceClient::RDSDataServiceClient(const RDSDataService::RDSDataServiceC
                                            std::shared_ptr<RDSDataServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RDSDataServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -94,7 +94,7 @@ RDSDataServiceClient::RDSDataServiceClient(const std::shared_ptr<AWSCredentialsP
   RDSDataServiceClient::RDSDataServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RDSDataServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-rds/source/RDSClient.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/RDSClient.cpp
@@ -199,7 +199,7 @@ RDSClient::RDSClient(const RDS::RDSClientConfiguration& clientConfiguration,
                      std::shared_ptr<RDSEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RDSErrorMarshaller>(ALLOCATION_TAG)),
@@ -246,7 +246,7 @@ RDSClient::RDSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   RDSClient::RDSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RDSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-redshift-data/source/RedshiftDataAPIServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-redshift-data/source/RedshiftDataAPIServiceClient.cpp
@@ -52,7 +52,7 @@ RedshiftDataAPIServiceClient::RedshiftDataAPIServiceClient(const RedshiftDataAPI
                                                            std::shared_ptr<RedshiftDataAPIServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RedshiftDataAPIServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -99,7 +99,7 @@ RedshiftDataAPIServiceClient::RedshiftDataAPIServiceClient(const std::shared_ptr
   RedshiftDataAPIServiceClient::RedshiftDataAPIServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RedshiftDataAPIServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-redshift-serverless/source/RedshiftServerlessClient.cpp
+++ b/generated/src/aws-cpp-sdk-redshift-serverless/source/RedshiftServerlessClient.cpp
@@ -97,7 +97,7 @@ RedshiftServerlessClient::RedshiftServerlessClient(const RedshiftServerless::Red
                                                    std::shared_ptr<RedshiftServerlessEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RedshiftServerlessErrorMarshaller>(ALLOCATION_TAG)),
@@ -144,7 +144,7 @@ RedshiftServerlessClient::RedshiftServerlessClient(const std::shared_ptr<AWSCred
   RedshiftServerlessClient::RedshiftServerlessClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RedshiftServerlessErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-redshift/source/RedshiftClient.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/RedshiftClient.cpp
@@ -175,7 +175,7 @@ RedshiftClient::RedshiftClient(const Redshift::RedshiftClientConfiguration& clie
                                std::shared_ptr<RedshiftEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RedshiftErrorMarshaller>(ALLOCATION_TAG)),
@@ -222,7 +222,7 @@ RedshiftClient::RedshiftClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   RedshiftClient::RedshiftClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RedshiftErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-rekognition/source/RekognitionClient.cpp
+++ b/generated/src/aws-cpp-sdk-rekognition/source/RekognitionClient.cpp
@@ -117,7 +117,7 @@ RekognitionClient::RekognitionClient(const Rekognition::RekognitionClientConfigu
                                      std::shared_ptr<RekognitionEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RekognitionErrorMarshaller>(ALLOCATION_TAG)),
@@ -164,7 +164,7 @@ RekognitionClient::RekognitionClient(const std::shared_ptr<AWSCredentialsProvide
   RekognitionClient::RekognitionClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RekognitionErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-repostspace/source/RepostspaceClient.cpp
+++ b/generated/src/aws-cpp-sdk-repostspace/source/RepostspaceClient.cpp
@@ -53,7 +53,7 @@ RepostspaceClient::RepostspaceClient(const repostspace::RepostspaceClientConfigu
                                      std::shared_ptr<RepostspaceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RepostspaceErrorMarshaller>(ALLOCATION_TAG)),
@@ -100,7 +100,7 @@ RepostspaceClient::RepostspaceClient(const std::shared_ptr<AWSCredentialsProvide
   RepostspaceClient::RepostspaceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RepostspaceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-resiliencehub/source/ResilienceHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-resiliencehub/source/ResilienceHubClient.cpp
@@ -96,7 +96,7 @@ ResilienceHubClient::ResilienceHubClient(const ResilienceHub::ResilienceHubClien
                                          std::shared_ptr<ResilienceHubEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ResilienceHubErrorMarshaller>(ALLOCATION_TAG)),
@@ -143,7 +143,7 @@ ResilienceHubClient::ResilienceHubClient(const std::shared_ptr<AWSCredentialsPro
   ResilienceHubClient::ResilienceHubClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ResilienceHubErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-resource-explorer-2/source/ResourceExplorer2Client.cpp
+++ b/generated/src/aws-cpp-sdk-resource-explorer-2/source/ResourceExplorer2Client.cpp
@@ -63,7 +63,7 @@ ResourceExplorer2Client::ResourceExplorer2Client(const ResourceExplorer2::Resour
                                                  std::shared_ptr<ResourceExplorer2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ResourceExplorer2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -110,7 +110,7 @@ ResourceExplorer2Client::ResourceExplorer2Client(const std::shared_ptr<AWSCreden
   ResourceExplorer2Client::ResourceExplorer2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ResourceExplorer2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-resource-groups/source/ResourceGroupsClient.cpp
+++ b/generated/src/aws-cpp-sdk-resource-groups/source/ResourceGroupsClient.cpp
@@ -60,7 +60,7 @@ ResourceGroupsClient::ResourceGroupsClient(const ResourceGroups::ResourceGroupsC
                                            std::shared_ptr<ResourceGroupsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ResourceGroupsErrorMarshaller>(ALLOCATION_TAG)),
@@ -107,7 +107,7 @@ ResourceGroupsClient::ResourceGroupsClient(const std::shared_ptr<AWSCredentialsP
   ResourceGroupsClient::ResourceGroupsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ResourceGroupsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-resourcegroupstaggingapi/source/ResourceGroupsTaggingAPIClient.cpp
+++ b/generated/src/aws-cpp-sdk-resourcegroupstaggingapi/source/ResourceGroupsTaggingAPIClient.cpp
@@ -50,7 +50,7 @@ ResourceGroupsTaggingAPIClient::ResourceGroupsTaggingAPIClient(const ResourceGro
                                                                std::shared_ptr<ResourceGroupsTaggingAPIEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ResourceGroupsTaggingAPIErrorMarshaller>(ALLOCATION_TAG)),
@@ -97,7 +97,7 @@ ResourceGroupsTaggingAPIClient::ResourceGroupsTaggingAPIClient(const std::shared
   ResourceGroupsTaggingAPIClient::ResourceGroupsTaggingAPIClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ResourceGroupsTaggingAPIErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-robomaker/source/RoboMakerClient.cpp
+++ b/generated/src/aws-cpp-sdk-robomaker/source/RoboMakerClient.cpp
@@ -84,7 +84,7 @@ RoboMakerClient::RoboMakerClient(const RoboMaker::RoboMakerClientConfiguration& 
                                  std::shared_ptr<RoboMakerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RoboMakerErrorMarshaller>(ALLOCATION_TAG)),
@@ -131,7 +131,7 @@ RoboMakerClient::RoboMakerClient(const std::shared_ptr<AWSCredentialsProvider>& 
   RoboMakerClient::RoboMakerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RoboMakerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-rolesanywhere/source/RolesAnywhereClient.cpp
+++ b/generated/src/aws-cpp-sdk-rolesanywhere/source/RolesAnywhereClient.cpp
@@ -70,7 +70,7 @@ RolesAnywhereClient::RolesAnywhereClient(const RolesAnywhere::RolesAnywhereClien
                                          std::shared_ptr<RolesAnywhereEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RolesAnywhereErrorMarshaller>(ALLOCATION_TAG)),
@@ -117,7 +117,7 @@ RolesAnywhereClient::RolesAnywhereClient(const std::shared_ptr<AWSCredentialsPro
   RolesAnywhereClient::RolesAnywhereClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RolesAnywhereErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-route53-recovery-cluster/source/Route53RecoveryClusterClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53-recovery-cluster/source/Route53RecoveryClusterClient.cpp
@@ -46,7 +46,7 @@ Route53RecoveryClusterClient::Route53RecoveryClusterClient(const Route53Recovery
                                                            std::shared_ptr<Route53RecoveryClusterEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53RecoveryClusterErrorMarshaller>(ALLOCATION_TAG)),
@@ -93,7 +93,7 @@ Route53RecoveryClusterClient::Route53RecoveryClusterClient(const std::shared_ptr
   Route53RecoveryClusterClient::Route53RecoveryClusterClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53RecoveryClusterErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-route53-recovery-control-config/source/Route53RecoveryControlConfigClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53-recovery-control-config/source/Route53RecoveryControlConfigClient.cpp
@@ -66,7 +66,7 @@ Route53RecoveryControlConfigClient::Route53RecoveryControlConfigClient(const Rou
                                                                        std::shared_ptr<Route53RecoveryControlConfigEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53RecoveryControlConfigErrorMarshaller>(ALLOCATION_TAG)),
@@ -113,7 +113,7 @@ Route53RecoveryControlConfigClient::Route53RecoveryControlConfigClient(const std
   Route53RecoveryControlConfigClient::Route53RecoveryControlConfigClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53RecoveryControlConfigErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-route53-recovery-readiness/source/Route53RecoveryReadinessClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53-recovery-readiness/source/Route53RecoveryReadinessClient.cpp
@@ -74,7 +74,7 @@ Route53RecoveryReadinessClient::Route53RecoveryReadinessClient(const Route53Reco
                                                                std::shared_ptr<Route53RecoveryReadinessEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53RecoveryReadinessErrorMarshaller>(ALLOCATION_TAG)),
@@ -121,7 +121,7 @@ Route53RecoveryReadinessClient::Route53RecoveryReadinessClient(const std::shared
   Route53RecoveryReadinessClient::Route53RecoveryReadinessClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53RecoveryReadinessErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-route53/source/Route53Client.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/Route53Client.cpp
@@ -113,7 +113,7 @@ Route53Client::Route53Client(const Route53::Route53ClientConfiguration& clientCo
                              std::shared_ptr<Route53EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53ErrorMarshaller>(ALLOCATION_TAG)),
@@ -160,7 +160,7 @@ Route53Client::Route53Client(const std::shared_ptr<AWSCredentialsProvider>& cred
   Route53Client::Route53Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-route53domains/source/Route53DomainsClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53domains/source/Route53DomainsClient.cpp
@@ -76,7 +76,7 @@ Route53DomainsClient::Route53DomainsClient(const Route53Domains::Route53DomainsC
                                            std::shared_ptr<Route53DomainsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53DomainsErrorMarshaller>(ALLOCATION_TAG)),
@@ -123,7 +123,7 @@ Route53DomainsClient::Route53DomainsClient(const std::shared_ptr<AWSCredentialsP
   Route53DomainsClient::Route53DomainsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53DomainsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-route53resolver/source/Route53ResolverClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53resolver/source/Route53ResolverClient.cpp
@@ -110,7 +110,7 @@ Route53ResolverClient::Route53ResolverClient(const Route53Resolver::Route53Resol
                                              std::shared_ptr<Route53ResolverEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53ResolverErrorMarshaller>(ALLOCATION_TAG)),
@@ -157,7 +157,7 @@ Route53ResolverClient::Route53ResolverClient(const std::shared_ptr<AWSCredential
   Route53ResolverClient::Route53ResolverClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53ResolverErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-rum/source/CloudWatchRUMClient.cpp
+++ b/generated/src/aws-cpp-sdk-rum/source/CloudWatchRUMClient.cpp
@@ -59,7 +59,7 @@ CloudWatchRUMClient::CloudWatchRUMClient(const CloudWatchRUM::CloudWatchRUMClien
                                          std::shared_ptr<CloudWatchRUMEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchRUMErrorMarshaller>(ALLOCATION_TAG)),
@@ -106,7 +106,7 @@ CloudWatchRUMClient::CloudWatchRUMClient(const std::shared_ptr<AWSCredentialsPro
   CloudWatchRUMClient::CloudWatchRUMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchRUMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp
@@ -207,7 +207,7 @@ S3Client::S3Client(const S3::S3ClientConfiguration& clientConfiguration,
                    std::shared_ptr<S3EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
-                                                                Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                GetDefaultCredentialsProviderChain(),
                                                                 clientConfiguration.identityProviderSupplier(*this),
                                                                 SERVICE_NAME,
                                                                 Aws::Region::ComputeSignerRegion(clientConfiguration.region),
@@ -266,7 +266,7 @@ S3Client::S3Client(const std::shared_ptr<AWSCredentialsProvider>& credentialsPro
                    Aws::S3::US_EAST_1_REGIONAL_ENDPOINT_OPTION USEast1RegionalEndPointOption) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
-                                                                Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                GetDefaultCredentialsProviderChain(),
                                                                 Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this),
                                                                 SERVICE_NAME,
                                                                 Aws::Region::ComputeSignerRegion(clientConfiguration.region),

--- a/generated/src/aws-cpp-sdk-s3control/source/S3ControlClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/S3ControlClient.cpp
@@ -136,7 +136,7 @@ S3ControlClient::S3ControlClient(const S3Control::S3ControlClientConfiguration& 
                                  std::shared_ptr<S3ControlEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region),
                                              Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::RequestDependent,
@@ -189,7 +189,7 @@ S3ControlClient::S3ControlClient(const std::shared_ptr<AWSCredentialsProvider>& 
   S3ControlClient::S3ControlClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region),
                                              Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::RequestDependent,

--- a/generated/src/aws-cpp-sdk-s3outposts/source/S3OutpostsClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3outposts/source/S3OutpostsClient.cpp
@@ -47,7 +47,7 @@ S3OutpostsClient::S3OutpostsClient(const S3Outposts::S3OutpostsClientConfigurati
                                    std::shared_ptr<S3OutpostsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<S3OutpostsErrorMarshaller>(ALLOCATION_TAG)),
@@ -94,7 +94,7 @@ S3OutpostsClient::S3OutpostsClient(const std::shared_ptr<AWSCredentialsProvider>
   S3OutpostsClient::S3OutpostsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<S3OutpostsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sagemaker-a2i-runtime/source/AugmentedAIRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-a2i-runtime/source/AugmentedAIRuntimeClient.cpp
@@ -47,7 +47,7 @@ AugmentedAIRuntimeClient::AugmentedAIRuntimeClient(const AugmentedAIRuntime::Aug
                                                    std::shared_ptr<AugmentedAIRuntimeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AugmentedAIRuntimeErrorMarshaller>(ALLOCATION_TAG)),
@@ -94,7 +94,7 @@ AugmentedAIRuntimeClient::AugmentedAIRuntimeClient(const std::shared_ptr<AWSCred
   AugmentedAIRuntimeClient::AugmentedAIRuntimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AugmentedAIRuntimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sagemaker-edge/source/SagemakerEdgeManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-edge/source/SagemakerEdgeManagerClient.cpp
@@ -45,7 +45,7 @@ SagemakerEdgeManagerClient::SagemakerEdgeManagerClient(const SagemakerEdgeManage
                                                        std::shared_ptr<SagemakerEdgeManagerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SagemakerEdgeManagerErrorMarshaller>(ALLOCATION_TAG)),
@@ -92,7 +92,7 @@ SagemakerEdgeManagerClient::SagemakerEdgeManagerClient(const std::shared_ptr<AWS
   SagemakerEdgeManagerClient::SagemakerEdgeManagerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SagemakerEdgeManagerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sagemaker-featurestore-runtime/source/SageMakerFeatureStoreRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-featurestore-runtime/source/SageMakerFeatureStoreRuntimeClient.cpp
@@ -46,7 +46,7 @@ SageMakerFeatureStoreRuntimeClient::SageMakerFeatureStoreRuntimeClient(const Sag
                                                                        std::shared_ptr<SageMakerFeatureStoreRuntimeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerFeatureStoreRuntimeErrorMarshaller>(ALLOCATION_TAG)),
@@ -93,7 +93,7 @@ SageMakerFeatureStoreRuntimeClient::SageMakerFeatureStoreRuntimeClient(const std
   SageMakerFeatureStoreRuntimeClient::SageMakerFeatureStoreRuntimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerFeatureStoreRuntimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sagemaker-geospatial/source/SageMakerGeospatialClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-geospatial/source/SageMakerGeospatialClient.cpp
@@ -61,7 +61,7 @@ SageMakerGeospatialClient::SageMakerGeospatialClient(const SageMakerGeospatial::
                                                      std::shared_ptr<SageMakerGeospatialEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerGeospatialErrorMarshaller>(ALLOCATION_TAG)),
@@ -108,7 +108,7 @@ SageMakerGeospatialClient::SageMakerGeospatialClient(const std::shared_ptr<AWSCr
   SageMakerGeospatialClient::SageMakerGeospatialClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerGeospatialErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sagemaker-metrics/source/SageMakerMetricsClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-metrics/source/SageMakerMetricsClient.cpp
@@ -43,7 +43,7 @@ SageMakerMetricsClient::SageMakerMetricsClient(const SageMakerMetrics::SageMaker
                                                std::shared_ptr<SageMakerMetricsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerMetricsErrorMarshaller>(ALLOCATION_TAG)),
@@ -90,7 +90,7 @@ SageMakerMetricsClient::SageMakerMetricsClient(const std::shared_ptr<AWSCredenti
   SageMakerMetricsClient::SageMakerMetricsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerMetricsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sagemaker-runtime/source/SageMakerRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-runtime/source/SageMakerRuntimeClient.cpp
@@ -46,7 +46,7 @@ SageMakerRuntimeClient::SageMakerRuntimeClient(const SageMakerRuntime::SageMaker
                                                std::shared_ptr<SageMakerRuntimeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerRuntimeErrorMarshaller>(ALLOCATION_TAG)),
@@ -93,7 +93,7 @@ SageMakerRuntimeClient::SageMakerRuntimeClient(const std::shared_ptr<AWSCredenti
   SageMakerRuntimeClient::SageMakerRuntimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerRuntimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sagemaker/source/SageMakerClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker/source/SageMakerClient.cpp
@@ -142,7 +142,7 @@ SageMakerClient::SageMakerClient(const SageMaker::SageMakerClientConfiguration& 
                                  std::shared_ptr<SageMakerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerErrorMarshaller>(ALLOCATION_TAG)),
@@ -189,7 +189,7 @@ SageMakerClient::SageMakerClient(const std::shared_ptr<AWSCredentialsProvider>& 
   SageMakerClient::SageMakerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-savingsplans/source/SavingsPlansClient.cpp
+++ b/generated/src/aws-cpp-sdk-savingsplans/source/SavingsPlansClient.cpp
@@ -51,7 +51,7 @@ SavingsPlansClient::SavingsPlansClient(const SavingsPlans::SavingsPlansClientCon
                                        std::shared_ptr<SavingsPlansEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SavingsPlansErrorMarshaller>(ALLOCATION_TAG)),
@@ -98,7 +98,7 @@ SavingsPlansClient::SavingsPlansClient(const std::shared_ptr<AWSCredentialsProvi
   SavingsPlansClient::SavingsPlansClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SavingsPlansErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-scheduler/source/SchedulerClient.cpp
+++ b/generated/src/aws-cpp-sdk-scheduler/source/SchedulerClient.cpp
@@ -54,7 +54,7 @@ SchedulerClient::SchedulerClient(const Scheduler::SchedulerClientConfiguration& 
                                  std::shared_ptr<SchedulerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SchedulerErrorMarshaller>(ALLOCATION_TAG)),
@@ -101,7 +101,7 @@ SchedulerClient::SchedulerClient(const std::shared_ptr<AWSCredentialsProvider>& 
   SchedulerClient::SchedulerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SchedulerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-schemas/source/SchemasClient.cpp
+++ b/generated/src/aws-cpp-sdk-schemas/source/SchemasClient.cpp
@@ -73,7 +73,7 @@ SchemasClient::SchemasClient(const Schemas::SchemasClientConfiguration& clientCo
                              std::shared_ptr<SchemasEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SchemasErrorMarshaller>(ALLOCATION_TAG)),
@@ -120,7 +120,7 @@ SchemasClient::SchemasClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   SchemasClient::SchemasClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SchemasErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sdb/source/SimpleDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-sdb/source/SimpleDBClient.cpp
@@ -53,7 +53,7 @@ SimpleDBClient::SimpleDBClient(const SimpleDB::SimpleDBClientConfiguration& clie
                                std::shared_ptr<SimpleDBEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SimpleDBErrorMarshaller>(ALLOCATION_TAG)),
@@ -100,7 +100,7 @@ SimpleDBClient::SimpleDBClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   SimpleDBClient::SimpleDBClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SimpleDBErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-secretsmanager/source/SecretsManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-secretsmanager/source/SecretsManagerClient.cpp
@@ -65,7 +65,7 @@ SecretsManagerClient::SecretsManagerClient(const SecretsManager::SecretsManagerC
                                            std::shared_ptr<SecretsManagerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SecretsManagerErrorMarshaller>(ALLOCATION_TAG)),
@@ -112,7 +112,7 @@ SecretsManagerClient::SecretsManagerClient(const std::shared_ptr<AWSCredentialsP
   SecretsManagerClient::SecretsManagerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SecretsManagerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-securityhub/source/SecurityHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-securityhub/source/SecurityHubClient.cpp
@@ -118,7 +118,7 @@ SecurityHubClient::SecurityHubClient(const SecurityHub::SecurityHubClientConfigu
                                      std::shared_ptr<SecurityHubEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SecurityHubErrorMarshaller>(ALLOCATION_TAG)),
@@ -165,7 +165,7 @@ SecurityHubClient::SecurityHubClient(const std::shared_ptr<AWSCredentialsProvide
   SecurityHubClient::SecurityHubClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SecurityHubErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-securitylake/source/SecurityLakeClient.cpp
+++ b/generated/src/aws-cpp-sdk-securitylake/source/SecurityLakeClient.cpp
@@ -73,7 +73,7 @@ SecurityLakeClient::SecurityLakeClient(const SecurityLake::SecurityLakeClientCon
                                        std::shared_ptr<SecurityLakeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SecurityLakeErrorMarshaller>(ALLOCATION_TAG)),
@@ -120,7 +120,7 @@ SecurityLakeClient::SecurityLakeClient(const std::shared_ptr<AWSCredentialsProvi
   SecurityLakeClient::SecurityLakeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SecurityLakeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-serverlessrepo/source/ServerlessApplicationRepositoryClient.cpp
+++ b/generated/src/aws-cpp-sdk-serverlessrepo/source/ServerlessApplicationRepositoryClient.cpp
@@ -56,7 +56,7 @@ ServerlessApplicationRepositoryClient::ServerlessApplicationRepositoryClient(con
                                                                              std::shared_ptr<ServerlessApplicationRepositoryEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ServerlessApplicationRepositoryErrorMarshaller>(ALLOCATION_TAG)),
@@ -103,7 +103,7 @@ ServerlessApplicationRepositoryClient::ServerlessApplicationRepositoryClient(con
   ServerlessApplicationRepositoryClient::ServerlessApplicationRepositoryClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ServerlessApplicationRepositoryErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-service-quotas/source/ServiceQuotasClient.cpp
+++ b/generated/src/aws-cpp-sdk-service-quotas/source/ServiceQuotasClient.cpp
@@ -61,7 +61,7 @@ ServiceQuotasClient::ServiceQuotasClient(const ServiceQuotas::ServiceQuotasClien
                                          std::shared_ptr<ServiceQuotasEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ServiceQuotasErrorMarshaller>(ALLOCATION_TAG)),
@@ -108,7 +108,7 @@ ServiceQuotasClient::ServiceQuotasClient(const std::shared_ptr<AWSCredentialsPro
   ServiceQuotasClient::ServiceQuotasClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ServiceQuotasErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-servicecatalog-appregistry/source/AppRegistryClient.cpp
+++ b/generated/src/aws-cpp-sdk-servicecatalog-appregistry/source/AppRegistryClient.cpp
@@ -66,7 +66,7 @@ AppRegistryClient::AppRegistryClient(const AppRegistry::AppRegistryClientConfigu
                                      std::shared_ptr<AppRegistryEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppRegistryErrorMarshaller>(ALLOCATION_TAG)),
@@ -113,7 +113,7 @@ AppRegistryClient::AppRegistryClient(const std::shared_ptr<AWSCredentialsProvide
   AppRegistryClient::AppRegistryClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppRegistryErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-servicecatalog/source/ServiceCatalogClient.cpp
+++ b/generated/src/aws-cpp-sdk-servicecatalog/source/ServiceCatalogClient.cpp
@@ -132,7 +132,7 @@ ServiceCatalogClient::ServiceCatalogClient(const ServiceCatalog::ServiceCatalogC
                                            std::shared_ptr<ServiceCatalogEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ServiceCatalogErrorMarshaller>(ALLOCATION_TAG)),
@@ -179,7 +179,7 @@ ServiceCatalogClient::ServiceCatalogClient(const std::shared_ptr<AWSCredentialsP
   ServiceCatalogClient::ServiceCatalogClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ServiceCatalogErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-servicediscovery/source/ServiceDiscoveryClient.cpp
+++ b/generated/src/aws-cpp-sdk-servicediscovery/source/ServiceDiscoveryClient.cpp
@@ -69,7 +69,7 @@ ServiceDiscoveryClient::ServiceDiscoveryClient(const ServiceDiscovery::ServiceDi
                                                std::shared_ptr<ServiceDiscoveryEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ServiceDiscoveryErrorMarshaller>(ALLOCATION_TAG)),
@@ -116,7 +116,7 @@ ServiceDiscoveryClient::ServiceDiscoveryClient(const std::shared_ptr<AWSCredenti
   ServiceDiscoveryClient::ServiceDiscoveryClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ServiceDiscoveryErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sesv2/source/SESV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-sesv2/source/SESV2Client.cpp
@@ -134,7 +134,7 @@ SESV2Client::SESV2Client(const SESV2::SESV2ClientConfiguration& clientConfigurat
                          std::shared_ptr<SESV2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SESV2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -181,7 +181,7 @@ SESV2Client::SESV2Client(const std::shared_ptr<AWSCredentialsProvider>& credenti
   SESV2Client::SESV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SESV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-shield/source/ShieldClient.cpp
+++ b/generated/src/aws-cpp-sdk-shield/source/ShieldClient.cpp
@@ -77,7 +77,7 @@ ShieldClient::ShieldClient(const Shield::ShieldClientConfiguration& clientConfig
                            std::shared_ptr<ShieldEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ShieldErrorMarshaller>(ALLOCATION_TAG)),
@@ -124,7 +124,7 @@ ShieldClient::ShieldClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   ShieldClient::ShieldClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ShieldErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-signer/source/SignerClient.cpp
+++ b/generated/src/aws-cpp-sdk-signer/source/SignerClient.cpp
@@ -61,7 +61,7 @@ SignerClient::SignerClient(const signer::SignerClientConfiguration& clientConfig
                            std::shared_ptr<SignerEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SignerErrorMarshaller>(ALLOCATION_TAG)),
@@ -108,7 +108,7 @@ SignerClient::SignerClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   SignerClient::SignerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SignerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-simspaceweaver/source/SimSpaceWeaverClient.cpp
+++ b/generated/src/aws-cpp-sdk-simspaceweaver/source/SimSpaceWeaverClient.cpp
@@ -58,7 +58,7 @@ SimSpaceWeaverClient::SimSpaceWeaverClient(const SimSpaceWeaver::SimSpaceWeaverC
                                            std::shared_ptr<SimSpaceWeaverEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SimSpaceWeaverErrorMarshaller>(ALLOCATION_TAG)),
@@ -105,7 +105,7 @@ SimSpaceWeaverClient::SimSpaceWeaverClient(const std::shared_ptr<AWSCredentialsP
   SimSpaceWeaverClient::SimSpaceWeaverClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SimSpaceWeaverErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sms-voice/source/PinpointSMSVoiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-sms-voice/source/PinpointSMSVoiceClient.cpp
@@ -50,7 +50,7 @@ PinpointSMSVoiceClient::PinpointSMSVoiceClient(const PinpointSMSVoice::PinpointS
                                                std::shared_ptr<PinpointSMSVoiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PinpointSMSVoiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -97,7 +97,7 @@ PinpointSMSVoiceClient::PinpointSMSVoiceClient(const std::shared_ptr<AWSCredenti
   PinpointSMSVoiceClient::PinpointSMSVoiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PinpointSMSVoiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sms/source/SMSClient.cpp
+++ b/generated/src/aws-cpp-sdk-sms/source/SMSClient.cpp
@@ -77,7 +77,7 @@ SMSClient::SMSClient(const SMS::SMSClientConfiguration& clientConfiguration,
                      std::shared_ptr<SMSEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SMSErrorMarshaller>(ALLOCATION_TAG)),
@@ -124,7 +124,7 @@ SMSClient::SMSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SMSClient::SMSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SMSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-snow-device-management/source/SnowDeviceManagementClient.cpp
+++ b/generated/src/aws-cpp-sdk-snow-device-management/source/SnowDeviceManagementClient.cpp
@@ -55,7 +55,7 @@ SnowDeviceManagementClient::SnowDeviceManagementClient(const SnowDeviceManagemen
                                                        std::shared_ptr<SnowDeviceManagementEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SnowDeviceManagementErrorMarshaller>(ALLOCATION_TAG)),
@@ -102,7 +102,7 @@ SnowDeviceManagementClient::SnowDeviceManagementClient(const std::shared_ptr<AWS
   SnowDeviceManagementClient::SnowDeviceManagementClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SnowDeviceManagementErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-snowball/source/SnowballClient.cpp
+++ b/generated/src/aws-cpp-sdk-snowball/source/SnowballClient.cpp
@@ -69,7 +69,7 @@ SnowballClient::SnowballClient(const Snowball::SnowballClientConfiguration& clie
                                std::shared_ptr<SnowballEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SnowballErrorMarshaller>(ALLOCATION_TAG)),
@@ -116,7 +116,7 @@ SnowballClient::SnowballClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   SnowballClient::SnowballClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SnowballErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sns/source/SNSClient.cpp
+++ b/generated/src/aws-cpp-sdk-sns/source/SNSClient.cpp
@@ -85,7 +85,7 @@ SNSClient::SNSClient(const SNS::SNSClientConfiguration& clientConfiguration,
                      std::shared_ptr<SNSEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SNSErrorMarshaller>(ALLOCATION_TAG)),
@@ -132,7 +132,7 @@ SNSClient::SNSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SNSClient::SNSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SNSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sqs/source/SQSClient.cpp
+++ b/generated/src/aws-cpp-sdk-sqs/source/SQSClient.cpp
@@ -65,7 +65,7 @@ SQSClient::SQSClient(const SQS::SQSClientConfiguration& clientConfiguration,
                      std::shared_ptr<SQSEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SQSErrorMarshaller>(ALLOCATION_TAG)),
@@ -112,7 +112,7 @@ SQSClient::SQSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SQSClient::SQSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SQSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ssm-contacts/source/SSMContactsClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm-contacts/source/SSMContactsClient.cpp
@@ -81,7 +81,7 @@ SSMContactsClient::SSMContactsClient(const SSMContacts::SSMContactsClientConfigu
                                      std::shared_ptr<SSMContactsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSMContactsErrorMarshaller>(ALLOCATION_TAG)),
@@ -128,7 +128,7 @@ SSMContactsClient::SSMContactsClient(const std::shared_ptr<AWSCredentialsProvide
   SSMContactsClient::SSMContactsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSMContactsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ssm-incidents/source/SSMIncidentsClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm-incidents/source/SSMIncidentsClient.cpp
@@ -73,7 +73,7 @@ SSMIncidentsClient::SSMIncidentsClient(const SSMIncidents::SSMIncidentsClientCon
                                        std::shared_ptr<SSMIncidentsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSMIncidentsErrorMarshaller>(ALLOCATION_TAG)),
@@ -120,7 +120,7 @@ SSMIncidentsClient::SSMIncidentsClient(const std::shared_ptr<AWSCredentialsProvi
   SSMIncidentsClient::SSMIncidentsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSMIncidentsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ssm-sap/source/SsmSapClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm-sap/source/SsmSapClient.cpp
@@ -60,7 +60,7 @@ SsmSapClient::SsmSapClient(const SsmSap::SsmSapClientConfiguration& clientConfig
                            std::shared_ptr<SsmSapEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SsmSapErrorMarshaller>(ALLOCATION_TAG)),
@@ -107,7 +107,7 @@ SsmSapClient::SsmSapClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   SsmSapClient::SsmSapClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SsmSapErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ssm/source/SSMClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm/source/SSMClient.cpp
@@ -181,7 +181,7 @@ SSMClient::SSMClient(const SSM::SSMClientConfiguration& clientConfiguration,
                      std::shared_ptr<SSMEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSMErrorMarshaller>(ALLOCATION_TAG)),
@@ -228,7 +228,7 @@ SSMClient::SSMClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SSMClient::SSMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sso-admin/source/SSOAdminClient.cpp
+++ b/generated/src/aws-cpp-sdk-sso-admin/source/SSOAdminClient.cpp
@@ -115,7 +115,7 @@ SSOAdminClient::SSOAdminClient(const SSOAdmin::SSOAdminClientConfiguration& clie
                                std::shared_ptr<SSOAdminEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSOAdminErrorMarshaller>(ALLOCATION_TAG)),
@@ -162,7 +162,7 @@ SSOAdminClient::SSOAdminClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   SSOAdminClient::SSOAdminClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSOAdminErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sso-oidc/source/SSOOIDCClient.cpp
+++ b/generated/src/aws-cpp-sdk-sso-oidc/source/SSOOIDCClient.cpp
@@ -46,7 +46,7 @@ SSOOIDCClient::SSOOIDCClient(const SSOOIDC::SSOOIDCClientConfiguration& clientCo
                              std::shared_ptr<SSOOIDCEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSOOIDCErrorMarshaller>(ALLOCATION_TAG)),
@@ -93,7 +93,7 @@ SSOOIDCClient::SSOOIDCClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   SSOOIDCClient::SSOOIDCClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSOOIDCErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sso/source/SSOClient.cpp
+++ b/generated/src/aws-cpp-sdk-sso/source/SSOClient.cpp
@@ -46,7 +46,7 @@ SSOClient::SSOClient(const SSO::SSOClientConfiguration& clientConfiguration,
                      std::shared_ptr<SSOEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSOErrorMarshaller>(ALLOCATION_TAG)),
@@ -93,7 +93,7 @@ SSOClient::SSOClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SSOClient::SSOClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSOErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-states/source/SFNClient.cpp
+++ b/generated/src/aws-cpp-sdk-states/source/SFNClient.cpp
@@ -78,7 +78,7 @@ SFNClient::SFNClient(const SFN::SFNClientConfiguration& clientConfiguration,
                      std::shared_ptr<SFNEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SFNErrorMarshaller>(ALLOCATION_TAG)),
@@ -125,7 +125,7 @@ SFNClient::SFNClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SFNClient::SFNClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SFNErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-storagegateway/source/StorageGatewayClient.cpp
+++ b/generated/src/aws-cpp-sdk-storagegateway/source/StorageGatewayClient.cpp
@@ -132,7 +132,7 @@ StorageGatewayClient::StorageGatewayClient(const StorageGateway::StorageGatewayC
                                            std::shared_ptr<StorageGatewayEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<StorageGatewayErrorMarshaller>(ALLOCATION_TAG)),
@@ -179,7 +179,7 @@ StorageGatewayClient::StorageGatewayClient(const std::shared_ptr<AWSCredentialsP
   StorageGatewayClient::StorageGatewayClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<StorageGatewayErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sts/source/STSClient.cpp
+++ b/generated/src/aws-cpp-sdk-sts/source/STSClient.cpp
@@ -51,7 +51,7 @@ STSClient::STSClient(const STS::STSClientConfiguration& clientConfiguration,
                      std::shared_ptr<STSEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<STSErrorMarshaller>(ALLOCATION_TAG)),
@@ -98,7 +98,7 @@ STSClient::STSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   STSClient::STSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<STSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-supplychain/source/SupplyChainClient.cpp
+++ b/generated/src/aws-cpp-sdk-supplychain/source/SupplyChainClient.cpp
@@ -44,7 +44,7 @@ SupplyChainClient::SupplyChainClient(const SupplyChain::SupplyChainClientConfigu
                                      std::shared_ptr<SupplyChainEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SupplyChainErrorMarshaller>(ALLOCATION_TAG)),
@@ -91,7 +91,7 @@ SupplyChainClient::SupplyChainClient(const std::shared_ptr<AWSCredentialsProvide
   SupplyChainClient::SupplyChainClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SupplyChainErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-support-app/source/SupportAppClient.cpp
+++ b/generated/src/aws-cpp-sdk-support-app/source/SupportAppClient.cpp
@@ -52,7 +52,7 @@ SupportAppClient::SupportAppClient(const SupportApp::SupportAppClientConfigurati
                                    std::shared_ptr<SupportAppEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SupportAppErrorMarshaller>(ALLOCATION_TAG)),
@@ -99,7 +99,7 @@ SupportAppClient::SupportAppClient(const std::shared_ptr<AWSCredentialsProvider>
   SupportAppClient::SupportAppClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SupportAppErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-support/source/SupportClient.cpp
+++ b/generated/src/aws-cpp-sdk-support/source/SupportClient.cpp
@@ -58,7 +58,7 @@ SupportClient::SupportClient(const Support::SupportClientConfiguration& clientCo
                              std::shared_ptr<SupportEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SupportErrorMarshaller>(ALLOCATION_TAG)),
@@ -105,7 +105,7 @@ SupportClient::SupportClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   SupportClient::SupportClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SupportErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-swf/source/SWFClient.cpp
+++ b/generated/src/aws-cpp-sdk-swf/source/SWFClient.cpp
@@ -79,7 +79,7 @@ SWFClient::SWFClient(const SWF::SWFClientConfiguration& clientConfiguration,
                      std::shared_ptr<SWFEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SWFErrorMarshaller>(ALLOCATION_TAG)),
@@ -126,7 +126,7 @@ SWFClient::SWFClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SWFClient::SWFClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SWFErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-synthetics/source/SyntheticsClient.cpp
+++ b/generated/src/aws-cpp-sdk-synthetics/source/SyntheticsClient.cpp
@@ -63,7 +63,7 @@ SyntheticsClient::SyntheticsClient(const Synthetics::SyntheticsClientConfigurati
                                    std::shared_ptr<SyntheticsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SyntheticsErrorMarshaller>(ALLOCATION_TAG)),
@@ -110,7 +110,7 @@ SyntheticsClient::SyntheticsClient(const std::shared_ptr<AWSCredentialsProvider>
   SyntheticsClient::SyntheticsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SyntheticsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-textract/source/TextractClient.cpp
+++ b/generated/src/aws-cpp-sdk-textract/source/TextractClient.cpp
@@ -67,7 +67,7 @@ TextractClient::TextractClient(const Textract::TextractClientConfiguration& clie
                                std::shared_ptr<TextractEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TextractErrorMarshaller>(ALLOCATION_TAG)),
@@ -114,7 +114,7 @@ TextractClient::TextractClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   TextractClient::TextractClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TextractErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-timestream-query/source/TimestreamQueryClient.cpp
+++ b/generated/src/aws-cpp-sdk-timestream-query/source/TimestreamQueryClient.cpp
@@ -56,7 +56,7 @@ TimestreamQueryClient::TimestreamQueryClient(const TimestreamQuery::TimestreamQu
                                              std::shared_ptr<TimestreamQueryEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TimestreamQueryErrorMarshaller>(ALLOCATION_TAG)),
@@ -103,7 +103,7 @@ TimestreamQueryClient::TimestreamQueryClient(const std::shared_ptr<AWSCredential
   TimestreamQueryClient::TimestreamQueryClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TimestreamQueryErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-timestream-write/source/TimestreamWriteClient.cpp
+++ b/generated/src/aws-cpp-sdk-timestream-write/source/TimestreamWriteClient.cpp
@@ -62,7 +62,7 @@ TimestreamWriteClient::TimestreamWriteClient(const TimestreamWrite::TimestreamWr
                                              std::shared_ptr<TimestreamWriteEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TimestreamWriteErrorMarshaller>(ALLOCATION_TAG)),
@@ -109,7 +109,7 @@ TimestreamWriteClient::TimestreamWriteClient(const std::shared_ptr<AWSCredential
   TimestreamWriteClient::TimestreamWriteClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TimestreamWriteErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-tnb/source/TnbClient.cpp
+++ b/generated/src/aws-cpp-sdk-tnb/source/TnbClient.cpp
@@ -75,7 +75,7 @@ TnbClient::TnbClient(const tnb::TnbClientConfiguration& clientConfiguration,
                      std::shared_ptr<TnbEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TnbErrorMarshaller>(ALLOCATION_TAG)),
@@ -122,7 +122,7 @@ TnbClient::TnbClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   TnbClient::TnbClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TnbErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-transcribe/source/TranscribeServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-transcribe/source/TranscribeServiceClient.cpp
@@ -85,7 +85,7 @@ TranscribeServiceClient::TranscribeServiceClient(const TranscribeService::Transc
                                                  std::shared_ptr<TranscribeServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TranscribeServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -132,7 +132,7 @@ TranscribeServiceClient::TranscribeServiceClient(const std::shared_ptr<AWSCreden
   TranscribeServiceClient::TranscribeServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TranscribeServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
@@ -46,7 +46,7 @@ TranscribeStreamingServiceClient::TranscribeStreamingServiceClient(const Transcr
                                                                    std::shared_ptr<TranscribeStreamingServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TranscribeStreamingServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -93,7 +93,7 @@ TranscribeStreamingServiceClient::TranscribeStreamingServiceClient(const std::sh
   TranscribeStreamingServiceClient::TranscribeStreamingServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  GetDefaultCredentialsProviderChain(),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TranscribeStreamingServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-translate/source/TranslateClient.cpp
+++ b/generated/src/aws-cpp-sdk-translate/source/TranslateClient.cpp
@@ -61,7 +61,7 @@ TranslateClient::TranslateClient(const Translate::TranslateClientConfiguration& 
                                  std::shared_ptr<TranslateEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TranslateErrorMarshaller>(ALLOCATION_TAG)),
@@ -108,7 +108,7 @@ TranslateClient::TranslateClient(const std::shared_ptr<AWSCredentialsProvider>& 
   TranslateClient::TranslateClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TranslateErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-trustedadvisor/source/TrustedAdvisorClient.cpp
+++ b/generated/src/aws-cpp-sdk-trustedadvisor/source/TrustedAdvisorClient.cpp
@@ -52,7 +52,7 @@ TrustedAdvisorClient::TrustedAdvisorClient(const TrustedAdvisor::TrustedAdvisorC
                                            std::shared_ptr<TrustedAdvisorEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TrustedAdvisorErrorMarshaller>(ALLOCATION_TAG)),
@@ -99,7 +99,7 @@ TrustedAdvisorClient::TrustedAdvisorClient(const std::shared_ptr<AWSCredentialsP
   TrustedAdvisorClient::TrustedAdvisorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TrustedAdvisorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-verifiedpermissions/source/VerifiedPermissionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-verifiedpermissions/source/VerifiedPermissionsClient.cpp
@@ -67,7 +67,7 @@ VerifiedPermissionsClient::VerifiedPermissionsClient(const VerifiedPermissions::
                                                      std::shared_ptr<VerifiedPermissionsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<VerifiedPermissionsErrorMarshaller>(ALLOCATION_TAG)),
@@ -114,7 +114,7 @@ VerifiedPermissionsClient::VerifiedPermissionsClient(const std::shared_ptr<AWSCr
   VerifiedPermissionsClient::VerifiedPermissionsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<VerifiedPermissionsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-voice-id/source/VoiceIDClient.cpp
+++ b/generated/src/aws-cpp-sdk-voice-id/source/VoiceIDClient.cpp
@@ -71,7 +71,7 @@ VoiceIDClient::VoiceIDClient(const VoiceID::VoiceIDClientConfiguration& clientCo
                              std::shared_ptr<VoiceIDEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<VoiceIDErrorMarshaller>(ALLOCATION_TAG)),
@@ -118,7 +118,7 @@ VoiceIDClient::VoiceIDClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   VoiceIDClient::VoiceIDClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<VoiceIDErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-vpc-lattice/source/VPCLatticeClient.cpp
+++ b/generated/src/aws-cpp-sdk-vpc-lattice/source/VPCLatticeClient.cpp
@@ -94,7 +94,7 @@ VPCLatticeClient::VPCLatticeClient(const VPCLattice::VPCLatticeClientConfigurati
                                    std::shared_ptr<VPCLatticeEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<VPCLatticeErrorMarshaller>(ALLOCATION_TAG)),
@@ -141,7 +141,7 @@ VPCLatticeClient::VPCLatticeClient(const std::shared_ptr<AWSCredentialsProvider>
   VPCLatticeClient::VPCLatticeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<VPCLatticeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-waf-regional/source/WAFRegionalClient.cpp
+++ b/generated/src/aws-cpp-sdk-waf-regional/source/WAFRegionalClient.cpp
@@ -123,7 +123,7 @@ WAFRegionalClient::WAFRegionalClient(const WAFRegional::WAFRegionalClientConfigu
                                      std::shared_ptr<WAFRegionalEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WAFRegionalErrorMarshaller>(ALLOCATION_TAG)),
@@ -170,7 +170,7 @@ WAFRegionalClient::WAFRegionalClient(const std::shared_ptr<AWSCredentialsProvide
   WAFRegionalClient::WAFRegionalClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WAFRegionalErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-waf/source/WAFClient.cpp
+++ b/generated/src/aws-cpp-sdk-waf/source/WAFClient.cpp
@@ -119,7 +119,7 @@ WAFClient::WAFClient(const WAF::WAFClientConfiguration& clientConfiguration,
                      std::shared_ptr<WAFEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WAFErrorMarshaller>(ALLOCATION_TAG)),
@@ -166,7 +166,7 @@ WAFClient::WAFClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   WAFClient::WAFClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WAFErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-wafv2/source/WAFV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-wafv2/source/WAFV2Client.cpp
@@ -95,7 +95,7 @@ WAFV2Client::WAFV2Client(const WAFV2::WAFV2ClientConfiguration& clientConfigurat
                          std::shared_ptr<WAFV2EndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WAFV2ErrorMarshaller>(ALLOCATION_TAG)),
@@ -142,7 +142,7 @@ WAFV2Client::WAFV2Client(const std::shared_ptr<AWSCredentialsProvider>& credenti
   WAFV2Client::WAFV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WAFV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-wellarchitected/source/WellArchitectedClient.cpp
+++ b/generated/src/aws-cpp-sdk-wellarchitected/source/WellArchitectedClient.cpp
@@ -112,7 +112,7 @@ WellArchitectedClient::WellArchitectedClient(const WellArchitected::WellArchitec
                                              std::shared_ptr<WellArchitectedEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WellArchitectedErrorMarshaller>(ALLOCATION_TAG)),
@@ -159,7 +159,7 @@ WellArchitectedClient::WellArchitectedClient(const std::shared_ptr<AWSCredential
   WellArchitectedClient::WellArchitectedClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WellArchitectedErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-wisdom/source/ConnectWisdomServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-wisdom/source/ConnectWisdomServiceClient.cpp
@@ -81,7 +81,7 @@ ConnectWisdomServiceClient::ConnectWisdomServiceClient(const ConnectWisdomServic
                                                        std::shared_ptr<ConnectWisdomServiceEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectWisdomServiceErrorMarshaller>(ALLOCATION_TAG)),
@@ -128,7 +128,7 @@ ConnectWisdomServiceClient::ConnectWisdomServiceClient(const std::shared_ptr<AWS
   ConnectWisdomServiceClient::ConnectWisdomServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectWisdomServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-workdocs/source/WorkDocsClient.cpp
+++ b/generated/src/aws-cpp-sdk-workdocs/source/WorkDocsClient.cpp
@@ -86,7 +86,7 @@ WorkDocsClient::WorkDocsClient(const WorkDocs::WorkDocsClientConfiguration& clie
                                std::shared_ptr<WorkDocsEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkDocsErrorMarshaller>(ALLOCATION_TAG)),
@@ -133,7 +133,7 @@ WorkDocsClient::WorkDocsClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   WorkDocsClient::WorkDocsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkDocsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-worklink/source/WorkLinkClient.cpp
+++ b/generated/src/aws-cpp-sdk-worklink/source/WorkLinkClient.cpp
@@ -42,7 +42,7 @@ WorkLinkClient::WorkLinkClient(const WorkLink::WorkLinkClientConfiguration& clie
                                std::shared_ptr<WorkLinkEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkLinkErrorMarshaller>(ALLOCATION_TAG)),
@@ -89,7 +89,7 @@ WorkLinkClient::WorkLinkClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   WorkLinkClient::WorkLinkClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkLinkErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-workmail/source/WorkMailClient.cpp
+++ b/generated/src/aws-cpp-sdk-workmail/source/WorkMailClient.cpp
@@ -126,7 +126,7 @@ WorkMailClient::WorkMailClient(const WorkMail::WorkMailClientConfiguration& clie
                                std::shared_ptr<WorkMailEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkMailErrorMarshaller>(ALLOCATION_TAG)),
@@ -173,7 +173,7 @@ WorkMailClient::WorkMailClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   WorkMailClient::WorkMailClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkMailErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-workmailmessageflow/source/WorkMailMessageFlowClient.cpp
+++ b/generated/src/aws-cpp-sdk-workmailmessageflow/source/WorkMailMessageFlowClient.cpp
@@ -44,7 +44,7 @@ WorkMailMessageFlowClient::WorkMailMessageFlowClient(const WorkMailMessageFlow::
                                                      std::shared_ptr<WorkMailMessageFlowEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkMailMessageFlowErrorMarshaller>(ALLOCATION_TAG)),
@@ -91,7 +91,7 @@ WorkMailMessageFlowClient::WorkMailMessageFlowClient(const std::shared_ptr<AWSCr
   WorkMailMessageFlowClient::WorkMailMessageFlowClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkMailMessageFlowErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-workspaces-thin-client/source/WorkSpacesThinClientClient.cpp
+++ b/generated/src/aws-cpp-sdk-workspaces-thin-client/source/WorkSpacesThinClientClient.cpp
@@ -58,7 +58,7 @@ WorkSpacesThinClientClient::WorkSpacesThinClientClient(const WorkSpacesThinClien
                                                        std::shared_ptr<WorkSpacesThinClientEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkSpacesThinClientErrorMarshaller>(ALLOCATION_TAG)),
@@ -105,7 +105,7 @@ WorkSpacesThinClientClient::WorkSpacesThinClientClient(const std::shared_ptr<AWS
   WorkSpacesThinClientClient::WorkSpacesThinClientClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkSpacesThinClientErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-workspaces-web/source/WorkSpacesWebClient.cpp
+++ b/generated/src/aws-cpp-sdk-workspaces-web/source/WorkSpacesWebClient.cpp
@@ -100,7 +100,7 @@ WorkSpacesWebClient::WorkSpacesWebClient(const WorkSpacesWeb::WorkSpacesWebClien
                                          std::shared_ptr<WorkSpacesWebEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkSpacesWebErrorMarshaller>(ALLOCATION_TAG)),
@@ -147,7 +147,7 @@ WorkSpacesWebClient::WorkSpacesWebClient(const std::shared_ptr<AWSCredentialsPro
   WorkSpacesWebClient::WorkSpacesWebClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkSpacesWebErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-workspaces/source/WorkSpacesClient.cpp
+++ b/generated/src/aws-cpp-sdk-workspaces/source/WorkSpacesClient.cpp
@@ -115,7 +115,7 @@ WorkSpacesClient::WorkSpacesClient(const WorkSpaces::WorkSpacesClientConfigurati
                                    std::shared_ptr<WorkSpacesEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkSpacesErrorMarshaller>(ALLOCATION_TAG)),
@@ -162,7 +162,7 @@ WorkSpacesClient::WorkSpacesClient(const std::shared_ptr<AWSCredentialsProvider>
   WorkSpacesClient::WorkSpacesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkSpacesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-xray/source/XRayClient.cpp
+++ b/generated/src/aws-cpp-sdk-xray/source/XRayClient.cpp
@@ -72,7 +72,7 @@ XRayClient::XRayClient(const XRay::XRayClientConfiguration& clientConfiguration,
                        std::shared_ptr<XRayEndpointProviderBase> endpointProvider) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<XRayErrorMarshaller>(ALLOCATION_TAG)),
@@ -119,7 +119,7 @@ XRayClient::XRayClient(const std::shared_ptr<AWSCredentialsProvider>& credential
   XRayClient::XRayClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             GetDefaultCredentialsProviderChain(),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<XRayErrorMarshaller>(ALLOCATION_TAG)),

--- a/src/aws-cpp-sdk-core/include/aws/core/Aws.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/Aws.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <aws/core/auth/AWSCredentialsProviderChain.h>
 #include <aws/core/utils/logging/LogLevel.h>
 #include <aws/core/utils/logging/LogSystemInterface.h>
 #include <aws/core/utils/logging/CRTLogSystem.h>
@@ -105,6 +106,17 @@ namespace Aws
          * Disable legacy URL encoding that leaves `$&,:@=` unescaped for legacy purposes.
          */
         bool compliantRfc3986Encoding;
+    };
+
+    /**
+    * SDK wide options for Credentials Provider Chain
+    */
+    struct CredentialsProviderChainOptions
+    {
+        /**
+         * Defaults to empty, if this is set, then the result of your closure will be installed and used instead of the system defaults
+         */
+        std::function<std::shared_ptr<Aws::Auth::AWSCredentialsProviderChain>()> credentialsProviderChain_create_fn;
     };
 
     /**
@@ -236,6 +248,10 @@ namespace Aws
          * SDK wide options for crypto
          */
         CryptoOptions cryptoOptions;
+        /**
+         * SDK wide options for credentials provider chain
+         */
+        CredentialsProviderChainOptions credentialsProviderChainOptions;
 
         /**
          * Options used to set up customized monitoring implementations

--- a/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProviderChain.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProviderChain.h
@@ -68,5 +68,14 @@ namespace Aws
             DefaultAWSCredentialsProviderChain(const DefaultAWSCredentialsProviderChain& chain);
         };
 
+        /**
+        * Configures the default credentials provider chain
+        */
+        AWS_CORE_API void SetDefaultCredentialsProviderChain(const std::shared_ptr<AWSCredentialsProviderChain> &credentialsProviderChain);
+
+        /**
+        * Get currently configured credentials provider chain instance.
+        */
+        AWS_CORE_API std::shared_ptr<AWSCredentialsProviderChain> &GetDefaultCredentialsProviderChain();
     } // namespace Auth
 } // namespace Aws

--- a/src/aws-cpp-sdk-core/source/Aws.cpp
+++ b/src/aws-cpp-sdk-core/source/Aws.cpp
@@ -180,6 +180,16 @@ namespace Aws
               << "ABI is not guaranteed, please don't mix different versions of built libraries "
               << "and different versions of headers and corresponding built libraries.");
         }
+
+        if(options.credentialsProviderChainOptions.credentialsProviderChain_create_fn) {
+            Aws::Auth::SetDefaultCredentialsProviderChain(options.credentialsProviderChainOptions.credentialsProviderChain_create_fn());
+        }
+        else
+        {
+            Aws::Auth::SetDefaultCredentialsProviderChain(
+                Aws::MakeShared<Aws::Auth::DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG)
+            );
+        }
     }
 
     void ShutdownAPI(const SDKOptions& options)

--- a/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProviderChain.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProviderChain.cpp
@@ -14,6 +14,8 @@
 using namespace Aws::Auth;
 using namespace Aws::Utils::Threading;
 
+static std::shared_ptr<AWSCredentialsProviderChain> ConfiguredAWSCredentialsProviderChain(nullptr);
+
 static const char AWS_EC2_METADATA_DISABLED[] = "AWS_EC2_METADATA_DISABLED";
 static const char DefaultCredentialsProviderChainTag[] = "DefaultAWSCredentialsProviderChain";
 
@@ -89,4 +91,14 @@ DefaultAWSCredentialsProviderChain::DefaultAWSCredentialsProviderChain(const Def
     for (const auto& provider: chain.GetProviders()) {
         AddProvider(provider);
     }
+}
+
+std::shared_ptr<AWSCredentialsProviderChain>& Aws::Auth::GetDefaultCredentialsProviderChain()
+{
+    static std::shared_ptr<AWSCredentialsProviderChain> s_CredentialsProviderChain(nullptr);
+    return s_CredentialsProviderChain;
+}
+
+void Aws::Auth::SetDefaultCredentialsProviderChain(const std::shared_ptr<AWSCredentialsProviderChain>& credentialsProviderChain) {
+    Aws::Auth::GetDefaultCredentialsProviderChain() = credentialsProviderChain;
 }

--- a/tests/aws-cpp-sdk-ec2-integration-tests/EC2Tests.cpp
+++ b/tests/aws-cpp-sdk-ec2-integration-tests/EC2Tests.cpp
@@ -67,7 +67,7 @@ protected:
         config.scheme = Scheme::HTTPS;
         config.region = AWS_TEST_REGION;
 
-        m_EC2Client = Aws::MakeShared<Aws::EC2::EC2Client>(ALLOCATION_TAG, Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG), config);
+        m_EC2Client = Aws::MakeShared<Aws::EC2::EC2Client>(ALLOCATION_TAG, GetDefaultCredentialsProviderChain(), config);
 
         DeleteSecurityGroup(BuildResourceName(BASE_SECURITY_GROUP_NAME));
     }

--- a/tests/aws-cpp-sdk-rds-integration-tests/RDSTest.cpp
+++ b/tests/aws-cpp-sdk-rds-integration-tests/RDSTest.cpp
@@ -57,7 +57,7 @@ namespace
     class MockAWSClient : public AWSClient
     {
     public:
-        MockAWSClient() : AWSClient(ClientConfiguration(), Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG, Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+        MockAWSClient() : AWSClient(ClientConfiguration(), Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG, GetDefaultCredentialsProviderChain(),
             "rds", Aws::Region::US_EAST_1), Aws::MakeShared<XmlErrorMarshaller>(ALLOCATION_TAG)) {}
         MockAWSClient(const Aws::Client::ClientConfiguration& configuration, const std::shared_ptr<Aws::Client::AWSAuthSigner>& signer) :
             AWSClient(configuration, signer, Aws::MakeShared<XmlErrorMarshaller>(ALLOCATION_TAG)) {}

--- a/tests/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/tests/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp
@@ -176,14 +176,14 @@ namespace
             s3ClientConfig.partSize = 5 * 1024 * 1024;
 
             Client = Aws::MakeShared<S3CrtClient>(ALLOCATION_TAG,
-                Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG), s3ClientConfig,
+                GetDefaultCredentialsProviderChain(), s3ClientConfig,
                 AWSAuthV4Signer::PayloadSigningPolicy::Never /*signPayloads*/, true /*useVirtualAddressing*/,
                 Aws::S3Crt::US_EAST_1_REGIONAL_ENDPOINT_OPTION::LEGACY);
 
             s3ClientConfig.region = Aws::Region::US_WEST_2;
             s3ClientConfig.useDualStack = true;
             oregonClient = Aws::MakeShared<S3CrtClient>(ALLOCATION_TAG,
-                Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG), s3ClientConfig,
+                GetDefaultCredentialsProviderChain(), s3ClientConfig,
                 AWSAuthV4Signer::PayloadSigningPolicy::Never /*signPayloads*/, true /*useVirtualAddressing*/);
             m_HttpClient = Aws::Http::CreateHttpClient(s3ClientConfig);
         }

--- a/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
@@ -186,22 +186,22 @@ namespace
             }
 
             Client = Aws::MakeShared<S3Client>(ALLOCATION_TAG,
-                    Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG), config,
+                    GetDefaultCredentialsProviderChain(), config,
                         AWSAuthV4Signer::PayloadSigningPolicy::Never /*signPayloads*/, true /*useVirtualAddressing*/, Aws::S3::US_EAST_1_REGIONAL_ENDPOINT_OPTION::LEGACY);
             config.region = Aws::Region::AWS_GLOBAL;
             globalClient = Aws::MakeShared<S3Client>(ALLOCATION_TAG,
-                Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG), config,
+                GetDefaultCredentialsProviderChain(), config,
                     AWSAuthV4Signer::PayloadSigningPolicy::Never /*signPayloads*/, true /*useVirtualAddressing*/);
             config.region = Aws::Region::US_WEST_2;
             config.useDualStack = true;
             oregonClient = Aws::MakeShared<S3Client>(ALLOCATION_TAG,
-                    Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG), config,
+                    GetDefaultCredentialsProviderChain(), config,
                         AWSAuthV4Signer::PayloadSigningPolicy::Never /*signPayloads*/, true /*useVirtualAddressing*/);
             m_HttpClient = Aws::Http::CreateHttpClient(config);
 
             config.retryStrategy = Aws::MakeShared<RetryFiveTimesRetryStrategy>(ALLOCATION_TAG);
             retryClient = Aws::MakeShared<S3Client>(ALLOCATION_TAG,
-                    Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG), config,
+                    GetDefaultCredentialsProviderChain(), config,
                         AWSAuthV4Signer::PayloadSigningPolicy::Never /*signPayloads*/, true /*useVirtualAddressing*/);
             // Using client side monitoring for endpoint override testing.
             TestingMonitoringManager::InitTestingMonitoring();

--- a/tests/aws-cpp-sdk-sqs-integration-tests/QueueOperationTest.cpp
+++ b/tests/aws-cpp-sdk-sqs-integration-tests/QueueOperationTest.cpp
@@ -107,7 +107,7 @@ protected:
 
     void SetUp()
     {
-        sqsClient = Aws::MakeShared<SQSClient>(ALLOCATION_TAG, Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG), GetConfig());
+        sqsClient = Aws::MakeShared<SQSClient>(ALLOCATION_TAG, GetDefaultCredentialsProviderChain(), GetConfig());
     }
 
     void TearDown()

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm
@@ -61,7 +61,7 @@
 #set($AdditionalServiceSpecificConfigLoadString = "Load${metadata.classNamePrefix}SpecificConfig(config);")
 #end
 #set($clientConfigurationNamespace = "Client")
-#set($defaultCredentialsProviderChainParam = "Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG)")
+#set($defaultCredentialsProviderChainParam = "GetDefaultCredentialsProviderChain()")
 #set($s3ExpressIdentityProviderParam = "clientConfiguration.identityProviderSupplier(*this)")
 #set($simpleCredentialsProviderParam = "Aws::MakeShared<SimpleAWSCredentialsProvider>(ALLOCATION_TAG, credentials)")
 #set($hasEventStreamInputOperation = $serviceModel.hasStreamingRequestShapes())

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceLegacyConstructors.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceLegacyConstructors.vm
@@ -57,7 +57,7 @@
 #set($AdditionalServiceSpecificConfigLoadString = "Load${metadata.classNamePrefix}SpecificConfig(config);")
 #end
 #set($clientConfigurationNamespace = "Client")
-#set($defaultCredentialsProviderChainParam = "Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG)")
+#set($defaultCredentialsProviderChainParam = "GetDefaultCredentialsProviderChain()")
 #set($simpleCredentialsProviderParam = "Aws::MakeShared<SimpleAWSCredentialsProvider>(ALLOCATION_TAG, credentials)")
 #set($hasEventStreamInputOperation = $serviceModel.hasStreamingRequestShapes())
 #set($signerToMake = "AWSAuthV4Signer")


### PR DESCRIPTION
*Issue #, if available:* related to [150](https://github.com/aws/aws-sdk-cpp/issues/150); this is kind of a workaround whereby developer can set their default chain to include `STSProfileCredentialsProvider`. Just opened an [issue / feature request 2814](https://github.com/aws/aws-sdk-cpp/issues/2814).

*Description of changes:* If provided in `SDKOption`, initialization will resolve closure and set that value in static variable. If not provided, configure static variable with `DefaultAWSCredentialsProviderChain`. Most usages of `DefaultAWSCredentialsProviderChain` throughout clients has been replaced with `GetDefaultCredentialsProviderChain`.

I could use some help writing test cases, and I probably missed a couple places where I need to replace `DefaultAWSCredentialsProviderChain`.

I know this looks tedious to review; but, all of the logic changes are in `src/aws-cpp-sdk-core`. Everything outside of that is just changing existing usages of `DefaultAWSCredentialsProviderChain` => `GetDefaultCredentialsProviderChain` across the services' clients.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
