### PR TITLE
change integ tests to have strong consistency

### DIFF
--- a/tests/aws-cpp-sdk-dynamodb-integration-tests/TableOperationTest.cpp
+++ b/tests/aws-cpp-sdk-dynamodb-integration-tests/TableOperationTest.cpp
@@ -681,6 +681,7 @@ TEST_F(TableOperationTest, TestCrudOperationsWithCallbacks)
         hashKey.SetS(ss.str());
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(crudCallbacksTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
         Aws::Vector<Aws::String> attributesToGet;
         attributesToGet.push_back(HASH_KEY_NAME);
@@ -716,6 +717,7 @@ TEST_F(TableOperationTest, TestCrudOperationsWithCallbacks)
 
     ScanRequest scanRequest;
     scanRequest.WithTableName(crudCallbacksTestTableName);
+    scanRequest.WithConsistentRead(true);
 
     ScanOutcome scanOutcome = m_client->Scan(scanRequest);
     AWS_EXPECT_SUCCESS(scanOutcome);
@@ -759,6 +761,7 @@ TEST_F(TableOperationTest, TestCrudOperationsWithCallbacks)
         hashKey.SetS(ss.str());
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(crudCallbacksTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
 
         Aws::Vector<Aws::String> attributesToGet;


### PR DESCRIPTION
*Description of changes:*

change integ tests to use consistent reads in dynamo integ test.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
