### PR TITLE
Avoid setting the checksum algorithm to NOT_SET because this is causi…

### DIFF
--- a/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -526,9 +526,6 @@ namespace Aws
             TriggerTransferStatusUpdatedCallback(handle);
 
             auto putObjectRequest = m_transferConfig.putObjectTemplate;
-            putObjectRequest.SetChecksumAlgorithm(m_transferConfig.computeContentMD5
-                                                  ? S3::Model::ChecksumAlgorithm::NOT_SET
-                                                  : m_transferConfig.checksumAlgorithm);
             putObjectRequest.SetChecksumAlgorithm(m_transferConfig.checksumAlgorithm);
             putObjectRequest.SetBucket(handle->GetBucketName());
             putObjectRequest.SetKey(handle->GetKey());


### PR DESCRIPTION
…ng an error later on

*Issue #, if available:* https://github.com/aws/aws-sdk-cpp/issues/1961

*Description of changes: this change is about not setting a checksum algorithm if the transfer_config is set to NOT_SET
Not sure it is the best place to fix this.. Also note the strange code that was there for the putObjectRequest where the setter for the checksum algorithm was called 2x.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [X] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
