### PR TITLE
Add constructor overload to `STSProfileCredentialsProvider` where the client factory returns a shared pointer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Release
 *#
 *.iml
 tags
+.vs
 .vscode
 
 # CI Artifacts

--- a/src/aws-cpp-sdk-identity-management/include/aws/identity-management/auth/STSProfileCredentialsProvider.h
+++ b/src/aws-cpp-sdk-identity-management/include/aws/identity-management/auth/STSProfileCredentialsProvider.h
@@ -52,7 +52,46 @@ namespace Aws
              */
             STSProfileCredentialsProvider(const Aws::String& profileName, std::chrono::minutes duration = std::chrono::minutes(60));
 
+            /**
+             * Use the provided profile name from the shared configuration file and a custom STS client.
+             *
+             * @param profileName The name of the profile in the shared configuration file.
+             * @param duration The duration, in minutes, of the role session, after which the credentials are expired.
+             * The value can range from 15 minutes up to the maximum session duration setting for the role. By default,
+             * the duration is set to 1 hour.
+             * Note: This credential provider refreshes the credentials 5 minutes before their expiration time. That
+             * ensures the credentials do not expire between the time they're checked and the time they're returned to
+             * the user.
+             * If the duration for the credentials is 5 minutes or less, the provider will refresh the credentials only
+             * when they expire.
+             * @param stsClientFactory A factory function that creates an STSClient with specific credentials.
+             * Using the overload where the function returns a shared_ptr is preferred.
+             *
+             */
             STSProfileCredentialsProvider(const Aws::String& profileName, std::chrono::minutes duration, const std::function<Aws::STS::STSClient*(const AWSCredentials&)> &stsClientFactory);
+
+            /**
+             * Use the provided profile name from the shared configuration file and a custom STS client.
+             *
+             * @param profileName The name of the profile in the shared configuration file.
+             * @param duration The duration, in minutes, of the role session, after which the credentials are expired.
+             * The value can range from 15 minutes up to the maximum session duration setting for the role. By default,
+             * the duration is set to 1 hour.
+             * Note: This credential provider refreshes the credentials 5 minutes before their expiration time. That
+             * ensures the credentials do not expire between the time they're checked and the time they're returned to
+             * the user.
+             * If the duration for the credentials is 5 minutes or less, the provider will refresh the credentials only
+             * when they expire.
+             * @param stsClientFactory A factory function that creates an STSClient with specific credentials.
+             *
+             */
+            STSProfileCredentialsProvider(const Aws::String& profileName, std::chrono::minutes duration, const std::function<std::shared_ptr<Aws::STS::STSClient>(const AWSCredentials&)> &stsClientFactory);
+
+            /**
+             * Compatibility constructor to assist with overload resolution when passing nullptr for the client factory.
+             *
+             */
+            STSProfileCredentialsProvider(const Aws::String& profileName, std::chrono::minutes duration, std::nullptr_t);
 
             /**
              * Fetches the credentials set from STS following the rules defined in the shared configuration file.
@@ -74,7 +113,7 @@ namespace Aws
             AWSCredentials m_credentials;
             const std::chrono::minutes m_duration;
             const std::chrono::milliseconds m_reloadFrequency;
-            std::function<Aws::STS::STSClient*(const AWSCredentials&)> m_stsClientFactory;
+            std::function<std::shared_ptr<Aws::STS::STSClient>(const AWSCredentials&)> m_stsClientFactory;
         };
     }
 }

--- a/tests/aws-cpp-sdk-identity-management-tests/auth/STSProfileCredentialsProviderTest.cpp
+++ b/tests/aws-cpp-sdk-identity-management-tests/auth/STSProfileCredentialsProviderTest.cpp
@@ -313,7 +313,7 @@ TEST_F(STSProfileCredentialsProviderTest, AssumeRoleWithoutRoleARN)
 
     STSProfileCredentialsProvider credsProvider("default", roleSessionDuration, [](const AWSCredentials&) {
             ADD_FAILURE() << "STS Service client should not be used in this scenario.";
-            return nullptr;
+            return (STSClient*)nullptr;
     });
 
     auto actualCredentials = credsProvider.GetAWSCredentials();
@@ -383,7 +383,7 @@ TEST_F(STSProfileCredentialsProviderTest, AssumeRoleWithoutSourceProfile)
 
     STSProfileCredentialsProvider credsProvider("default", roleSessionDuration, [](const AWSCredentials&) {
             ADD_FAILURE() << "STS Service client should not be used in this scenario.";
-            return nullptr;
+            return (STSClient*)nullptr;
     });
 
     auto actualCredentials = credsProvider.GetAWSCredentials();
@@ -409,7 +409,7 @@ TEST_F(STSProfileCredentialsProviderTest, AssumeRoleWithNonExistentSourceProfile
 
     STSProfileCredentialsProvider credsProvider("default", roleSessionDuration, [](const AWSCredentials&) {
             ADD_FAILURE() << "STS Service client should not be used in this scenario.";
-            return nullptr;
+            return (STSClient*)nullptr;
     });
 
     auto actualCredentials = credsProvider.GetAWSCredentials();
@@ -556,7 +556,7 @@ TEST_F(STSProfileCredentialsProviderTest, AssumeRoleSelfReferencingSourceProfile
 
     Model::AssumeRoleResult mockResult;
     mockResult.SetCredentials(stsCredentials);
-    Aws::UniquePtr<MockSTSClient> stsClient;
+    std::shared_ptr<MockSTSClient> stsClient;
 
     int stsCallCounter = 0;
 
@@ -572,9 +572,9 @@ TEST_F(STSProfileCredentialsProviderTest, AssumeRoleSelfReferencingSourceProfile
                     EXPECT_STREQ(ACCESS_KEY_ID_2, creds.GetAWSAccessKeyId().c_str());
                     EXPECT_STREQ(SECRET_ACCESS_KEY_ID_2, creds.GetAWSSecretKey().c_str());
                 }
-                stsClient = Aws::MakeUnique<MockSTSClient>(CLASS_TAG, creds);
+                stsClient = Aws::MakeShared<MockSTSClient>(CLASS_TAG, creds);
                 stsClient->MockAssumeRole(mockResult);
-                return stsClient.get();
+                return stsClient;
             });
 
     auto actualCredentials = credsProvider.GetAWSCredentials();
@@ -614,7 +614,7 @@ TEST_F(STSProfileCredentialsProviderTest, AssumeRoleRecursivelyCircularReference
 
     STSProfileCredentialsProvider credsProvider("default", roleSessionDuration, [](const AWSCredentials&) {
             ADD_FAILURE() << "STS Service client should not be used in this scenario.";
-            return nullptr;
+            return (STSClient*)nullptr;
     });
 
     auto actualCredentials = credsProvider.GetAWSCredentials();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `STSProfileCredentialProvider` class has a constructor overload that accepts an `STSClient` factory function. The problem with this function is that it returns an `STSClient*`, making lifetime management tricky in certain cases.

This PR introduces an additional overload that accepts an factory that returns a `shared_ptr<STSClient>`. This will enable the client to be freed automatically when the credentials provider no longer needs it.

The existing constructor overload wraps the `STSClient*` into a shared pointer with a deleter that does nothing, maintaining compatibility. I also added an overload to disambiguate between creating a credential provider with a `nullptr` factory.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [Χ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [Χ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [Χ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
