### PR TITLE
use add test instead of discover test

### DIFF
--- a/tests/aws-cpp-sdk-s3-unit-tests/CMakeLists.txt
+++ b/tests/aws-cpp-sdk-s3-unit-tests/CMakeLists.txt
@@ -30,4 +30,4 @@ if(MSVC AND BUILD_SHARED_LIBS)
 endif()
 
 include(GoogleTest)
-gtest_discover_tests(${PROJECT_NAME})
+gtest_add_tests(TARGET ${PROJECT_NAME})


### PR DESCRIPTION
*Description of changes:*

Fixes cross compilation for s3-unit-tests from the [CMake Documentation](https://cmake.org/cmake/help/latest/module/GoogleTest.html)

> gtest_add_tests attempts to identify tests by scanning source files. Although this is generally effective, it uses only a basic regular expression match, which can be defeated by atypical test declarations, and is unable to fully "split" parameterized tests. Additionally, it requires that CMake be re-run to discover any newly added, removed or renamed tests (by default, this means that CMake is re-run when any test source file is changed, but see SKIP_DEPENDENCY). However, it has the advantage of declaring tests at CMake time, which somewhat simplifies setting additional properties on tests, and always works in a cross-compiling environment.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
