### PR TITLE
fix issue https://github.com/aws/aws-sdk-cpp/issues/2846

### DIFF
--- a/src/aws-cpp-sdk-core/source/utils/event/EventEncoderStream.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/event/EventEncoderStream.cpp
@@ -29,7 +29,7 @@ namespace Aws
                 auto bits = m_encoder.EncodeAndSign(msg);
 
                 AWS_LOGSTREAM_TRACE("EventEncoderStream::WriteEvent", "Encoded event (base64 encoded): " <<
-                                    Aws::Utils::HashingUtils::Base64Encode((bits.data(), bits.size())));
+                                    Aws::Utils::HashingUtils::Base64Encode(Aws::Utils::ByteBuffer(bits.data(), bits.size())));
 
                 // write buffer to underlying rdbuf (ConcurrentStreamBuf), this may call overflow()
                 // and block until data is consumed by HTTP Client


### PR DESCRIPTION
*Issue #, if available: 2846*

*Description of changes:*
Removed implicit use of `Aws::Utils::ByteBuffer`, which led MSVC2022 to consider `bits.data()` as not being consumed.

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [X ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
