### PR TITLE
add configuration to preserve path seperator in URIs

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/Aws.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/Aws.h
@@ -105,6 +105,14 @@ namespace Aws
          * Disable legacy URL encoding that leaves `$&,:@=` unescaped for legacy purposes.
          */
         bool compliantRfc3986Encoding;
+        /**
+         * When constructing Path segments in a URI preserve path separators instead of collapsing
+         * slashes. This is useful for aligning with other SDKs and tools on key path for S3 objects
+         * as currently the C++ SDK sanitizes the path.
+         *
+         * TODO: In the next major release, this will become the default to align better with other SDKs.
+         */
+        bool preservePathSeparators = false;
     };
 
     /**

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/StringUtils.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/StringUtils.h
@@ -79,9 +79,13 @@ namespace Aws
                  */
                 NOT_SET,
                 /**
-                 * Includes empty entries in the vector returned by Split()
+                 * Deprecated use INCLUDE_EMPTY_SEGMENTS instead.
                  */
-                INCLUDE_EMPTY_ENTRIES
+                INCLUDE_EMPTY_ENTRIES,
+                /**
+                 * Include delimiters as empty segments in the split string
+                 */
+                INCLUDE_EMPTY_SEGMENTS,
             };
 
             /**
@@ -115,6 +119,13 @@ namespace Aws
              * @param option, if INCLUDE_EMPTY_ENTRIES, includes empty entries in the result, otherwise removes empty entries.
              */
             static Aws::Vector<Aws::String> Split(const Aws::String& toSplit, char splitOn, size_t numOfTargetParts, SplitOptions option);
+
+            /**
+             * Splits a string on delimeter, keeping the delimiter in the string as a empty space.
+             * @param toSplit, the original string to split
+             * @param splitOn, the delimiter you want to use.
+             */
+            static Aws::Vector<Aws::String> SplitWithSpaces(const Aws::String& toSplit, char splitOn);
 
             /**
             * Splits a string on new line characters.

--- a/src/aws-cpp-sdk-core/source/Aws.cpp
+++ b/src/aws-cpp-sdk-core/source/Aws.cpp
@@ -155,6 +155,7 @@ namespace Aws
         Aws::Http::SetInitCleanupCurlFlag(options.httpOptions.initAndCleanupCurl);
         Aws::Http::SetInstallSigPipeHandlerFlag(options.httpOptions.installSigPipeHandler);
         Aws::Http::SetCompliantRfc3986Encoding(options.httpOptions.compliantRfc3986Encoding);
+        Aws::Http::SetPreservePathSeparators(options.httpOptions.preservePathSeparators);
         Aws::Http::InitHttp();
         Aws::InitializeEnumOverflowContainer();
         cJSON_AS4CPP_Hooks hooks;

--- a/src/aws-cpp-sdk-core/source/http/URI.cpp
+++ b/src/aws-cpp-sdk-core/source/http/URI.cpp
@@ -27,6 +27,9 @@ const char* SEPARATOR = "://";
 bool s_compliantRfc3986Encoding = false;
 void SetCompliantRfc3986Encoding(bool compliant) { s_compliantRfc3986Encoding = compliant; }
 
+bool s_preservePathSeparators = false;
+void SetPreservePathSeparators(bool preservePathSeparators) { s_preservePathSeparators = preservePathSeparators; }
+
 Aws::String urlEncodeSegment(const Aws::String& segment, bool rfcEncoded = false)
 {
     // consolidates legacy escaping logic into one local method

--- a/src/aws-cpp-sdk-core/source/utils/StringUtils.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/StringUtils.cpp
@@ -90,6 +90,11 @@ Aws::Vector<Aws::String> StringUtils::Split(const Aws::String& toSplit, char spl
 
 Aws::Vector<Aws::String> StringUtils::Split(const Aws::String& toSplit, char splitOn, size_t numOfTargetParts, SplitOptions option)
 {
+    if (option == SplitOptions::INCLUDE_EMPTY_SEGMENTS)
+    {
+        return StringUtils::SplitWithSpaces(toSplit, splitOn);
+    }
+
     Aws::Vector<Aws::String> returnValues;
     Aws::StringStream input(toSplit);
     Aws::String item;
@@ -125,6 +130,21 @@ Aws::Vector<Aws::String> StringUtils::Split(const Aws::String& toSplit, char spl
         returnValues.emplace_back();
     }
 
+    return returnValues;
+}
+
+Aws::Vector<Aws::String> StringUtils::SplitWithSpaces(const Aws::String& toSplit, char splitOn)
+{
+    size_t pos = 0;
+    String split{toSplit};
+    Vector<String> returnValues;
+    while ((pos = split.find(splitOn)) != std::string::npos) {
+        returnValues.emplace_back(split.substr(0, pos));
+        split.erase(0, pos + 1);
+    }
+    if (!split.empty()) {
+        returnValues.emplace_back(split);
+    }
     return returnValues;
 }
 


### PR DESCRIPTION
*Description of changes:*

Currently the C++ SDK sanitizes/normalizes uri paths that prevents us from interacting with other SDKs S3 keys. for example a S3 object with the key `///cpp/sdk/fizz` would become `cpp/sdk/fizz` currently. as well as `/cpp////sdk/fizz` becoming `cpp/sdk/fizz`. This introduces a SDK configuration level option to keep delimiters when constructing URIs. _**THIS WILL BE OFF BY DEFAULT FOR BACKWARD COMPATIBILITY**_. By enabling this configuration the SDK will be aligned with other SDKs and the CLI on key paths.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
