### PR TITLE
Avoid processing log statement if logger has been destructed

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/logging/DefaultLogSystem.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/logging/DefaultLogSystem.h
@@ -58,12 +58,13 @@ namespace Aws
                 struct LogSynchronizationData
                 {
                 public:
-                    LogSynchronizationData() : m_stopLogging(false) {}
+                    LogSynchronizationData() : m_stopLogging(false), m_loggingThreadStopped(false) {}
 
                     std::mutex m_logQueueMutex;
                     std::condition_variable m_queueSignal;
                     Aws::Vector<Aws::String> m_queuedLogMessages;
-                    bool m_stopLogging;
+                    bool m_stopLogging = false;
+                    bool m_loggingThreadStopped = false;
 
                 private:
                     LogSynchronizationData(const LogSynchronizationData& rhs) = delete;


### PR DESCRIPTION
in the middle of logging

*Issue #, if available:*

in case of heavy mis-use of basic-use such as in
```
TEST(AwsMemoryManagementTest, MultiInitParallel)
```

the logger may perform
```
m_syncData.m_queuedLogMessages.emplace_back(std::move(statement));
```
on already destructed self.
With custom memory management enabled, it will result in UB.

*Description of changes:*

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
