### PR TITLE
Fix Transcribe streaming "A complete signal was sent without ending frame"

### DIFF
--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/AudioStream.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/AudioStream.h
@@ -31,10 +31,13 @@ namespace Model
     AudioStream& WriteAudioEvent(const AudioEvent& value)
     {
        Aws::Utils::Event::Message msg;
-       msg.InsertEventHeader(":message-type", Aws::String("event"));
-       msg.InsertEventHeader(":event-type", Aws::String("AudioEvent"));
-       msg.InsertEventHeader(":content-type", Aws::String("application/octet-stream"));
-       msg.WriteEventPayload(value.GetAudioChunk());
+       if(!value.GetAudioChunk().empty())
+       {
+           msg.InsertEventHeader(":message-type", Aws::String("event"));
+           msg.InsertEventHeader(":event-type", Aws::String("AudioEvent"));
+           msg.InsertEventHeader(":content-type", Aws::String("application/octet-stream"));
+           msg.WriteEventPayload(value.GetAudioChunk());
+       }
        WriteEvent(msg);
        return *this;
     }

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/event/EventStreamEncoder.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/event/EventStreamEncoder.h
@@ -49,11 +49,12 @@ namespace Aws
                 bool InitEncodedStruct(const Aws::Utils::Event::Message& msg, aws_event_stream_message* encoded);
 
                 /**
-                 * Initialize signed C struct based on unsigned C struct.
+                 * Initialize signed C struct with a content of a payload message.
                  * Returns true if successful.
+                 * signedmsg will contain an AWS Stream Event with a payload in a H2 frame payload section.
                  * A successfully initialized struct must be cleaned up when you're done with it.
                  */
-                bool InitSignedStruct(const aws_event_stream_message* msg, aws_event_stream_message* signedmsg);
+                bool InitSignedStruct(const aws_event_stream_message* payload, aws_event_stream_message* signedmsg);
 
                 Aws::Client::AWSAuthSigner* m_signer;
                 Aws::String m_signatureSeed;

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/stream/ConcurrentStreamBuf.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/stream/ConcurrentStreamBuf.h
@@ -30,7 +30,7 @@ namespace Aws
             {
             public:
 
-                explicit ConcurrentStreamBuf(size_t bufferLength = 4 * 1024);
+                explicit ConcurrentStreamBuf(size_t bufferLength = 8 * 1024);
 
                 void SetEof();
 

--- a/src/aws-cpp-sdk-core/source/utils/event/EventStreamBuf.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/event/EventStreamBuf.cpp
@@ -11,7 +11,7 @@ namespace Aws
     {
         namespace Event
         {
-            const size_t DEFAULT_BUF_SIZE = 1024;
+            const size_t DEFAULT_BUF_SIZE = 8096;
 
             EventStreamBuf::EventStreamBuf(EventStreamDecoder& decoder, size_t bufferLength) :
                 m_byteBuffer(bufferLength),

--- a/src/aws-cpp-sdk-core/source/utils/event/EventStreamEncoder.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/event/EventStreamEncoder.cpp
@@ -83,10 +83,18 @@ namespace Aws
                 Aws::Vector<unsigned char> outputBits;
 
                 aws_event_stream_message encoded;
-                if (InitEncodedStruct(msg, &encoded))
+                aws_event_stream_message* encodedPayload = nullptr;
+                bool msgEncodeSuccess = true; // empty message "successes" to encode
+                if (!msg.GetEventHeaders().empty() || !msg.GetEventPayload().empty())
+                {
+                    InitEncodedStruct(msg, &encoded);
+                    encodedPayload = &encoded;
+                }
+
+                if (msgEncodeSuccess)
                 {
                     aws_event_stream_message signedMessage;
-                    if (InitSignedStruct(&encoded, &signedMessage))
+                    if (InitSignedStruct(encodedPayload, &signedMessage))
                     {
                         // success!
                         const auto signedMessageBuffer = aws_event_stream_message_buffer(&signedMessage);
@@ -96,7 +104,10 @@ namespace Aws
 
                         aws_event_stream_message_clean_up(&signedMessage);
                     }
-                    aws_event_stream_message_clean_up(&encoded);
+                    if (encodedPayload)
+                    {
+                        aws_event_stream_message_clean_up(encodedPayload);
+                    }
                 }
 
                 return outputBits;
@@ -124,14 +135,17 @@ namespace Aws
                 return success;
             }
 
-            bool EventStreamEncoder::InitSignedStruct(const aws_event_stream_message* msg, aws_event_stream_message* signedmsg)
+            bool EventStreamEncoder::InitSignedStruct(const aws_event_stream_message* payload, aws_event_stream_message* signedmsg)
             {
                 bool success = false;
 
-                const auto msgbuf = aws_event_stream_message_buffer(msg);
-                const auto msglen = aws_event_stream_message_total_length(msg);
                 Event::Message signedMessage;
-                signedMessage.WriteEventPayload(msgbuf, msglen);
+                if (payload)
+                {
+                    const auto msgbuf = aws_event_stream_message_buffer(payload);
+                    const auto msglen = aws_event_stream_message_total_length(payload);
+                    signedMessage.WriteEventPayload(msgbuf, msglen);
+                }
 
                 assert(m_signer);
                 if (m_signer->SignEventMessage(signedMessage, m_signatureSeed))
@@ -139,9 +153,9 @@ namespace Aws
                     aws_array_list headers;
                     EncodeHeaders(signedMessage, &headers);
 
-                    aws_byte_buf payload = aws_byte_buf_from_array(signedMessage.GetEventPayload().data(), signedMessage.GetEventPayload().size());
+                    aws_byte_buf signedPayload = aws_byte_buf_from_array(signedMessage.GetEventPayload().data(), signedMessage.GetEventPayload().size());
 
-                    if(aws_event_stream_message_init(signedmsg, get_aws_allocator(), &headers, &payload) == AWS_OP_SUCCESS)
+                    if(aws_event_stream_message_init(signedmsg, get_aws_allocator(), &headers, &signedPayload) == AWS_OP_SUCCESS)
                     {
                         success = true;
                     }

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/EventStreamHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/EventStreamHeader.vm
@@ -48,17 +48,24 @@ namespace Model
     ${typeInfo.className}& Write${entry.value.shape.name}(const ${entry.value.shape.name}& value)
     {
        Aws::Utils::Event::Message msg;
+#if(!$entry.value.shape.eventPayloadType.equals("blob"))
        msg.InsertEventHeader(":message-type", Aws::String("event"));
        msg.InsertEventHeader(":event-type", Aws::String("${entry.value.shape.name}"));
-#if($entry.value.shape.eventPayloadType.equals("blob"))
-       msg.InsertEventHeader(":content-type", Aws::String("application/octet-stream"));
-       msg.WriteEventPayload(value.Get$CppViewHelper.capitalizeFirstChar(${entry.value.shape.eventPayloadMemberName})());
-#elseif($entry.value.shape.eventPayloadType.equals("string"))
+#if($entry.value.shape.eventPayloadType.equals("string"))
        msg.InsertEventHeader(":content-type", Aws::String("text/plain"));
        msg.WriteEventPayload(value.Get$CppViewHelper.capitalizeFirstChar(${entry.value.shape.eventPayloadMemberName})()));
 #elseif($entry.value.shape.eventPayloadType.equals("structure") || $entry.value.shape.eventPayloadType.equals("list"))
        msg.InsertEventHeader(":content-type", Aws::String("application/json"));
        msg.WriteEventPayload(value.Jsonize().View().WriteCompact());
+#end
+#else##if($entry.value.shape.eventPayloadType.equals("blob"))
+       if(!value.Get$CppViewHelper.capitalizeFirstChar(${entry.value.shape.eventPayloadMemberName})().empty())
+       {
+           msg.InsertEventHeader(":message-type", Aws::String("event"));
+           msg.InsertEventHeader(":event-type", Aws::String("${entry.value.shape.name}"));
+           msg.InsertEventHeader(":content-type", Aws::String("application/octet-stream"));
+           msg.WriteEventPayload(value.Get$CppViewHelper.capitalizeFirstChar(${entry.value.shape.eventPayloadMemberName})());
+       }
 #end
        WriteEvent(msg);
        return *this;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Encode very empty frame (=no payload section) http2 frame instead of a frame with headers as a payload.

This does not fix performance issues of HTTP2 streaming within the SDK.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
