### PR TITLE
S3express symbols

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3ExpressSigner.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3ExpressSigner.cpp
@@ -17,10 +17,10 @@ using namespace Aws::Config;
 using namespace Aws::Environment;
 using namespace Aws::Utils;
 
-const char *S3_EXPRESS_SIGNER_NAME = "S3ExpressSigner";
-const char *S3_EXPRESS_HEADER = "x-amz-s3session-token";
-const char *S3_EXPRESS_QUERY_PARAM = "X-Amz-S3session-Token";
-const char *S3_EXPRESS_SERVICE_NAME = "s3express";
+static const char *S3_EXPRESS_SIGNER_NAME = "S3ExpressSigner";
+static const char *S3_EXPRESS_HEADER = "x-amz-s3session-token";
+static const char *S3_EXPRESS_QUERY_PARAM = "X-Amz-S3session-Token";
+static const char *S3_EXPRESS_SERVICE_NAME = "s3express";
 
 S3ExpressSigner::S3ExpressSigner(
     std::shared_ptr<S3ExpressIdentityProvider> S3ExpressIdentityProvider,

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3ExpressSignerProvider.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3ExpressSignerProvider.cpp
@@ -7,7 +7,7 @@
 #include <aws/s3-crt/S3ExpressSignerProvider.h>
 #include <aws/s3-crt/S3ExpressSigner.h>
 
-const char *CLASS_TAG = "S3ExpressSignerProvider";
+static const char *CLASS_TAG = "S3ExpressSignerProvider";
 
 Aws::Auth::S3ExpressSignerProvider::S3ExpressSignerProvider(
     const std::shared_ptr<AWSCredentialsProvider> &credentialsProvider,

--- a/generated/src/aws-cpp-sdk-s3/source/S3ExpressSigner.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3ExpressSigner.cpp
@@ -17,10 +17,10 @@ using namespace Aws::Config;
 using namespace Aws::Environment;
 using namespace Aws::Utils;
 
-const char *S3_EXPRESS_SIGNER_NAME = "S3ExpressSigner";
-const char *S3_EXPRESS_HEADER = "x-amz-s3session-token";
-const char *S3_EXPRESS_QUERY_PARAM = "X-Amz-S3session-Token";
-const char *S3_EXPRESS_SERVICE_NAME = "s3express";
+static const char *S3_EXPRESS_SIGNER_NAME = "S3ExpressSigner";
+static const char *S3_EXPRESS_HEADER = "x-amz-s3session-token";
+static const char *S3_EXPRESS_QUERY_PARAM = "X-Amz-S3session-Token";
+static const char *S3_EXPRESS_SERVICE_NAME = "s3express";
 
 S3ExpressSigner::S3ExpressSigner(
     std::shared_ptr<S3ExpressIdentityProvider> S3ExpressIdentityProvider,

--- a/generated/src/aws-cpp-sdk-s3/source/S3ExpressSignerProvider.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3ExpressSignerProvider.cpp
@@ -7,7 +7,7 @@
 #include <aws/s3/S3ExpressSignerProvider.h>
 #include <aws/s3/S3ExpressSigner.h>
 
-const char *CLASS_TAG = "S3ExpressSignerProvider";
+static const char *CLASS_TAG = "S3ExpressSignerProvider";
 
 Aws::Auth::S3ExpressSignerProvider::S3ExpressSignerProvider(
     const std::shared_ptr<AWSCredentialsProvider> &credentialsProvider,

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressSignerProviderSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressSignerProviderSource.vm
@@ -7,7 +7,7 @@
 \#include <aws/${metadata.projectName}/S3ExpressSignerProvider.h>
 \#include <aws/${metadata.projectName}/S3ExpressSigner.h>
 
-const char *CLASS_TAG = "S3ExpressSignerProvider";
+static const char *CLASS_TAG = "S3ExpressSignerProvider";
 
 ${rootNamespace}::Auth::S3ExpressSignerProvider::S3ExpressSignerProvider(
     const std::shared_ptr<AWSCredentialsProvider> &credentialsProvider,

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressSignerSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressSignerSource.vm
@@ -17,10 +17,10 @@ using namespace ${rootNamespace}::Config;
 using namespace ${rootNamespace}::Environment;
 using namespace ${rootNamespace}::Utils;
 
-const char *S3_EXPRESS_SIGNER_NAME = "S3ExpressSigner";
-const char *S3_EXPRESS_HEADER = "x-amz-s3session-token";
-const char *S3_EXPRESS_QUERY_PARAM = "X-Amz-S3session-Token";
-const char *S3_EXPRESS_SERVICE_NAME = "s3express";
+static const char *S3_EXPRESS_SIGNER_NAME = "S3ExpressSigner";
+static const char *S3_EXPRESS_HEADER = "x-amz-s3session-token";
+static const char *S3_EXPRESS_QUERY_PARAM = "X-Amz-S3session-Token";
+static const char *S3_EXPRESS_SERVICE_NAME = "s3express";
 
 S3ExpressSigner::S3ExpressSigner(
     std::shared_ptr<S3ExpressIdentityProvider> S3ExpressIdentityProvider,


### PR DESCRIPTION
*Issue #, if available:*

[issues/2842](https://github.com/aws/aws-sdk-cpp/issues/2842)

*Description of changes:*

There is symbol collision for string constants in the s3 express signer translation units. This fixes the by picking up @thierryba 's fixes and adding coden.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
