### PR TITLE
only call curl_global_cleanup once

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -530,8 +530,11 @@ void CurlHttpClient::InitGlobalState()
 
 void CurlHttpClient::CleanupGlobalState()
 {
-    curl_global_cleanup();
-    isInit = false;
+    if (isInit)
+    {
+        curl_global_cleanup();
+        isInit = false;
+    }
 }
 
 Aws::String CurlInfoTypeToString(curl_infotype type)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/issues/2538

*Description of changes:*
only call curl_glabal_cleanup once

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
