### PR TITLE
use curl in config mode if include and lib missing

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -12,6 +12,12 @@ function(compute_links lib)
         message(FATAL_ERROR "Circular dependency for library '${lib}'")
     endif()
 
+    #check if target is an alias and use that
+    get_property(aliased_target TARGET "${lib}" PROPERTY ALIASED_TARGET)
+    if(NOT "${aliased_target}" STREQUAL "")
+        set(lib "${aliased_target}")
+    endif()
+
     #interface libraries cannot be set
     get_target_property(target_type ${lib} TYPE)
     if ("INTERFACE_LIBRARY"  STREQUAL ${target_type})

--- a/cmake/external_dependencies.cmake
+++ b/cmake/external_dependencies.cmake
@@ -83,20 +83,28 @@ if(NOT NO_HTTP_CLIENT AND NOT USE_CRT_HTTP_CLIENT)
             include(FindCURL)
             if(NOT CURL_FOUND)
                 message(FATAL_ERROR "Could not find curl")
-            else()
-                message(STATUS "  Curl include directory: ${CURL_INCLUDE_DIRS}")
-                message(STATUS "  Curl library: ${CURL_LIBRARIES}")
             endif()
-            List(APPEND EXTERNAL_DEPS_INCLUDE_DIRS ${CURL_INCLUDE_DIRS})
+
+            # When built from source using cmake, curl does not include
+            # CURL_INCLUDE_DIRS or CURL_INCLUDE_DIRS so we need to use
+            # find_package to fix it
+            if ("${CURL_INCLUDE_DIRS}" STREQUAL "" AND "${CURL_LIBRARIES}" STREQUAL "")
+                message(STATUS "Could not find curl include or library path, falling back to find with config.")
+                find_package(CURL)
+                set(CURL_LIBRARIES CURL::libcurl)
+            else ()
+                message(STATUS "  Curl include directory: ${CURL_INCLUDE_DIRS}")
+                List(APPEND EXTERNAL_DEPS_INCLUDE_DIRS ${CURL_INCLUDE_DIRS})
+                set(CLIENT_LIBS ${CURL_LIBRARIES})
+            endif ()
+            set(CLIENT_LIBS_ABSTRACT_NAME curl)
+            message(STATUS "  Curl target link: ${CURL_LIBRARIES}")
         endif()
 
         if(TEST_CERT_PATH)
             message(STATUS "Setting curl cert path to ${TEST_CERT_PATH}")
             add_definitions(-DTEST_CERT_PATH="\"${TEST_CERT_PATH}\"")
         endif()
-
-        set(CLIENT_LIBS ${CURL_LIBRARIES})
-        set(CLIENT_LIBS_ABSTRACT_NAME curl)
     elseif(ENABLE_WINDOWS_CLIENT)
         add_definitions(-DENABLE_WINDOWS_CLIENT)
 

--- a/src/aws-cpp-sdk-core/CMakeLists.txt
+++ b/src/aws-cpp-sdk-core/CMakeLists.txt
@@ -118,7 +118,18 @@ include(CheckCXXSourceRuns)
 if(ENABLE_CURL_CLIENT)
     file(GLOB HTTP_CURL_CLIENT_HEADERS "include/aws/core/http/curl/*.h")
     file(GLOB HTTP_CURL_CLIENT_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/http/curl/*.cpp")
-    set(CMAKE_REQUIRED_LIBRARIES ${CURL_LIBRARIES})
+    # If using aliased curl we need actual target.
+    if(TARGET "${CURL_LIBRARIES}")
+        get_property(aliased_target TARGET "${CURL_LIBRARIES}" PROPERTY ALIASED_TARGET)
+        if(NOT "${aliased_target}" STREQUAL "")
+            set(curl_lib "${aliased_target}")
+        else ()
+            set(curl_lib "${CURL_LIBRARIES}")
+        endif()
+    else ()
+        set(curl_lib "${CURL_LIBRARIES}")
+    endif ()
+    set(CMAKE_REQUIRED_LIBRARIES ${curl_lib})
     set(CHECK_CURL_HAS_H2 "
     #include <curl/curl.h>
     int main() {


### PR DESCRIPTION
*Issue #, if available:*

[issues/2717](https://github.com/aws/aws-sdk-cpp/issues/2717)

*Description of changes:*

As mentioned in the issue

```
Right now it does not seem possible to use a custom build of Curl built with CMake when it is installed in Config mode.
```

which is true, as of the moment if you build curl from source the only way you can is by building it with autoconf. This changes to fall back to use curl by configuration if we cannot find the needed include or lib dirs from `FindCURL`.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
