### PR TITLE
fix disable ssl in windows http client

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
@@ -151,7 +151,7 @@ void* WinHttpSyncHttpClient::OpenRequest(const std::shared_ptr<HttpRequest>& req
     LPCWSTR accept[2] = { nullptr, nullptr };
 
     DWORD requestFlags = WINHTTP_FLAG_REFRESH |
-        (request->GetUri().GetScheme() == Scheme::HTTPS ? WINHTTP_FLAG_SECURE : 0);
+        (request->GetUri().GetScheme() == Scheme::HTTPS && m_verifySSL ? WINHTTP_FLAG_SECURE : 0);
 
     Aws::WString acceptHeader(L"*/*");
 


### PR DESCRIPTION
*Issue #, if available:*

[issues/1445](https://github.com/aws/aws-sdk-cpp/issues/1445)

*Description of changes:*

Fixes a issue where when verify ssl is disabled on windows we still set `WINHTTP_FLAG_SECURE`


[according to msft documentation](https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpopenrequest)
```
Uses secure transaction semantics. This translates to using Secure Sockets Layer (SSL)/Transport Layer Security (TLS).
```

This checks to not set it when verify ssl has been turned off.

Tested using the code provided in the above issues using a opensearch distro

```
#include <aws/core/Aws.h>
#include <aws/core/http/HttpClient.h>
#include <aws/core/utils/HashingUtils.h>

using namespace Aws;

auto main() -> int {
    SDKOptions options;
    options.loggingOptions.logLevel = Utils::Logging::LogLevel::Trace;
    InitAPI(options); {
        // Set client configuration
        Client::ClientConfiguration config;
        config.scheme = Aws::Http::Scheme::HTTPS;
        config.verifySSL = false;

        const auto client = Aws::Http::CreateHttpClient(config);

        // Generate http request
        const auto request = CreateHttpRequest(
          String("https://localhost:9200/_cat/plugins?format=json"),
          Http::HttpMethod::HTTP_GET,
          Utils::Stream::DefaultResponseStreamFactoryMethod);

        // Set Authentication
        std::string authString = "admin:admin";
        Utils::Array<unsigned char> userpw_arr(reinterpret_cast<const unsigned char *>(authString.c_str()),authString.length());
        const auto basicAuth = Utils::HashingUtils::Base64Encode(userpw_arr);
        request->SetAuthorization("Basic " + basicAuth);

        // Issue request
        const auto response = client->MakeRequest(request);
        //assert(response->GetResponseCode() == Http::HttpResponseCode::OK);
        std::stringstream ss;
        ss << response->GetResponseBody().rdbuf();
        std::cout << ss.str() << "\n";
    }
    ShutdownAPI(options);
    return 0;
}
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [x] IOS
- [x] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
