### PR TITLE
Enum not present serialization

### DIFF
--- a/generated/src/aws-cpp-sdk-clouddirectory/source/model/BatchReadRequest.cpp
+++ b/generated/src/aws-cpp-sdk-clouddirectory/source/model/BatchReadRequest.cpp
@@ -50,7 +50,7 @@ Aws::Http::HeaderValueCollection BatchReadRequest::GetRequestSpecificHeaders() c
     ss.str("");
   }
 
-  if(m_consistencyLevelHasBeenSet)
+  if(m_consistencyLevelHasBeenSet && m_consistencyLevel != ConsistencyLevel::NOT_SET)
   {
     headers.emplace("x-amz-consistency-level", ConsistencyLevelMapper::GetNameForConsistencyLevel(m_consistencyLevel));
   }

--- a/generated/src/aws-cpp-sdk-clouddirectory/source/model/GetObjectAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-clouddirectory/source/model/GetObjectAttributesRequest.cpp
@@ -64,7 +64,7 @@ Aws::Http::HeaderValueCollection GetObjectAttributesRequest::GetRequestSpecificH
     ss.str("");
   }
 
-  if(m_consistencyLevelHasBeenSet)
+  if(m_consistencyLevelHasBeenSet && m_consistencyLevel != ConsistencyLevel::NOT_SET)
   {
     headers.emplace("x-amz-consistency-level", ConsistencyLevelMapper::GetNameForConsistencyLevel(m_consistencyLevel));
   }

--- a/generated/src/aws-cpp-sdk-clouddirectory/source/model/GetObjectInformationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-clouddirectory/source/model/GetObjectInformationRequest.cpp
@@ -45,7 +45,7 @@ Aws::Http::HeaderValueCollection GetObjectInformationRequest::GetRequestSpecific
     ss.str("");
   }
 
-  if(m_consistencyLevelHasBeenSet)
+  if(m_consistencyLevelHasBeenSet && m_consistencyLevel != ConsistencyLevel::NOT_SET)
   {
     headers.emplace("x-amz-consistency-level", ConsistencyLevelMapper::GetNameForConsistencyLevel(m_consistencyLevel));
   }

--- a/generated/src/aws-cpp-sdk-clouddirectory/source/model/ListAttachedIndicesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-clouddirectory/source/model/ListAttachedIndicesRequest.cpp
@@ -60,7 +60,7 @@ Aws::Http::HeaderValueCollection ListAttachedIndicesRequest::GetRequestSpecificH
     ss.str("");
   }
 
-  if(m_consistencyLevelHasBeenSet)
+  if(m_consistencyLevelHasBeenSet && m_consistencyLevel != ConsistencyLevel::NOT_SET)
   {
     headers.emplace("x-amz-consistency-level", ConsistencyLevelMapper::GetNameForConsistencyLevel(m_consistencyLevel));
   }

--- a/generated/src/aws-cpp-sdk-clouddirectory/source/model/ListIndexRequest.cpp
+++ b/generated/src/aws-cpp-sdk-clouddirectory/source/model/ListIndexRequest.cpp
@@ -72,7 +72,7 @@ Aws::Http::HeaderValueCollection ListIndexRequest::GetRequestSpecificHeaders() c
     ss.str("");
   }
 
-  if(m_consistencyLevelHasBeenSet)
+  if(m_consistencyLevelHasBeenSet && m_consistencyLevel != ConsistencyLevel::NOT_SET)
   {
     headers.emplace("x-amz-consistency-level", ConsistencyLevelMapper::GetNameForConsistencyLevel(m_consistencyLevel));
   }

--- a/generated/src/aws-cpp-sdk-clouddirectory/source/model/ListObjectAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-clouddirectory/source/model/ListObjectAttributesRequest.cpp
@@ -67,7 +67,7 @@ Aws::Http::HeaderValueCollection ListObjectAttributesRequest::GetRequestSpecific
     ss.str("");
   }
 
-  if(m_consistencyLevelHasBeenSet)
+  if(m_consistencyLevelHasBeenSet && m_consistencyLevel != ConsistencyLevel::NOT_SET)
   {
     headers.emplace("x-amz-consistency-level", ConsistencyLevelMapper::GetNameForConsistencyLevel(m_consistencyLevel));
   }

--- a/generated/src/aws-cpp-sdk-clouddirectory/source/model/ListObjectChildrenRequest.cpp
+++ b/generated/src/aws-cpp-sdk-clouddirectory/source/model/ListObjectChildrenRequest.cpp
@@ -60,7 +60,7 @@ Aws::Http::HeaderValueCollection ListObjectChildrenRequest::GetRequestSpecificHe
     ss.str("");
   }
 
-  if(m_consistencyLevelHasBeenSet)
+  if(m_consistencyLevelHasBeenSet && m_consistencyLevel != ConsistencyLevel::NOT_SET)
   {
     headers.emplace("x-amz-consistency-level", ConsistencyLevelMapper::GetNameForConsistencyLevel(m_consistencyLevel));
   }

--- a/generated/src/aws-cpp-sdk-clouddirectory/source/model/ListObjectParentsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-clouddirectory/source/model/ListObjectParentsRequest.cpp
@@ -68,7 +68,7 @@ Aws::Http::HeaderValueCollection ListObjectParentsRequest::GetRequestSpecificHea
     ss.str("");
   }
 
-  if(m_consistencyLevelHasBeenSet)
+  if(m_consistencyLevelHasBeenSet && m_consistencyLevel != ConsistencyLevel::NOT_SET)
   {
     headers.emplace("x-amz-consistency-level", ConsistencyLevelMapper::GetNameForConsistencyLevel(m_consistencyLevel));
   }

--- a/generated/src/aws-cpp-sdk-clouddirectory/source/model/ListObjectPoliciesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-clouddirectory/source/model/ListObjectPoliciesRequest.cpp
@@ -60,7 +60,7 @@ Aws::Http::HeaderValueCollection ListObjectPoliciesRequest::GetRequestSpecificHe
     ss.str("");
   }
 
-  if(m_consistencyLevelHasBeenSet)
+  if(m_consistencyLevelHasBeenSet && m_consistencyLevel != ConsistencyLevel::NOT_SET)
   {
     headers.emplace("x-amz-consistency-level", ConsistencyLevelMapper::GetNameForConsistencyLevel(m_consistencyLevel));
   }

--- a/generated/src/aws-cpp-sdk-clouddirectory/source/model/ListPolicyAttachmentsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-clouddirectory/source/model/ListPolicyAttachmentsRequest.cpp
@@ -60,7 +60,7 @@ Aws::Http::HeaderValueCollection ListPolicyAttachmentsRequest::GetRequestSpecifi
     ss.str("");
   }
 
-  if(m_consistencyLevelHasBeenSet)
+  if(m_consistencyLevelHasBeenSet && m_consistencyLevel != ConsistencyLevel::NOT_SET)
   {
     headers.emplace("x-amz-consistency-level", ConsistencyLevelMapper::GetNameForConsistencyLevel(m_consistencyLevel));
   }

--- a/generated/src/aws-cpp-sdk-ebs/source/model/CompleteSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-ebs/source/model/CompleteSnapshotRequest.cpp
@@ -48,12 +48,12 @@ Aws::Http::HeaderValueCollection CompleteSnapshotRequest::GetRequestSpecificHead
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }
 
-  if(m_checksumAggregationMethodHasBeenSet)
+  if(m_checksumAggregationMethodHasBeenSet && m_checksumAggregationMethod != ChecksumAggregationMethod::NOT_SET)
   {
     headers.emplace("x-amz-checksum-aggregation-method", ChecksumAggregationMethodMapper::GetNameForChecksumAggregationMethod(m_checksumAggregationMethod));
   }

--- a/generated/src/aws-cpp-sdk-ebs/source/model/PutSnapshotBlockRequest.cpp
+++ b/generated/src/aws-cpp-sdk-ebs/source/model/PutSnapshotBlockRequest.cpp
@@ -56,7 +56,7 @@ Aws::Http::HeaderValueCollection PutSnapshotBlockRequest::GetRequestSpecificHead
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-iot-data/source/model/PublishRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iot-data/source/model/PublishRequest.cpp
@@ -78,7 +78,7 @@ Aws::Http::HeaderValueCollection PublishRequest::GetRequestSpecificHeaders() con
     ss.str("");
   }
 
-  if(m_payloadFormatIndicatorHasBeenSet)
+  if(m_payloadFormatIndicatorHasBeenSet && m_payloadFormatIndicator != PayloadFormatIndicator::NOT_SET)
   {
     headers.emplace("x-amz-mqtt5-payload-format-indicator", PayloadFormatIndicatorMapper::GetNameForPayloadFormatIndicator(m_payloadFormatIndicator));
   }

--- a/generated/src/aws-cpp-sdk-lambda/source/model/InvokeRequest.cpp
+++ b/generated/src/aws-cpp-sdk-lambda/source/model/InvokeRequest.cpp
@@ -45,12 +45,12 @@ Aws::Http::HeaderValueCollection InvokeRequest::GetRequestSpecificHeaders() cons
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_invocationTypeHasBeenSet)
+  if(m_invocationTypeHasBeenSet && m_invocationType != InvocationType::NOT_SET)
   {
     headers.emplace("x-amz-invocation-type", InvocationTypeMapper::GetNameForInvocationType(m_invocationType));
   }
 
-  if(m_logTypeHasBeenSet)
+  if(m_logTypeHasBeenSet && m_logType != LogType::NOT_SET)
   {
     headers.emplace("x-amz-log-type", LogTypeMapper::GetNameForLogType(m_logType));
   }

--- a/generated/src/aws-cpp-sdk-lambda/source/model/InvokeWithResponseStreamRequest.cpp
+++ b/generated/src/aws-cpp-sdk-lambda/source/model/InvokeWithResponseStreamRequest.cpp
@@ -46,12 +46,12 @@ Aws::Http::HeaderValueCollection InvokeWithResponseStreamRequest::GetRequestSpec
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_invocationTypeHasBeenSet)
+  if(m_invocationTypeHasBeenSet && m_invocationType != ResponseStreamingInvocationType::NOT_SET)
   {
     headers.emplace("x-amz-invocation-type", ResponseStreamingInvocationTypeMapper::GetNameForResponseStreamingInvocationType(m_invocationType));
   }
 
-  if(m_logTypeHasBeenSet)
+  if(m_logTypeHasBeenSet && m_logType != LogType::NOT_SET)
   {
     headers.emplace("x-amz-log-type", LogTypeMapper::GetNameForLogType(m_logType));
   }

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/source/model/StartConversationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/source/model/StartConversationRequest.cpp
@@ -36,7 +36,7 @@ Aws::Http::HeaderValueCollection StartConversationRequest::GetRequestSpecificHea
   Aws::Http::HeaderValueCollection headers;
   headers.emplace(Aws::Http::CONTENT_TYPE_HEADER, Aws::AMZN_EVENTSTREAM_CONTENT_TYPE);
   Aws::StringStream ss;
-  if(m_conversationModeHasBeenSet)
+  if(m_conversationModeHasBeenSet && m_conversationMode != ConversationMode::NOT_SET)
   {
     headers.emplace("x-amz-lex-conversation-mode", ConversationModeMapper::GetNameForConversationMode(m_conversationMode));
   }

--- a/generated/src/aws-cpp-sdk-medialive/source/model/DescribeInputDeviceThumbnailRequest.cpp
+++ b/generated/src/aws-cpp-sdk-medialive/source/model/DescribeInputDeviceThumbnailRequest.cpp
@@ -29,7 +29,7 @@ Aws::Http::HeaderValueCollection DescribeInputDeviceThumbnailRequest::GetRequest
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_acceptHasBeenSet)
+  if(m_acceptHasBeenSet && m_accept != AcceptHeader::NOT_SET)
   {
     headers.emplace("accept", AcceptHeaderMapper::GetNameForAcceptHeader(m_accept));
   }

--- a/generated/src/aws-cpp-sdk-mediastore-data/source/model/PutObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-mediastore-data/source/model/PutObjectRequest.cpp
@@ -38,12 +38,12 @@ Aws::Http::HeaderValueCollection PutObjectRequest::GetRequestSpecificHeaders() c
     ss.str("");
   }
 
-  if(m_storageClassHasBeenSet)
+  if(m_storageClassHasBeenSet && m_storageClass != StorageClass::NOT_SET)
   {
     headers.emplace("x-amz-storage-class", StorageClassMapper::GetNameForStorageClass(m_storageClass));
   }
 
-  if(m_uploadAvailabilityHasBeenSet)
+  if(m_uploadAvailabilityHasBeenSet && m_uploadAvailability != UploadAvailability::NOT_SET)
   {
     headers.emplace("x-amz-upload-availability", UploadAvailabilityMapper::GetNameForUploadAvailability(m_uploadAvailability));
   }

--- a/generated/src/aws-cpp-sdk-neptunedata/source/model/GetPropertygraphStreamRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptunedata/source/model/GetPropertygraphStreamRequest.cpp
@@ -38,7 +38,7 @@ Aws::Http::HeaderValueCollection GetPropertygraphStreamRequest::GetRequestSpecif
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_encodingHasBeenSet)
+  if(m_encodingHasBeenSet && m_encoding != Encoding::NOT_SET)
   {
     headers.emplace("accept-encoding", EncodingMapper::GetNameForEncoding(m_encoding));
   }

--- a/generated/src/aws-cpp-sdk-neptunedata/source/model/GetSparqlStreamRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptunedata/source/model/GetSparqlStreamRequest.cpp
@@ -38,7 +38,7 @@ Aws::Http::HeaderValueCollection GetSparqlStreamRequest::GetRequestSpecificHeade
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_encodingHasBeenSet)
+  if(m_encodingHasBeenSet && m_encoding != Encoding::NOT_SET)
   {
     headers.emplace("accept-encoding", EncodingMapper::GetNameForEncoding(m_encoding));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/AbortMultipartUploadRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/AbortMultipartUploadRequest.cpp
@@ -65,7 +65,7 @@ Aws::Http::HeaderValueCollection AbortMultipartUploadRequest::GetRequestSpecific
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/CompleteMultipartUploadRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/CompleteMultipartUploadRequest.cpp
@@ -134,7 +134,7 @@ Aws::Http::HeaderValueCollection CompleteMultipartUploadRequest::GetRequestSpeci
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/CopyObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/CopyObjectRequest.cpp
@@ -125,7 +125,7 @@ Aws::Http::HeaderValueCollection CopyObjectRequest::GetRequestSpecificHeaders() 
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_aCLHasBeenSet)
+  if(m_aCLHasBeenSet && m_aCL != ObjectCannedACL::NOT_SET)
   {
     headers.emplace("x-amz-acl", ObjectCannedACLMapper::GetNameForObjectCannedACL(m_aCL));
   }
@@ -137,7 +137,7 @@ Aws::Http::HeaderValueCollection CopyObjectRequest::GetRequestSpecificHeaders() 
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }
@@ -244,22 +244,22 @@ Aws::Http::HeaderValueCollection CopyObjectRequest::GetRequestSpecificHeaders() 
     }
   }
 
-  if(m_metadataDirectiveHasBeenSet)
+  if(m_metadataDirectiveHasBeenSet && m_metadataDirective != MetadataDirective::NOT_SET)
   {
     headers.emplace("x-amz-metadata-directive", MetadataDirectiveMapper::GetNameForMetadataDirective(m_metadataDirective));
   }
 
-  if(m_taggingDirectiveHasBeenSet)
+  if(m_taggingDirectiveHasBeenSet && m_taggingDirective != TaggingDirective::NOT_SET)
   {
     headers.emplace("x-amz-tagging-directive", TaggingDirectiveMapper::GetNameForTaggingDirective(m_taggingDirective));
   }
 
-  if(m_serverSideEncryptionHasBeenSet)
+  if(m_serverSideEncryptionHasBeenSet && m_serverSideEncryption != ServerSideEncryption::NOT_SET)
   {
     headers.emplace("x-amz-server-side-encryption", ServerSideEncryptionMapper::GetNameForServerSideEncryption(m_serverSideEncryption));
   }
 
-  if(m_storageClassHasBeenSet)
+  if(m_storageClassHasBeenSet && m_storageClass != StorageClass::NOT_SET)
   {
     headers.emplace("x-amz-storage-class", StorageClassMapper::GetNameForStorageClass(m_storageClass));
   }
@@ -334,7 +334,7 @@ Aws::Http::HeaderValueCollection CopyObjectRequest::GetRequestSpecificHeaders() 
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -346,7 +346,7 @@ Aws::Http::HeaderValueCollection CopyObjectRequest::GetRequestSpecificHeaders() 
     ss.str("");
   }
 
-  if(m_objectLockModeHasBeenSet)
+  if(m_objectLockModeHasBeenSet && m_objectLockMode != ObjectLockMode::NOT_SET)
   {
     headers.emplace("x-amz-object-lock-mode", ObjectLockModeMapper::GetNameForObjectLockMode(m_objectLockMode));
   }
@@ -356,7 +356,7 @@ Aws::Http::HeaderValueCollection CopyObjectRequest::GetRequestSpecificHeaders() 
     headers.emplace("x-amz-object-lock-retain-until-date", m_objectLockRetainUntilDate.ToGmtString(Aws::Utils::DateFormat::ISO_8601));
   }
 
-  if(m_objectLockLegalHoldStatusHasBeenSet)
+  if(m_objectLockLegalHoldStatusHasBeenSet && m_objectLockLegalHoldStatus != ObjectLockLegalHoldStatus::NOT_SET)
   {
     headers.emplace("x-amz-object-lock-legal-hold", ObjectLockLegalHoldStatusMapper::GetNameForObjectLockLegalHoldStatus(m_objectLockLegalHoldStatus));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateBucketRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateBucketRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection CreateBucketRequest::GetRequestSpecificHeaders(
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_aCLHasBeenSet)
+  if(m_aCLHasBeenSet && m_aCL != BucketCannedACL::NOT_SET)
   {
     headers.emplace("x-amz-acl", BucketCannedACLMapper::GetNameForBucketCannedACL(m_aCL));
   }
@@ -123,7 +123,7 @@ Aws::Http::HeaderValueCollection CreateBucketRequest::GetRequestSpecificHeaders(
     ss.str("");
   }
 
-  if(m_objectOwnershipHasBeenSet)
+  if(m_objectOwnershipHasBeenSet && m_objectOwnership != ObjectOwnership::NOT_SET)
   {
     headers.emplace("x-amz-object-ownership", ObjectOwnershipMapper::GetNameForObjectOwnership(m_objectOwnership));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateMultipartUploadRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateMultipartUploadRequest.cpp
@@ -90,7 +90,7 @@ Aws::Http::HeaderValueCollection CreateMultipartUploadRequest::GetRequestSpecifi
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_aCLHasBeenSet)
+  if(m_aCLHasBeenSet && m_aCL != ObjectCannedACL::NOT_SET)
   {
     headers.emplace("x-amz-acl", ObjectCannedACLMapper::GetNameForObjectCannedACL(m_aCL));
   }
@@ -173,12 +173,12 @@ Aws::Http::HeaderValueCollection CreateMultipartUploadRequest::GetRequestSpecifi
     }
   }
 
-  if(m_serverSideEncryptionHasBeenSet)
+  if(m_serverSideEncryptionHasBeenSet && m_serverSideEncryption != ServerSideEncryption::NOT_SET)
   {
     headers.emplace("x-amz-server-side-encryption", ServerSideEncryptionMapper::GetNameForServerSideEncryption(m_serverSideEncryption));
   }
 
-  if(m_storageClassHasBeenSet)
+  if(m_storageClassHasBeenSet && m_storageClass != StorageClass::NOT_SET)
   {
     headers.emplace("x-amz-storage-class", StorageClassMapper::GetNameForStorageClass(m_storageClass));
   }
@@ -232,7 +232,7 @@ Aws::Http::HeaderValueCollection CreateMultipartUploadRequest::GetRequestSpecifi
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -244,7 +244,7 @@ Aws::Http::HeaderValueCollection CreateMultipartUploadRequest::GetRequestSpecifi
     ss.str("");
   }
 
-  if(m_objectLockModeHasBeenSet)
+  if(m_objectLockModeHasBeenSet && m_objectLockMode != ObjectLockMode::NOT_SET)
   {
     headers.emplace("x-amz-object-lock-mode", ObjectLockModeMapper::GetNameForObjectLockMode(m_objectLockMode));
   }
@@ -254,7 +254,7 @@ Aws::Http::HeaderValueCollection CreateMultipartUploadRequest::GetRequestSpecifi
     headers.emplace("x-amz-object-lock-retain-until-date", m_objectLockRetainUntilDate.ToGmtString(Aws::Utils::DateFormat::ISO_8601));
   }
 
-  if(m_objectLockLegalHoldStatusHasBeenSet)
+  if(m_objectLockLegalHoldStatusHasBeenSet && m_objectLockLegalHoldStatus != ObjectLockLegalHoldStatus::NOT_SET)
   {
     headers.emplace("x-amz-object-lock-legal-hold", ObjectLockLegalHoldStatusMapper::GetNameForObjectLockLegalHoldStatus(m_objectLockLegalHoldStatus));
   }
@@ -266,7 +266,7 @@ Aws::Http::HeaderValueCollection CreateMultipartUploadRequest::GetRequestSpecifi
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateSessionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateSessionRequest.cpp
@@ -55,7 +55,7 @@ Aws::Http::HeaderValueCollection CreateSessionRequest::GetRequestSpecificHeaders
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_sessionModeHasBeenSet)
+  if(m_sessionModeHasBeenSet && m_sessionMode != SessionMode::NOT_SET)
   {
     headers.emplace("x-amz-create-session-mode", SessionModeMapper::GetNameForSessionMode(m_sessionMode));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/DeleteObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/DeleteObjectRequest.cpp
@@ -75,7 +75,7 @@ Aws::Http::HeaderValueCollection DeleteObjectRequest::GetRequestSpecificHeaders(
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/DeleteObjectsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/DeleteObjectsRequest.cpp
@@ -80,7 +80,7 @@ Aws::Http::HeaderValueCollection DeleteObjectsRequest::GetRequestSpecificHeaders
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -99,7 +99,7 @@ Aws::Http::HeaderValueCollection DeleteObjectsRequest::GetRequestSpecificHeaders
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/GetBucketAccelerateConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/GetBucketAccelerateConfigurationRequest.cpp
@@ -63,7 +63,7 @@ Aws::Http::HeaderValueCollection GetBucketAccelerateConfigurationRequest::GetReq
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectAclRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectAclRequest.cpp
@@ -65,7 +65,7 @@ Aws::Http::HeaderValueCollection GetObjectAclRequest::GetRequestSpecificHeaders(
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectAttributesRequest.cpp
@@ -109,7 +109,7 @@ Aws::Http::HeaderValueCollection GetObjectAttributesRequest::GetRequestSpecificH
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectLegalHoldRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectLegalHoldRequest.cpp
@@ -65,7 +65,7 @@ Aws::Http::HeaderValueCollection GetObjectLegalHoldRequest::GetRequestSpecificHe
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectRequest.cpp
@@ -184,7 +184,7 @@ Aws::Http::HeaderValueCollection GetObjectRequest::GetRequestSpecificHeaders() c
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -196,7 +196,7 @@ Aws::Http::HeaderValueCollection GetObjectRequest::GetRequestSpecificHeaders() c
     ss.str("");
   }
 
-  if(m_checksumModeHasBeenSet)
+  if(m_checksumModeHasBeenSet && m_checksumMode != ChecksumMode::NOT_SET)
   {
     headers.emplace("x-amz-checksum-mode", ChecksumModeMapper::GetNameForChecksumMode(m_checksumMode));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectRetentionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectRetentionRequest.cpp
@@ -65,7 +65,7 @@ Aws::Http::HeaderValueCollection GetObjectRetentionRequest::GetRequestSpecificHe
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectTaggingRequest.cpp
@@ -72,7 +72,7 @@ Aws::Http::HeaderValueCollection GetObjectTaggingRequest::GetRequestSpecificHead
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectTorrentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectTorrentRequest.cpp
@@ -57,7 +57,7 @@ Aws::Http::HeaderValueCollection GetObjectTorrentRequest::GetRequestSpecificHead
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/HeadObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/HeadObjectRequest.cpp
@@ -136,7 +136,7 @@ Aws::Http::HeaderValueCollection HeadObjectRequest::GetRequestSpecificHeaders() 
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -148,7 +148,7 @@ Aws::Http::HeaderValueCollection HeadObjectRequest::GetRequestSpecificHeaders() 
     ss.str("");
   }
 
-  if(m_checksumModeHasBeenSet)
+  if(m_checksumModeHasBeenSet && m_checksumMode != ChecksumMode::NOT_SET)
   {
     headers.emplace("x-amz-checksum-mode", ChecksumModeMapper::GetNameForChecksumMode(m_checksumMode));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/ListMultipartUploadsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/ListMultipartUploadsRequest.cpp
@@ -113,7 +113,7 @@ Aws::Http::HeaderValueCollection ListMultipartUploadsRequest::GetRequestSpecific
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/ListObjectVersionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/ListObjectVersionsRequest.cpp
@@ -115,7 +115,7 @@ Aws::Http::HeaderValueCollection ListObjectVersionsRequest::GetRequestSpecificHe
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/ListObjectsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/ListObjectsRequest.cpp
@@ -100,7 +100,7 @@ Aws::Http::HeaderValueCollection ListObjectsRequest::GetRequestSpecificHeaders()
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/ListObjectsV2Request.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/ListObjectsV2Request.cpp
@@ -117,7 +117,7 @@ Aws::Http::HeaderValueCollection ListObjectsV2Request::GetRequestSpecificHeaders
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/ListPartsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/ListPartsRequest.cpp
@@ -86,7 +86,7 @@ Aws::Http::HeaderValueCollection ListPartsRequest::GetRequestSpecificHeaders() c
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAccelerateConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAccelerateConfigurationRequest.cpp
@@ -75,7 +75,7 @@ Aws::Http::HeaderValueCollection PutBucketAccelerateConfigurationRequest::GetReq
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAclRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAclRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutBucketAclRequest::GetRequestSpecificHeaders(
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_aCLHasBeenSet)
+  if(m_aCLHasBeenSet && m_aCL != BucketCannedACL::NOT_SET)
   {
     headers.emplace("x-amz-acl", BucketCannedACLMapper::GetNameForBucketCannedACL(m_aCL));
   }
@@ -88,7 +88,7 @@ Aws::Http::HeaderValueCollection PutBucketAclRequest::GetRequestSpecificHeaders(
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketCorsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketCorsRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutBucketCorsRequest::GetRequestSpecificHeaders
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketEncryptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketEncryptionRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutBucketEncryptionRequest::GetRequestSpecificH
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketLifecycleConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketLifecycleConfigurationRequest.cpp
@@ -68,7 +68,7 @@ Aws::Http::HeaderValueCollection PutBucketLifecycleConfigurationRequest::GetRequ
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketLoggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketLoggingRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutBucketLoggingRequest::GetRequestSpecificHead
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketPolicyRequest.cpp
@@ -62,7 +62,7 @@ Aws::Http::HeaderValueCollection PutBucketPolicyRequest::GetRequestSpecificHeade
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketReplicationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketReplicationRequest.cpp
@@ -77,7 +77,7 @@ Aws::Http::HeaderValueCollection PutBucketReplicationRequest::GetRequestSpecific
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketRequestPaymentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketRequestPaymentRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutBucketRequestPaymentRequest::GetRequestSpeci
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketTaggingRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutBucketTaggingRequest::GetRequestSpecificHead
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketVersioningRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketVersioningRequest.cpp
@@ -77,7 +77,7 @@ Aws::Http::HeaderValueCollection PutBucketVersioningRequest::GetRequestSpecificH
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketWebsiteRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketWebsiteRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutBucketWebsiteRequest::GetRequestSpecificHead
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectAclRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectAclRequest.cpp
@@ -87,7 +87,7 @@ Aws::Http::HeaderValueCollection PutObjectAclRequest::GetRequestSpecificHeaders(
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_aCLHasBeenSet)
+  if(m_aCLHasBeenSet && m_aCL != ObjectCannedACL::NOT_SET)
   {
     headers.emplace("x-amz-acl", ObjectCannedACLMapper::GetNameForObjectCannedACL(m_aCL));
   }
@@ -99,7 +99,7 @@ Aws::Http::HeaderValueCollection PutObjectAclRequest::GetRequestSpecificHeaders(
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }
@@ -139,7 +139,7 @@ Aws::Http::HeaderValueCollection PutObjectAclRequest::GetRequestSpecificHeaders(
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectLegalHoldRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectLegalHoldRequest.cpp
@@ -80,7 +80,7 @@ Aws::Http::HeaderValueCollection PutObjectLegalHoldRequest::GetRequestSpecificHe
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -92,7 +92,7 @@ Aws::Http::HeaderValueCollection PutObjectLegalHoldRequest::GetRequestSpecificHe
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectLockConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectLockConfigurationRequest.cpp
@@ -72,7 +72,7 @@ Aws::Http::HeaderValueCollection PutObjectLockConfigurationRequest::GetRequestSp
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -91,7 +91,7 @@ Aws::Http::HeaderValueCollection PutObjectLockConfigurationRequest::GetRequestSp
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectRequest.cpp
@@ -93,7 +93,7 @@ Aws::Http::HeaderValueCollection PutObjectRequest::GetRequestSpecificHeaders() c
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_aCLHasBeenSet)
+  if(m_aCLHasBeenSet && m_aCL != ObjectCannedACL::NOT_SET)
   {
     headers.emplace("x-amz-acl", ObjectCannedACLMapper::GetNameForObjectCannedACL(m_aCL));
   }
@@ -140,7 +140,7 @@ Aws::Http::HeaderValueCollection PutObjectRequest::GetRequestSpecificHeaders() c
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }
@@ -216,12 +216,12 @@ Aws::Http::HeaderValueCollection PutObjectRequest::GetRequestSpecificHeaders() c
     }
   }
 
-  if(m_serverSideEncryptionHasBeenSet)
+  if(m_serverSideEncryptionHasBeenSet && m_serverSideEncryption != ServerSideEncryption::NOT_SET)
   {
     headers.emplace("x-amz-server-side-encryption", ServerSideEncryptionMapper::GetNameForServerSideEncryption(m_serverSideEncryption));
   }
 
-  if(m_storageClassHasBeenSet)
+  if(m_storageClassHasBeenSet && m_storageClass != StorageClass::NOT_SET)
   {
     headers.emplace("x-amz-storage-class", StorageClassMapper::GetNameForStorageClass(m_storageClass));
   }
@@ -275,7 +275,7 @@ Aws::Http::HeaderValueCollection PutObjectRequest::GetRequestSpecificHeaders() c
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -287,7 +287,7 @@ Aws::Http::HeaderValueCollection PutObjectRequest::GetRequestSpecificHeaders() c
     ss.str("");
   }
 
-  if(m_objectLockModeHasBeenSet)
+  if(m_objectLockModeHasBeenSet && m_objectLockMode != ObjectLockMode::NOT_SET)
   {
     headers.emplace("x-amz-object-lock-mode", ObjectLockModeMapper::GetNameForObjectLockMode(m_objectLockMode));
   }
@@ -297,7 +297,7 @@ Aws::Http::HeaderValueCollection PutObjectRequest::GetRequestSpecificHeaders() c
     headers.emplace("x-amz-object-lock-retain-until-date", m_objectLockRetainUntilDate.ToGmtString(Aws::Utils::DateFormat::ISO_8601));
   }
 
-  if(m_objectLockLegalHoldStatusHasBeenSet)
+  if(m_objectLockLegalHoldStatusHasBeenSet && m_objectLockLegalHoldStatus != ObjectLockLegalHoldStatus::NOT_SET)
   {
     headers.emplace("x-amz-object-lock-legal-hold", ObjectLockLegalHoldStatusMapper::GetNameForObjectLockLegalHoldStatus(m_objectLockLegalHoldStatus));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectRetentionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectRetentionRequest.cpp
@@ -82,7 +82,7 @@ Aws::Http::HeaderValueCollection PutObjectRetentionRequest::GetRequestSpecificHe
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -101,7 +101,7 @@ Aws::Http::HeaderValueCollection PutObjectRetentionRequest::GetRequestSpecificHe
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectTaggingRequest.cpp
@@ -87,7 +87,7 @@ Aws::Http::HeaderValueCollection PutObjectTaggingRequest::GetRequestSpecificHead
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }
@@ -99,7 +99,7 @@ Aws::Http::HeaderValueCollection PutObjectTaggingRequest::GetRequestSpecificHead
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutPublicAccessBlockRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutPublicAccessBlockRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutPublicAccessBlockRequest::GetRequestSpecific
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/RestoreObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/RestoreObjectRequest.cpp
@@ -79,12 +79,12 @@ Aws::Http::HeaderValueCollection RestoreObjectRequest::GetRequestSpecificHeaders
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/UploadPartCopyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/UploadPartCopyRequest.cpp
@@ -189,7 +189,7 @@ Aws::Http::HeaderValueCollection UploadPartCopyRequest::GetRequestSpecificHeader
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/UploadPartRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/UploadPartRequest.cpp
@@ -97,7 +97,7 @@ Aws::Http::HeaderValueCollection UploadPartRequest::GetRequestSpecificHeaders() 
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }
@@ -151,7 +151,7 @@ Aws::Http::HeaderValueCollection UploadPartRequest::GetRequestSpecificHeaders() 
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/WriteGetObjectResponseRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/WriteGetObjectResponseRequest.cpp
@@ -260,12 +260,12 @@ Aws::Http::HeaderValueCollection WriteGetObjectResponseRequest::GetRequestSpecif
     }
   }
 
-  if(m_objectLockModeHasBeenSet)
+  if(m_objectLockModeHasBeenSet && m_objectLockMode != ObjectLockMode::NOT_SET)
   {
     headers.emplace("x-amz-fwd-header-x-amz-object-lock-mode", ObjectLockModeMapper::GetNameForObjectLockMode(m_objectLockMode));
   }
 
-  if(m_objectLockLegalHoldStatusHasBeenSet)
+  if(m_objectLockLegalHoldStatusHasBeenSet && m_objectLockLegalHoldStatus != ObjectLockLegalHoldStatus::NOT_SET)
   {
     headers.emplace("x-amz-fwd-header-x-amz-object-lock-legal-hold", ObjectLockLegalHoldStatusMapper::GetNameForObjectLockLegalHoldStatus(m_objectLockLegalHoldStatus));
   }
@@ -282,12 +282,12 @@ Aws::Http::HeaderValueCollection WriteGetObjectResponseRequest::GetRequestSpecif
     ss.str("");
   }
 
-  if(m_replicationStatusHasBeenSet)
+  if(m_replicationStatusHasBeenSet && m_replicationStatus != ReplicationStatus::NOT_SET)
   {
     headers.emplace("x-amz-fwd-header-x-amz-replication-status", ReplicationStatusMapper::GetNameForReplicationStatus(m_replicationStatus));
   }
 
-  if(m_requestChargedHasBeenSet)
+  if(m_requestChargedHasBeenSet && m_requestCharged != RequestCharged::NOT_SET)
   {
     headers.emplace("x-amz-fwd-header-x-amz-request-charged", RequestChargedMapper::GetNameForRequestCharged(m_requestCharged));
   }
@@ -299,7 +299,7 @@ Aws::Http::HeaderValueCollection WriteGetObjectResponseRequest::GetRequestSpecif
     ss.str("");
   }
 
-  if(m_serverSideEncryptionHasBeenSet)
+  if(m_serverSideEncryptionHasBeenSet && m_serverSideEncryption != ServerSideEncryption::NOT_SET)
   {
     headers.emplace("x-amz-fwd-header-x-amz-server-side-encryption", ServerSideEncryptionMapper::GetNameForServerSideEncryption(m_serverSideEncryption));
   }
@@ -325,7 +325,7 @@ Aws::Http::HeaderValueCollection WriteGetObjectResponseRequest::GetRequestSpecif
     ss.str("");
   }
 
-  if(m_storageClassHasBeenSet)
+  if(m_storageClassHasBeenSet && m_storageClass != StorageClass::NOT_SET)
   {
     headers.emplace("x-amz-fwd-header-x-amz-storage-class", StorageClassMapper::GetNameForStorageClass(m_storageClass));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/AbortMultipartUploadRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/AbortMultipartUploadRequest.cpp
@@ -65,7 +65,7 @@ Aws::Http::HeaderValueCollection AbortMultipartUploadRequest::GetRequestSpecific
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/CompleteMultipartUploadRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/CompleteMultipartUploadRequest.cpp
@@ -134,7 +134,7 @@ Aws::Http::HeaderValueCollection CompleteMultipartUploadRequest::GetRequestSpeci
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/CopyObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/CopyObjectRequest.cpp
@@ -125,7 +125,7 @@ Aws::Http::HeaderValueCollection CopyObjectRequest::GetRequestSpecificHeaders() 
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_aCLHasBeenSet)
+  if(m_aCLHasBeenSet && m_aCL != ObjectCannedACL::NOT_SET)
   {
     headers.emplace("x-amz-acl", ObjectCannedACLMapper::GetNameForObjectCannedACL(m_aCL));
   }
@@ -137,7 +137,7 @@ Aws::Http::HeaderValueCollection CopyObjectRequest::GetRequestSpecificHeaders() 
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }
@@ -244,22 +244,22 @@ Aws::Http::HeaderValueCollection CopyObjectRequest::GetRequestSpecificHeaders() 
     }
   }
 
-  if(m_metadataDirectiveHasBeenSet)
+  if(m_metadataDirectiveHasBeenSet && m_metadataDirective != MetadataDirective::NOT_SET)
   {
     headers.emplace("x-amz-metadata-directive", MetadataDirectiveMapper::GetNameForMetadataDirective(m_metadataDirective));
   }
 
-  if(m_taggingDirectiveHasBeenSet)
+  if(m_taggingDirectiveHasBeenSet && m_taggingDirective != TaggingDirective::NOT_SET)
   {
     headers.emplace("x-amz-tagging-directive", TaggingDirectiveMapper::GetNameForTaggingDirective(m_taggingDirective));
   }
 
-  if(m_serverSideEncryptionHasBeenSet)
+  if(m_serverSideEncryptionHasBeenSet && m_serverSideEncryption != ServerSideEncryption::NOT_SET)
   {
     headers.emplace("x-amz-server-side-encryption", ServerSideEncryptionMapper::GetNameForServerSideEncryption(m_serverSideEncryption));
   }
 
-  if(m_storageClassHasBeenSet)
+  if(m_storageClassHasBeenSet && m_storageClass != StorageClass::NOT_SET)
   {
     headers.emplace("x-amz-storage-class", StorageClassMapper::GetNameForStorageClass(m_storageClass));
   }
@@ -334,7 +334,7 @@ Aws::Http::HeaderValueCollection CopyObjectRequest::GetRequestSpecificHeaders() 
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -346,7 +346,7 @@ Aws::Http::HeaderValueCollection CopyObjectRequest::GetRequestSpecificHeaders() 
     ss.str("");
   }
 
-  if(m_objectLockModeHasBeenSet)
+  if(m_objectLockModeHasBeenSet && m_objectLockMode != ObjectLockMode::NOT_SET)
   {
     headers.emplace("x-amz-object-lock-mode", ObjectLockModeMapper::GetNameForObjectLockMode(m_objectLockMode));
   }
@@ -356,7 +356,7 @@ Aws::Http::HeaderValueCollection CopyObjectRequest::GetRequestSpecificHeaders() 
     headers.emplace("x-amz-object-lock-retain-until-date", m_objectLockRetainUntilDate.ToGmtString(Aws::Utils::DateFormat::ISO_8601));
   }
 
-  if(m_objectLockLegalHoldStatusHasBeenSet)
+  if(m_objectLockLegalHoldStatusHasBeenSet && m_objectLockLegalHoldStatus != ObjectLockLegalHoldStatus::NOT_SET)
   {
     headers.emplace("x-amz-object-lock-legal-hold", ObjectLockLegalHoldStatusMapper::GetNameForObjectLockLegalHoldStatus(m_objectLockLegalHoldStatus));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/CreateBucketRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/CreateBucketRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection CreateBucketRequest::GetRequestSpecificHeaders(
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_aCLHasBeenSet)
+  if(m_aCLHasBeenSet && m_aCL != BucketCannedACL::NOT_SET)
   {
     headers.emplace("x-amz-acl", BucketCannedACLMapper::GetNameForBucketCannedACL(m_aCL));
   }
@@ -123,7 +123,7 @@ Aws::Http::HeaderValueCollection CreateBucketRequest::GetRequestSpecificHeaders(
     ss.str("");
   }
 
-  if(m_objectOwnershipHasBeenSet)
+  if(m_objectOwnershipHasBeenSet && m_objectOwnership != ObjectOwnership::NOT_SET)
   {
     headers.emplace("x-amz-object-ownership", ObjectOwnershipMapper::GetNameForObjectOwnership(m_objectOwnership));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/CreateMultipartUploadRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/CreateMultipartUploadRequest.cpp
@@ -90,7 +90,7 @@ Aws::Http::HeaderValueCollection CreateMultipartUploadRequest::GetRequestSpecifi
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_aCLHasBeenSet)
+  if(m_aCLHasBeenSet && m_aCL != ObjectCannedACL::NOT_SET)
   {
     headers.emplace("x-amz-acl", ObjectCannedACLMapper::GetNameForObjectCannedACL(m_aCL));
   }
@@ -173,12 +173,12 @@ Aws::Http::HeaderValueCollection CreateMultipartUploadRequest::GetRequestSpecifi
     }
   }
 
-  if(m_serverSideEncryptionHasBeenSet)
+  if(m_serverSideEncryptionHasBeenSet && m_serverSideEncryption != ServerSideEncryption::NOT_SET)
   {
     headers.emplace("x-amz-server-side-encryption", ServerSideEncryptionMapper::GetNameForServerSideEncryption(m_serverSideEncryption));
   }
 
-  if(m_storageClassHasBeenSet)
+  if(m_storageClassHasBeenSet && m_storageClass != StorageClass::NOT_SET)
   {
     headers.emplace("x-amz-storage-class", StorageClassMapper::GetNameForStorageClass(m_storageClass));
   }
@@ -232,7 +232,7 @@ Aws::Http::HeaderValueCollection CreateMultipartUploadRequest::GetRequestSpecifi
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -244,7 +244,7 @@ Aws::Http::HeaderValueCollection CreateMultipartUploadRequest::GetRequestSpecifi
     ss.str("");
   }
 
-  if(m_objectLockModeHasBeenSet)
+  if(m_objectLockModeHasBeenSet && m_objectLockMode != ObjectLockMode::NOT_SET)
   {
     headers.emplace("x-amz-object-lock-mode", ObjectLockModeMapper::GetNameForObjectLockMode(m_objectLockMode));
   }
@@ -254,7 +254,7 @@ Aws::Http::HeaderValueCollection CreateMultipartUploadRequest::GetRequestSpecifi
     headers.emplace("x-amz-object-lock-retain-until-date", m_objectLockRetainUntilDate.ToGmtString(Aws::Utils::DateFormat::ISO_8601));
   }
 
-  if(m_objectLockLegalHoldStatusHasBeenSet)
+  if(m_objectLockLegalHoldStatusHasBeenSet && m_objectLockLegalHoldStatus != ObjectLockLegalHoldStatus::NOT_SET)
   {
     headers.emplace("x-amz-object-lock-legal-hold", ObjectLockLegalHoldStatusMapper::GetNameForObjectLockLegalHoldStatus(m_objectLockLegalHoldStatus));
   }
@@ -266,7 +266,7 @@ Aws::Http::HeaderValueCollection CreateMultipartUploadRequest::GetRequestSpecifi
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/CreateSessionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/CreateSessionRequest.cpp
@@ -55,7 +55,7 @@ Aws::Http::HeaderValueCollection CreateSessionRequest::GetRequestSpecificHeaders
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_sessionModeHasBeenSet)
+  if(m_sessionModeHasBeenSet && m_sessionMode != SessionMode::NOT_SET)
   {
     headers.emplace("x-amz-create-session-mode", SessionModeMapper::GetNameForSessionMode(m_sessionMode));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/DeleteObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/DeleteObjectRequest.cpp
@@ -75,7 +75,7 @@ Aws::Http::HeaderValueCollection DeleteObjectRequest::GetRequestSpecificHeaders(
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/DeleteObjectsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/DeleteObjectsRequest.cpp
@@ -80,7 +80,7 @@ Aws::Http::HeaderValueCollection DeleteObjectsRequest::GetRequestSpecificHeaders
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -99,7 +99,7 @@ Aws::Http::HeaderValueCollection DeleteObjectsRequest::GetRequestSpecificHeaders
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/GetBucketAccelerateConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/GetBucketAccelerateConfigurationRequest.cpp
@@ -63,7 +63,7 @@ Aws::Http::HeaderValueCollection GetBucketAccelerateConfigurationRequest::GetReq
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/GetObjectAclRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/GetObjectAclRequest.cpp
@@ -65,7 +65,7 @@ Aws::Http::HeaderValueCollection GetObjectAclRequest::GetRequestSpecificHeaders(
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/GetObjectAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/GetObjectAttributesRequest.cpp
@@ -109,7 +109,7 @@ Aws::Http::HeaderValueCollection GetObjectAttributesRequest::GetRequestSpecificH
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/GetObjectLegalHoldRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/GetObjectLegalHoldRequest.cpp
@@ -65,7 +65,7 @@ Aws::Http::HeaderValueCollection GetObjectLegalHoldRequest::GetRequestSpecificHe
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/GetObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/GetObjectRequest.cpp
@@ -184,7 +184,7 @@ Aws::Http::HeaderValueCollection GetObjectRequest::GetRequestSpecificHeaders() c
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -196,7 +196,7 @@ Aws::Http::HeaderValueCollection GetObjectRequest::GetRequestSpecificHeaders() c
     ss.str("");
   }
 
-  if(m_checksumModeHasBeenSet)
+  if(m_checksumModeHasBeenSet && m_checksumMode != ChecksumMode::NOT_SET)
   {
     headers.emplace("x-amz-checksum-mode", ChecksumModeMapper::GetNameForChecksumMode(m_checksumMode));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/GetObjectRetentionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/GetObjectRetentionRequest.cpp
@@ -65,7 +65,7 @@ Aws::Http::HeaderValueCollection GetObjectRetentionRequest::GetRequestSpecificHe
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/GetObjectTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/GetObjectTaggingRequest.cpp
@@ -72,7 +72,7 @@ Aws::Http::HeaderValueCollection GetObjectTaggingRequest::GetRequestSpecificHead
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/GetObjectTorrentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/GetObjectTorrentRequest.cpp
@@ -57,7 +57,7 @@ Aws::Http::HeaderValueCollection GetObjectTorrentRequest::GetRequestSpecificHead
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/HeadObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/HeadObjectRequest.cpp
@@ -136,7 +136,7 @@ Aws::Http::HeaderValueCollection HeadObjectRequest::GetRequestSpecificHeaders() 
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -148,7 +148,7 @@ Aws::Http::HeaderValueCollection HeadObjectRequest::GetRequestSpecificHeaders() 
     ss.str("");
   }
 
-  if(m_checksumModeHasBeenSet)
+  if(m_checksumModeHasBeenSet && m_checksumMode != ChecksumMode::NOT_SET)
   {
     headers.emplace("x-amz-checksum-mode", ChecksumModeMapper::GetNameForChecksumMode(m_checksumMode));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/ListMultipartUploadsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/ListMultipartUploadsRequest.cpp
@@ -113,7 +113,7 @@ Aws::Http::HeaderValueCollection ListMultipartUploadsRequest::GetRequestSpecific
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/ListObjectVersionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/ListObjectVersionsRequest.cpp
@@ -115,7 +115,7 @@ Aws::Http::HeaderValueCollection ListObjectVersionsRequest::GetRequestSpecificHe
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/ListObjectsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/ListObjectsRequest.cpp
@@ -100,7 +100,7 @@ Aws::Http::HeaderValueCollection ListObjectsRequest::GetRequestSpecificHeaders()
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/ListObjectsV2Request.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/ListObjectsV2Request.cpp
@@ -117,7 +117,7 @@ Aws::Http::HeaderValueCollection ListObjectsV2Request::GetRequestSpecificHeaders
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/ListPartsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/ListPartsRequest.cpp
@@ -86,7 +86,7 @@ Aws::Http::HeaderValueCollection ListPartsRequest::GetRequestSpecificHeaders() c
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAccelerateConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAccelerateConfigurationRequest.cpp
@@ -75,7 +75,7 @@ Aws::Http::HeaderValueCollection PutBucketAccelerateConfigurationRequest::GetReq
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAclRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAclRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutBucketAclRequest::GetRequestSpecificHeaders(
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_aCLHasBeenSet)
+  if(m_aCLHasBeenSet && m_aCL != BucketCannedACL::NOT_SET)
   {
     headers.emplace("x-amz-acl", BucketCannedACLMapper::GetNameForBucketCannedACL(m_aCL));
   }
@@ -88,7 +88,7 @@ Aws::Http::HeaderValueCollection PutBucketAclRequest::GetRequestSpecificHeaders(
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketCorsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketCorsRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutBucketCorsRequest::GetRequestSpecificHeaders
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketEncryptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketEncryptionRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutBucketEncryptionRequest::GetRequestSpecificH
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketLifecycleConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketLifecycleConfigurationRequest.cpp
@@ -68,7 +68,7 @@ Aws::Http::HeaderValueCollection PutBucketLifecycleConfigurationRequest::GetRequ
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketLoggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketLoggingRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutBucketLoggingRequest::GetRequestSpecificHead
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketPolicyRequest.cpp
@@ -62,7 +62,7 @@ Aws::Http::HeaderValueCollection PutBucketPolicyRequest::GetRequestSpecificHeade
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketReplicationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketReplicationRequest.cpp
@@ -77,7 +77,7 @@ Aws::Http::HeaderValueCollection PutBucketReplicationRequest::GetRequestSpecific
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketRequestPaymentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketRequestPaymentRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutBucketRequestPaymentRequest::GetRequestSpeci
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketTaggingRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutBucketTaggingRequest::GetRequestSpecificHead
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketVersioningRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketVersioningRequest.cpp
@@ -77,7 +77,7 @@ Aws::Http::HeaderValueCollection PutBucketVersioningRequest::GetRequestSpecificH
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketWebsiteRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketWebsiteRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutBucketWebsiteRequest::GetRequestSpecificHead
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectAclRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectAclRequest.cpp
@@ -87,7 +87,7 @@ Aws::Http::HeaderValueCollection PutObjectAclRequest::GetRequestSpecificHeaders(
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_aCLHasBeenSet)
+  if(m_aCLHasBeenSet && m_aCL != ObjectCannedACL::NOT_SET)
   {
     headers.emplace("x-amz-acl", ObjectCannedACLMapper::GetNameForObjectCannedACL(m_aCL));
   }
@@ -99,7 +99,7 @@ Aws::Http::HeaderValueCollection PutObjectAclRequest::GetRequestSpecificHeaders(
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }
@@ -139,7 +139,7 @@ Aws::Http::HeaderValueCollection PutObjectAclRequest::GetRequestSpecificHeaders(
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectLegalHoldRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectLegalHoldRequest.cpp
@@ -80,7 +80,7 @@ Aws::Http::HeaderValueCollection PutObjectLegalHoldRequest::GetRequestSpecificHe
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -92,7 +92,7 @@ Aws::Http::HeaderValueCollection PutObjectLegalHoldRequest::GetRequestSpecificHe
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectLockConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectLockConfigurationRequest.cpp
@@ -72,7 +72,7 @@ Aws::Http::HeaderValueCollection PutObjectLockConfigurationRequest::GetRequestSp
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -91,7 +91,7 @@ Aws::Http::HeaderValueCollection PutObjectLockConfigurationRequest::GetRequestSp
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectRequest.cpp
@@ -93,7 +93,7 @@ Aws::Http::HeaderValueCollection PutObjectRequest::GetRequestSpecificHeaders() c
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_aCLHasBeenSet)
+  if(m_aCLHasBeenSet && m_aCL != ObjectCannedACL::NOT_SET)
   {
     headers.emplace("x-amz-acl", ObjectCannedACLMapper::GetNameForObjectCannedACL(m_aCL));
   }
@@ -140,7 +140,7 @@ Aws::Http::HeaderValueCollection PutObjectRequest::GetRequestSpecificHeaders() c
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }
@@ -216,12 +216,12 @@ Aws::Http::HeaderValueCollection PutObjectRequest::GetRequestSpecificHeaders() c
     }
   }
 
-  if(m_serverSideEncryptionHasBeenSet)
+  if(m_serverSideEncryptionHasBeenSet && m_serverSideEncryption != ServerSideEncryption::NOT_SET)
   {
     headers.emplace("x-amz-server-side-encryption", ServerSideEncryptionMapper::GetNameForServerSideEncryption(m_serverSideEncryption));
   }
 
-  if(m_storageClassHasBeenSet)
+  if(m_storageClassHasBeenSet && m_storageClass != StorageClass::NOT_SET)
   {
     headers.emplace("x-amz-storage-class", StorageClassMapper::GetNameForStorageClass(m_storageClass));
   }
@@ -275,7 +275,7 @@ Aws::Http::HeaderValueCollection PutObjectRequest::GetRequestSpecificHeaders() c
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -287,7 +287,7 @@ Aws::Http::HeaderValueCollection PutObjectRequest::GetRequestSpecificHeaders() c
     ss.str("");
   }
 
-  if(m_objectLockModeHasBeenSet)
+  if(m_objectLockModeHasBeenSet && m_objectLockMode != ObjectLockMode::NOT_SET)
   {
     headers.emplace("x-amz-object-lock-mode", ObjectLockModeMapper::GetNameForObjectLockMode(m_objectLockMode));
   }
@@ -297,7 +297,7 @@ Aws::Http::HeaderValueCollection PutObjectRequest::GetRequestSpecificHeaders() c
     headers.emplace("x-amz-object-lock-retain-until-date", m_objectLockRetainUntilDate.ToGmtString(Aws::Utils::DateFormat::ISO_8601));
   }
 
-  if(m_objectLockLegalHoldStatusHasBeenSet)
+  if(m_objectLockLegalHoldStatusHasBeenSet && m_objectLockLegalHoldStatus != ObjectLockLegalHoldStatus::NOT_SET)
   {
     headers.emplace("x-amz-object-lock-legal-hold", ObjectLockLegalHoldStatusMapper::GetNameForObjectLockLegalHoldStatus(m_objectLockLegalHoldStatus));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectRetentionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectRetentionRequest.cpp
@@ -82,7 +82,7 @@ Aws::Http::HeaderValueCollection PutObjectRetentionRequest::GetRequestSpecificHe
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
@@ -101,7 +101,7 @@ Aws::Http::HeaderValueCollection PutObjectRetentionRequest::GetRequestSpecificHe
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectTaggingRequest.cpp
@@ -87,7 +87,7 @@ Aws::Http::HeaderValueCollection PutObjectTaggingRequest::GetRequestSpecificHead
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }
@@ -99,7 +99,7 @@ Aws::Http::HeaderValueCollection PutObjectTaggingRequest::GetRequestSpecificHead
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutPublicAccessBlockRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutPublicAccessBlockRequest.cpp
@@ -76,7 +76,7 @@ Aws::Http::HeaderValueCollection PutPublicAccessBlockRequest::GetRequestSpecific
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/RestoreObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/RestoreObjectRequest.cpp
@@ -79,12 +79,12 @@ Aws::Http::HeaderValueCollection RestoreObjectRequest::GetRequestSpecificHeaders
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/UploadPartCopyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/UploadPartCopyRequest.cpp
@@ -189,7 +189,7 @@ Aws::Http::HeaderValueCollection UploadPartCopyRequest::GetRequestSpecificHeader
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/UploadPartRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/UploadPartRequest.cpp
@@ -97,7 +97,7 @@ Aws::Http::HeaderValueCollection UploadPartRequest::GetRequestSpecificHeaders() 
     ss.str("");
   }
 
-  if(m_checksumAlgorithmHasBeenSet)
+  if(m_checksumAlgorithmHasBeenSet && m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET)
   {
     headers.emplace("x-amz-sdk-checksum-algorithm", ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm));
   }
@@ -151,7 +151,7 @@ Aws::Http::HeaderValueCollection UploadPartRequest::GetRequestSpecificHeaders() 
     ss.str("");
   }
 
-  if(m_requestPayerHasBeenSet)
+  if(m_requestPayerHasBeenSet && m_requestPayer != RequestPayer::NOT_SET)
   {
     headers.emplace("x-amz-request-payer", RequestPayerMapper::GetNameForRequestPayer(m_requestPayer));
   }

--- a/generated/src/aws-cpp-sdk-s3/source/model/WriteGetObjectResponseRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/WriteGetObjectResponseRequest.cpp
@@ -260,12 +260,12 @@ Aws::Http::HeaderValueCollection WriteGetObjectResponseRequest::GetRequestSpecif
     }
   }
 
-  if(m_objectLockModeHasBeenSet)
+  if(m_objectLockModeHasBeenSet && m_objectLockMode != ObjectLockMode::NOT_SET)
   {
     headers.emplace("x-amz-fwd-header-x-amz-object-lock-mode", ObjectLockModeMapper::GetNameForObjectLockMode(m_objectLockMode));
   }
 
-  if(m_objectLockLegalHoldStatusHasBeenSet)
+  if(m_objectLockLegalHoldStatusHasBeenSet && m_objectLockLegalHoldStatus != ObjectLockLegalHoldStatus::NOT_SET)
   {
     headers.emplace("x-amz-fwd-header-x-amz-object-lock-legal-hold", ObjectLockLegalHoldStatusMapper::GetNameForObjectLockLegalHoldStatus(m_objectLockLegalHoldStatus));
   }
@@ -282,12 +282,12 @@ Aws::Http::HeaderValueCollection WriteGetObjectResponseRequest::GetRequestSpecif
     ss.str("");
   }
 
-  if(m_replicationStatusHasBeenSet)
+  if(m_replicationStatusHasBeenSet && m_replicationStatus != ReplicationStatus::NOT_SET)
   {
     headers.emplace("x-amz-fwd-header-x-amz-replication-status", ReplicationStatusMapper::GetNameForReplicationStatus(m_replicationStatus));
   }
 
-  if(m_requestChargedHasBeenSet)
+  if(m_requestChargedHasBeenSet && m_requestCharged != RequestCharged::NOT_SET)
   {
     headers.emplace("x-amz-fwd-header-x-amz-request-charged", RequestChargedMapper::GetNameForRequestCharged(m_requestCharged));
   }
@@ -299,7 +299,7 @@ Aws::Http::HeaderValueCollection WriteGetObjectResponseRequest::GetRequestSpecif
     ss.str("");
   }
 
-  if(m_serverSideEncryptionHasBeenSet)
+  if(m_serverSideEncryptionHasBeenSet && m_serverSideEncryption != ServerSideEncryption::NOT_SET)
   {
     headers.emplace("x-amz-fwd-header-x-amz-server-side-encryption", ServerSideEncryptionMapper::GetNameForServerSideEncryption(m_serverSideEncryption));
   }
@@ -325,7 +325,7 @@ Aws::Http::HeaderValueCollection WriteGetObjectResponseRequest::GetRequestSpecif
     ss.str("");
   }
 
-  if(m_storageClassHasBeenSet)
+  if(m_storageClassHasBeenSet && m_storageClass != StorageClass::NOT_SET)
   {
     headers.emplace("x-amz-fwd-header-x-amz-storage-class", StorageClassMapper::GetNameForStorageClass(m_storageClass));
   }

--- a/generated/src/aws-cpp-sdk-s3control/source/model/CreateBucketRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/CreateBucketRequest.cpp
@@ -51,7 +51,7 @@ Aws::Http::HeaderValueCollection CreateBucketRequest::GetRequestSpecificHeaders(
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_aCLHasBeenSet)
+  if(m_aCLHasBeenSet && m_aCL != BucketCannedACL::NOT_SET)
   {
     headers.emplace("x-amz-acl", BucketCannedACLMapper::GetNameForBucketCannedACL(m_aCL));
   }

--- a/generated/src/aws-cpp-sdk-tnb/source/model/GetSolFunctionPackageContentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-tnb/source/model/GetSolFunctionPackageContentRequest.cpp
@@ -29,7 +29,7 @@ Aws::Http::HeaderValueCollection GetSolFunctionPackageContentRequest::GetRequest
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_acceptHasBeenSet)
+  if(m_acceptHasBeenSet && m_accept != PackageContentType::NOT_SET)
   {
     headers.emplace("accept", PackageContentTypeMapper::GetNameForPackageContentType(m_accept));
   }

--- a/generated/src/aws-cpp-sdk-tnb/source/model/GetSolFunctionPackageDescriptorRequest.cpp
+++ b/generated/src/aws-cpp-sdk-tnb/source/model/GetSolFunctionPackageDescriptorRequest.cpp
@@ -29,7 +29,7 @@ Aws::Http::HeaderValueCollection GetSolFunctionPackageDescriptorRequest::GetRequ
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_acceptHasBeenSet)
+  if(m_acceptHasBeenSet && m_accept != DescriptorContentType::NOT_SET)
   {
     headers.emplace("accept", DescriptorContentTypeMapper::GetNameForDescriptorContentType(m_accept));
   }

--- a/generated/src/aws-cpp-sdk-tnb/source/model/GetSolNetworkPackageContentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-tnb/source/model/GetSolNetworkPackageContentRequest.cpp
@@ -29,7 +29,7 @@ Aws::Http::HeaderValueCollection GetSolNetworkPackageContentRequest::GetRequestS
 {
   Aws::Http::HeaderValueCollection headers;
   Aws::StringStream ss;
-  if(m_acceptHasBeenSet)
+  if(m_acceptHasBeenSet && m_accept != PackageContentType::NOT_SET)
   {
     headers.emplace("accept", PackageContentTypeMapper::GetNameForPackageContentType(m_accept));
   }

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartCallAnalyticsStreamTranscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartCallAnalyticsStreamTranscriptionRequest.cpp
@@ -51,7 +51,7 @@ Aws::Http::HeaderValueCollection StartCallAnalyticsStreamTranscriptionRequest::G
   Aws::Http::HeaderValueCollection headers;
   headers.emplace(Aws::Http::CONTENT_TYPE_HEADER, Aws::AMZN_EVENTSTREAM_CONTENT_TYPE);
   Aws::StringStream ss;
-  if(m_languageCodeHasBeenSet)
+  if(m_languageCodeHasBeenSet && m_languageCode != CallAnalyticsLanguageCode::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-language-code", CallAnalyticsLanguageCodeMapper::GetNameForCallAnalyticsLanguageCode(m_languageCode));
   }
@@ -63,7 +63,7 @@ Aws::Http::HeaderValueCollection StartCallAnalyticsStreamTranscriptionRequest::G
     ss.str("");
   }
 
-  if(m_mediaEncodingHasBeenSet)
+  if(m_mediaEncodingHasBeenSet && m_mediaEncoding != MediaEncoding::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-media-encoding", MediaEncodingMapper::GetNameForMediaEncoding(m_mediaEncoding));
   }
@@ -89,7 +89,7 @@ Aws::Http::HeaderValueCollection StartCallAnalyticsStreamTranscriptionRequest::G
     ss.str("");
   }
 
-  if(m_vocabularyFilterMethodHasBeenSet)
+  if(m_vocabularyFilterMethodHasBeenSet && m_vocabularyFilterMethod != VocabularyFilterMethod::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-vocabulary-filter-method", VocabularyFilterMethodMapper::GetNameForVocabularyFilterMethod(m_vocabularyFilterMethod));
   }
@@ -108,17 +108,17 @@ Aws::Http::HeaderValueCollection StartCallAnalyticsStreamTranscriptionRequest::G
     ss.str("");
   }
 
-  if(m_partialResultsStabilityHasBeenSet)
+  if(m_partialResultsStabilityHasBeenSet && m_partialResultsStability != PartialResultsStability::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-partial-results-stability", PartialResultsStabilityMapper::GetNameForPartialResultsStability(m_partialResultsStability));
   }
 
-  if(m_contentIdentificationTypeHasBeenSet)
+  if(m_contentIdentificationTypeHasBeenSet && m_contentIdentificationType != ContentIdentificationType::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-content-identification-type", ContentIdentificationTypeMapper::GetNameForContentIdentificationType(m_contentIdentificationType));
   }
 
-  if(m_contentRedactionTypeHasBeenSet)
+  if(m_contentRedactionTypeHasBeenSet && m_contentRedactionType != ContentRedactionType::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-content-redaction-type", ContentRedactionTypeMapper::GetNameForContentRedactionType(m_contentRedactionType));
   }

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartMedicalStreamTranscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartMedicalStreamTranscriptionRequest.cpp
@@ -50,7 +50,7 @@ Aws::Http::HeaderValueCollection StartMedicalStreamTranscriptionRequest::GetRequ
   Aws::Http::HeaderValueCollection headers;
   headers.emplace(Aws::Http::CONTENT_TYPE_HEADER, Aws::AMZN_EVENTSTREAM_CONTENT_TYPE);
   Aws::StringStream ss;
-  if(m_languageCodeHasBeenSet)
+  if(m_languageCodeHasBeenSet && m_languageCode != LanguageCode::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-language-code", LanguageCodeMapper::GetNameForLanguageCode(m_languageCode));
   }
@@ -62,7 +62,7 @@ Aws::Http::HeaderValueCollection StartMedicalStreamTranscriptionRequest::GetRequ
     ss.str("");
   }
 
-  if(m_mediaEncodingHasBeenSet)
+  if(m_mediaEncodingHasBeenSet && m_mediaEncoding != MediaEncoding::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-media-encoding", MediaEncodingMapper::GetNameForMediaEncoding(m_mediaEncoding));
   }
@@ -74,12 +74,12 @@ Aws::Http::HeaderValueCollection StartMedicalStreamTranscriptionRequest::GetRequ
     ss.str("");
   }
 
-  if(m_specialtyHasBeenSet)
+  if(m_specialtyHasBeenSet && m_specialty != Specialty::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-specialty", SpecialtyMapper::GetNameForSpecialty(m_specialty));
   }
 
-  if(m_typeHasBeenSet)
+  if(m_typeHasBeenSet && m_type != Type::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-type", TypeMapper::GetNameForType(m_type));
   }
@@ -112,7 +112,7 @@ Aws::Http::HeaderValueCollection StartMedicalStreamTranscriptionRequest::GetRequ
     ss.str("");
   }
 
-  if(m_contentIdentificationTypeHasBeenSet)
+  if(m_contentIdentificationTypeHasBeenSet && m_contentIdentificationType != MedicalContentIdentificationType::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-content-identification-type", MedicalContentIdentificationTypeMapper::GetNameForMedicalContentIdentificationType(m_contentIdentificationType));
   }

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartStreamTranscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartStreamTranscriptionRequest.cpp
@@ -66,7 +66,7 @@ Aws::Http::HeaderValueCollection StartStreamTranscriptionRequest::GetRequestSpec
   Aws::Http::HeaderValueCollection headers;
   headers.emplace(Aws::Http::CONTENT_TYPE_HEADER, Aws::AMZN_EVENTSTREAM_CONTENT_TYPE);
   Aws::StringStream ss;
-  if(m_languageCodeHasBeenSet)
+  if(m_languageCodeHasBeenSet && m_languageCode != LanguageCode::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-language-code", LanguageCodeMapper::GetNameForLanguageCode(m_languageCode));
   }
@@ -78,7 +78,7 @@ Aws::Http::HeaderValueCollection StartStreamTranscriptionRequest::GetRequestSpec
     ss.str("");
   }
 
-  if(m_mediaEncodingHasBeenSet)
+  if(m_mediaEncodingHasBeenSet && m_mediaEncoding != MediaEncoding::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-media-encoding", MediaEncodingMapper::GetNameForMediaEncoding(m_mediaEncoding));
   }
@@ -104,7 +104,7 @@ Aws::Http::HeaderValueCollection StartStreamTranscriptionRequest::GetRequestSpec
     ss.str("");
   }
 
-  if(m_vocabularyFilterMethodHasBeenSet)
+  if(m_vocabularyFilterMethodHasBeenSet && m_vocabularyFilterMethod != VocabularyFilterMethod::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-vocabulary-filter-method", VocabularyFilterMethodMapper::GetNameForVocabularyFilterMethod(m_vocabularyFilterMethod));
   }
@@ -137,17 +137,17 @@ Aws::Http::HeaderValueCollection StartStreamTranscriptionRequest::GetRequestSpec
     ss.str("");
   }
 
-  if(m_partialResultsStabilityHasBeenSet)
+  if(m_partialResultsStabilityHasBeenSet && m_partialResultsStability != PartialResultsStability::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-partial-results-stability", PartialResultsStabilityMapper::GetNameForPartialResultsStability(m_partialResultsStability));
   }
 
-  if(m_contentIdentificationTypeHasBeenSet)
+  if(m_contentIdentificationTypeHasBeenSet && m_contentIdentificationType != ContentIdentificationType::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-content-identification-type", ContentIdentificationTypeMapper::GetNameForContentIdentificationType(m_contentIdentificationType));
   }
 
-  if(m_contentRedactionTypeHasBeenSet)
+  if(m_contentRedactionTypeHasBeenSet && m_contentRedactionType != ContentRedactionType::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-content-redaction-type", ContentRedactionTypeMapper::GetNameForContentRedactionType(m_contentRedactionType));
   }
@@ -180,7 +180,7 @@ Aws::Http::HeaderValueCollection StartStreamTranscriptionRequest::GetRequestSpec
     ss.str("");
   }
 
-  if(m_preferredLanguageHasBeenSet)
+  if(m_preferredLanguageHasBeenSet && m_preferredLanguage != LanguageCode::NOT_SET)
   {
     headers.emplace("x-amzn-transcribe-preferred-language", LanguageCodeMapper::GetNameForLanguageCode(m_preferredLanguage));
   }

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassHeaderMembersSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassHeaderMembersSource.vm
@@ -12,7 +12,11 @@
 #if($member.usedForHeader)
 #set($lowerCaseVarName = $CppViewHelper.computeVariableName($memberName))
 #set($memberVarName = $CppViewHelper.computeMemberVariableName($memberName))
+#if($member.shape.enum && !$member.shape.enumValues.contains("NOT_SET"))
+#set($varNameHasBeenSet = "$CppViewHelper.computeVariableHasBeenSetName($memberName) && $memberVarName != ${member.shape.name}::NOT_SET")
+#else
 #set($varNameHasBeenSet = $CppViewHelper.computeVariableHasBeenSetName($memberName))
+#end
 #if(!$member.required && $useRequiredField)
 #set($spaces = '  ')
   if($varNameHasBeenSet)


### PR DESCRIPTION
*Issue #, if available:*

[issues/1961](https://github.com/aws/aws-sdk-cpp/issues/1961)

*Description of changes:*

Customers have been seeing problems using S3 API compatible implementations that we send a empty string for checksum when it is explicitly set to `NOT_SET`.
> x-amz-sdk-checksum-algorithm: ''

the concept of a enum value not being set is part of our custom enum generation logic, and the serialization of the value falls back on sending a empty string. This change removes sending the header at all.

This is line with the the [smithy  protocol tests](https://github.com/smithy-lang/smithy/blob/367c4a5ac4f9bae217c0f00b45344f0872d7491d/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy#L426-L439)
> Do not send null values, empty strings, or empty lists over the wire in headers

removing sending empty string for not present enums will reduce data on the wire, and is more correct according to smithy.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
