### PR TITLE
fix s3 flex checksums for bad memory access

### DIFF
--- a/src/aws-cpp-sdk-core/source/utils/crypto/PrecalculatedHash.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/crypto/PrecalculatedHash.cpp
@@ -5,11 +5,17 @@
 
 
 #include <aws/core/utils/crypto/PrecalculatedHash.h>
-#include <aws/core/utils/HashingUtils.h>
+#include <aws/crt/Types.h>
 
 using namespace Aws::Utils::Crypto;
+using namespace Aws::Crt;
 
-PrecalculatedHash::PrecalculatedHash(const Aws::String &hash) : m_hashString(hash), m_decodedHashString(HashingUtils::Base64Decode(hash)) {}
+PrecalculatedHash::PrecalculatedHash(const Aws::String &hash) : m_hashString(hash)
+{
+    const auto decoded = Base64Decode(hash.c_str());
+    ByteBuffer buf{decoded.data(), decoded.size()};
+    m_decodedHashString = std::move(buf);
+}
 
 PrecalculatedHash::~PrecalculatedHash() = default;
 


### PR DESCRIPTION
*Description of changes:*

Currently our S3 integration tests will emit a valgrind warning for using unitialized memory when using a "bad" pre-calculated checksum that is not of Base64 format. When you execute the code

```
const auto badDecoded = HashingUtils::Base64Decode("If he came back and wanted you?");
const auto encodedAgain = HashingUtils::Base64Encode(badDecoded);
```

you will get a valgrind warning. This is due to a bug in our base64 implementation. I fix this in this case by using the CRT implementation of Base64 that fixes this issue. Going forward it would be recommended to use the CRT implentation and not the SDK implementation.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
