### PR TITLE
Workaround race condition in ShutdownAPI and logging and custom mem mngmt

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/logging/DefaultLogSystem.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/logging/DefaultLogSystem.h
@@ -53,6 +53,11 @@ namespace Aws
                 void Flush() override;
 
                 /**
+                 * Stops logging on this logger without destroying the object.
+                 */
+                void Stop() override;
+
+                /**
                  * Structure containing semaphores, queue etc... 
                  */
                 struct LogSynchronizationData

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/logging/FormattedLogSystem.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/logging/FormattedLogSystem.h
@@ -50,6 +50,10 @@ namespace Aws
                  */
                 virtual void LogStream(LogLevel logLevel, const char* tag, const Aws::OStringStream &messageStream) override;
 
+                /**
+                 * Stops logging on this logger without destroying the object.
+                 */
+                virtual void Stop() override { return SetLogLevel(Aws::Utils::Logging::LogLevel::Off); };
             protected:
                 /**
                  * This is the method that most logger implementations will want to override.

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/logging/LogSystemInterface.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/logging/LogSystemInterface.h
@@ -44,6 +44,10 @@ namespace Aws
                  * Writes any buffered messages to the underlying device if the logger supports buffering.
                  */
                 virtual void Flush() = 0;
+                /**
+                 * Stops logging on this logger without destroying the object.
+                 */
+                virtual void Stop() { return; };
             };
 
         } // namespace Logging

--- a/src/aws-cpp-sdk-core/source/Aws.cpp
+++ b/src/aws-cpp-sdk-core/source/Aws.cpp
@@ -212,10 +212,12 @@ namespace Aws
         if (options.loggingOptions.logLevel != Aws::Utils::Logging::LogLevel::Off)
         {
             Aws::Utils::Logging::ShutdownCRTLogging();
-            Aws::Utils::Logging::ShutdownAWSLogging();
+            Aws::Utils::Logging::PushLogger(nullptr); // stops further logging but keeps old logger object alive
         }
         Aws::Client::CoreErrorsMapper::CleanupCoreErrorsMapper();
         Aws::CleanupCrt();
+
+        Aws::Utils::Logging::ShutdownAWSLogging();
 #ifdef USE_AWS_MEMORY_MANAGEMENT
         if(options.memoryManagementOptions.memoryManager)
         {

--- a/src/aws-cpp-sdk-core/source/utils/logging/AWSLogging.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/logging/AWSLogging.cpp
@@ -9,6 +9,7 @@
 #include <aws/core/utils/memory/stl/AWSStack.h>
 
 #include <memory>
+#include <thread>
 
 using namespace Aws::Utils;
 using namespace Aws::Utils::Logging;
@@ -28,6 +29,11 @@ void InitializeAWSLogging(const std::shared_ptr<LogSystemInterface> &logSystem) 
 
 void ShutdownAWSLogging(void) {
     InitializeAWSLogging(nullptr);
+    // GetLogSystem returns a raw pointer
+    // so this is a hack to let all other threads finish their log statement after getting a LogSystem pointer
+    // otherwise we would need to perform ref-counting on each logging statement
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    OldLogger.reset();
 }
 
 LogSystemInterface *GetLogSystem() {

--- a/src/aws-cpp-sdk-core/source/utils/logging/DefaultLogSystem.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/logging/DefaultLogSystem.cpp
@@ -90,11 +90,7 @@ DefaultLogSystem::DefaultLogSystem(LogLevel logLevel, const Aws::String& filenam
 
 DefaultLogSystem::~DefaultLogSystem()
 {
-    {
-        std::lock_guard<std::mutex> locker(m_syncData.m_logQueueMutex);
-        m_syncData.m_stopLogging = true;
-        m_syncData.m_queueSignal.notify_one();
-    }
+    Stop();
 
     // explicitly wait for logging thread to finish
     {
@@ -128,5 +124,17 @@ void DefaultLogSystem::Flush()
 {
     std::lock_guard<std::mutex> locker(m_syncData.m_logQueueMutex);
     m_syncData.m_queueSignal.notify_one();
+}
+
+void DefaultLogSystem::Stop()
+{
+    FormattedLogSystem::Stop();
+    Flush();
+
+    {
+        std::lock_guard<std::mutex> locker(m_syncData.m_logQueueMutex);
+        m_syncData.m_stopLogging = true;
+        m_syncData.m_queueSignal.notify_one();
+    }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
`TEST(AwsMemoryManagementTest, MultiInitParallel)` fails once in a blue moon with sanitizer report in case of custom memory management enabled.
It is not an issue in case of [basic-use](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/basic-use.html) non-violated.
We really need to refactor the InitAPI-ShutdownAPI design...
*Description of changes:*
Preserve the logger for some time to let all pending logging statements to finish.
This is a workaround not a real fix.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
