### PR TITLE
fix potential deadlock on shutdown

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHandleContainer.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHandleContainer.cpp
@@ -44,7 +44,7 @@ CURL* CurlHandleContainer::AcquireCurlHandle()
         CheckAndGrowPool();
     }
 
-    CURL* handle = m_handleContainer.Acquire();
+    CURL* handle = m_handleContainer.TryAcquire();
     AWS_LOGSTREAM_DEBUG(CURL_HANDLE_CONTAINER_TAG, "Connection has been released. Continuing.");
     AWS_LOGSTREAM_DEBUG(CURL_HANDLE_CONTAINER_TAG, "Returning connection handle " << handle);
     return handle;


### PR DESCRIPTION
*Description of changes:*

A customer was seeing a issue where `ExclusiveOwnershipResourceManager` would see a deadlock on shutdown. specifically in `ShutdownAndWait` which currently looks like

```
Aws::Vector<RESOURCE_TYPE> ShutdownAndWait(size_t resourceCount) {
  std::unique_lock<std::mutex> locker(m_queueLock);
  m_shutdown = true;
  ... drain all resources
}
```

and issue could arise if in `Acquire`
```
RESOURCE_TYPE Acquire() {
  std::unique_lock<std::mutex> locker(m_queueLock);
  while(!m_shutdown.load() && m_resources.size() == 0) {
    m_semaphore.wait(locker, [&](){ return m_shutdown.load() || m_resources.size() > 0; });
  }
  ...
}
```

where m_resources never dips to zero making it so that the queue lock is never released which would never allow for `ShutdownAndWait` to run. by swapping `ShutdownAndWait` to be 

```
Aws::Vector<RESOURCE_TYPE> ShutdownAndWait(size_t resourceCount) {
  m_shutdown = true;
  std::unique_lock<std::mutex> locker(m_queueLock);
  ... drain all resources
}
```

we actually short circuit that while loops -- as intended. Also `m_shutdown` is atomic and can live outside of the lock.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
