### PR TITLE
Fix floating point excpetion in ssl connect metric

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -887,14 +887,19 @@ std::shared_ptr<HttpResponse> CurlHttpClient::MakeRequest(const std::shared_ptr<
         }
 
 #if LIBCURL_VERSION_NUM >= 0x073700 // 7.55.0
-        ret = curl_easy_getinfo(connectionHandle, CURLINFO_APPCONNECT_TIME_T, &timep); // Ssl Latency
+        curl_off_t AppConnectT;
+        ret = curl_easy_getinfo(connectionHandle, CURLINFO_APPCONNECT_TIME_T, &AppConnectT); // Ssl Latency
+        if (ret == CURLE_OK)
+        {
+            request->AddRequestMetric(GetHttpClientMetricNameByType(HttpClientMetricsType::SslLatency), AppConnectT * 1000);
+        }
 #else
         ret = curl_easy_getinfo(connectionHandle, CURLINFO_APPCONNECT_TIME, &timep); // Ssl Latency
-#endif
         if (ret == CURLE_OK)
         {
             request->AddRequestMetric(GetHttpClientMetricNameByType(HttpClientMetricsType::SslLatency), static_cast<int64_t>(timep * 1000));
         }
+#endif
 
         curl_off_t speed;
 #if LIBCURL_VERSION_NUM >= 0x073700 // 7.55.0


### PR DESCRIPTION
*Issue #, if available:*

[issues/2883](https://github.com/aws/aws-sdk-cpp/issues/2883)

*Description of changes:*

use `curl_off_t` for curl connect time instead of reading into a double.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
