### PR TITLE
change argument to avoid UB in pointer dreference

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3ExpressIdentityProvider.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3ExpressIdentityProvider.h
@@ -25,7 +25,7 @@ namespace Aws {
             explicit S3ExpressIdentityProvider(const S3CrtClient &s3Client) : m_s3Client(s3Client) {}
 
             virtual S3ExpressIdentity
-            GetS3ExpressIdentity(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) = 0;
+            GetS3ExpressIdentity(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) = 0;
 
             virtual ~S3ExpressIdentityProvider() {}
 
@@ -53,7 +53,7 @@ namespace Aws {
 
             virtual ~DefaultS3ExpressIdentityProvider() override = default;
 
-            S3ExpressIdentity GetS3ExpressIdentity(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) override;
+            S3ExpressIdentity GetS3ExpressIdentity(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) override;
 
         private:
             mutable std::shared_ptr<Aws::Utils::ConcurrentCache<Aws::String, S3ExpressIdentity>> m_credentialsCache;
@@ -75,7 +75,7 @@ namespace Aws {
 
             virtual ~DefaultAsyncS3ExpressIdentityProvider() override;
 
-            S3ExpressIdentity GetS3ExpressIdentity(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) override;
+            S3ExpressIdentity GetS3ExpressIdentity(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) override;
 
         private:
             void refreshIdentities(std::chrono::minutes refreshPeriod);

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3ExpressSigner.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3ExpressSigner.h
@@ -41,7 +41,7 @@ namespace Aws {
                 long long expirationInSeconds
             ) const override;
 
-            Aws::Auth::AWSCredentials GetCredentials(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) const override;
+            Aws::Auth::AWSCredentials GetCredentials(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) const override;
 
         protected:
             bool ServiceRequireUnsignedPayload(const String &serviceName) const override;

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtIdentityProviderAdapter.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtIdentityProviderAdapter.cpp
@@ -8,6 +8,8 @@
 
 using namespace Aws::S3Crt;
 
+static const char* ALLOC_TAG = "S3CrtIdentityProviderAdapter";
+
 aws_s3express_credentials_provider *S3CrtIdentityProviderAdapter::ProviderFactory(struct aws_allocator *allocator,
     struct aws_s3_client *client,
     aws_simple_completion_callback *on_provider_shutdown_callback,
@@ -42,7 +44,8 @@ aws_s3express_credentials_provider *S3CrtIdentityProviderAdapter::ProviderFactor
     // hostname at this point in theory will always be this way for express hosts.
     auto bucketName = hostname.substr(0, hostname.find('.'));
     params.emplace("bucketName", bucketName);
-    Http::ServiceSpecificParameters serviceSpecificParameters{std::move(params)};
+    const auto serviceSpecificParameters = Aws::MakeShared<Http::ServiceSpecificParameters>(ALLOC_TAG);
+    serviceSpecificParameters->parameterMap = std::move(params);
 
     //Get creds as raw ptr
     auto providerImpl = static_cast<S3ExpressIdentityProvider *>(provider->impl);

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3ExpressIdentityProvider.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3ExpressIdentityProvider.cpp
@@ -70,9 +70,9 @@ Aws::S3Crt::DefaultS3ExpressIdentityProvider::DefaultS3ExpressIdentityProvider(
 
 }
 
-S3ExpressIdentity DefaultS3ExpressIdentityProvider::GetS3ExpressIdentity(const ServiceSpecificParameters &serviceSpecificParameters) {
-    auto bucketNameIter = serviceSpecificParameters.parameterMap.find("bucketName");
-    if (bucketNameIter == serviceSpecificParameters.parameterMap.end()) {
+S3ExpressIdentity DefaultS3ExpressIdentityProvider::GetS3ExpressIdentity(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) {
+    auto bucketNameIter = serviceSpecificParameters->parameterMap.find("bucketName");
+    if (bucketNameIter == serviceSpecificParameters->parameterMap.end()) {
         AWS_LOGSTREAM_ERROR(S3_EXPRESS_IDENTITY_PROVIDER, "property bucketName Required to make call")
         return {"", "", "", {}};
     }
@@ -146,9 +146,9 @@ void DefaultAsyncS3ExpressIdentityProvider::refreshIdentities(std::chrono::minut
     }
 }
 
-S3ExpressIdentity DefaultAsyncS3ExpressIdentityProvider::GetS3ExpressIdentity(const ServiceSpecificParameters &serviceSpecificParameters) {
-    auto bucketNameIter = serviceSpecificParameters.parameterMap.find("bucketName");
-    if (bucketNameIter == serviceSpecificParameters.parameterMap.end()) {
+S3ExpressIdentity DefaultAsyncS3ExpressIdentityProvider::GetS3ExpressIdentity(const std::shared_ptr<ServiceSpecificParameters> &serviceSpecificParameters) {
+    auto bucketNameIter = serviceSpecificParameters->parameterMap.find("bucketName");
+    if (bucketNameIter == serviceSpecificParameters->parameterMap.end()) {
         AWS_LOGSTREAM_ERROR(S3_EXPRESS_IDENTITY_PROVIDER, "property bucketName Required to make call")
         return {"", "", "", {}};
     }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3ExpressSigner.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3ExpressSigner.cpp
@@ -58,7 +58,7 @@ bool S3ExpressSigner::SignRequest(Aws::Http::HttpRequest &request,
         return false;
     }
     putRequestId(requestId);
-    auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(*request.GetServiceSpecificParameters());
+    auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(request.GetServiceSpecificParameters());
     request.SetHeaderValue(S3_EXPRESS_HEADER, identity.getSessionToken());
     auto isSigned = AWSAuthV4Signer::SignRequest(request, region, serviceName, signBody);
     deleteRequestId(requestId);
@@ -80,7 +80,7 @@ bool S3ExpressSigner::PresignRequest(Aws::Http::HttpRequest &request,
         return false;
     }
     putRequestId(requestId);
-    auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(*request.GetServiceSpecificParameters());
+    auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(request.GetServiceSpecificParameters());
     request.AddQueryStringParameter(S3_EXPRESS_QUERY_PARAM, identity.getSessionToken());
     auto isSigned = AWSAuthV4Signer::PresignRequest(request, region, serviceName, expirationInSeconds);
     deleteRequestId(requestId);
@@ -91,7 +91,7 @@ bool S3ExpressSigner::ServiceRequireUnsignedPayload(const Aws::String &serviceNa
     return S3_EXPRESS_SERVICE_NAME == serviceName || AWSAuthV4Signer::ServiceRequireUnsignedPayload(serviceName);
 }
 
-Aws::Auth::AWSCredentials S3ExpressSigner::GetCredentials(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) const {
+Aws::Auth::AWSCredentials S3ExpressSigner::GetCredentials(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) const {
     auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(serviceSpecificParameters);
     return {identity.getAccessKeyId(), identity.getSecretKeyId()};
 }

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ExpressIdentityProvider.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ExpressIdentityProvider.h
@@ -25,7 +25,7 @@ namespace Aws {
             explicit S3ExpressIdentityProvider(const S3Client &s3Client) : m_s3Client(s3Client) {}
 
             virtual S3ExpressIdentity
-            GetS3ExpressIdentity(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) = 0;
+            GetS3ExpressIdentity(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) = 0;
 
             virtual ~S3ExpressIdentityProvider() {}
 
@@ -53,7 +53,7 @@ namespace Aws {
 
             virtual ~DefaultS3ExpressIdentityProvider() override = default;
 
-            S3ExpressIdentity GetS3ExpressIdentity(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) override;
+            S3ExpressIdentity GetS3ExpressIdentity(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) override;
 
         private:
             mutable std::shared_ptr<Aws::Utils::ConcurrentCache<Aws::String, S3ExpressIdentity>> m_credentialsCache;
@@ -75,7 +75,7 @@ namespace Aws {
 
             virtual ~DefaultAsyncS3ExpressIdentityProvider() override;
 
-            S3ExpressIdentity GetS3ExpressIdentity(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) override;
+            S3ExpressIdentity GetS3ExpressIdentity(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) override;
 
         private:
             void refreshIdentities(std::chrono::minutes refreshPeriod);

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ExpressSigner.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ExpressSigner.h
@@ -41,7 +41,7 @@ namespace Aws {
                 long long expirationInSeconds
             ) const override;
 
-            Aws::Auth::AWSCredentials GetCredentials(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) const override;
+            Aws::Auth::AWSCredentials GetCredentials(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) const override;
 
         protected:
             bool ServiceRequireUnsignedPayload(const String &serviceName) const override;

--- a/generated/src/aws-cpp-sdk-s3/source/S3ExpressIdentityProvider.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3ExpressIdentityProvider.cpp
@@ -70,9 +70,9 @@ Aws::S3::DefaultS3ExpressIdentityProvider::DefaultS3ExpressIdentityProvider(
 
 }
 
-S3ExpressIdentity DefaultS3ExpressIdentityProvider::GetS3ExpressIdentity(const ServiceSpecificParameters &serviceSpecificParameters) {
-    auto bucketNameIter = serviceSpecificParameters.parameterMap.find("bucketName");
-    if (bucketNameIter == serviceSpecificParameters.parameterMap.end()) {
+S3ExpressIdentity DefaultS3ExpressIdentityProvider::GetS3ExpressIdentity(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) {
+    auto bucketNameIter = serviceSpecificParameters->parameterMap.find("bucketName");
+    if (bucketNameIter == serviceSpecificParameters->parameterMap.end()) {
         AWS_LOGSTREAM_ERROR(S3_EXPRESS_IDENTITY_PROVIDER, "property bucketName Required to make call")
         return {"", "", "", {}};
     }
@@ -146,9 +146,9 @@ void DefaultAsyncS3ExpressIdentityProvider::refreshIdentities(std::chrono::minut
     }
 }
 
-S3ExpressIdentity DefaultAsyncS3ExpressIdentityProvider::GetS3ExpressIdentity(const ServiceSpecificParameters &serviceSpecificParameters) {
-    auto bucketNameIter = serviceSpecificParameters.parameterMap.find("bucketName");
-    if (bucketNameIter == serviceSpecificParameters.parameterMap.end()) {
+S3ExpressIdentity DefaultAsyncS3ExpressIdentityProvider::GetS3ExpressIdentity(const std::shared_ptr<ServiceSpecificParameters> &serviceSpecificParameters) {
+    auto bucketNameIter = serviceSpecificParameters->parameterMap.find("bucketName");
+    if (bucketNameIter == serviceSpecificParameters->parameterMap.end()) {
         AWS_LOGSTREAM_ERROR(S3_EXPRESS_IDENTITY_PROVIDER, "property bucketName Required to make call")
         return {"", "", "", {}};
     }

--- a/generated/src/aws-cpp-sdk-s3/source/S3ExpressSigner.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3ExpressSigner.cpp
@@ -58,7 +58,7 @@ bool S3ExpressSigner::SignRequest(Aws::Http::HttpRequest &request,
         return false;
     }
     putRequestId(requestId);
-    auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(*request.GetServiceSpecificParameters());
+    auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(request.GetServiceSpecificParameters());
     request.SetHeaderValue(S3_EXPRESS_HEADER, identity.getSessionToken());
     auto isSigned = AWSAuthV4Signer::SignRequest(request, region, serviceName, signBody);
     deleteRequestId(requestId);
@@ -80,7 +80,7 @@ bool S3ExpressSigner::PresignRequest(Aws::Http::HttpRequest &request,
         return false;
     }
     putRequestId(requestId);
-    auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(*request.GetServiceSpecificParameters());
+    auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(request.GetServiceSpecificParameters());
     request.AddQueryStringParameter(S3_EXPRESS_QUERY_PARAM, identity.getSessionToken());
     auto isSigned = AWSAuthV4Signer::PresignRequest(request, region, serviceName, expirationInSeconds);
     deleteRequestId(requestId);
@@ -91,7 +91,7 @@ bool S3ExpressSigner::ServiceRequireUnsignedPayload(const Aws::String &serviceNa
     return S3_EXPRESS_SERVICE_NAME == serviceName || AWSAuthV4Signer::ServiceRequireUnsignedPayload(serviceName);
 }
 
-Aws::Auth::AWSCredentials S3ExpressSigner::GetCredentials(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) const {
+Aws::Auth::AWSCredentials S3ExpressSigner::GetCredentials(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) const {
     auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(serviceSpecificParameters);
     return {identity.getAccessKeyId(), identity.getSecretKeyId()};
 }

--- a/src/aws-cpp-sdk-core/include/aws/core/auth/signer/AWSAuthV4Signer.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/signer/AWSAuthV4Signer.h
@@ -165,7 +165,7 @@ namespace Aws
             */
             bool PresignRequest(Aws::Http::HttpRequest& request, const char* region, const char* serviceName, long long expirationInSeconds = 0) const override;
 
-            virtual Aws::Auth::AWSCredentials GetCredentials(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) const;
+            virtual Aws::Auth::AWSCredentials GetCredentials(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) const;
 
             Aws::String GetServiceName() const { return m_serviceName; }
             Aws::String GetRegion() const { return m_region; }

--- a/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
@@ -79,7 +79,7 @@ AWSAuthV4Signer::~AWSAuthV4Signer()
 bool AWSAuthV4Signer::SignRequestWithSigV4a(Aws::Http::HttpRequest& request, const char* region, const char* serviceName,
     bool signBody, long long expirationTimeInSeconds, Aws::Crt::Auth::SignatureType signatureType) const
 {
-    AWSCredentials credentials = GetCredentials(*request.GetServiceSpecificParameters());
+    AWSCredentials credentials = GetCredentials(request.GetServiceSpecificParameters());
     auto crtCredentials = Aws::MakeShared<Aws::Crt::Auth::Credentials>(v4AsymmetricLogTag,
         Aws::Crt::ByteCursorFromCString(credentials.GetAWSAccessKeyId().c_str()),
         Aws::Crt::ByteCursorFromCString(credentials.GetAWSSecretKey().c_str()),
@@ -191,7 +191,7 @@ bool AWSAuthV4Signer::SignRequest(Aws::Http::HttpRequest& request, const char* r
 {
     Aws::String signingRegion = region ? region : m_region;
     Aws::String signingServiceName = serviceName ? serviceName : m_serviceName;
-    AWSCredentials credentials = GetCredentials(*request.GetServiceSpecificParameters());
+    AWSCredentials credentials = GetCredentials(request.GetServiceSpecificParameters());
 
     //don't sign anonymous requests
     if (credentials.GetAWSAccessKeyId().empty() || credentials.GetAWSSecretKey().empty())
@@ -364,7 +364,7 @@ bool AWSAuthV4Signer::PresignRequest(Aws::Http::HttpRequest& request, const char
 {
     Aws::String signingRegion = region ? region : m_region;
     Aws::String signingServiceName = serviceName ? serviceName : m_serviceName;
-    AWSCredentials credentials = GetCredentials(*request.GetServiceSpecificParameters());
+    AWSCredentials credentials = GetCredentials(request.GetServiceSpecificParameters());
 
     //don't sign anonymous requests
     if (credentials.GetAWSAccessKeyId().empty() || credentials.GetAWSSecretKey().empty())
@@ -603,7 +603,7 @@ Aws::Utils::ByteBuffer AWSAuthV4Signer::ComputeHash(const Aws::String& secretKey
     return hashResult.GetResult();
 }
 
-Aws::Auth::AWSCredentials AWSAuthV4Signer::GetCredentials(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) const {
+Aws::Auth::AWSCredentials AWSAuthV4Signer::GetCredentials(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) const {
     AWS_UNREFERENCED_PARAM(serviceSpecificParameters);
     return m_credentialsProvider->GetAWSCredentials();
 }

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3CrtIdentityProviderAdapterSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3CrtIdentityProviderAdapterSource.vm
@@ -5,6 +5,8 @@
 
 using namespace Aws::S3Crt;
 
+static const char* ALLOC_TAG = "S3CrtIdentityProviderAdapter";
+
 aws_s3express_credentials_provider *S3CrtIdentityProviderAdapter::ProviderFactory(struct aws_allocator *allocator,
     struct aws_s3_client *client,
     aws_simple_completion_callback *on_provider_shutdown_callback,
@@ -39,7 +41,8 @@ aws_s3express_credentials_provider *S3CrtIdentityProviderAdapter::ProviderFactor
     // hostname at this point in theory will always be this way for express hosts.
     auto bucketName = hostname.substr(0, hostname.find('.'));
     params.emplace("bucketName", bucketName);
-    Http::ServiceSpecificParameters serviceSpecificParameters{std::move(params)};
+    const auto serviceSpecificParameters = Aws::MakeShared<Http::ServiceSpecificParameters>(ALLOC_TAG);
+    serviceSpecificParameters->parameterMap = std::move(params);
 
     //Get creds as raw ptr
     auto providerImpl = static_cast<S3ExpressIdentityProvider *>(provider->impl);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressIdentityProviderHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressIdentityProviderHeader.vm
@@ -25,7 +25,7 @@ namespace ${rootNamespace} {
             explicit S3ExpressIdentityProvider(const ${metadata.classNamePrefix}Client &s3Client) : m_s3Client(s3Client) {}
 
             virtual S3ExpressIdentity
-            GetS3ExpressIdentity(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) = 0;
+            GetS3ExpressIdentity(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) = 0;
 
             virtual ~S3ExpressIdentityProvider() {}
 
@@ -53,7 +53,7 @@ namespace ${rootNamespace} {
 
             virtual ~DefaultS3ExpressIdentityProvider() override = default;
 
-            S3ExpressIdentity GetS3ExpressIdentity(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) override;
+            S3ExpressIdentity GetS3ExpressIdentity(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) override;
 
         private:
             mutable std::shared_ptr<Aws::Utils::ConcurrentCache<Aws::String, S3ExpressIdentity>> m_credentialsCache;
@@ -75,7 +75,7 @@ namespace ${rootNamespace} {
 
             virtual ~DefaultAsyncS3ExpressIdentityProvider() override;
 
-            S3ExpressIdentity GetS3ExpressIdentity(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) override;
+            S3ExpressIdentity GetS3ExpressIdentity(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) override;
 
         private:
             void refreshIdentities(std::chrono::minutes refreshPeriod);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressIdentityProviderSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressIdentityProviderSource.vm
@@ -70,9 +70,9 @@ Aws::${serviceNamespace}::DefaultS3ExpressIdentityProvider::DefaultS3ExpressIden
 
 }
 
-S3ExpressIdentity DefaultS3ExpressIdentityProvider::GetS3ExpressIdentity(const ServiceSpecificParameters &serviceSpecificParameters) {
-    auto bucketNameIter = serviceSpecificParameters.parameterMap.find("bucketName");
-    if (bucketNameIter == serviceSpecificParameters.parameterMap.end()) {
+S3ExpressIdentity DefaultS3ExpressIdentityProvider::GetS3ExpressIdentity(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) {
+    auto bucketNameIter = serviceSpecificParameters->parameterMap.find("bucketName");
+    if (bucketNameIter == serviceSpecificParameters->parameterMap.end()) {
         AWS_LOGSTREAM_ERROR(S3_EXPRESS_IDENTITY_PROVIDER, "property bucketName Required to make call")
         return {"", "", "", {}};
     }
@@ -146,9 +146,9 @@ void DefaultAsyncS3ExpressIdentityProvider::refreshIdentities(std::chrono::minut
     }
 }
 
-S3ExpressIdentity DefaultAsyncS3ExpressIdentityProvider::GetS3ExpressIdentity(const ServiceSpecificParameters &serviceSpecificParameters) {
-    auto bucketNameIter = serviceSpecificParameters.parameterMap.find("bucketName");
-    if (bucketNameIter == serviceSpecificParameters.parameterMap.end()) {
+S3ExpressIdentity DefaultAsyncS3ExpressIdentityProvider::GetS3ExpressIdentity(const std::shared_ptr<ServiceSpecificParameters> &serviceSpecificParameters) {
+    auto bucketNameIter = serviceSpecificParameters->parameterMap.find("bucketName");
+    if (bucketNameIter == serviceSpecificParameters->parameterMap.end()) {
         AWS_LOGSTREAM_ERROR(S3_EXPRESS_IDENTITY_PROVIDER, "property bucketName Required to make call")
         return {"", "", "", {}};
     }

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressSignerHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressSignerHeader.vm
@@ -41,7 +41,7 @@ namespace ${rootNamespace} {
                 long long expirationInSeconds
             ) const override;
 
-            Aws::Auth::AWSCredentials GetCredentials(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) const override;
+            Aws::Auth::AWSCredentials GetCredentials(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) const override;
 
         protected:
             bool ServiceRequireUnsignedPayload(const String &serviceName) const override;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressSignerSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressSignerSource.vm
@@ -58,7 +58,7 @@ bool S3ExpressSigner::SignRequest(Aws::Http::HttpRequest &request,
         return false;
     }
     putRequestId(requestId);
-    auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(*request.GetServiceSpecificParameters());
+    auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(request.GetServiceSpecificParameters());
     request.SetHeaderValue(S3_EXPRESS_HEADER, identity.getSessionToken());
     auto isSigned = AWSAuthV4Signer::SignRequest(request, region, serviceName, signBody);
     deleteRequestId(requestId);
@@ -80,7 +80,7 @@ bool S3ExpressSigner::PresignRequest(Aws::Http::HttpRequest &request,
         return false;
     }
     putRequestId(requestId);
-    auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(*request.GetServiceSpecificParameters());
+    auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(request.GetServiceSpecificParameters());
     request.AddQueryStringParameter(S3_EXPRESS_QUERY_PARAM, identity.getSessionToken());
     auto isSigned = AWSAuthV4Signer::PresignRequest(request, region, serviceName, expirationInSeconds);
     deleteRequestId(requestId);
@@ -91,7 +91,7 @@ bool S3ExpressSigner::ServiceRequireUnsignedPayload(const Aws::String &serviceNa
     return S3_EXPRESS_SERVICE_NAME == serviceName || AWSAuthV4Signer::ServiceRequireUnsignedPayload(serviceName);
 }
 
-Aws::Auth::AWSCredentials S3ExpressSigner::GetCredentials(const Aws::Http::ServiceSpecificParameters &serviceSpecificParameters) const {
+Aws::Auth::AWSCredentials S3ExpressSigner::GetCredentials(const std::shared_ptr<Aws::Http::ServiceSpecificParameters> &serviceSpecificParameters) const {
     auto identity = m_S3ExpressIdentityProvider->GetS3ExpressIdentity(serviceSpecificParameters);
     return {identity.getAccessKeyId(), identity.getSecretKeyId()};
 }


### PR DESCRIPTION
*Issue #, if available:*

[issues/2862](https://github.com/aws/aws-sdk-cpp/issues/2862)

*Description of changes:*

Fixes a UB issue when built with GCC and `_GLIBCXX_ASSERTIONS ` turned on. It is specifically that we are passing a nullptr to a function where it is not used, it is only used in the S3 client. Although it will not actually cause runtime UB a compiler will flag it as such, and we should fix it.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
