### PR TITLE
Align request compression config options to other SDKs

### DIFF
--- a/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
@@ -31,8 +31,8 @@ namespace Client
 {
 
 static const char* CLIENT_CONFIG_TAG = "ClientConfiguration";
-static const char* USE_REQUEST_COMPRESSION_ENV_VAR = "USE_REQUEST_COMPRESSION";
-static const char* USE_REQUEST_COMPRESSION_CONFIG_VAR = "use_request_compression";
+static const char* DISABLE_REQUEST_COMPRESSION_ENV_VAR = "DISABLE_REQUEST_COMPRESSION";
+static const char* DISABLE_REQUEST_COMPRESSION_CONFIG_VAR = "disable_request_compression";
 static const char* REQUEST_MIN_COMPRESSION_SIZE_BYTES_ENV_VAR = "REQUEST_MIN_COMPRESSION_SIZE_BYTES";
 static const char* REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_VAR = "request_min_compression_size_bytes";
 static const char* AWS_EXECUTION_ENV = "AWS_EXECUTION_ENV";
@@ -142,15 +142,15 @@ void setLegacyClientConfigurationParameters(ClientConfiguration& clientConfig)
     clientConfig.enableHostPrefixInjection = true;
     clientConfig.profileName = Aws::Auth::GetConfigProfileName();
 
-    Aws::String useCompressionConfig = clientConfig.LoadConfigFromEnvOrProfile(
-        USE_REQUEST_COMPRESSION_ENV_VAR,
+    Aws::String disableCompressionConfig = clientConfig.LoadConfigFromEnvOrProfile(
+        DISABLE_REQUEST_COMPRESSION_ENV_VAR,
         Aws::Auth::GetConfigProfileName(),
-        USE_REQUEST_COMPRESSION_CONFIG_VAR,
-        {"ENABLE", "DISABLE", "enable", "disable"},
-        "ENABLE"
+        DISABLE_REQUEST_COMPRESSION_CONFIG_VAR,
+        {"TRUE", "FALSE", "true", "false"},
+        "false"
         );
 
-    if (Aws::Utils::StringUtils::ToLower(useCompressionConfig.c_str())  == "disable") {
+    if (Aws::Utils::StringUtils::ToLower(disableCompressionConfig.c_str())  == "true") {
       clientConfig.requestCompressionConfig.useRequestCompression = Aws::Client::UseRequestCompression::DISABLE;
       AWS_LOGSTREAM_DEBUG(CLIENT_CONFIG_TAG, "Request Compression disabled");
     } else {

--- a/tests/aws-cpp-sdk-core-tests/aws/client/AwsConfigTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/aws/client/AwsConfigTest.cpp
@@ -27,7 +27,7 @@ protected:
     SaveEnvironmentVariable("AWS_DEFAULT_REGION");
     SaveEnvironmentVariable("AWS_REGION");
     SaveEnvironmentVariable("AWS_EC2_METADATA_SERVICE_ENDPOINT");
-    SaveEnvironmentVariable("USE_REQUEST_COMPRESSION");
+    SaveEnvironmentVariable("DISABLE_REQUEST_COMPRESSION");
 
     Aws::StringStream ss;
     ss << Aws::Auth::GetConfigProfileFilename() + "_blah" << std::this_thread::get_id();
@@ -38,7 +38,7 @@ protected:
     Aws::Environment::UnSetEnv("AWS_DEFAULT_REGION");
     Aws::Environment::UnSetEnv("AWS_REGION");
     Aws::Environment::UnSetEnv("AWS_EC2_METADATA_SERVICE_ENDPOINT");
-    Aws::Environment::UnSetEnv("USE_REQUEST_COMPRESSION");
+    Aws::Environment::UnSetEnv("DISABLE_REQUEST_COMPRESSION");
 
     auto profileDirectory = Aws::Auth::ProfileConfigFileAWSCredentialsProvider::GetProfileDirectory();
     Aws::FileSystem::CreateDirectoryIfNotExists(profileDirectory.c_str());
@@ -139,7 +139,7 @@ TEST_F(AWSConfigTestSuite, TestNoEnvNoConfigSetsUseRequestCompressionToTrue){
 
 TEST_F(AWSConfigTestSuite, TestEnvToFalseAndNoConfigSetsUseRequestCompressionToFalse){
   //Set Env variable
-  Aws::Environment::SetEnv("USE_REQUEST_COMPRESSION", "DISABLE", 1/*overwrite*/);
+  Aws::Environment::SetEnv("DISABLE_REQUEST_COMPRESSION", "true", 1/*overwrite*/);
   // create an empty config file
   Aws::OFStream configFileNew(m_configFileName.c_str(), Aws::OFStream::out | Aws::OFStream::trunc);
 
@@ -157,11 +157,11 @@ TEST_F(AWSConfigTestSuite, TestEnvToFalseAndNoConfigSetsUseRequestCompressionToF
 
 TEST_F(AWSConfigTestSuite, TestEnvToTrueAndConfigSetToFalseSetsUseRequestCompressionToTrue){
   //Set Env variable
-  Aws::Environment::SetEnv("USE_REQUEST_COMPRESSION", "ENABLE", 1/*overwrite*/);
+  Aws::Environment::SetEnv("DISABLE_REQUEST_COMPRESSION", "false", 1/*overwrite*/);
   // create an empty config file
   Aws::OFStream configFileNew(m_configFileName.c_str(), Aws::OFStream::out | Aws::OFStream::trunc);
   configFileNew << "[profile Dijkstra]" << std::endl;  // profile keyword is mandatory per specification
-  configFileNew << "use_request_compression = enable" << std::endl;
+  configFileNew << "disable_request_compression = false" << std::endl;
 
   configFileNew.flush();
   configFileNew.close();
@@ -179,7 +179,7 @@ TEST_F(AWSConfigTestSuite, TestNoEnvAndConfigSetToFalseSetsUseRequestCompression
   // create an empty config file
   Aws::OFStream configFileNew(m_configFileName.c_str(), Aws::OFStream::out | Aws::OFStream::trunc);
   configFileNew << "[profile default]" << std::endl;  // profile keyword is mandatory per specification
-  configFileNew << "use_request_compression = disable" << std::endl;
+  configFileNew << "disable_request_compression = true" << std::endl;
 
   configFileNew.flush();
   configFileNew.close();


### PR DESCRIPTION
*Description of changes:*

Our environment variables and configuration variables are not aligned with what other SDKs use for request compression being enabled.

[aws docs for reference](https://docs.aws.amazon.com/sdkref/latest/guide/feature-compression.html)

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
