### PR TITLE
change asserts to expects to prevent early test termination

### DIFF
--- a/tests/aws-cpp-sdk-s3-crt-integration-tests/S3ExpressTest.cpp
+++ b/tests/aws-cpp-sdk-s3-crt-integration-tests/S3ExpressTest.cpp
@@ -470,11 +470,11 @@ namespace {
       request.SetBody(body);
       const auto response = client->PutObject(request);
       if (!response.IsSuccess()) {
-        ASSERT_EQ(testCase.responseCode, response.GetError().GetResponseCode());
+        EXPECT_EQ(testCase.responseCode, response.GetError().GetResponseCode());
       }
       else {
-        ASSERT_EQ(testCase.responseCode, HttpResponseCode::OK);
-        ASSERT_TRUE(response.IsSuccess());
+        EXPECT_EQ(testCase.responseCode, HttpResponseCode::OK);
+        EXPECT_TRUE(response.IsSuccess());
       }
     }
   }

--- a/tests/aws-cpp-sdk-s3-integration-tests/S3ExpressTest.cpp
+++ b/tests/aws-cpp-sdk-s3-integration-tests/S3ExpressTest.cpp
@@ -470,11 +470,11 @@ namespace {
       request.SetBody(body);
       const auto response = client->PutObject(request);
       if (!response.IsSuccess()) {
-        ASSERT_EQ(testCase.responseCode, response.GetError().GetResponseCode());
+        EXPECT_EQ(testCase.responseCode, response.GetError().GetResponseCode());
       }
       else {
-        ASSERT_EQ(testCase.responseCode, HttpResponseCode::OK);
-        ASSERT_TRUE(response.IsSuccess());
+        EXPECT_EQ(testCase.responseCode, HttpResponseCode::OK);
+        EXPECT_TRUE(response.IsSuccess());
       }
     }
   }


### PR DESCRIPTION
*Description of changes:*

changes S3Express checksum tests to expect and not assert to avoid early test termination. which can cause bucket resource leakage.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
