### PR TITLE
fix compressions trait casing

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/c2j/C2jOperation.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/c2j/C2jOperation.java
@@ -32,5 +32,5 @@ public class C2jOperation {
     // For Cellular Request Routing
     private boolean endpointoperation; // endpointoperation trait
     private C2jEndpointDiscovery endpointdiscovery; //endpointdiscovery trait
-    private C2jRequestCompression requestCompression;
+    private C2jRequestCompression requestcompression;
 }

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
@@ -648,8 +648,8 @@ public class C2jModelToGeneratorModelTransformer {
         }
 
         //RequestCompression
-        if (c2jOperation.getRequestCompression() != null) {
-            C2jRequestCompression c2jRequestCompression = c2jOperation.getRequestCompression();
+        if (c2jOperation.getRequestcompression() != null) {
+            C2jRequestCompression c2jRequestCompression = c2jOperation.getRequestcompression();
             // Supporting only Gzip for now.
             if (c2jRequestCompression.getEncodings().isEmpty()) {
                 throw new RuntimeException("When Request Compression is requested, at least 1 algorithm needs to be declared");


### PR DESCRIPTION
*Description of changes:*

the compression trait for s2j will be `requestcompression` and not `requestCompression`, fixing.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
