### PR TITLE
Fix CMake warning: Policy CMP0148 is not set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,8 +166,7 @@ if (LEGACY_BUILD)
     # build the sdk targets
     project("aws-cpp-sdk-all" VERSION "${PROJECT_VERSION}" LANGUAGES CXX)
 
-    set(Python_ADDITIONAL_VERSIONS 3.7 3.8 3.9 3.10)
-    find_package(PythonInterp)
+    find_package(Python3 COMPONENTS Interpreter Development)
     set(PYTHON3_CMD ${PYTHON_EXECUTABLE})
 
     # ENABLE_ZLIB_REQUEST_COMPRESSION should be ON by default if ZLIB is available


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed below warning show when using latest versions of cmake (cmake 3.29.1):
```
CMake Warning (dev) at CMakeLists.txt:170 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.
```

[FindPython3](https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3) is the new method to replace `PythonInterp`. This new function is supported since cmake 3.12 and this sdk requires 3.13. 

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
