### PR TITLE
Fix rare memory leak in XML Error copy-assignment

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/xml/XmlSerializer.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/xml/XmlSerializer.h
@@ -142,8 +142,8 @@ namespace Aws
                 //we do not own these.... I just had to change it from ref because the compiler was
                 //confused about which assignment operator to call. Do not... I repeat... do not delete
                 //these pointers in your destructor.
-                Aws::External::tinyxml2::XMLNode* m_node;
-                const XmlDocument* m_doc;
+                Aws::External::tinyxml2::XMLNode* m_node = nullptr;
+                const XmlDocument* m_doc = nullptr;
 
                 friend class XmlDocument;
             };
@@ -200,7 +200,7 @@ namespace Aws
             private:
                 void InitDoc();
 
-                Aws::External::tinyxml2::XMLDocument* m_doc;
+                Aws::External::tinyxml2::XMLDocument* m_doc = nullptr;
 
                 friend class XmlNode;
 

--- a/src/aws-cpp-sdk-core/source/utils/xml/XmlSerializer.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/xml/XmlSerializer.cpp
@@ -134,6 +134,7 @@ void XmlNode::SetText(const Aws::String& textValue)
 {
     if (m_node != nullptr)
     {
+        assert(m_doc && m_doc->m_doc == m_node->GetDocument());
         Aws::External::tinyxml2::XMLText* text = m_doc->m_doc->NewText(textValue.c_str());
         m_node->InsertEndChild(text);
     }
@@ -141,12 +142,14 @@ void XmlNode::SetText(const Aws::String& textValue)
 
 XmlNode XmlNode::CreateChildElement(const Aws::String& name)
 {
+    assert(m_doc && m_doc->m_doc == m_node->GetDocument());
     Aws::External::tinyxml2::XMLElement* element = m_doc->m_doc->NewElement(name.c_str());
     return XmlNode(m_node->InsertEndChild(element), *m_doc);
 }
 
 XmlNode XmlNode::CreateSiblingElement(const Aws::String& name)
 {
+    assert(m_doc && m_doc->m_doc == m_node->GetDocument());
     Aws::External::tinyxml2::XMLElement* element = m_doc->m_doc->NewElement(name.c_str());
     return XmlNode(m_node->Parent()->InsertEndChild(element), *m_doc);
 }
@@ -193,6 +196,7 @@ XmlDocument& XmlDocument::operator=(const XmlDocument& other)
         if (m_doc != nullptr)
         {
             m_doc->Clear();
+            Aws::Delete(m_doc);
             m_doc = nullptr;
         }
     }
@@ -228,11 +232,13 @@ XmlDocument::~XmlDocument()
     if (m_doc)
     {
         Aws::Delete(m_doc);
+        m_doc = nullptr;
     }
 }
 
 void XmlDocument::InitDoc()
 {
+    assert(!m_doc);
     m_doc = Aws::New<Aws::External::tinyxml2::XMLDocument>(XML_SERIALIZER_ALLOCATION_TAG, true, Aws::External::tinyxml2::Whitespace::PRESERVE_WHITESPACE);
 }
 

--- a/tests/aws-cpp-sdk-core-tests/aws/client/AWSErrorMashallerTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/aws/client/AWSErrorMashallerTest.cpp
@@ -183,6 +183,9 @@ TEST_F(AWSErrorMarshallerTest, TestXmlErrorPayload)
     ASSERT_EQ("", error.GetMessage());
     ASSERT_EQ("", error.GetRequestId());
     ASSERT_TRUE(error.ShouldRetry());
+
+    AWSError<CoreErrors> emptyError;
+    error = emptyError; // ASAN must not complain.
 }
 
 TEST_F(AWSErrorMarshallerTest, TestCombinationsOfJsonErrorPayload)


### PR DESCRIPTION
*Issue #, if available:*
rare memory leak in such conditions:
```
    AWSError<CoreErrors> error = awsErrorMarshaller.Marshall(*BuildHttpXmlResponse("IncompleteSignatureException", message, requestId, IllFormed));
    AWSError<CoreErrors> emptyError;
    error = emptyError; // i.e. assign empty AWSError to a non-empty XML AWSError
```
*Description of changes:*
add Aws::Delete to
```
XmlDocument& XmlDocument::operator=(const XmlDocument& other)
<...>
Aws::Delete(m_doc);
```
*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
