### PR TITLE
fix header list arguments to use correct type

### DIFF
--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassHeaderMembersSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassHeaderMembersSource.vm
@@ -45,7 +45,7 @@
   ${spaces}headers.emplace("${locationName}", std::accumulate(std::begin($memberVarName),
   ${spaces}  std::end($memberVarName),
   ${spaces}  Aws::String{},
-  ${spaces}  [](const Aws::String &acc, const ${member.shape.listMember.shape.name} &item) -> Aws::String {
+  ${spaces}  [](const Aws::String &acc, const $CppViewHelper.computeCppType($member.shape.listMember.shape) &item) -> Aws::String {
 #if($member.shape.listMember.shape.enum)
   ${spaces}    const auto headerValue = ${member.shape.listMember.shape.name}Mapper::GetNameFor${member.shape.listMember.shape.name}(item);
 #else


### PR DESCRIPTION
*Description of changes:*

fixes an issue in codegen where when a header has mlutiple values in a comma deliminated list we generated for the name instead of the type.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
