### PR TITLE
Do not log within signal handler as it is not safe

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/HttpClientFactory.cpp
+++ b/src/aws-cpp-sdk-core/source/http/HttpClientFactory.cpp
@@ -50,16 +50,8 @@ namespace Aws
         static const char* HTTP_CLIENT_FACTORY_ALLOCATION_TAG = "HttpClientFactory";
 
 #if ENABLE_CURL_CLIENT && !defined(_WIN32)
-        static void LogAndSwallowHandler(int signal)
+        static void LogAndSwallowHandler(int)
         {
-            switch(signal)
-            {
-                case SIGPIPE:
-                    AWS_LOGSTREAM_ERROR(HTTP_CLIENT_FACTORY_ALLOCATION_TAG, "Received a SIGPIPE error");
-                    break;
-                default:
-                    AWS_LOGSTREAM_ERROR(HTTP_CLIENT_FACTORY_ALLOCATION_TAG, "Unhandled system SIGNAL error"  << signal);
-            }
         }
 #endif
 


### PR DESCRIPTION
*Issue #, if available:*

CPP-34195

*Description of changes:*

Disable logging in the LogAndSwallow signal handler.  Logging is not safe during signal handling as it can allocate memory.

*Check all that applies:*
- [X] Did a review by yourself: that's why I submitted a pull request.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.): existing are sufficient.
- [X] Checked if this PR is a breaking (APIs have been changed) change: no.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior: correct.
- [X] Checked if this PR would require a ReadMe/Wiki update: no.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
