### PR TITLE
update doc and variable name for datetime ctor

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/DateTime.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/DateTime.h
@@ -70,9 +70,11 @@ namespace Aws
             DateTime(int64_t millisSinceEpoch);
 
             /**
-             * Initializes time point to epoch time in seconds.millis
+             * Initializes time point to epoch time in seconds with a millis mantissa,
+             *
+             * i.e. 1.1 would be 1100 milliseconds
              */
-            DateTime(double epoch_millis);
+            DateTime(double secondsSinceEpoch);
 
             /**
              * Initializes time point to value represented by timestamp and format.
@@ -95,7 +97,9 @@ namespace Aws
             DateTime operator-(const std::chrono::milliseconds& a) const;
 
             /**
-             * Assign from seconds.millis since epoch.
+             * Initializes time point to epoch time in seconds with a millis mantissa,
+             *
+             * i.e. 1.1 would be 1100 milliseconds
              */
             DateTime& operator=(double secondsSinceEpoch);
 
@@ -145,7 +149,9 @@ namespace Aws
             Aws::String ToGmtStringWithMs() const;
 
             /**
-             * Get the representation of this datetime as seconds.milliseconds since epoch
+             * Get the representation of this datetime as seconds with a millis mantissa since epoch
+             *
+             * i.e. 1.1 would be 1100 milliseconds
              */
             double SecondsWithMSPrecision() const;
 

--- a/src/aws-cpp-sdk-core/source/utils/DateTimeCommon.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/DateTimeCommon.cpp
@@ -1121,9 +1121,9 @@ DateTime::DateTime(int64_t millisSinceEpoch) : m_valid(true)
     m_time = std::chrono::system_clock::time_point(timestamp);
 }
 
-DateTime::DateTime(double epoch_millis) : m_valid(true)
+DateTime::DateTime(double secondsSinceEpoch) : m_valid(true)
 {
-    std::chrono::duration<double, std::chrono::seconds::period> timestamp(epoch_millis);
+    std::chrono::duration<double, std::chrono::seconds::period> timestamp(secondsSinceEpoch);
     m_time = std::chrono::system_clock::time_point(std::chrono::duration_cast<std::chrono::milliseconds>(timestamp));
 }
 


### PR DESCRIPTION
*Description of changes:*

Got a customer reach out about the argument being named `epoch_millis` even thought it was processing the argument as seconds with a milliseconds mantissa. An example of this could be

```
int64_t timeMillis = 1708552755100;
Utils::DateTime millis(timeMillis);
std::cout << millis.ToGmtString(Utils::DateFormat::ISO_8601) << "\n";
double timeSeconds = 1708552755.100;
Utils::DateTime date(timeSeconds);
std::cout << date.ToGmtString(Utils::DateFormat::ISO_8601) << "\n";
```

updates the name and comment to make more clear about what the function is doing.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
