### PR TITLE
Fix version check for CURLINFO_APPCONNECT_TIME_T

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -904,7 +904,7 @@ std::shared_ptr<HttpResponse> CurlHttpClient::MakeRequest(const std::shared_ptr<
             request->AddRequestMetric(GetHttpClientMetricNameByType(HttpClientMetricsType::ConnectLatency), static_cast<int64_t>(timep * 1000));
         }
 
-#if LIBCURL_VERSION_NUM >= 0x073700 // 7.55.0
+#if LIBCURL_VERSION_NUM >= 0x073D00 // 7.61.0
         curl_off_t metric;
         ret = curl_easy_getinfo(connectionHandle, CURLINFO_APPCONNECT_TIME_T, &metric); // Ssl Latency
 #else


### PR DESCRIPTION
*Issue #, if available:*

[issues/2931](https://github.com/aws/aws-sdk-cpp/issues/2931)

*Description of changes:*

Fixes a version check for [CURLINFO_APPCONNECT_TIME_T](https://curl.se/libcurl/c/CURLINFO_APPCONNECT_TIME_T.html) that checked for 7.55.0 incorrectly instead of 7.61.0,

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
