### PR TITLE
Fix keep alive setting on WinHTTP, trace more error codes from WinHTTP

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -39,7 +39,7 @@
         // MSVC
         "msvc", "MSFT", "LPDWORD", "DATAW", "mkgmtime", "vscprintf", "wtoi", "msxml", "runtimeobject", "winhttp",
         "Wininet", "HINTERNET", "ADDREQ", "LPCSTR", "MAKELANGID", "SUBLANG", "WSADATA", "Initate", "ioctlsocket",
-        "dupenv", "USERPROFILE", "subblock", "LANGANDCODEPAGE", "CPPUNWIND",
+        "dupenv", "USERPROFILE", "subblock", "LANGANDCODEPAGE", "CPPUNWIND", "keepalivetime", "keepaliveinterval",
         // Crypto
         "decryptor", "encryptor", "NTSTATUS", "PBYTE", "PUCHAR", "noconf", "HAMC", "PBCRYPT", "BCRYPT", "libcrypto",
         "AWSLC", "CBCCTS", "tweaklen", "taglen", "blockcipher", "AESGCM", "compated", "outdata", "Decrypto", "GCMAAD",

--- a/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinHttpSyncHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinHttpSyncHttpClient.h
@@ -55,6 +55,8 @@ namespace Aws
             bool DoReadData(void* hHttpRequest, char* body, uint64_t size, uint64_t& read) const override;
             void* GetClientModule() const override;
 
+            const char* GetActualHttpVersionUsed(void* hHttpRequest) const override;
+
             bool m_usingProxy = false;
             bool m_verifySSL = true;
             Aws::Http::Version m_version = Aws::Http::Version::HTTP_VERSION_2TLS;

--- a/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinINetSyncHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinINetSyncHttpClient.h
@@ -53,6 +53,8 @@ namespace Aws
             bool DoReadData(void* hHttpRequest, char* body, uint64_t size, uint64_t& read) const override;
             void* GetClientModule() const override;
 
+            const char* GetActualHttpVersionUsed(void* hHttpRequest) const override;
+
             WinINetSyncHttpClient &operator =(const WinINetSyncHttpClient &rhs);
 
             bool m_usingProxy;

--- a/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinSyncHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinSyncHttpClient.h
@@ -82,6 +82,8 @@ namespace Aws
              */
             bool m_allowRedirects;
 
+            bool m_enableHttpClientTrace = false;
+
         private:
             virtual void* OpenRequest(const std::shared_ptr<HttpRequest>& request, void* connection, const Aws::StringStream& ss) const = 0;
             virtual void DoAddHeaders(void* hHttpRequest, Aws::String& headerStr) const = 0;
@@ -93,6 +95,8 @@ namespace Aws
             virtual bool DoQueryDataAvailable(void* hHttpRequest, uint64_t& available) const = 0;
             virtual bool DoReadData(void* hHttpRequest, char* body, uint64_t size, uint64_t& read) const = 0;
             virtual void* GetClientModule() const = 0;
+
+            virtual const char* GetActualHttpVersionUsed(void* hHttpRequest) const = 0;
 
             bool StreamPayloadToRequest(const std::shared_ptr<HttpRequest>& request, void* hHttpRequest, Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter) const;
             void LogRequestInternalFailure() const;

--- a/src/aws-cpp-sdk-core/source/http/windows/WinINetSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinINetSyncHttpClient.cpp
@@ -255,6 +255,12 @@ bool WinINetSyncHttpClient::DoReadData(void* hHttpRequest, char* body, uint64_t 
     return (InternetReadFile(hHttpRequest, body, (DWORD)size, (LPDWORD)&read) != 0);
 }
 
+const char* WinINetSyncHttpClient::GetActualHttpVersionUsed(void* hHttpRequest) const
+{
+    AWS_UNREFERENCED_PARAM(hHttpRequest);
+    return "Unknown";
+}
+
 void* WinINetSyncHttpClient::GetClientModule() const
 {
     return GetModuleHandle(TEXT("wininet.dll"));

--- a/src/aws-cpp-sdk-core/source/http/windows/WinSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinSyncHttpClient.cpp
@@ -74,7 +74,15 @@ void WinSyncHttpClient::AddHeadersToRequest(const std::shared_ptr<HttpRequest>& 
         AWS_LOGSTREAM_DEBUG(GetLogTag(), "with headers:");
         for (auto& header : request->GetHeaders())
         {
-            ss << header.first << ": " << header.second << "\r\n";
+            if (!header.first.empty() && !header.second.empty())
+            {
+                ss << header.first << ": " << header.second << "\r\n";
+            }
+            else
+            {
+                // WinHttp does not accept empty header key or value
+                AWS_LOGSTREAM_DEBUG(GetLogTag(), "Empty header is ignored: " << header.first << ": " << header.second);
+            }
         }
 
         Aws::String headerString = ss.str();
@@ -402,6 +410,7 @@ std::shared_ptr<HttpResponse> WinSyncHttpClient::MakeRequest(const std::shared_p
     }
     else if(!success)
     {
+        AWS_LOGSTREAM_INFO(GetLogTag(), "Actual HTTP Version used " <<  GetActualHttpVersionUsed(hHttpRequest));
         LogRequestInternalFailure();
     }
 


### PR DESCRIPTION
*Issue #, if available:*
WinHttp client wrapper always logs an error about keep-alive
*Description of changes:*
Set keep-alive according to the MSFT docs; various logging updates
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
