### PR TITLE
fix header argument for list arguemnts

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectAttributesRequest.cpp
@@ -10,6 +10,7 @@
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 
 #include <utility>
+#include <numeric>
 
 using namespace Aws::S3Crt::Model;
 using namespace Aws::Utils::Xml;
@@ -122,12 +123,13 @@ Aws::Http::HeaderValueCollection GetObjectAttributesRequest::GetRequestSpecificH
 
   if(m_objectAttributesHasBeenSet)
   {
-    for(const auto& item : m_objectAttributes)
-    {
-      ss << ObjectAttributesMapper::GetNameForObjectAttributes(item);
-      headers.emplace("x-amz-object-attributes", ss.str());
-      ss.str("");
-    }
+    headers.emplace("x-amz-object-attributes", std::accumulate(std::begin(m_objectAttributes),
+      std::end(m_objectAttributes),
+      Aws::String{},
+      [](const Aws::String &acc, const ObjectAttributes &item) -> Aws::String {
+        const auto headerValue = ObjectAttributesMapper::GetNameForObjectAttributes(item);
+        return acc.empty() ? headerValue : acc + "," + headerValue;
+      }));
   }
 
   return headers;

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/ListObjectVersionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/ListObjectVersionsRequest.cpp
@@ -10,6 +10,7 @@
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 
 #include <utility>
+#include <numeric>
 
 using namespace Aws::S3Crt::Model;
 using namespace Aws::Utils::Xml;
@@ -121,12 +122,13 @@ Aws::Http::HeaderValueCollection ListObjectVersionsRequest::GetRequestSpecificHe
 
   if(m_optionalObjectAttributesHasBeenSet)
   {
-    for(const auto& item : m_optionalObjectAttributes)
-    {
-      ss << OptionalObjectAttributesMapper::GetNameForOptionalObjectAttributes(item);
-      headers.emplace("x-amz-optional-object-attributes", ss.str());
-      ss.str("");
-    }
+    headers.emplace("x-amz-optional-object-attributes", std::accumulate(std::begin(m_optionalObjectAttributes),
+      std::end(m_optionalObjectAttributes),
+      Aws::String{},
+      [](const Aws::String &acc, const OptionalObjectAttributes &item) -> Aws::String {
+        const auto headerValue = OptionalObjectAttributesMapper::GetNameForOptionalObjectAttributes(item);
+        return acc.empty() ? headerValue : acc + "," + headerValue;
+      }));
   }
 
   return headers;

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/ListObjectsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/ListObjectsRequest.cpp
@@ -10,6 +10,7 @@
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 
 #include <utility>
+#include <numeric>
 
 using namespace Aws::S3Crt::Model;
 using namespace Aws::Utils::Xml;
@@ -113,12 +114,13 @@ Aws::Http::HeaderValueCollection ListObjectsRequest::GetRequestSpecificHeaders()
 
   if(m_optionalObjectAttributesHasBeenSet)
   {
-    for(const auto& item : m_optionalObjectAttributes)
-    {
-      ss << OptionalObjectAttributesMapper::GetNameForOptionalObjectAttributes(item);
-      headers.emplace("x-amz-optional-object-attributes", ss.str());
-      ss.str("");
-    }
+    headers.emplace("x-amz-optional-object-attributes", std::accumulate(std::begin(m_optionalObjectAttributes),
+      std::end(m_optionalObjectAttributes),
+      Aws::String{},
+      [](const Aws::String &acc, const OptionalObjectAttributes &item) -> Aws::String {
+        const auto headerValue = OptionalObjectAttributesMapper::GetNameForOptionalObjectAttributes(item);
+        return acc.empty() ? headerValue : acc + "," + headerValue;
+      }));
   }
 
   return headers;

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/ListObjectsV2Request.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/ListObjectsV2Request.cpp
@@ -10,6 +10,7 @@
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 
 #include <utility>
+#include <numeric>
 
 using namespace Aws::S3Crt::Model;
 using namespace Aws::Utils::Xml;
@@ -130,12 +131,13 @@ Aws::Http::HeaderValueCollection ListObjectsV2Request::GetRequestSpecificHeaders
 
   if(m_optionalObjectAttributesHasBeenSet)
   {
-    for(const auto& item : m_optionalObjectAttributes)
-    {
-      ss << OptionalObjectAttributesMapper::GetNameForOptionalObjectAttributes(item);
-      headers.emplace("x-amz-optional-object-attributes", ss.str());
-      ss.str("");
-    }
+    headers.emplace("x-amz-optional-object-attributes", std::accumulate(std::begin(m_optionalObjectAttributes),
+      std::end(m_optionalObjectAttributes),
+      Aws::String{},
+      [](const Aws::String &acc, const OptionalObjectAttributes &item) -> Aws::String {
+        const auto headerValue = OptionalObjectAttributesMapper::GetNameForOptionalObjectAttributes(item);
+        return acc.empty() ? headerValue : acc + "," + headerValue;
+      }));
   }
 
   return headers;

--- a/generated/src/aws-cpp-sdk-s3/source/model/GetObjectAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/GetObjectAttributesRequest.cpp
@@ -10,6 +10,7 @@
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 
 #include <utility>
+#include <numeric>
 
 using namespace Aws::S3::Model;
 using namespace Aws::Utils::Xml;
@@ -122,12 +123,13 @@ Aws::Http::HeaderValueCollection GetObjectAttributesRequest::GetRequestSpecificH
 
   if(m_objectAttributesHasBeenSet)
   {
-    for(const auto& item : m_objectAttributes)
-    {
-      ss << ObjectAttributesMapper::GetNameForObjectAttributes(item);
-      headers.emplace("x-amz-object-attributes", ss.str());
-      ss.str("");
-    }
+    headers.emplace("x-amz-object-attributes", std::accumulate(std::begin(m_objectAttributes),
+      std::end(m_objectAttributes),
+      Aws::String{},
+      [](const Aws::String &acc, const ObjectAttributes &item) -> Aws::String {
+        const auto headerValue = ObjectAttributesMapper::GetNameForObjectAttributes(item);
+        return acc.empty() ? headerValue : acc + "," + headerValue;
+      }));
   }
 
   return headers;

--- a/generated/src/aws-cpp-sdk-s3/source/model/ListObjectVersionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/ListObjectVersionsRequest.cpp
@@ -10,6 +10,7 @@
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 
 #include <utility>
+#include <numeric>
 
 using namespace Aws::S3::Model;
 using namespace Aws::Utils::Xml;
@@ -121,12 +122,13 @@ Aws::Http::HeaderValueCollection ListObjectVersionsRequest::GetRequestSpecificHe
 
   if(m_optionalObjectAttributesHasBeenSet)
   {
-    for(const auto& item : m_optionalObjectAttributes)
-    {
-      ss << OptionalObjectAttributesMapper::GetNameForOptionalObjectAttributes(item);
-      headers.emplace("x-amz-optional-object-attributes", ss.str());
-      ss.str("");
-    }
+    headers.emplace("x-amz-optional-object-attributes", std::accumulate(std::begin(m_optionalObjectAttributes),
+      std::end(m_optionalObjectAttributes),
+      Aws::String{},
+      [](const Aws::String &acc, const OptionalObjectAttributes &item) -> Aws::String {
+        const auto headerValue = OptionalObjectAttributesMapper::GetNameForOptionalObjectAttributes(item);
+        return acc.empty() ? headerValue : acc + "," + headerValue;
+      }));
   }
 
   return headers;

--- a/generated/src/aws-cpp-sdk-s3/source/model/ListObjectsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/ListObjectsRequest.cpp
@@ -10,6 +10,7 @@
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 
 #include <utility>
+#include <numeric>
 
 using namespace Aws::S3::Model;
 using namespace Aws::Utils::Xml;
@@ -113,12 +114,13 @@ Aws::Http::HeaderValueCollection ListObjectsRequest::GetRequestSpecificHeaders()
 
   if(m_optionalObjectAttributesHasBeenSet)
   {
-    for(const auto& item : m_optionalObjectAttributes)
-    {
-      ss << OptionalObjectAttributesMapper::GetNameForOptionalObjectAttributes(item);
-      headers.emplace("x-amz-optional-object-attributes", ss.str());
-      ss.str("");
-    }
+    headers.emplace("x-amz-optional-object-attributes", std::accumulate(std::begin(m_optionalObjectAttributes),
+      std::end(m_optionalObjectAttributes),
+      Aws::String{},
+      [](const Aws::String &acc, const OptionalObjectAttributes &item) -> Aws::String {
+        const auto headerValue = OptionalObjectAttributesMapper::GetNameForOptionalObjectAttributes(item);
+        return acc.empty() ? headerValue : acc + "," + headerValue;
+      }));
   }
 
   return headers;

--- a/generated/src/aws-cpp-sdk-s3/source/model/ListObjectsV2Request.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/ListObjectsV2Request.cpp
@@ -10,6 +10,7 @@
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 
 #include <utility>
+#include <numeric>
 
 using namespace Aws::S3::Model;
 using namespace Aws::Utils::Xml;
@@ -130,12 +131,13 @@ Aws::Http::HeaderValueCollection ListObjectsV2Request::GetRequestSpecificHeaders
 
   if(m_optionalObjectAttributesHasBeenSet)
   {
-    for(const auto& item : m_optionalObjectAttributes)
-    {
-      ss << OptionalObjectAttributesMapper::GetNameForOptionalObjectAttributes(item);
-      headers.emplace("x-amz-optional-object-attributes", ss.str());
-      ss.str("");
-    }
+    headers.emplace("x-amz-optional-object-attributes", std::accumulate(std::begin(m_optionalObjectAttributes),
+      std::end(m_optionalObjectAttributes),
+      Aws::String{},
+      [](const Aws::String &acc, const OptionalObjectAttributes &item) -> Aws::String {
+        const auto headerValue = OptionalObjectAttributesMapper::GetNameForOptionalObjectAttributes(item);
+        return acc.empty() ? headerValue : acc + "," + headerValue;
+      }));
   }
 
   return headers;

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
@@ -481,4 +481,9 @@ public class CppViewHelper {
                 .map(__ -> prefix + cppType)
                 .orElse(functionName);
     }
+
+    public static boolean hasListMemberUsedForHeader(final Shape shape) {
+        return shape.getMembers().values().stream()
+                .anyMatch(shapeMember -> shapeMember.getShape().isList() && shapeMember.isUsedForHeader());
+    }
 }

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassHeaderMembersSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassHeaderMembersSource.vm
@@ -38,16 +38,17 @@
   ${spaces}  ss.str("");
   ${spaces}}
 #elseif($member.shape.list)
-  ${spaces}for(const auto& item : $memberVarName)
-  ${spaces}{
+  ${spaces}headers.emplace("${locationName}", std::accumulate(std::begin($memberVarName),
+  ${spaces}  std::end($memberVarName),
+  ${spaces}  Aws::String{},
+  ${spaces}  [](const Aws::String &acc, const ${member.shape.listMember.shape.name} &item) -> Aws::String {
 #if($member.shape.listMember.shape.enum)
-  ${spaces}  ss << ${member.shape.listMember.shape.name}Mapper::GetNameFor${member.shape.listMember.shape.name}(item);
+  ${spaces}    const auto headerValue = ${member.shape.listMember.shape.name}Mapper::GetNameFor${member.shape.listMember.shape.name}(item);
 #else
-  ${spaces}  ss << item;
+  ${spaces}    const auto headerValue = item;
 #end
-  ${spaces}  headers.emplace("${locationName}", ss.str());
-  ${spaces}  ss.str("");
-  ${spaces}}
+  ${spaces}    return acc.empty() ? headerValue : acc + "," + headerValue;
+  ${spaces}  }));
 #else
   ${spaces}ss << m_${lowerCaseVarName};
   ${spaces}headers.emplace("${locationName}", #if($member.requiresHeaderEncoding())URI::URLEncodePath(ss.str())#else ss.str()#end);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/StreamRequestSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/StreamRequestSource.vm
@@ -13,6 +13,9 @@
 #end
 
 \#include <utility>
+#if(${CppViewHelper.hasListMemberUsedForHeader($shape)})
+\#include <numeric>
+#end
 
 using namespace ${rootNamespace}::${serviceNamespace}::Model;
 using namespace Aws::Utils::Stream;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonRequestSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonRequestSource.vm
@@ -16,6 +16,9 @@
 #end
 
 \#include <utility>
+#if(${CppViewHelper.hasListMemberUsedForHeader($shape)})
+\#include <numeric>
+#end
 
 using namespace ${rootNamespace}::${serviceNamespace}::Model;
 using namespace Aws::Utils::Json;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/PutBucketNotificationConfigurationRequest.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/PutBucketNotificationConfigurationRequest.vm
@@ -14,6 +14,9 @@
 #end
 
 \#include <utility>
+#if(${CppViewHelper.hasListMemberUsedForHeader($shape)})
+\#include <numeric>
+#end
 
 using namespace ${rootNamespace}::${serviceNamespace}::Model;
 using namespace Aws::Utils::Xml;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlRequestSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlRequestSource.vm
@@ -19,6 +19,9 @@
 #end
 
 \#include <utility>
+#if(${CppViewHelper.hasListMemberUsedForHeader($shape)})
+\#include <numeric>
+#end
 
 using namespace ${rootNamespace}::${serviceNamespace}::Model;
 using namespace Aws::Utils::Xml;


### PR DESCRIPTION
*Issue #, if available:*

[issues/2866](https://github.com/aws/aws-sdk-cpp/issues/2866)

*Description of changes:*

Fixes a bug where when header arguments are lists, only the last value is seralized and sent.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
