### PR TITLE
Change code to handle empty vector

### DIFF
--- a/src/aws-cpp-sdk-core/source/utils/stream/ConcurrentStreamBuf.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/stream/ConcurrentStreamBuf.cpp
@@ -184,7 +184,7 @@ namespace Aws
                     return std::char_traits<char>::eof();
                 }
 
-                char* gbegin = reinterpret_cast<char*>(&m_getArea[0]);
+                char* gbegin = reinterpret_cast<char*>(m_getArea.data());
                 setg(gbegin, gbegin, gbegin + m_getArea.size());
 
                 if (!m_getArea.empty())


### PR DESCRIPTION
On Windows, an exception was thrown because the array index was out of bounds on an empty buffer.
Changes made in PR #2827 now allow an empty buffer in this section of code.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Changed one line of code. No additional tests needed.
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
