### PR TITLE
allow to build s3-crt as static libs without duplicate symbols

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3ExpressSigner.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3ExpressSigner.cpp
@@ -17,10 +17,10 @@ using namespace Aws::Config;
 using namespace Aws::Environment;
 using namespace Aws::Utils;
 
-const char *S3_EXPRESS_SIGNER_NAME = "S3ExpressSigner";
-const char *S3_EXPRESS_HEADER = "x-amz-s3session-token";
-const char *S3_EXPRESS_QUERY_PARAM = "X-Amz-S3session-Token";
-const char *S3_EXPRESS_SERVICE_NAME = "s3express";
+static const char *S3_EXPRESS_SIGNER_NAME = "S3ExpressSigner";
+static const char *S3_EXPRESS_HEADER = "x-amz-s3session-token";
+static const char *S3_EXPRESS_QUERY_PARAM = "X-Amz-S3session-Token";
+static const char *S3_EXPRESS_SERVICE_NAME = "s3express";
 
 S3ExpressSigner::S3ExpressSigner(
     std::shared_ptr<S3ExpressIdentityProvider> S3ExpressIdentityProvider,

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3ExpressSignerProvider.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3ExpressSignerProvider.cpp
@@ -7,7 +7,7 @@
 #include <aws/s3-crt/S3ExpressSignerProvider.h>
 #include <aws/s3-crt/S3ExpressSigner.h>
 
-const char *CLASS_TAG = "S3ExpressSignerProvider";
+static const char *CLASS_TAG = "S3ExpressSignerProvider";
 
 Aws::Auth::S3ExpressSignerProvider::S3ExpressSignerProvider(
     const std::shared_ptr<AWSCredentialsProvider> &credentialsProvider,

--- a/generated/src/aws-cpp-sdk-s3/source/S3ExpressSigner.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3ExpressSigner.cpp
@@ -17,10 +17,10 @@ using namespace Aws::Config;
 using namespace Aws::Environment;
 using namespace Aws::Utils;
 
-const char *S3_EXPRESS_SIGNER_NAME = "S3ExpressSigner";
-const char *S3_EXPRESS_HEADER = "x-amz-s3session-token";
-const char *S3_EXPRESS_QUERY_PARAM = "X-Amz-S3session-Token";
-const char *S3_EXPRESS_SERVICE_NAME = "s3express";
+static const char *S3_EXPRESS_SIGNER_NAME = "S3ExpressSigner";
+static const char *S3_EXPRESS_HEADER = "x-amz-s3session-token";
+static const char *S3_EXPRESS_QUERY_PARAM = "X-Amz-S3session-Token";
+static const char *S3_EXPRESS_SERVICE_NAME = "s3express";
 
 S3ExpressSigner::S3ExpressSigner(
     std::shared_ptr<S3ExpressIdentityProvider> S3ExpressIdentityProvider,

--- a/generated/src/aws-cpp-sdk-s3/source/S3ExpressSignerProvider.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3ExpressSignerProvider.cpp
@@ -7,7 +7,7 @@
 #include <aws/s3/S3ExpressSignerProvider.h>
 #include <aws/s3/S3ExpressSigner.h>
 
-const char *CLASS_TAG = "S3ExpressSignerProvider";
+static const char *CLASS_TAG = "S3ExpressSignerProvider";
 
 Aws::Auth::S3ExpressSignerProvider::S3ExpressSignerProvider(
     const std::shared_ptr<AWSCredentialsProvider> &credentialsProvider,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/issues/2842

*Description of changes:*
the s3 and s3crt are defining some common symbols. So when you build as static libs, it does not link due to duplicate symbols.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [X] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
