### PR TITLE
fix JsonView:GetBool

### DIFF
--- a/src/aws-cpp-sdk-core/source/utils/json/JsonSerializer.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/json/JsonSerializer.cpp
@@ -441,7 +441,7 @@ bool JsonView::GetBool(const Aws::String& key) const
     assert(m_value);
     auto item = cJSON_AS4CPP_GetObjectItemCaseSensitive(m_value, key.c_str());
     assert(item);
-    return item->valueint != 0;
+    return cJSON_AS4CPP_IsTrue(item) != 0;
 }
 
 bool JsonView::AsBool() const


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/issues/1731

*Description of changes:*
Json Library uses `type` not `valueint` to determine if value is bool. ie. type '2' is true and type '1' is false.
Fixed the return value for GetBool to take this into account.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [x] IOS
- [x] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
