### PR TITLE
Increase codegen timeout from 5 minutes to 6

### DIFF
--- a/tools/scripts/run_code_generation.py
+++ b/tools/scripts/run_code_generation.py
@@ -152,7 +152,7 @@ def build_generator(generator_dir: str, max_workers: int) -> None:
     """
 
     mvn_cmd = [shutil.which("mvn"), "package", "-q"]  # subprocess.run does expand Path by default
-    process = subprocess.run(mvn_cmd, cwd=generator_dir, timeout=5*60, check=True)
+    process = subprocess.run(mvn_cmd, cwd=generator_dir, timeout=6*60, check=True)
     process.check_returncode()
 
 
@@ -166,7 +166,7 @@ def run_generator_once(service_name: str, run_command: list, output_filename: st
     """
     # run_command_str = str(run_command).replace(', ', ' ').replace('\'','')
     # print(f"RUNNING COMMAND\n{run_command_str}\n")
-    process = subprocess.run(run_command, timeout=5 * 60, check=True, capture_output=True)
+    process = subprocess.run(run_command, timeout=6*60, check=True, capture_output=True)
     process.check_returncode()
 
     if output_filename != "STDOUT":


### PR DESCRIPTION
*Description of changes:*

Increases timeout of codegen that we hit in some clients in rare occasions.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
