### PR TITLE
Allow benchmark test to be build with CRT Client

### DIFF
--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -5,6 +5,7 @@
 add_project(benchmark
         "A Cli for running benchmark tests"
         aws-cpp-sdk-s3
+        aws-cpp-sdk-s3-crt
         aws-cpp-sdk-monitoring
         aws-cpp-sdk-core)
 
@@ -24,6 +25,11 @@ if (BUILD_OPTEL_OTLP_BENCHMARKS)
     find_package(CURL REQUIRED)
     find_package(nlohmann_json REQUIRED)
     find_package(opentelemetry-cpp CONFIG REQUIRED)
+endif ()
+
+option(AWS_SDK_BENCHMARK_USE_CRT "Option to use the S3 CRT client instead of the vanilla S3 Client" ON)
+if (AWS_SDK_BENCHMARK_USE_CRT)
+    add_definitions(-DAWS_SDK_BENCHMARK_USE_CRT)
 endif ()
 
 set_compiler_flags(${PROJECT_NAME})

--- a/tests/benchmark/include/service/S3Utils.h
+++ b/tests/benchmark/include/service/S3Utils.h
@@ -4,17 +4,23 @@
  */
 #pragma once
 
+#ifdef AWS_SDK_BENCHMARK_USE_CRT
+#include <aws/s3-crt/S3CrtClient.h>
+using S3Client = Aws::S3Crt::S3CrtClient;
+#else
 #include <aws/s3/S3Client.h>
+using S3Client = Aws::S3::S3Client;
+#endif
+
 #include <metric/Metrics.h>
 #include <string>
-#include <map>
 
 namespace Benchmark {
+
     class S3Utils final {
     public:
         S3Utils() = delete;
-
-        static std::unique_ptr<Aws::S3::S3Client> makeClient(const std::map<std::string, std::string> &cliDimensions);
+        static std::unique_ptr<S3Client> makeClient(const std::map<std::string, std::string> &cliDimensions);
 
         static std::string getBucketPrefix(const std::map<std::string, std::string> &cliDimensions);
 

--- a/tests/benchmark/src/service/S3GetObject.cpp
+++ b/tests/benchmark/src/service/S3GetObject.cpp
@@ -2,11 +2,23 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+#ifdef AWS_SDK_BENCHMARK_USE_CRT
+#include <aws/s3-crt/model/CreateBucketRequest.h>
+#include <aws/s3-crt/model/DeleteBucketRequest.h>
+#include <aws/s3-crt/model/PutObjectRequest.h>
+#include <aws/s3-crt/model/GetObjectRequest.h>
+#include <aws/s3-crt/model/DeleteObjectRequest.h>
+using namespace Aws::S3Crt;
+using namespace Aws::S3Crt::Model;
+#else
 #include <aws/s3/model/CreateBucketRequest.h>
 #include <aws/s3/model/DeleteBucketRequest.h>
 #include <aws/s3/model/PutObjectRequest.h>
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/DeleteObjectRequest.h>
+using namespace Aws::S3;
+using namespace Aws::S3::Model;
+#endif
 #include <aws/core/utils/UUID.h>
 #include <service/S3GetObject.h>
 #include <service/S3Utils.h>
@@ -15,8 +27,6 @@
 
 using namespace Aws;
 using namespace Aws::Utils;
-using namespace Aws::S3;
-using namespace Aws::S3::Model;
 using namespace std::chrono;
 
 Benchmark::TestFunction Benchmark::S3GetObject::CreateTestFunction() {

--- a/tests/benchmark/src/service/S3PutObject.cpp
+++ b/tests/benchmark/src/service/S3PutObject.cpp
@@ -2,23 +2,33 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+#ifdef AWS_SDK_BENCHMARK_USE_CRT
+#include <aws/s3-crt/model/CreateBucketRequest.h>
+#include <aws/s3-crt/model/DeleteBucketRequest.h>
+#include <aws/s3-crt/model/PutObjectRequest.h>
+#include <aws/s3-crt/model/DeleteObjectRequest.h>
+using namespace Aws::S3Crt;
+using namespace Aws::S3Crt::Model;
+#else
+#include <aws/s3/model/CreateBucketRequest.h>
+#include <aws/s3/model/DeleteBucketRequest.h>
+#include <aws/s3/model/PutObjectRequest.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/DeleteObjectRequest.h>
+using namespace Aws::S3;
+using namespace Aws::S3::Model;
+#endif
 #include <service/S3PutObject.h>
 #include <service/S3Utils.h>
 #include <Util.h>
 #include <metric/Metrics.h>
 #include <aws/core/utils/UUID.h>
-#include <aws/s3/model/CreateBucketRequest.h>
-#include <aws/s3/model/DeleteBucketRequest.h>
-#include <aws/s3/model/PutObjectRequest.h>
-#include <aws/s3/model/DeleteObjectRequest.h>
 #include <iostream>
 #include <chrono>
 #include <memory>
 
 using namespace Aws;
 using namespace Aws::Utils;
-using namespace Aws::S3;
-using namespace Aws::S3::Model;
 using namespace std::chrono;
 
 Benchmark::TestFunction Benchmark::S3PutObject::CreateTestFunction() {

--- a/tests/benchmark/src/service/S3Utils.cpp
+++ b/tests/benchmark/src/service/S3Utils.cpp
@@ -3,7 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 #include <service/S3Utils.h>
+#ifdef AWS_SDK_BENCHMARK_USE_CRT
+#include <aws/s3-crt/S3CrtClientConfiguration.h>
+using namespace Aws::S3Crt;
+using S3ClientConfiguration = Aws::S3Crt::ClientConfiguration;
+using S3Client = S3CrtClient;
+#else
 #include <aws/s3/S3ClientConfiguration.h>
+using namespace Aws::S3;
+#endif
 #ifdef USE_OTLP
 #include <smithy/tracing/impl/opentelemetry/OtelTelemetryProvider.h>
 #include <opentelemetry/exporters/ostream/span_exporter_factory.h>
@@ -15,7 +23,6 @@
 #endif
 
 using namespace Benchmark;
-using namespace Aws::S3;
 #ifdef USE_OTLP
 using namespace smithy::components::tracing;
 using namespace opentelemetry::exporter::otlp;
@@ -23,7 +30,7 @@ using namespace opentelemetry::exporter::otlp;
 
 const char* ALLOC_TAG = "S3_BENCHMARK";
 
-std::unique_ptr<Aws::S3::S3Client> S3Utils::makeClient(const std::map<std::string, std::string> &cliDimensions) {
+std::unique_ptr<S3Client> S3Utils::makeClient(const std::map<std::string, std::string> &cliDimensions) {
     S3ClientConfiguration configuration;
     if (cliDimensions.find("TelemetryHost") != cliDimensions.end() &&
         cliDimensions.find("TelemetryPort") != cliDimensions.end())


### PR DESCRIPTION
*Description of changes:*

Defaults the benchmark tests to use CRT client, can be optionally turned off. ie.

Build benchmarks with CRT client:
`-DBUILD_ONLY="s3;s3-crt;monitoring" -DBUILD_BENCHMARKS=ON -DAWS_SDK_BENCHMARK_USE_CRT=ON`

Build benchmarks with vanilla client:
`-DBUILD_ONLY="s3;s3-crt;monitoring" -DBUILD_BENCHMARKS=ON -DAWS_SDK_BENCHMARK_USE_CRT=OFF`

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
