### PR TITLE
Do not fail build on newer MSVS on GTEST_SKIP macro

### DIFF
--- a/tests/testing-resources/include/aws/testing/AwsCppSdkGTestSuite.h
+++ b/tests/testing-resources/include/aws/testing/AwsCppSdkGTestSuite.h
@@ -13,6 +13,11 @@
 
 #include <aws/core/Aws.h>
 
+#if defined(_WIN32)
+// disable "warning C4702: unreachable code" from GTEST_SKIP on newer MSVS
+#pragma warning(disable: 4702)
+#endif
+
 namespace Aws
 {
     namespace Testing


### PR DESCRIPTION
*Issue #, if available:*
```
...\aws-cpp-sdk-core-tests\utils\threading\ReaderWriterLockTest.cpp(94): error C2220: the following warning is treated as an erro
r [...\aws-sdk-cpp\build\tests\aws-cpp-sdk-core-tests\aws-cpp-sdk-core-tests.vcxproj]
...\aws-sdk-cpp\tests\aws-cpp-sdk-core-tests\utils\threading\ReaderWriterLockTest.cpp(94): warning C4702: unreachable code [...\aws-sdk
-cpp\build\tests\aws-cpp-sdk-core-tests\aws-cpp-sdk-core-tests.vcxproj]
```
*Description of changes:*
pragma ignore warning in AwsGTestSuite header (should be used only in tests).
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
