### PR TITLE
Allow disabling HTTP2 (or specifying different version) on WinHTTP

### DIFF
--- a/src/aws-cpp-sdk-core/CMakeLists.txt
+++ b/src/aws-cpp-sdk-core/CMakeLists.txt
@@ -194,6 +194,25 @@ elseif(ENABLE_WINDOWS_CLIENT)
         return 1;
         }" WINHTTP_HAS_H2)
 
+        check_cxx_source_runs("
+        #include <Windows.h>
+        #include <winhttp.h>
+        int main() {
+
+        auto handle = WinHttpOpen(L\"aws-cpp-sdk\"/*user-agent*/,
+        WINHTTP_ACCESS_TYPE_NO_PROXY,
+        nullptr/*pszProxyW*/,
+        nullptr/*pszProxyBypassW*/,
+        0/*dwFlags*/);
+
+        DWORD http3 = WINHTTP_PROTOCOL_FLAG_HTTP3;
+        if (WinHttpSetOption(handle, WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL, &http3, sizeof(http3)))
+        {
+            return 0;
+        }
+        return 1;
+        }" WINHTTP_HAS_H3)
+
         set(CMAKE_REQUIRED_LIBRARIES "Wininet.lib")
         check_cxx_source_runs("
         #include <Windows.h>
@@ -528,6 +547,10 @@ endif()
 
 if (WINHTTP_HAS_H2)
     target_compile_definitions(${PROJECT_NAME} PRIVATE "WINHTTP_HAS_H2")
+endif()
+
+if (WINHTTP_HAS_H3)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE "WINHTTP_HAS_H3")
 endif()
 
 if (CURL_HAS_H2)

--- a/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinHttpSyncHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinHttpSyncHttpClient.h
@@ -8,6 +8,7 @@
 #include <aws/core/Core_EXPORTS.h>
 
 #include <aws/core/http/HttpClient.h>
+#include <aws/core/http/Version.h>
 #include <aws/core/http/windows/WinSyncHttpClient.h>
 
 namespace Aws
@@ -53,8 +54,9 @@ namespace Aws
             bool DoReadData(void* hHttpRequest, char* body, uint64_t size, uint64_t& read) const override;
             void* GetClientModule() const override;
 
-            bool m_usingProxy;
-            bool m_verifySSL;
+            bool m_usingProxy = false;
+            bool m_verifySSL = true;
+            Aws::Http::Version m_version = Aws::Http::Version::HTTP_VERSION_2TLS;
             Aws::WString m_proxyUserName;
             Aws::WString m_proxyPassword;
         };


### PR DESCRIPTION
*Issue #, if available:*
There is no way to disable http2 on WinHTTP client
*Description of changes:*
Map this ClientConfig option to WinHTTP config
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
