### PR TITLE
Fix delay load dll

### DIFF
--- a/generated/src/aws-cpp-sdk-cognito-identity/include/aws/cognito-identity/CognitoIdentityClient.h
+++ b/generated/src/aws-cpp-sdk-cognito-identity/include/aws/cognito-identity/CognitoIdentityClient.h
@@ -37,8 +37,8 @@ namespace CognitoIdentity
   {
     public:
       typedef Aws::Client::AWSJsonClient BASECLASS;
-      static const char* SERVICE_NAME;
-      static const char* ALLOCATION_TAG;
+      static const char* GetServiceName();
+      static const char* GetAllocationTag();
 
       typedef CognitoIdentityClientConfiguration ClientConfigurationType;
       typedef CognitoIdentityEndpointProvider EndpointProviderType;
@@ -48,14 +48,14 @@ namespace CognitoIdentity
         * is not specified, it will be initialized to default values.
         */
         CognitoIdentityClient(const Aws::CognitoIdentity::CognitoIdentityClientConfiguration& clientConfiguration = Aws::CognitoIdentity::CognitoIdentityClientConfiguration(),
-                              std::shared_ptr<CognitoIdentityEndpointProviderBase> endpointProvider = Aws::MakeShared<CognitoIdentityEndpointProvider>(ALLOCATION_TAG));
+                              std::shared_ptr<CognitoIdentityEndpointProviderBase> endpointProvider = nullptr);
 
        /**
         * Initializes client to use SimpleAWSCredentialsProvider, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.
         */
         CognitoIdentityClient(const Aws::Auth::AWSCredentials& credentials,
-                              std::shared_ptr<CognitoIdentityEndpointProviderBase> endpointProvider = Aws::MakeShared<CognitoIdentityEndpointProvider>(ALLOCATION_TAG),
+                              std::shared_ptr<CognitoIdentityEndpointProviderBase> endpointProvider = nullptr,
                               const Aws::CognitoIdentity::CognitoIdentityClientConfiguration& clientConfiguration = Aws::CognitoIdentity::CognitoIdentityClientConfiguration());
 
        /**
@@ -63,7 +63,7 @@ namespace CognitoIdentity
         * the default http client factory will be used
         */
         CognitoIdentityClient(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
-                              std::shared_ptr<CognitoIdentityEndpointProviderBase> endpointProvider = Aws::MakeShared<CognitoIdentityEndpointProvider>(ALLOCATION_TAG),
+                              std::shared_ptr<CognitoIdentityEndpointProviderBase> endpointProvider = nullptr,
                               const Aws::CognitoIdentity::CognitoIdentityClientConfiguration& clientConfiguration = Aws::CognitoIdentity::CognitoIdentityClientConfiguration());
 
 

--- a/generated/src/aws-cpp-sdk-cognito-identity/source/CognitoIdentityClient.cpp
+++ b/generated/src/aws-cpp-sdk-cognito-identity/source/CognitoIdentityClient.cpp
@@ -58,8 +58,16 @@ using namespace Aws::Utils::Json;
 using namespace smithy::components::tracing;
 using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
-const char* CognitoIdentityClient::SERVICE_NAME = "cognito-identity";
-const char* CognitoIdentityClient::ALLOCATION_TAG = "CognitoIdentityClient";
+namespace Aws
+{
+  namespace CognitoIdentity
+  {
+    const char SERVICE_NAME[] = "cognito-identity";
+    const char ALLOCATION_TAG[] = "CognitoIdentityClient";
+  }
+}
+const char* CognitoIdentityClient::GetServiceName() {return SERVICE_NAME;}
+const char* CognitoIdentityClient::GetAllocationTag() {return ALLOCATION_TAG;}
 
 CognitoIdentityClient::CognitoIdentityClient(const CognitoIdentity::CognitoIdentityClientConfiguration& clientConfiguration,
                                              std::shared_ptr<CognitoIdentityEndpointProviderBase> endpointProvider) :
@@ -71,7 +79,7 @@ CognitoIdentityClient::CognitoIdentityClient(const CognitoIdentity::CognitoIdent
             Aws::MakeShared<CognitoIdentityErrorMarshaller>(ALLOCATION_TAG)),
   m_clientConfiguration(clientConfiguration),
   m_executor(clientConfiguration.executor),
-  m_endpointProvider(std::move(endpointProvider))
+  m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<CognitoIdentityEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -87,7 +95,7 @@ CognitoIdentityClient::CognitoIdentityClient(const AWSCredentials& credentials,
             Aws::MakeShared<CognitoIdentityErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<CognitoIdentityEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -103,7 +111,7 @@ CognitoIdentityClient::CognitoIdentityClient(const std::shared_ptr<AWSCredential
             Aws::MakeShared<CognitoIdentityErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<CognitoIdentityEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }

--- a/generated/src/aws-cpp-sdk-cognito-idp/include/aws/cognito-idp/CognitoIdentityProviderClient.h
+++ b/generated/src/aws-cpp-sdk-cognito-idp/include/aws/cognito-idp/CognitoIdentityProviderClient.h
@@ -76,8 +76,8 @@ namespace CognitoIdentityProvider
   {
     public:
       typedef Aws::Client::AWSJsonClient BASECLASS;
-      static const char* SERVICE_NAME;
-      static const char* ALLOCATION_TAG;
+      static const char* GetServiceName();
+      static const char* GetAllocationTag();
 
       typedef CognitoIdentityProviderClientConfiguration ClientConfigurationType;
       typedef CognitoIdentityProviderEndpointProvider EndpointProviderType;
@@ -87,14 +87,14 @@ namespace CognitoIdentityProvider
         * is not specified, it will be initialized to default values.
         */
         CognitoIdentityProviderClient(const Aws::CognitoIdentityProvider::CognitoIdentityProviderClientConfiguration& clientConfiguration = Aws::CognitoIdentityProvider::CognitoIdentityProviderClientConfiguration(),
-                                      std::shared_ptr<CognitoIdentityProviderEndpointProviderBase> endpointProvider = Aws::MakeShared<CognitoIdentityProviderEndpointProvider>(ALLOCATION_TAG));
+                                      std::shared_ptr<CognitoIdentityProviderEndpointProviderBase> endpointProvider = nullptr);
 
        /**
         * Initializes client to use SimpleAWSCredentialsProvider, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.
         */
         CognitoIdentityProviderClient(const Aws::Auth::AWSCredentials& credentials,
-                                      std::shared_ptr<CognitoIdentityProviderEndpointProviderBase> endpointProvider = Aws::MakeShared<CognitoIdentityProviderEndpointProvider>(ALLOCATION_TAG),
+                                      std::shared_ptr<CognitoIdentityProviderEndpointProviderBase> endpointProvider = nullptr,
                                       const Aws::CognitoIdentityProvider::CognitoIdentityProviderClientConfiguration& clientConfiguration = Aws::CognitoIdentityProvider::CognitoIdentityProviderClientConfiguration());
 
        /**
@@ -102,7 +102,7 @@ namespace CognitoIdentityProvider
         * the default http client factory will be used
         */
         CognitoIdentityProviderClient(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
-                                      std::shared_ptr<CognitoIdentityProviderEndpointProviderBase> endpointProvider = Aws::MakeShared<CognitoIdentityProviderEndpointProvider>(ALLOCATION_TAG),
+                                      std::shared_ptr<CognitoIdentityProviderEndpointProviderBase> endpointProvider = nullptr,
                                       const Aws::CognitoIdentityProvider::CognitoIdentityProviderClientConfiguration& clientConfiguration = Aws::CognitoIdentityProvider::CognitoIdentityProviderClientConfiguration());
 
 

--- a/generated/src/aws-cpp-sdk-cognito-idp/source/CognitoIdentityProviderClient.cpp
+++ b/generated/src/aws-cpp-sdk-cognito-idp/source/CognitoIdentityProviderClient.cpp
@@ -138,8 +138,16 @@ using namespace Aws::Utils::Json;
 using namespace smithy::components::tracing;
 using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
-const char* CognitoIdentityProviderClient::SERVICE_NAME = "cognito-idp";
-const char* CognitoIdentityProviderClient::ALLOCATION_TAG = "CognitoIdentityProviderClient";
+namespace Aws
+{
+  namespace CognitoIdentityProvider
+  {
+    const char SERVICE_NAME[] = "cognito-idp";
+    const char ALLOCATION_TAG[] = "CognitoIdentityProviderClient";
+  }
+}
+const char* CognitoIdentityProviderClient::GetServiceName() {return SERVICE_NAME;}
+const char* CognitoIdentityProviderClient::GetAllocationTag() {return ALLOCATION_TAG;}
 
 CognitoIdentityProviderClient::CognitoIdentityProviderClient(const CognitoIdentityProvider::CognitoIdentityProviderClientConfiguration& clientConfiguration,
                                                              std::shared_ptr<CognitoIdentityProviderEndpointProviderBase> endpointProvider) :
@@ -151,7 +159,7 @@ CognitoIdentityProviderClient::CognitoIdentityProviderClient(const CognitoIdenti
             Aws::MakeShared<CognitoIdentityProviderErrorMarshaller>(ALLOCATION_TAG)),
   m_clientConfiguration(clientConfiguration),
   m_executor(clientConfiguration.executor),
-  m_endpointProvider(std::move(endpointProvider))
+  m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<CognitoIdentityProviderEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -167,7 +175,7 @@ CognitoIdentityProviderClient::CognitoIdentityProviderClient(const AWSCredential
             Aws::MakeShared<CognitoIdentityProviderErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<CognitoIdentityProviderEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -183,7 +191,7 @@ CognitoIdentityProviderClient::CognitoIdentityProviderClient(const std::shared_p
             Aws::MakeShared<CognitoIdentityProviderErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<CognitoIdentityProviderEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }

--- a/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBClient.h
+++ b/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBClient.h
@@ -37,8 +37,8 @@ namespace DynamoDB
   {
     public:
       typedef Aws::Client::AWSJsonClient BASECLASS;
-      static const char* SERVICE_NAME;
-      static const char* ALLOCATION_TAG;
+      static const char* GetServiceName();
+      static const char* GetAllocationTag();
 
       typedef DynamoDBClientConfiguration ClientConfigurationType;
       typedef DynamoDBEndpointProvider EndpointProviderType;
@@ -48,14 +48,14 @@ namespace DynamoDB
         * is not specified, it will be initialized to default values.
         */
         DynamoDBClient(const Aws::DynamoDB::DynamoDBClientConfiguration& clientConfiguration = Aws::DynamoDB::DynamoDBClientConfiguration(),
-                       std::shared_ptr<DynamoDBEndpointProviderBase> endpointProvider = Aws::MakeShared<DynamoDBEndpointProvider>(ALLOCATION_TAG));
+                       std::shared_ptr<DynamoDBEndpointProviderBase> endpointProvider = nullptr);
 
        /**
         * Initializes client to use SimpleAWSCredentialsProvider, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.
         */
         DynamoDBClient(const Aws::Auth::AWSCredentials& credentials,
-                       std::shared_ptr<DynamoDBEndpointProviderBase> endpointProvider = Aws::MakeShared<DynamoDBEndpointProvider>(ALLOCATION_TAG),
+                       std::shared_ptr<DynamoDBEndpointProviderBase> endpointProvider = nullptr,
                        const Aws::DynamoDB::DynamoDBClientConfiguration& clientConfiguration = Aws::DynamoDB::DynamoDBClientConfiguration());
 
        /**
@@ -63,7 +63,7 @@ namespace DynamoDB
         * the default http client factory will be used
         */
         DynamoDBClient(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
-                       std::shared_ptr<DynamoDBEndpointProviderBase> endpointProvider = Aws::MakeShared<DynamoDBEndpointProvider>(ALLOCATION_TAG),
+                       std::shared_ptr<DynamoDBEndpointProviderBase> endpointProvider = nullptr,
                        const Aws::DynamoDB::DynamoDBClientConfiguration& clientConfiguration = Aws::DynamoDB::DynamoDBClientConfiguration());
 
 

--- a/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClient.cpp
@@ -90,8 +90,16 @@ using namespace Aws::Utils::Json;
 using namespace smithy::components::tracing;
 using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
-const char* DynamoDBClient::SERVICE_NAME = "dynamodb";
-const char* DynamoDBClient::ALLOCATION_TAG = "DynamoDBClient";
+namespace Aws
+{
+  namespace DynamoDB
+  {
+    const char SERVICE_NAME[] = "dynamodb";
+    const char ALLOCATION_TAG[] = "DynamoDBClient";
+  }
+}
+const char* DynamoDBClient::GetServiceName() {return SERVICE_NAME;}
+const char* DynamoDBClient::GetAllocationTag() {return ALLOCATION_TAG;}
 
 DynamoDBClient::DynamoDBClient(const DynamoDB::DynamoDBClientConfiguration& clientConfiguration,
                                std::shared_ptr<DynamoDBEndpointProviderBase> endpointProvider) :
@@ -103,7 +111,7 @@ DynamoDBClient::DynamoDBClient(const DynamoDB::DynamoDBClientConfiguration& clie
             Aws::MakeShared<DynamoDBErrorMarshaller>(ALLOCATION_TAG)),
   m_clientConfiguration(clientConfiguration),
   m_executor(clientConfiguration.executor),
-  m_endpointProvider(std::move(endpointProvider))
+  m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<DynamoDBEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -119,7 +127,7 @@ DynamoDBClient::DynamoDBClient(const AWSCredentials& credentials,
             Aws::MakeShared<DynamoDBErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<DynamoDBEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -135,7 +143,7 @@ DynamoDBClient::DynamoDBClient(const std::shared_ptr<AWSCredentialsProvider>& cr
             Aws::MakeShared<DynamoDBErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<DynamoDBEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }

--- a/generated/src/aws-cpp-sdk-eventbridge/include/aws/eventbridge/EventBridgeClient.h
+++ b/generated/src/aws-cpp-sdk-eventbridge/include/aws/eventbridge/EventBridgeClient.h
@@ -35,8 +35,8 @@ namespace EventBridge
   {
     public:
       typedef Aws::Client::AWSJsonClient BASECLASS;
-      static const char* SERVICE_NAME;
-      static const char* ALLOCATION_TAG;
+      static const char* GetServiceName();
+      static const char* GetAllocationTag();
 
       typedef EventBridgeClientConfiguration ClientConfigurationType;
       typedef EventBridgeEndpointProvider EndpointProviderType;
@@ -46,14 +46,14 @@ namespace EventBridge
         * is not specified, it will be initialized to default values.
         */
         EventBridgeClient(const Aws::EventBridge::EventBridgeClientConfiguration& clientConfiguration = Aws::EventBridge::EventBridgeClientConfiguration(),
-                          std::shared_ptr<EventBridgeEndpointProviderBase> endpointProvider = Aws::MakeShared<EventBridgeEndpointProvider>(ALLOCATION_TAG));
+                          std::shared_ptr<EventBridgeEndpointProviderBase> endpointProvider = nullptr);
 
        /**
         * Initializes client to use SimpleAWSCredentialsProvider, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.
         */
         EventBridgeClient(const Aws::Auth::AWSCredentials& credentials,
-                          std::shared_ptr<EventBridgeEndpointProviderBase> endpointProvider = Aws::MakeShared<EventBridgeEndpointProvider>(ALLOCATION_TAG),
+                          std::shared_ptr<EventBridgeEndpointProviderBase> endpointProvider = nullptr,
                           const Aws::EventBridge::EventBridgeClientConfiguration& clientConfiguration = Aws::EventBridge::EventBridgeClientConfiguration());
 
        /**
@@ -61,7 +61,7 @@ namespace EventBridge
         * the default http client factory will be used
         */
         EventBridgeClient(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
-                          std::shared_ptr<EventBridgeEndpointProviderBase> endpointProvider = Aws::MakeShared<EventBridgeEndpointProvider>(ALLOCATION_TAG),
+                          std::shared_ptr<EventBridgeEndpointProviderBase> endpointProvider = nullptr,
                           const Aws::EventBridge::EventBridgeClientConfiguration& clientConfiguration = Aws::EventBridge::EventBridgeClientConfiguration());
 
 

--- a/generated/src/aws-cpp-sdk-eventbridge/source/EventBridgeClient.cpp
+++ b/generated/src/aws-cpp-sdk-eventbridge/source/EventBridgeClient.cpp
@@ -91,8 +91,16 @@ using namespace Aws::Utils::Json;
 using namespace smithy::components::tracing;
 using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
-const char* EventBridgeClient::SERVICE_NAME = "events";
-const char* EventBridgeClient::ALLOCATION_TAG = "EventBridgeClient";
+namespace Aws
+{
+  namespace EventBridge
+  {
+    const char SERVICE_NAME[] = "events";
+    const char ALLOCATION_TAG[] = "EventBridgeClient";
+  }
+}
+const char* EventBridgeClient::GetServiceName() {return SERVICE_NAME;}
+const char* EventBridgeClient::GetAllocationTag() {return ALLOCATION_TAG;}
 
 EventBridgeClient::EventBridgeClient(const EventBridge::EventBridgeClientConfiguration& clientConfiguration,
                                      std::shared_ptr<EventBridgeEndpointProviderBase> endpointProvider) :
@@ -104,7 +112,7 @@ EventBridgeClient::EventBridgeClient(const EventBridge::EventBridgeClientConfigu
             Aws::MakeShared<EventBridgeErrorMarshaller>(ALLOCATION_TAG)),
   m_clientConfiguration(clientConfiguration),
   m_executor(clientConfiguration.executor),
-  m_endpointProvider(std::move(endpointProvider))
+  m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<EventBridgeEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -120,7 +128,7 @@ EventBridgeClient::EventBridgeClient(const AWSCredentials& credentials,
             Aws::MakeShared<EventBridgeErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<EventBridgeEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -136,7 +144,7 @@ EventBridgeClient::EventBridgeClient(const std::shared_ptr<AWSCredentialsProvide
             Aws::MakeShared<EventBridgeErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<EventBridgeEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }

--- a/generated/src/aws-cpp-sdk-lambda/include/aws/lambda/LambdaClient.h
+++ b/generated/src/aws-cpp-sdk-lambda/include/aws/lambda/LambdaClient.h
@@ -73,8 +73,8 @@ namespace Lambda
   {
     public:
       typedef Aws::Client::AWSJsonClient BASECLASS;
-      static const char* SERVICE_NAME;
-      static const char* ALLOCATION_TAG;
+      static const char* GetServiceName();
+      static const char* GetAllocationTag();
 
       typedef LambdaClientConfiguration ClientConfigurationType;
       typedef LambdaEndpointProvider EndpointProviderType;
@@ -84,14 +84,14 @@ namespace Lambda
         * is not specified, it will be initialized to default values.
         */
         LambdaClient(const Aws::Lambda::LambdaClientConfiguration& clientConfiguration = Aws::Lambda::LambdaClientConfiguration(),
-                     std::shared_ptr<LambdaEndpointProviderBase> endpointProvider = Aws::MakeShared<LambdaEndpointProvider>(ALLOCATION_TAG));
+                     std::shared_ptr<LambdaEndpointProviderBase> endpointProvider = nullptr);
 
        /**
         * Initializes client to use SimpleAWSCredentialsProvider, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.
         */
         LambdaClient(const Aws::Auth::AWSCredentials& credentials,
-                     std::shared_ptr<LambdaEndpointProviderBase> endpointProvider = Aws::MakeShared<LambdaEndpointProvider>(ALLOCATION_TAG),
+                     std::shared_ptr<LambdaEndpointProviderBase> endpointProvider = nullptr,
                      const Aws::Lambda::LambdaClientConfiguration& clientConfiguration = Aws::Lambda::LambdaClientConfiguration());
 
        /**
@@ -99,7 +99,7 @@ namespace Lambda
         * the default http client factory will be used
         */
         LambdaClient(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
-                     std::shared_ptr<LambdaEndpointProviderBase> endpointProvider = Aws::MakeShared<LambdaEndpointProvider>(ALLOCATION_TAG),
+                     std::shared_ptr<LambdaEndpointProviderBase> endpointProvider = nullptr,
                      const Aws::Lambda::LambdaClientConfiguration& clientConfiguration = Aws::Lambda::LambdaClientConfiguration());
 
 

--- a/generated/src/aws-cpp-sdk-lambda/source/LambdaClient.cpp
+++ b/generated/src/aws-cpp-sdk-lambda/source/LambdaClient.cpp
@@ -101,8 +101,16 @@ using namespace Aws::Utils::Json;
 using namespace smithy::components::tracing;
 using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
-const char* LambdaClient::SERVICE_NAME = "lambda";
-const char* LambdaClient::ALLOCATION_TAG = "LambdaClient";
+namespace Aws
+{
+  namespace Lambda
+  {
+    const char SERVICE_NAME[] = "lambda";
+    const char ALLOCATION_TAG[] = "LambdaClient";
+  }
+}
+const char* LambdaClient::GetServiceName() {return SERVICE_NAME;}
+const char* LambdaClient::GetAllocationTag() {return ALLOCATION_TAG;}
 
 LambdaClient::LambdaClient(const Lambda::LambdaClientConfiguration& clientConfiguration,
                            std::shared_ptr<LambdaEndpointProviderBase> endpointProvider) :
@@ -114,7 +122,7 @@ LambdaClient::LambdaClient(const Lambda::LambdaClientConfiguration& clientConfig
             Aws::MakeShared<LambdaErrorMarshaller>(ALLOCATION_TAG)),
   m_clientConfiguration(clientConfiguration),
   m_executor(clientConfiguration.executor),
-  m_endpointProvider(std::move(endpointProvider))
+  m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<LambdaEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -130,7 +138,7 @@ LambdaClient::LambdaClient(const AWSCredentials& credentials,
             Aws::MakeShared<LambdaErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<LambdaEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -146,7 +154,7 @@ LambdaClient::LambdaClient(const std::shared_ptr<AWSCredentialsProvider>& creden
             Aws::MakeShared<LambdaErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<LambdaEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }

--- a/generated/src/aws-cpp-sdk-machinelearning/include/aws/machinelearning/MachineLearningClient.h
+++ b/generated/src/aws-cpp-sdk-machinelearning/include/aws/machinelearning/MachineLearningClient.h
@@ -22,8 +22,8 @@ namespace MachineLearning
   {
     public:
       typedef Aws::Client::AWSJsonClient BASECLASS;
-      static const char* SERVICE_NAME;
-      static const char* ALLOCATION_TAG;
+      static const char* GetServiceName();
+      static const char* GetAllocationTag();
 
       typedef MachineLearningClientConfiguration ClientConfigurationType;
       typedef MachineLearningEndpointProvider EndpointProviderType;
@@ -33,14 +33,14 @@ namespace MachineLearning
         * is not specified, it will be initialized to default values.
         */
         MachineLearningClient(const Aws::MachineLearning::MachineLearningClientConfiguration& clientConfiguration = Aws::MachineLearning::MachineLearningClientConfiguration(),
-                              std::shared_ptr<MachineLearningEndpointProviderBase> endpointProvider = Aws::MakeShared<MachineLearningEndpointProvider>(ALLOCATION_TAG));
+                              std::shared_ptr<MachineLearningEndpointProviderBase> endpointProvider = nullptr);
 
        /**
         * Initializes client to use SimpleAWSCredentialsProvider, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.
         */
         MachineLearningClient(const Aws::Auth::AWSCredentials& credentials,
-                              std::shared_ptr<MachineLearningEndpointProviderBase> endpointProvider = Aws::MakeShared<MachineLearningEndpointProvider>(ALLOCATION_TAG),
+                              std::shared_ptr<MachineLearningEndpointProviderBase> endpointProvider = nullptr,
                               const Aws::MachineLearning::MachineLearningClientConfiguration& clientConfiguration = Aws::MachineLearning::MachineLearningClientConfiguration());
 
        /**
@@ -48,7 +48,7 @@ namespace MachineLearning
         * the default http client factory will be used
         */
         MachineLearningClient(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
-                              std::shared_ptr<MachineLearningEndpointProviderBase> endpointProvider = Aws::MakeShared<MachineLearningEndpointProvider>(ALLOCATION_TAG),
+                              std::shared_ptr<MachineLearningEndpointProviderBase> endpointProvider = nullptr,
                               const Aws::MachineLearning::MachineLearningClientConfiguration& clientConfiguration = Aws::MachineLearning::MachineLearningClientConfiguration());
 
 

--- a/generated/src/aws-cpp-sdk-machinelearning/source/MachineLearningClient.cpp
+++ b/generated/src/aws-cpp-sdk-machinelearning/source/MachineLearningClient.cpp
@@ -63,8 +63,16 @@ using namespace smithy::components::tracing;
 using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
 
-const char* MachineLearningClient::SERVICE_NAME = "machinelearning";
-const char* MachineLearningClient::ALLOCATION_TAG = "MachineLearningClient";
+namespace Aws
+{
+  namespace MachineLearning
+  {
+    const char SERVICE_NAME[] = "machinelearning";
+    const char ALLOCATION_TAG[] = "MachineLearningClient";
+  }
+}
+const char* MachineLearningClient::GetServiceName() {return SERVICE_NAME;}
+const char* MachineLearningClient::GetAllocationTag() {return ALLOCATION_TAG;}
 
 MachineLearningClient::MachineLearningClient(const MachineLearning::MachineLearningClientConfiguration& clientConfiguration,
                                              std::shared_ptr<MachineLearningEndpointProviderBase> endpointProvider) :
@@ -76,7 +84,7 @@ MachineLearningClient::MachineLearningClient(const MachineLearning::MachineLearn
             Aws::MakeShared<MachineLearningErrorMarshaller>(ALLOCATION_TAG)),
   m_clientConfiguration(clientConfiguration),
   m_executor(clientConfiguration.executor),
-  m_endpointProvider(std::move(endpointProvider))
+  m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<MachineLearningEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -92,7 +100,7 @@ MachineLearningClient::MachineLearningClient(const AWSCredentials& credentials,
             Aws::MakeShared<MachineLearningErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<MachineLearningEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -108,7 +116,7 @@ MachineLearningClient::MachineLearningClient(const std::shared_ptr<AWSCredential
             Aws::MakeShared<MachineLearningErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<MachineLearningEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }

--- a/generated/src/aws-cpp-sdk-polly/include/aws/polly/PollyClient.h
+++ b/generated/src/aws-cpp-sdk-polly/include/aws/polly/PollyClient.h
@@ -26,8 +26,8 @@ namespace Polly
   {
     public:
       typedef Aws::Client::AWSJsonClient BASECLASS;
-      static const char* SERVICE_NAME;
-      static const char* ALLOCATION_TAG;
+      static const char* GetServiceName();
+      static const char* GetAllocationTag();
 
       typedef PollyClientConfiguration ClientConfigurationType;
       typedef PollyEndpointProvider EndpointProviderType;
@@ -37,14 +37,14 @@ namespace Polly
         * is not specified, it will be initialized to default values.
         */
         PollyClient(const Aws::Polly::PollyClientConfiguration& clientConfiguration = Aws::Polly::PollyClientConfiguration(),
-                    std::shared_ptr<PollyEndpointProviderBase> endpointProvider = Aws::MakeShared<PollyEndpointProvider>(ALLOCATION_TAG));
+                    std::shared_ptr<PollyEndpointProviderBase> endpointProvider = nullptr);
 
        /**
         * Initializes client to use SimpleAWSCredentialsProvider, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.
         */
         PollyClient(const Aws::Auth::AWSCredentials& credentials,
-                    std::shared_ptr<PollyEndpointProviderBase> endpointProvider = Aws::MakeShared<PollyEndpointProvider>(ALLOCATION_TAG),
+                    std::shared_ptr<PollyEndpointProviderBase> endpointProvider = nullptr,
                     const Aws::Polly::PollyClientConfiguration& clientConfiguration = Aws::Polly::PollyClientConfiguration());
 
        /**
@@ -52,7 +52,7 @@ namespace Polly
         * the default http client factory will be used
         */
         PollyClient(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
-                    std::shared_ptr<PollyEndpointProviderBase> endpointProvider = Aws::MakeShared<PollyEndpointProvider>(ALLOCATION_TAG),
+                    std::shared_ptr<PollyEndpointProviderBase> endpointProvider = nullptr,
                     const Aws::Polly::PollyClientConfiguration& clientConfiguration = Aws::Polly::PollyClientConfiguration());
 
 

--- a/generated/src/aws-cpp-sdk-polly/source/PollyClient.cpp
+++ b/generated/src/aws-cpp-sdk-polly/source/PollyClient.cpp
@@ -44,8 +44,16 @@ using namespace Aws::Utils::Json;
 using namespace smithy::components::tracing;
 using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
-const char* PollyClient::SERVICE_NAME = "polly";
-const char* PollyClient::ALLOCATION_TAG = "PollyClient";
+namespace Aws
+{
+  namespace Polly
+  {
+    const char SERVICE_NAME[] = "polly";
+    const char ALLOCATION_TAG[] = "PollyClient";
+  }
+}
+const char* PollyClient::GetServiceName() {return SERVICE_NAME;}
+const char* PollyClient::GetAllocationTag() {return ALLOCATION_TAG;}
 
 PollyClient::PollyClient(const Polly::PollyClientConfiguration& clientConfiguration,
                          std::shared_ptr<PollyEndpointProviderBase> endpointProvider) :
@@ -57,7 +65,7 @@ PollyClient::PollyClient(const Polly::PollyClientConfiguration& clientConfigurat
             Aws::MakeShared<PollyErrorMarshaller>(ALLOCATION_TAG)),
   m_clientConfiguration(clientConfiguration),
   m_executor(clientConfiguration.executor),
-  m_endpointProvider(std::move(endpointProvider))
+  m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<PollyEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -73,7 +81,7 @@ PollyClient::PollyClient(const AWSCredentials& credentials,
             Aws::MakeShared<PollyErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<PollyEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -89,7 +97,7 @@ PollyClient::PollyClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
             Aws::MakeShared<PollyErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<PollyEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
@@ -54,8 +54,8 @@ namespace Aws
     {
     public:
         typedef Aws::Client::AWSXMLClient BASECLASS;
-        static const char* SERVICE_NAME;
-        static const char* ALLOCATION_TAG;
+        static const char* GetServiceName();
+        static const char* GetAllocationTag();
 
       typedef S3CrtClientConfiguration ClientConfigurationType;
       typedef S3CrtEndpointProvider EndpointProviderType;

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -148,8 +148,16 @@ using namespace smithy::components::tracing;
 using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
 
-const char* S3CrtClient::SERVICE_NAME = "s3";
-const char* S3CrtClient::ALLOCATION_TAG = "S3CrtClient";
+namespace Aws
+{
+  namespace S3Crt
+  {
+    const char SERVICE_NAME[] = "s3";
+    const char ALLOCATION_TAG[] = "S3CrtClient";
+  }
+}
+const char* S3CrtClient::GetServiceName() {return SERVICE_NAME;}
+const char* S3CrtClient::GetAllocationTag() {return ALLOCATION_TAG;}
 
 S3CrtClient::S3CrtClient(const S3CrtClient &rhs) :
     BASECLASS(rhs.m_clientConfiguration,
@@ -532,7 +540,7 @@ static int S3CrtRequestGetBodyCallback(struct aws_s3_meta_request *meta_request,
   {
       receivedHandler(userData->request.get(), userData->response.get(), static_cast<long long>(body->len));
   }
-  AWS_LOGSTREAM_TRACE(S3CrtClient::ALLOCATION_TAG, body->len << " bytes written to response.");
+  AWS_LOGSTREAM_TRACE(ALLOCATION_TAG, body->len << " bytes written to response.");
 
   return AWS_OP_SUCCESS;
 }

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3Client.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3Client.h
@@ -43,8 +43,8 @@ namespace Aws
     {
     public:
         typedef Aws::Client::AWSXMLClient BASECLASS;
-        static const char* SERVICE_NAME;
-        static const char* ALLOCATION_TAG;
+        static const char* GetServiceName();
+        static const char* GetAllocationTag();
 
       typedef S3ClientConfiguration ClientConfigurationType;
       typedef S3EndpointProvider EndpointProviderType;
@@ -83,14 +83,14 @@ namespace Aws
         * is not specified, it will be initialized to default values.
         */
         S3Client(const Aws::S3::S3ClientConfiguration& clientConfiguration = Aws::S3::S3ClientConfiguration(),
-                 std::shared_ptr<S3EndpointProviderBase> endpointProvider = Aws::MakeShared<S3EndpointProvider>(ALLOCATION_TAG));
+                 std::shared_ptr<S3EndpointProviderBase> endpointProvider = nullptr);
 
        /**
         * Initializes client to use SimpleAWSCredentialsProvider, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.
         */
         S3Client(const Aws::Auth::AWSCredentials& credentials,
-                 std::shared_ptr<S3EndpointProviderBase> endpointProvider = Aws::MakeShared<S3EndpointProvider>(ALLOCATION_TAG),
+                 std::shared_ptr<S3EndpointProviderBase> endpointProvider = nullptr,
                  const Aws::S3::S3ClientConfiguration& clientConfiguration = Aws::S3::S3ClientConfiguration());
 
        /**
@@ -98,7 +98,7 @@ namespace Aws
         * the default http client factory will be used
         */
         S3Client(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
-                 std::shared_ptr<S3EndpointProviderBase> endpointProvider = Aws::MakeShared<S3EndpointProvider>(ALLOCATION_TAG),
+                 std::shared_ptr<S3EndpointProviderBase> endpointProvider = nullptr,
                  const Aws::S3::S3ClientConfiguration& clientConfiguration = Aws::S3::S3ClientConfiguration());
 
 

--- a/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp
@@ -134,8 +134,16 @@ using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 using namespace Aws::Utils;
 
 
-const char* S3Client::SERVICE_NAME = "s3";
-const char* S3Client::ALLOCATION_TAG = "S3Client";
+namespace Aws
+{
+  namespace S3
+  {
+    const char SERVICE_NAME[] = "s3";
+    const char ALLOCATION_TAG[] = "S3Client";
+  }
+}
+const char* S3Client::GetServiceName() {return SERVICE_NAME;}
+const char* S3Client::GetAllocationTag() {return ALLOCATION_TAG;}
 
 S3Client::S3Client(const S3Client &rhs) :
     BASECLASS(rhs.m_clientConfiguration,
@@ -216,7 +224,7 @@ S3Client::S3Client(const S3::S3ClientConfiguration& clientConfiguration,
             Aws::MakeShared<S3ErrorMarshaller>(ALLOCATION_TAG)),
   m_clientConfiguration(clientConfiguration),
   m_executor(clientConfiguration.executor),
-  m_endpointProvider(std::move(endpointProvider))
+  m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<S3EndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -235,7 +243,7 @@ S3Client::S3Client(const AWSCredentials& credentials,
             Aws::MakeShared<S3ErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<S3EndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -254,7 +262,7 @@ S3Client::S3Client(const std::shared_ptr<AWSCredentialsProvider>& credentialsPro
             Aws::MakeShared<S3ErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<S3EndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }

--- a/generated/src/aws-cpp-sdk-sqs/include/aws/sqs/SQSClient.h
+++ b/generated/src/aws-cpp-sdk-sqs/include/aws/sqs/SQSClient.h
@@ -46,8 +46,8 @@ namespace SQS
   {
     public:
       typedef Aws::Client::AWSJsonClient BASECLASS;
-      static const char* SERVICE_NAME;
-      static const char* ALLOCATION_TAG;
+      static const char* GetServiceName();
+      static const char* GetAllocationTag();
 
       typedef SQSClientConfiguration ClientConfigurationType;
       typedef SQSEndpointProvider EndpointProviderType;
@@ -57,14 +57,14 @@ namespace SQS
         * is not specified, it will be initialized to default values.
         */
         SQSClient(const Aws::SQS::SQSClientConfiguration& clientConfiguration = Aws::SQS::SQSClientConfiguration(),
-                  std::shared_ptr<SQSEndpointProviderBase> endpointProvider = Aws::MakeShared<SQSEndpointProvider>(ALLOCATION_TAG));
+                  std::shared_ptr<SQSEndpointProviderBase> endpointProvider = nullptr);
 
        /**
         * Initializes client to use SimpleAWSCredentialsProvider, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.
         */
         SQSClient(const Aws::Auth::AWSCredentials& credentials,
-                  std::shared_ptr<SQSEndpointProviderBase> endpointProvider = Aws::MakeShared<SQSEndpointProvider>(ALLOCATION_TAG),
+                  std::shared_ptr<SQSEndpointProviderBase> endpointProvider = nullptr,
                   const Aws::SQS::SQSClientConfiguration& clientConfiguration = Aws::SQS::SQSClientConfiguration());
 
        /**
@@ -72,7 +72,7 @@ namespace SQS
         * the default http client factory will be used
         */
         SQSClient(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
-                  std::shared_ptr<SQSEndpointProviderBase> endpointProvider = Aws::MakeShared<SQSEndpointProvider>(ALLOCATION_TAG),
+                  std::shared_ptr<SQSEndpointProviderBase> endpointProvider = nullptr,
                   const Aws::SQS::SQSClientConfiguration& clientConfiguration = Aws::SQS::SQSClientConfiguration());
 
 

--- a/generated/src/aws-cpp-sdk-sqs/source/SQSClient.cpp
+++ b/generated/src/aws-cpp-sdk-sqs/source/SQSClient.cpp
@@ -58,8 +58,10 @@ using namespace Aws::Utils::Json;
 using namespace smithy::components::tracing;
 using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
-const char* SQSClient::SERVICE_NAME = "sqs";
-const char* SQSClient::ALLOCATION_TAG = "SQSClient";
+const char* SERVICE_NAME = "sqs";
+const char* ALLOCATION_TAG = "SQSClient";
+const char* SQSClient::GetServiceName() {return SERVICE_NAME;}
+const char* SQSClient::GetAllocationTag() {return ALLOCATION_TAG;}
 
 SQSClient::SQSClient(const SQS::SQSClientConfiguration& clientConfiguration,
                      std::shared_ptr<SQSEndpointProviderBase> endpointProvider) :
@@ -71,7 +73,7 @@ SQSClient::SQSClient(const SQS::SQSClientConfiguration& clientConfiguration,
             Aws::MakeShared<SQSErrorMarshaller>(ALLOCATION_TAG)),
   m_clientConfiguration(clientConfiguration),
   m_executor(clientConfiguration.executor),
-  m_endpointProvider(std::move(endpointProvider))
+  m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<SQSEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -87,7 +89,7 @@ SQSClient::SQSClient(const AWSCredentials& credentials,
             Aws::MakeShared<SQSErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<SQSEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -103,7 +105,7 @@ SQSClient::SQSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
             Aws::MakeShared<SQSErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<SQSEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }

--- a/generated/src/aws-cpp-sdk-sts/include/aws/sts/STSClient.h
+++ b/generated/src/aws-cpp-sdk-sts/include/aws/sts/STSClient.h
@@ -28,8 +28,8 @@ namespace STS
   {
     public:
       typedef Aws::Client::AWSXMLClient BASECLASS;
-      static const char* SERVICE_NAME;
-      static const char* ALLOCATION_TAG;
+      static const char* GetServiceName();
+      static const char* GetAllocationTag();
 
       typedef STSClientConfiguration ClientConfigurationType;
       typedef STSEndpointProvider EndpointProviderType;
@@ -39,14 +39,14 @@ namespace STS
         * is not specified, it will be initialized to default values.
         */
         STSClient(const Aws::STS::STSClientConfiguration& clientConfiguration = Aws::STS::STSClientConfiguration(),
-                  std::shared_ptr<STSEndpointProviderBase> endpointProvider = Aws::MakeShared<STSEndpointProvider>(ALLOCATION_TAG));
+                  std::shared_ptr<STSEndpointProviderBase> endpointProvider = nullptr);
 
        /**
         * Initializes client to use SimpleAWSCredentialsProvider, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.
         */
         STSClient(const Aws::Auth::AWSCredentials& credentials,
-                  std::shared_ptr<STSEndpointProviderBase> endpointProvider = Aws::MakeShared<STSEndpointProvider>(ALLOCATION_TAG),
+                  std::shared_ptr<STSEndpointProviderBase> endpointProvider = nullptr,
                   const Aws::STS::STSClientConfiguration& clientConfiguration = Aws::STS::STSClientConfiguration());
 
        /**
@@ -54,7 +54,7 @@ namespace STS
         * the default http client factory will be used
         */
         STSClient(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
-                  std::shared_ptr<STSEndpointProviderBase> endpointProvider = Aws::MakeShared<STSEndpointProvider>(ALLOCATION_TAG),
+                  std::shared_ptr<STSEndpointProviderBase> endpointProvider = nullptr,
                   const Aws::STS::STSClientConfiguration& clientConfiguration = Aws::STS::STSClientConfiguration());
 
 

--- a/generated/src/aws-cpp-sdk-sts/source/STSClient.cpp
+++ b/generated/src/aws-cpp-sdk-sts/source/STSClient.cpp
@@ -44,8 +44,16 @@ using namespace smithy::components::tracing;
 using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
 
-const char* STSClient::SERVICE_NAME = "sts";
-const char* STSClient::ALLOCATION_TAG = "STSClient";
+namespace Aws
+{
+  namespace STS
+  {
+    const char SERVICE_NAME[] = "sts";
+    const char ALLOCATION_TAG[] = "STSClient";
+  }
+}
+const char* STSClient::GetServiceName() {return SERVICE_NAME;}
+const char* STSClient::GetAllocationTag() {return ALLOCATION_TAG;}
 
 STSClient::STSClient(const STS::STSClientConfiguration& clientConfiguration,
                      std::shared_ptr<STSEndpointProviderBase> endpointProvider) :
@@ -57,7 +65,7 @@ STSClient::STSClient(const STS::STSClientConfiguration& clientConfiguration,
             Aws::MakeShared<STSErrorMarshaller>(ALLOCATION_TAG)),
   m_clientConfiguration(clientConfiguration),
   m_executor(clientConfiguration.executor),
-  m_endpointProvider(std::move(endpointProvider))
+  m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<STSEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -73,7 +81,7 @@ STSClient::STSClient(const AWSCredentials& credentials,
             Aws::MakeShared<STSErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<STSEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -89,7 +97,7 @@ STSClient::STSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
             Aws::MakeShared<STSErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<STSEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }

--- a/generated/src/aws-cpp-sdk-transcribe/include/aws/transcribe/TranscribeServiceClient.h
+++ b/generated/src/aws-cpp-sdk-transcribe/include/aws/transcribe/TranscribeServiceClient.h
@@ -31,8 +31,8 @@ namespace TranscribeService
   {
     public:
       typedef Aws::Client::AWSJsonClient BASECLASS;
-      static const char* SERVICE_NAME;
-      static const char* ALLOCATION_TAG;
+      static const char* GetServiceName();
+      static const char* GetAllocationTag();
 
       typedef TranscribeServiceClientConfiguration ClientConfigurationType;
       typedef TranscribeServiceEndpointProvider EndpointProviderType;
@@ -42,14 +42,14 @@ namespace TranscribeService
         * is not specified, it will be initialized to default values.
         */
         TranscribeServiceClient(const Aws::TranscribeService::TranscribeServiceClientConfiguration& clientConfiguration = Aws::TranscribeService::TranscribeServiceClientConfiguration(),
-                                std::shared_ptr<TranscribeServiceEndpointProviderBase> endpointProvider = Aws::MakeShared<TranscribeServiceEndpointProvider>(ALLOCATION_TAG));
+                                std::shared_ptr<TranscribeServiceEndpointProviderBase> endpointProvider = nullptr);
 
        /**
         * Initializes client to use SimpleAWSCredentialsProvider, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.
         */
         TranscribeServiceClient(const Aws::Auth::AWSCredentials& credentials,
-                                std::shared_ptr<TranscribeServiceEndpointProviderBase> endpointProvider = Aws::MakeShared<TranscribeServiceEndpointProvider>(ALLOCATION_TAG),
+                                std::shared_ptr<TranscribeServiceEndpointProviderBase> endpointProvider = nullptr,
                                 const Aws::TranscribeService::TranscribeServiceClientConfiguration& clientConfiguration = Aws::TranscribeService::TranscribeServiceClientConfiguration());
 
        /**
@@ -57,7 +57,7 @@ namespace TranscribeService
         * the default http client factory will be used
         */
         TranscribeServiceClient(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
-                                std::shared_ptr<TranscribeServiceEndpointProviderBase> endpointProvider = Aws::MakeShared<TranscribeServiceEndpointProvider>(ALLOCATION_TAG),
+                                std::shared_ptr<TranscribeServiceEndpointProviderBase> endpointProvider = nullptr,
                                 const Aws::TranscribeService::TranscribeServiceClientConfiguration& clientConfiguration = Aws::TranscribeService::TranscribeServiceClientConfiguration());
 
 

--- a/generated/src/aws-cpp-sdk-transcribe/source/TranscribeServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-transcribe/source/TranscribeServiceClient.cpp
@@ -78,8 +78,16 @@ using namespace Aws::Utils::Json;
 using namespace smithy::components::tracing;
 using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
-const char* TranscribeServiceClient::SERVICE_NAME = "transcribe";
-const char* TranscribeServiceClient::ALLOCATION_TAG = "TranscribeServiceClient";
+namespace Aws
+{
+  namespace TranscribeService
+  {
+    const char SERVICE_NAME[] = "transcribe";
+    const char ALLOCATION_TAG[] = "TranscribeServiceClient";
+  }
+}
+const char* TranscribeServiceClient::GetServiceName() {return SERVICE_NAME;}
+const char* TranscribeServiceClient::GetAllocationTag() {return ALLOCATION_TAG;}
 
 TranscribeServiceClient::TranscribeServiceClient(const TranscribeService::TranscribeServiceClientConfiguration& clientConfiguration,
                                                  std::shared_ptr<TranscribeServiceEndpointProviderBase> endpointProvider) :
@@ -91,7 +99,7 @@ TranscribeServiceClient::TranscribeServiceClient(const TranscribeService::Transc
             Aws::MakeShared<TranscribeServiceErrorMarshaller>(ALLOCATION_TAG)),
   m_clientConfiguration(clientConfiguration),
   m_executor(clientConfiguration.executor),
-  m_endpointProvider(std::move(endpointProvider))
+  m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<TranscribeServiceEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -107,7 +115,7 @@ TranscribeServiceClient::TranscribeServiceClient(const AWSCredentials& credentia
             Aws::MakeShared<TranscribeServiceErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<TranscribeServiceEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -123,7 +131,7 @@ TranscribeServiceClient::TranscribeServiceClient(const std::shared_ptr<AWSCreden
             Aws::MakeShared<TranscribeServiceErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<TranscribeServiceEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/TranscribeStreamingServiceClient.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/TranscribeStreamingServiceClient.h
@@ -31,8 +31,8 @@ namespace TranscribeStreamingService
   {
     public:
       typedef Aws::Client::AWSJsonClient BASECLASS;
-      static const char* SERVICE_NAME;
-      static const char* ALLOCATION_TAG;
+      static const char* GetServiceName();
+      static const char* GetAllocationTag();
 
       typedef TranscribeStreamingServiceClientConfiguration ClientConfigurationType;
       typedef TranscribeStreamingServiceEndpointProvider EndpointProviderType;
@@ -42,14 +42,14 @@ namespace TranscribeStreamingService
         * is not specified, it will be initialized to default values.
         */
         TranscribeStreamingServiceClient(const Aws::TranscribeStreamingService::TranscribeStreamingServiceClientConfiguration& clientConfiguration = Aws::TranscribeStreamingService::TranscribeStreamingServiceClientConfiguration(),
-                                         std::shared_ptr<TranscribeStreamingServiceEndpointProviderBase> endpointProvider = Aws::MakeShared<TranscribeStreamingServiceEndpointProvider>(ALLOCATION_TAG));
+                                         std::shared_ptr<TranscribeStreamingServiceEndpointProviderBase> endpointProvider = nullptr);
 
        /**
         * Initializes client to use SimpleAWSCredentialsProvider, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.
         */
         TranscribeStreamingServiceClient(const Aws::Auth::AWSCredentials& credentials,
-                                         std::shared_ptr<TranscribeStreamingServiceEndpointProviderBase> endpointProvider = Aws::MakeShared<TranscribeStreamingServiceEndpointProvider>(ALLOCATION_TAG),
+                                         std::shared_ptr<TranscribeStreamingServiceEndpointProviderBase> endpointProvider = nullptr,
                                          const Aws::TranscribeStreamingService::TranscribeStreamingServiceClientConfiguration& clientConfiguration = Aws::TranscribeStreamingService::TranscribeStreamingServiceClientConfiguration());
 
        /**
@@ -57,7 +57,7 @@ namespace TranscribeStreamingService
         * the default http client factory will be used
         */
         TranscribeStreamingServiceClient(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
-                                         std::shared_ptr<TranscribeStreamingServiceEndpointProviderBase> endpointProvider = Aws::MakeShared<TranscribeStreamingServiceEndpointProvider>(ALLOCATION_TAG),
+                                         std::shared_ptr<TranscribeStreamingServiceEndpointProviderBase> endpointProvider = nullptr,
                                          const Aws::TranscribeStreamingService::TranscribeStreamingServiceClientConfiguration& clientConfiguration = Aws::TranscribeStreamingService::TranscribeStreamingServiceClientConfiguration());
 
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
@@ -39,8 +39,16 @@ using namespace Aws::Utils::Json;
 using namespace smithy::components::tracing;
 using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
-const char* TranscribeStreamingServiceClient::SERVICE_NAME = "transcribe";
-const char* TranscribeStreamingServiceClient::ALLOCATION_TAG = "TranscribeStreamingServiceClient";
+namespace Aws
+{
+  namespace TranscribeStreamingService
+  {
+    const char SERVICE_NAME[] = "transcribe";
+    const char ALLOCATION_TAG[] = "TranscribeStreamingServiceClient";
+  }
+}
+const char* TranscribeStreamingServiceClient::GetServiceName() {return SERVICE_NAME;}
+const char* TranscribeStreamingServiceClient::GetAllocationTag() {return ALLOCATION_TAG;}
 
 TranscribeStreamingServiceClient::TranscribeStreamingServiceClient(const TranscribeStreamingService::TranscribeStreamingServiceClientConfiguration& clientConfiguration,
                                                                    std::shared_ptr<TranscribeStreamingServiceEndpointProviderBase> endpointProvider) :
@@ -52,7 +60,7 @@ TranscribeStreamingServiceClient::TranscribeStreamingServiceClient(const Transcr
             Aws::MakeShared<TranscribeStreamingServiceErrorMarshaller>(ALLOCATION_TAG)),
   m_clientConfiguration(clientConfiguration),
   m_executor(clientConfiguration.executor),
-  m_endpointProvider(std::move(endpointProvider))
+  m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<TranscribeStreamingServiceEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -68,7 +76,7 @@ TranscribeStreamingServiceClient::TranscribeStreamingServiceClient(const AWSCred
             Aws::MakeShared<TranscribeStreamingServiceErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<TranscribeStreamingServiceEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -84,7 +92,7 @@ TranscribeStreamingServiceClient::TranscribeStreamingServiceClient(const std::sh
             Aws::MakeShared<TranscribeStreamingServiceErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<TranscribeStreamingServiceEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }

--- a/generated/src/aws-cpp-sdk-translate/include/aws/translate/TranslateClient.h
+++ b/generated/src/aws-cpp-sdk-translate/include/aws/translate/TranslateClient.h
@@ -23,8 +23,8 @@ namespace Translate
   {
     public:
       typedef Aws::Client::AWSJsonClient BASECLASS;
-      static const char* SERVICE_NAME;
-      static const char* ALLOCATION_TAG;
+      static const char* GetServiceName();
+      static const char* GetAllocationTag();
 
       typedef TranslateClientConfiguration ClientConfigurationType;
       typedef TranslateEndpointProvider EndpointProviderType;
@@ -34,14 +34,14 @@ namespace Translate
         * is not specified, it will be initialized to default values.
         */
         TranslateClient(const Aws::Translate::TranslateClientConfiguration& clientConfiguration = Aws::Translate::TranslateClientConfiguration(),
-                        std::shared_ptr<TranslateEndpointProviderBase> endpointProvider = Aws::MakeShared<TranslateEndpointProvider>(ALLOCATION_TAG));
+                        std::shared_ptr<TranslateEndpointProviderBase> endpointProvider = nullptr);
 
        /**
         * Initializes client to use SimpleAWSCredentialsProvider, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.
         */
         TranslateClient(const Aws::Auth::AWSCredentials& credentials,
-                        std::shared_ptr<TranslateEndpointProviderBase> endpointProvider = Aws::MakeShared<TranslateEndpointProvider>(ALLOCATION_TAG),
+                        std::shared_ptr<TranslateEndpointProviderBase> endpointProvider = nullptr,
                         const Aws::Translate::TranslateClientConfiguration& clientConfiguration = Aws::Translate::TranslateClientConfiguration());
 
        /**
@@ -49,7 +49,7 @@ namespace Translate
         * the default http client factory will be used
         */
         TranslateClient(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
-                        std::shared_ptr<TranslateEndpointProviderBase> endpointProvider = Aws::MakeShared<TranslateEndpointProvider>(ALLOCATION_TAG),
+                        std::shared_ptr<TranslateEndpointProviderBase> endpointProvider = nullptr,
                         const Aws::Translate::TranslateClientConfiguration& clientConfiguration = Aws::Translate::TranslateClientConfiguration());
 
 

--- a/generated/src/aws-cpp-sdk-translate/source/TranslateClient.cpp
+++ b/generated/src/aws-cpp-sdk-translate/source/TranslateClient.cpp
@@ -54,8 +54,16 @@ using namespace Aws::Utils::Json;
 using namespace smithy::components::tracing;
 using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
-const char* TranslateClient::SERVICE_NAME = "translate";
-const char* TranslateClient::ALLOCATION_TAG = "TranslateClient";
+namespace Aws
+{
+  namespace Translate
+  {
+    const char SERVICE_NAME[] = "translate";
+    const char ALLOCATION_TAG[] = "TranslateClient";
+  }
+}
+const char* TranslateClient::GetServiceName() {return SERVICE_NAME;}
+const char* TranslateClient::GetAllocationTag() {return ALLOCATION_TAG;}
 
 TranslateClient::TranslateClient(const Translate::TranslateClientConfiguration& clientConfiguration,
                                  std::shared_ptr<TranslateEndpointProviderBase> endpointProvider) :
@@ -67,7 +75,7 @@ TranslateClient::TranslateClient(const Translate::TranslateClientConfiguration& 
             Aws::MakeShared<TranslateErrorMarshaller>(ALLOCATION_TAG)),
   m_clientConfiguration(clientConfiguration),
   m_executor(clientConfiguration.executor),
-  m_endpointProvider(std::move(endpointProvider))
+  m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<TranslateEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -83,7 +91,7 @@ TranslateClient::TranslateClient(const AWSCredentials& credentials,
             Aws::MakeShared<TranslateErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<TranslateEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }
@@ -99,7 +107,7 @@ TranslateClient::TranslateClient(const std::shared_ptr<AWSCredentialsProvider>& 
             Aws::MakeShared<TranslateErrorMarshaller>(ALLOCATION_TAG)),
     m_clientConfiguration(clientConfiguration),
     m_executor(clientConfiguration.executor),
-    m_endpointProvider(std::move(endpointProvider))
+    m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<TranslateEndpointProvider>(ALLOCATION_TAG))
 {
   init(m_clientConfiguration);
 }

--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSClientAsyncCRTP.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSClientAsyncCRTP.h
@@ -47,7 +47,7 @@ namespace Client
            m_operationsProcessed(0)
         {
             AwsServiceClientT* pThis = static_cast<AwsServiceClientT*>(this);
-            Aws::Utils::ComponentRegistry::RegisterComponent(AwsServiceClientT::SERVICE_NAME,
+            Aws::Utils::ComponentRegistry::RegisterComponent(AwsServiceClientT::GetServiceName(),
                                                              pThis,
                                                              &AwsServiceClientT::ShutdownSdkClient);
 
@@ -58,7 +58,7 @@ namespace Client
            m_operationsProcessed(0)
         {
             AwsServiceClientT* pThis = static_cast<AwsServiceClientT*>(this);
-            Aws::Utils::ComponentRegistry::RegisterComponent(AwsServiceClientT::SERVICE_NAME,
+            Aws::Utils::ComponentRegistry::RegisterComponent(AwsServiceClientT::GetServiceName(),
                                                              pThis,
                                                              &AwsServiceClientT::ShutdownSdkClient);
         }
@@ -88,7 +88,7 @@ namespace Client
         static void ShutdownSdkClient(void* pThis, int64_t timeoutMs = -1)
         {
             AwsServiceClientT* pClient = reinterpret_cast<AwsServiceClientT*>(pThis);
-            AWS_CHECK_PTR(AwsServiceClientT::SERVICE_NAME, pClient);
+            AWS_CHECK_PTR(AwsServiceClientT::GetServiceName(), pClient);
             if(!pClient->m_isInitialized)
             {
                 return;
@@ -165,7 +165,7 @@ namespace Client
             -> std::future<decltype((static_cast<const AwsServiceClientT*>(nullptr)->*operationFunc)(request))>
         {
             const AwsServiceClientT* clientThis = static_cast<const AwsServiceClientT*>(this);
-            return Aws::Client::MakeCallableOperation(AwsServiceClientT::ALLOCATION_TAG, operationFunc, clientThis, request, clientThis->m_executor.get());
+            return Aws::Client::MakeCallableOperation(AwsServiceClientT::GetAllocationTag(), operationFunc, clientThis, request, clientThis->m_executor.get());
         }
 
         /**
@@ -178,7 +178,7 @@ namespace Client
             -> std::future<decltype((static_cast<const AwsServiceClientT*>(nullptr)->*operationFunc)(request))>
         {
             const AwsServiceClientT* clientThis = static_cast<const AwsServiceClientT*>(this);
-            return Aws::Client::MakeCallableStreamingOperation(AwsServiceClientT::ALLOCATION_TAG, operationFunc, clientThis, request, clientThis->m_executor.get());
+            return Aws::Client::MakeCallableStreamingOperation(AwsServiceClientT::GetAllocationTag(), operationFunc, clientThis, request, clientThis->m_executor.get());
         }
 
         /**
@@ -191,7 +191,7 @@ namespace Client
             -> std::future<decltype((static_cast<const AwsServiceClientT*>(nullptr)->*operationFunc)())>
         {
             const AwsServiceClientT* clientThis = static_cast<const AwsServiceClientT*>(this);
-            return Aws::Client::MakeCallableOperation(AwsServiceClientT::ALLOCATION_TAG, operationFunc, clientThis, clientThis->m_executor.get());
+            return Aws::Client::MakeCallableOperation(AwsServiceClientT::GetAllocationTag(), operationFunc, clientThis, clientThis->m_executor.get());
         }
     protected:
         std::atomic<bool> m_isInitialized;

--- a/tests/aws-cpp-sdk-cognitoidentity-integration-tests/CMakeLists.txt
+++ b/tests/aws-cpp-sdk-cognitoidentity-integration-tests/CMakeLists.txt
@@ -34,3 +34,8 @@ set_compiler_flags(${PROJECT_NAME})
 set_compiler_warnings(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} ${PROJECT_LIBS})
+
+if(MSVC AND BUILD_SHARED_LIBS)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS
+            "/DELAYLOAD:aws-cpp-sdk-access-management.dll /DELAYLOAD:aws-cpp-sdk-cognito-identity /DELAYLOAD:aws-cpp-sdk-iam /DELAYLOAD:aws-cpp-sdk-core.dll")
+endif()

--- a/tests/aws-cpp-sdk-s3-crt-integration-tests/CMakeLists.txt
+++ b/tests/aws-cpp-sdk-s3-crt-integration-tests/CMakeLists.txt
@@ -30,3 +30,7 @@ set_compiler_flags(${PROJECT_NAME})
 set_compiler_warnings(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} ${PROJECT_LIBS})
+
+if(MSVC AND BUILD_SHARED_LIBS)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DELAYLOAD:aws-cpp-sdk-s3-crt.dll /DELAYLOAD:aws-cpp-sdk-core.dll")
+endif()

--- a/tests/aws-cpp-sdk-s3-encryption-tests/DataHandlersTest.cpp
+++ b/tests/aws-cpp-sdk-s3-encryption-tests/DataHandlersTest.cpp
@@ -32,7 +32,7 @@ class MockS3Client : public Aws::S3::S3Client
 public:
     MockS3Client(Aws::Client::ClientConfiguration clientConfiguration = Aws::Client::ClientConfiguration()) :
         S3Client(Aws::Auth::AWSCredentials("", ""),
-                 Aws::MakeShared<Aws::S3::Endpoint::S3EndpointProvider>(ALLOCATION_TAG),
+                 Aws::MakeShared<Aws::S3::Endpoint::S3EndpointProvider>(Aws::S3::S3Client::GetAllocationTag()),
                          clientConfiguration), m_putObjectCalled(0), m_getObjectCalled(0), m_body(nullptr)
     {
     }

--- a/tests/aws-cpp-sdk-s3-integration-tests/CMakeLists.txt
+++ b/tests/aws-cpp-sdk-s3-integration-tests/CMakeLists.txt
@@ -30,3 +30,7 @@ set_compiler_flags(${PROJECT_NAME})
 set_compiler_warnings(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} ${PROJECT_LIBS})
+
+if(MSVC AND BUILD_SHARED_LIBS)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DELAYLOAD:aws-cpp-sdk-s3.dll /DELAYLOAD:aws-cpp-sdk-core.dll")
+endif()

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm
@@ -32,7 +32,7 @@
 #end
 #set($clsWSpace = $className.replaceAll(".", " "))
 #if($serviceModel.endpointRules)
-#set($endpointsProviderDefaultCtorCall = "Aws::MakeShared<" + ${metadata.classNamePrefix} + "EndpointProvider>(ALLOCATION_TAG)")
+#set($endpointsProviderDefaultCtorDummy = "nullptr")
 #set($clientConfigurationCls = "Aws::" + ${serviceNamespace} + "::" + ${metadata.classNamePrefix} + "ClientConfiguration")
 #else
 #set($clientConfigurationCls = "Aws::" + ${clientConfigurationNamespace} + "::ClientConfiguration")
@@ -79,7 +79,7 @@
         */
         ${className}(const Aws::Auth::BearerTokenAuthSignerProvider& bearerTokenProvider,
 #if($serviceModel.endpointRules)
-        ${clsWSpace} std::shared_ptr<${metadata.classNamePrefix}EndpointProviderBase> endpointProvider = ${endpointsProviderDefaultCtorCall},
+        ${clsWSpace} std::shared_ptr<${metadata.classNamePrefix}EndpointProviderBase> endpointProvider = ${endpointsProviderDefaultCtorDummy},
 #end
         ${clsWSpace} const ${clientConfigurationCls}& clientConfiguration = ${clientConfigurationCls}()#if($bearerAddCtorArgs.isEmpty()));#else,#end
 
@@ -99,7 +99,7 @@
         ${className}(const ${clientConfigurationCls}& clientConfiguration = ${clientConfigurationCls}()#if($defCredsChainCtor.isEmpty() && !$serviceModel.endpointRules));#else,#end
 
 #if($serviceModel.endpointRules)
-        ${clsWSpace} std::shared_ptr<${metadata.classNamePrefix}EndpointProviderBase> endpointProvider = ${endpointsProviderDefaultCtorCall}#if($defCredsChainCtor.isEmpty()));#else,#end
+        ${clsWSpace} std::shared_ptr<${metadata.classNamePrefix}EndpointProviderBase> endpointProvider = ${endpointsProviderDefaultCtorDummy}#if($defCredsChainCtor.isEmpty()));#else,#end
 
 #end
 #foreach($ctorArgument in $defCredsChainCtor)
@@ -117,7 +117,7 @@
         */
         ${className}(const Aws::Auth::AWSCredentials& credentials,
 #if($serviceModel.endpointRules)
-        ${clsWSpace} std::shared_ptr<${metadata.classNamePrefix}EndpointProviderBase> endpointProvider = ${endpointsProviderDefaultCtorCall},
+        ${clsWSpace} std::shared_ptr<${metadata.classNamePrefix}EndpointProviderBase> endpointProvider = ${endpointsProviderDefaultCtorDummy},
 #end
         ${clsWSpace} const ${clientConfigurationCls}& clientConfiguration = ${clientConfigurationCls}()#if($simpleCredsCtor.isEmpty()));#else,#end
 
@@ -136,7 +136,7 @@
         */
         ${className}(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
 #if($serviceModel.endpointRules)
-        ${clsWSpace} std::shared_ptr<${metadata.classNamePrefix}EndpointProviderBase> endpointProvider = ${endpointsProviderDefaultCtorCall},
+        ${clsWSpace} std::shared_ptr<${metadata.classNamePrefix}EndpointProviderBase> endpointProvider = ${endpointsProviderDefaultCtorDummy},
 #end
         ${clsWSpace} const ${clientConfigurationCls}& clientConfiguration = ${clientConfigurationCls}()#if($specCredsCtor.isEmpty()));#else,#end
 
@@ -157,7 +157,7 @@
         */
         ${className}(const std::shared_ptr<Aws::Auth::AWSAuthSignerProvider>& signerProvider,
 #if($serviceModel.endpointRules)
-        ${clsWSpace} std::shared_ptr<${metadata.classNamePrefix}EndpointProviderBase> endpointProvider = ${endpointsProviderDefaultCtorCall},
+        ${clsWSpace} std::shared_ptr<${metadata.classNamePrefix}EndpointProviderBase> endpointProvider = ${endpointsProviderDefaultCtorDummy},
 #end
         ${clsWSpace} const ${clientConfigurationCls}& clientConfiguration = ${clientConfigurationCls}()#if($standaloneCredsCtor.isEmpty()));#else,#end
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm
@@ -38,7 +38,8 @@
 #set($virtualAddressingInit = "")
 #end
 #if($serviceModel.endpointRules)
-#set($addArgDummy = $ctorMemberInitList.add("m_endpointProvider(std::move(endpointProvider))"))
+#set($endpointsProviderDefaultCtorCall = "m_endpointProvider(endpointProvider ? std::move(endpointProvider) : Aws::MakeShared<" + ${metadata.classNamePrefix} + "EndpointProvider>(ALLOCATION_TAG))")
+#set($addArgDummy = $ctorMemberInitList.add($endpointsProviderDefaultCtorCall))
 #end
 #if(!$USEast1RegionalEndpointArgString)
 #set($USEast1RegionalEndpointArgString = "")

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceClientHeader.vm
@@ -32,8 +32,8 @@ namespace ${serviceNamespace}
   {
     public:
       typedef Aws::Client::AWSJsonClient BASECLASS;
-      static const char* SERVICE_NAME;
-      static const char* ALLOCATION_TAG;
+      static const char* GetServiceName();
+      static const char* GetAllocationTag();
 
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConfigTypeDeclarations.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm")

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceClientSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceClientSource.vm
@@ -41,8 +41,16 @@ using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 #end
 
 #if(!${onlyGeneratedOperations})
-const char* ${className}::SERVICE_NAME = "${metadata.signingName}";
-const char* ${className}::ALLOCATION_TAG = "${className}";
+namespace Aws
+{
+  namespace ${metadata.namespace}
+  {
+    const char SERVICE_NAME[] = "${metadata.signingName}";
+    const char ALLOCATION_TAG[] = "${className}";
+  }
+}
+const char* ${className}::GetServiceName() {return SERVICE_NAME;}
+const char* ${className}::GetAllocationTag() {return ALLOCATION_TAG;}
 
 #parseOverrideOrDefault( "ServiceClientSourceInit_template" "com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm")
 #end

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/machinelearning/MachineLearningServiceClientSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/machinelearning/MachineLearningServiceClientSource.vm
@@ -35,8 +35,16 @@ using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
 
 #if(!$onlyGeneratedOperations)
-const char* ${className}::SERVICE_NAME = "${metadata.signingName}";
-const char* ${className}::ALLOCATION_TAG = "${className}";
+namespace Aws
+{
+  namespace ${metadata.namespace}
+  {
+    const char SERVICE_NAME[] = "${metadata.signingName}";
+    const char ALLOCATION_TAG[] = "${className}";
+  }
+}
+const char* ${className}::GetServiceName() {return SERVICE_NAME;}
+const char* ${className}::GetAllocationTag() {return ALLOCATION_TAG;}
 
 #parseOverrideOrDefault( "ServiceClientSourceInit_template" "com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm")
 #end

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/rds/RDSClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/rds/RDSClientHeader.vm
@@ -29,9 +29,9 @@ namespace ${rootNamespace}
     class ${CppViewHelper.computeExportValue($metadata.classNamePrefix)} ${className}$finalClass : public Aws::Client::AWSXMLClient, public Aws::Client::ClientWithAsyncTemplateMethods<${className}>
     {
     public:
-    typedef Aws::Client::AWSXMLClient BASECLASS;
-    static const char* SERVICE_NAME;
-    static const char* ALLOCATION_TAG;
+        typedef Aws::Client::AWSXMLClient BASECLASS;
+        static const char* GetServiceName();
+        static const char* GetAllocationTag();
 
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConfigTypeDeclarations.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm")

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
@@ -97,8 +97,8 @@ namespace ${rootNamespace}
     {
     public:
         typedef Aws::Client::AWSXMLClient BASECLASS;
-        static const char* SERVICE_NAME;
-        static const char* ALLOCATION_TAG;
+        static const char* GetServiceName();
+        static const char* GetAllocationTag();
 
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConfigTypeDeclarations.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm")

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
@@ -38,7 +38,7 @@ static int S3CrtRequestGetBodyCallback(struct aws_s3_meta_request *meta_request,
   {
       receivedHandler(userData->request.get(), userData->response.get(), static_cast<long long>(body->len));
   }
-  AWS_LOGSTREAM_TRACE(${className}::ALLOCATION_TAG, body->len << " bytes written to response.");
+  AWS_LOGSTREAM_TRACE(ALLOCATION_TAG, body->len << " bytes written to response.");
 
   return AWS_OP_SUCCESS;
 }
@@ -395,7 +395,7 @@ void ${className}::${operation.name}Async(${constText}${operation.name}ResponseR
 #end
 
   // make aws_s3_meta_request with callbacks
-  CrtRequestCallbackUserData *userData = Aws::New<CrtRequestCallbackUserData>(${className}::ALLOCATION_TAG);
+  CrtRequestCallbackUserData *userData = Aws::New<CrtRequestCallbackUserData>(ALLOCATION_TAG);
   aws_s3_meta_request_options options;
   AWS_ZERO_STRUCT(options);
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3control/S3ControlClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3control/S3ControlClientHeader.vm
@@ -51,8 +51,8 @@ namespace ${metadata.namespace}
     {
     public:
         typedef Aws::Client::AWSXMLClient BASECLASS;
-        static const char* SERVICE_NAME;
-        static const char* ALLOCATION_TAG;
+        static const char* GetServiceName();
+        static const char* GetAllocationTag();
 
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConfigTypeDeclarations.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm")

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/sqs/SQSServiceClientSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/sqs/SQSServiceClientSource.vm
@@ -37,8 +37,16 @@ using ResolveEndpointOutcome = Aws::Endpoint::ResolveEndpointOutcome;
 
 
 #if(!$onlyGeneratedOperations)
-const char* ${className}::SERVICE_NAME = "${metadata.signingName}";
-const char* ${className}::ALLOCATION_TAG = "${className}";
+namespace Aws
+{
+  namespace ${metadata.namespace}
+  {
+    const char SERVICE_NAME[] = "${metadata.signingName}";
+    const char ALLOCATION_TAG[] = "${className}";
+  }
+}
+const char* ${className}::GetServiceName() {return SERVICE_NAME;}
+const char* ${className}::GetAllocationTag() {return ALLOCATION_TAG;}s
 
 #parseOverrideOrDefault( "ServiceClientSourceInit_template" "com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm")
 #end

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlServiceClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlServiceClientHeader.vm
@@ -30,8 +30,8 @@ namespace ${serviceNamespace}
   {
     public:
       typedef Aws::Client::AWSXMLClient BASECLASS;
-      static const char* SERVICE_NAME;
-      static const char* ALLOCATION_TAG;
+      static const char* GetServiceName();
+      static const char* GetAllocationTag();
 
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConfigTypeDeclarations.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm")

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/rest/RestXmlServiceClientSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/rest/RestXmlServiceClientSource.vm
@@ -40,8 +40,16 @@ using namespace Aws::Utils;
 
 
 #if(!${onlyGeneratedOperations})
-const char* ${className}::SERVICE_NAME = "${metadata.signingName}";
-const char* ${className}::ALLOCATION_TAG = "${className}";
+namespace Aws
+{
+  namespace ${metadata.namespace}
+  {
+    const char SERVICE_NAME[] = "${metadata.signingName}";
+    const char ALLOCATION_TAG[] = "${className}";
+  }
+}
+const char* ${className}::GetServiceName() {return SERVICE_NAME;}
+const char* ${className}::GetAllocationTag() {return ALLOCATION_TAG;}
 #end
 #set($hostOverrideString = '')
 #if($metadata.globalEndpoint)


### PR DESCRIPTION
*Issue #, if available:*
[#2789 Static ALLOCATION_TAG and SERVICE_NAME symbols break DelayLoadDLLs on windows](https://github.com/aws/aws-sdk-cpp/issues/2789)

This fixes the regression for the given usecase I introduced back in https://github.com/aws/aws-sdk-cpp/pull/2157
*Description of changes:*
Do not expose static const variables from headers
Set few integration tests to test this config
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
