### PR TITLE
add s3 express integ tests bucket tags for cleaning

### DIFF
--- a/tests/aws-cpp-sdk-s3-crt-integration-tests/S3ExpressTest.cpp
+++ b/tests/aws-cpp-sdk-s3-crt-integration-tests/S3ExpressTest.cpp
@@ -30,6 +30,9 @@
 #include <aws/s3-crt/model/ListPartsRequest.h>
 #include <aws/s3-crt/model/AbortMultipartUploadRequest.h>
 #include <aws/s3-crt/model/ListMultipartUploadsRequest.h>
+#include <aws/s3-crt/model/PutBucketTaggingRequest.h>
+#include <aws/s3-crt/model/Tag.h>
+#include <aws/s3-crt/model/Tagging.h>
 #include <aws/testing/platform/PlatformTesting.h>
 #include <aws/testing/TestingEnvironment.h>
 #include <random>
@@ -52,6 +55,7 @@ using namespace Aws::Utils;
 namespace {
   const char* ALLOCATION_TAG = "S3CrtClientS3ExpressTest";
   const char* S3_EXPRESS_SUFFIX = "--use1-az6--x-s3";
+  const char* TEST_BUCKET_TAG = "IntegrationTestResource";
 
   class S3ExpressTest : public ::testing::Test {
   public:
@@ -67,6 +71,7 @@ namespace {
             .WithType(BucketType::Directory)
             .WithDataRedundancy(DataRedundancy::SingleAvailabilityZone))));
 
+      TagTestBucket(bucketName);
       if (!outcome.IsSuccess() && outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::CONFLICT &&
                                   (outcome.GetError().GetExceptionName() == "BucketAlreadyOwnedByYou" ||
                                    outcome.GetError().GetExceptionName() == "OperationAborted")) {
@@ -294,6 +299,22 @@ namespace {
           std::cout << "Failed to delete bucket: " << outcome.GetError().GetMessage() << "\n";
         }
       }
+    }
+
+    void TagTestBucket(const String& bucketName) {
+      PutBucketTaggingRequest taggingRequest;
+      taggingRequest.SetBucket(bucketName);
+      Tag tag;
+      tag.SetKey(TEST_BUCKET_TAG);
+      tag.SetValue(TEST_BUCKET_TAG);
+      Tagging tagging;
+      tagging.AddTagSet(tag);
+      taggingRequest.SetTagging(tagging);
+
+      const auto taggingOutcome = CallOperationWithUnconditionalRetry(client.get(),
+        &S3CrtClient::PutBucketTagging,
+        taggingRequest);
+      AWS_EXPECT_SUCCESS(taggingOutcome);
     }
 
   protected:


### PR DESCRIPTION
*Description of changes:*

Attempts to tag all created buckets so that we can target the for deletion in a janitor script incase of unintentional leakage.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
