### PR TITLE
Avoid excessive reply buffer copy in WinHTTP

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinHttpSyncHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinHttpSyncHttpClient.h
@@ -51,6 +51,7 @@ namespace Aws
             bool DoReceiveResponse(void* httpRequest) const override;
             bool DoQueryHeaders(void* httpRequest, std::shared_ptr<Aws::Http::HttpResponse>& response, Aws::StringStream& ss, uint64_t& read) const override;
             bool DoSendRequest(void* httpRequest) const override;
+            bool DoQueryDataAvailable(void* hHttpRequest, uint64_t& available) const override;
             bool DoReadData(void* hHttpRequest, char* body, uint64_t size, uint64_t& read) const override;
             void* GetClientModule() const override;
 

--- a/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinINetSyncHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinINetSyncHttpClient.h
@@ -49,6 +49,7 @@ namespace Aws
             bool DoReceiveResponse(void* hHttpRequest) const override;
             bool DoQueryHeaders(void* hHttpRequest, std::shared_ptr<Aws::Http::HttpResponse>& response, Aws::StringStream& ss, uint64_t& read) const override;
             bool DoSendRequest(void* hHttpRequest) const override;
+            bool DoQueryDataAvailable(void* hHttpRequest, uint64_t& available) const override;
             bool DoReadData(void* hHttpRequest, char* body, uint64_t size, uint64_t& read) const override;
             void* GetClientModule() const override;
 

--- a/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinSyncHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinSyncHttpClient.h
@@ -90,6 +90,7 @@ namespace Aws
             virtual bool DoReceiveResponse(void* hHttpRequest) const = 0;
             virtual bool DoQueryHeaders(void* hHttpRequest, std::shared_ptr<Aws::Http::HttpResponse>& response, Aws::StringStream& ss, uint64_t& read) const = 0;
             virtual bool DoSendRequest(void* hHttpRequest) const = 0;
+            virtual bool DoQueryDataAvailable(void* hHttpRequest, uint64_t& available) const = 0;
             virtual bool DoReadData(void* hHttpRequest, char* body, uint64_t size, uint64_t& read) const = 0;
             virtual void* GetClientModule() const = 0;
 

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/stream/StreamBufProtectedWriter.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/stream/StreamBufProtectedWriter.h
@@ -1,0 +1,120 @@
+
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+#include <aws/core/Core_EXPORTS.h>
+#include <aws/core/utils/Array.h>
+#include <streambuf>
+#include <functional>
+
+namespace Aws
+{
+    namespace Utils
+    {
+        namespace Stream
+        {
+            /**
+             * This is a wrapper to perform a hack to write directly to the put area of the underlying streambuf
+             */
+            class AWS_CORE_API StreamBufProtectedWriter : public std::streambuf
+            {
+            public:
+                StreamBufProtectedWriter() = delete;
+
+                using WriterFunc = std::function<bool(char* dst, uint64_t dstSz, uint64_t& read)>;
+
+                static uint64_t WriteToBuffer(Aws::IOStream& ioStream, const WriterFunc& writerFunc)
+                {
+                    uint64_t totalRead = 0;
+
+                    while (true)
+                    {
+                        StreamBufProtectedWriter* pBufferCasted = static_cast<StreamBufProtectedWriter*>(ioStream.rdbuf());
+                        bool bufferPresent = pBufferCasted && pBufferCasted->pptr() && (pBufferCasted->pptr() < pBufferCasted->epptr());
+                        uint64_t read = 0;
+                        bool success = false;
+                        if (bufferPresent)
+                        {
+                            // have access to underlying put ptr.
+                            success = WriteDirectlyToPtr(pBufferCasted, writerFunc, read);
+                        }
+                        else
+                        {
+                            // can't access underlying buffer, stream buffer maybe be customized to not use put ptr.
+                            // or underlying put buffer is simply not initialized yet.
+                            success = WriteWithHelperBuffer(ioStream, writerFunc, read);
+                        }
+                        totalRead += read;
+                        if (!success)
+                        {
+                            break;
+                        }
+
+                        if (pBufferCasted && pBufferCasted->pptr() && (pBufferCasted->pptr() >= pBufferCasted->epptr()))
+                        {
+                            if(!ForceOverflow(ioStream, writerFunc))
+                            {
+                                break;
+                            } else {
+                                totalRead++;
+                            }
+                        }
+                    }
+                    return totalRead;
+                }
+            protected:
+                static bool ForceOverflow(Aws::IOStream& ioStream, const WriterFunc& writerFunc)
+                {
+                    char dstChar;
+                    uint64_t read = 0;
+                    if (writerFunc(&dstChar, 1, read) && read > 0)
+                    {
+                        ioStream.write(&dstChar, 1);
+                        if (ioStream.fail()) {
+                            AWS_LOGSTREAM_ERROR("StreamBufProtectedWriter", "Failed to write 1 byte (eof: "
+                                    << ioStream.eof() << ", bad: " << ioStream.bad() << ")");
+                            return false;
+                        }
+                        return true;
+                    }
+                    return false;
+                }
+
+                static uint64_t WriteWithHelperBuffer(Aws::IOStream& ioStream, const WriterFunc& writerFunc, uint64_t& read)
+                {
+                    char tmpBuf[1024];
+                    uint64_t tmpBufSz = sizeof(tmpBuf);
+
+                    if(writerFunc(tmpBuf, tmpBufSz, read) && read > 0)
+                    {
+                        ioStream.write(tmpBuf, read);
+                        if (ioStream.fail()) {
+                            AWS_LOGSTREAM_ERROR("StreamBufProtectedWriter", "Failed to write " << tmpBufSz
+                            << " (eof: " << ioStream.eof() << ", bad: " << ioStream.bad() << ")");
+                            return false;
+                        }
+                        return true;
+                    }
+                    return false;
+                }
+
+                static uint64_t WriteDirectlyToPtr(StreamBufProtectedWriter* pBuffer, const WriterFunc& writerFunc, uint64_t& read)
+                {
+                    auto dstBegin = pBuffer->pptr();
+                    uint64_t dstSz = pBuffer->epptr() - dstBegin;
+                    if(writerFunc(dstBegin, dstSz, read) && read > 0)
+                    {
+                        assert(read <= dstSz);
+                        pBuffer->pbump((int) read);
+                        return true;
+                    }
+                    return false;
+                }
+            };
+        }
+    }
+}

--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -209,7 +209,7 @@ static size_t WriteData(char* ptr, size_t size, size_t nmemb, void* userdata)
             return 0;
         }
 
-        size_t cur = response->GetResponseBody().tellp();
+        auto cur = response->GetResponseBody().tellp();
         if (response->GetResponseBody().fail()) {
             const auto& ref = response->GetResponseBody();
             AWS_LOGSTREAM_ERROR(CURL_HTTP_CLIENT_TAG, "Unable to query response output position (eof: "
@@ -302,7 +302,7 @@ static size_t ReadBody(char* ptr, size_t size, size_t nmemb, void* userdata, boo
         {
             if (!ioStream->eof() && ioStream->peek() != EOF)
             {
-              amountRead = ioStream->readsome(ptr, amountToRead);
+                amountRead = (size_t) ioStream->readsome(ptr, amountToRead);
             }
             if (amountRead == 0 && !ioStream->eof())
             {

--- a/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
@@ -578,6 +578,11 @@ bool WinHttpSyncHttpClient::DoSendRequest(void* hHttpRequest) const
     return (WinHttpSendRequest(hHttpRequest, NULL, NULL, 0, 0, 0, NULL) != 0);
 }
 
+bool WinHttpSyncHttpClient::DoQueryDataAvailable(void* hHttpRequest, uint64_t& available) const
+{
+    return (WinHttpQueryDataAvailable(hHttpRequest, (LPDWORD)&available) != 0);
+}
+
 bool WinHttpSyncHttpClient::DoReadData(void* hHttpRequest, char* body, uint64_t size, uint64_t& read) const
 {
     return (WinHttpReadData(hHttpRequest, body, (DWORD)size, (LPDWORD)&read) != 0);

--- a/src/aws-cpp-sdk-core/source/http/windows/WinINetSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinINetSyncHttpClient.cpp
@@ -245,6 +245,11 @@ bool WinINetSyncHttpClient::DoSendRequest(void* hHttpRequest) const
     return (HttpSendRequestEx(hHttpRequest, NULL, NULL, 0, 0) != 0);
 }
 
+bool WinINetSyncHttpClient::DoQueryDataAvailable(void* hHttpRequest, uint64_t& available) const
+{
+    return (InternetQueryDataAvailable(hHttpRequest, (LPDWORD)&available, /*reserved*/ 0, /*reserved*/ 0) != 0);
+}
+
 bool WinINetSyncHttpClient::DoReadData(void* hHttpRequest, char* body, uint64_t size, uint64_t& read) const
 {
     return (InternetReadFile(hHttpRequest, body, (DWORD)size, (LPDWORD)&read) != 0);

--- a/src/aws-cpp-sdk-core/source/http/windows/WinSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinSyncHttpClient.cpp
@@ -9,6 +9,7 @@
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/HashingUtils.h>
 #include <aws/core/utils/logging/LogMacros.h>
+#include <aws/core/utils/stream/StreamBufProtectedWriter.h>
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/http/windows/WinConnectionPoolMgr.h>
 #include <aws/core/utils/memory/AWSMemory.h>
@@ -245,54 +246,103 @@ bool WinSyncHttpClient::BuildSuccessResponse(const std::shared_ptr<HttpRequest>&
 
     if (request->GetMethod() != HttpMethod::HTTP_HEAD)
     {
-        char body[1024];
-        uint64_t bodySize = sizeof(body);
-        int64_t numBytesResponseReceived = 0;
-        read = 0;
-
-        bool success = ContinueRequest(*request);
-
-        while (DoReadData(hHttpRequest, body, bodySize, read) && read > 0 && success)
+        if(!ContinueRequest(*request) || !IsRequestProcessingEnabled())
         {
-            response->GetResponseBody().write(body, read);
-            if (read > 0)
-            {
-                for (const auto& hashIterator : request->GetResponseValidationHashes())
-                {
-                    hashIterator.second->Update(reinterpret_cast<unsigned char*>(body), static_cast<size_t>(read));
-                }
-                numBytesResponseReceived += read;
-                if (readLimiter != nullptr)
-                {
-                    readLimiter->ApplyAndPayForCost(read);
-                }
-                auto& receivedHandler = request->GetDataReceivedEventHandler();
-                if (receivedHandler)
-                {
-                    receivedHandler(request.get(), response.get(), (long long)read);
-                }
-            }
-
-            success = success && ContinueRequest(*request) && IsRequestProcessingEnabled();
+            response->SetClientErrorType(CoreErrors::USER_CANCELLED);
+            response->SetClientErrorMessage("Request processing disabled or continuation cancelled by user's continuation handler.");
+            response->SetResponseCode(Aws::Http::HttpResponseCode::NO_RESPONSE);
+            return false;
         }
 
-        if (success && response->HasHeader(Aws::Http::CONTENT_LENGTH_HEADER))
+        if (response->GetResponseBody().fail()) {
+            const auto& ref = response->GetResponseBody();
+            AWS_LOGSTREAM_ERROR(GetLogTag(), "Response output stream is in a bad state (eof: " << ref.eof() << ", bad: " << ref.bad() << ")");
+            response->SetClientErrorType(CoreErrors::NETWORK_CONNECTION);
+            response->SetClientErrorMessage("Response output stream is in a bad state.");
+            return false;
+        }
+
+        bool connectionOpen = true;
+        auto writerFunc =
+                [this, hHttpRequest, &request, readLimiter, &response, &connectionOpen](char* dst, uint64_t dstSz, uint64_t& read) -> bool
+                {
+                    bool success = true;
+                    uint64_t available = 0;
+                    connectionOpen = DoQueryDataAvailable(hHttpRequest, available);
+
+                    if (connectionOpen && available)
+                    {
+                        dstSz = (std::min)(dstSz, available);
+                        success = DoReadData(hHttpRequest, dst, dstSz, read);
+                        if (success && read > 0)
+                        {
+                            for (const auto& hashIterator : request->GetResponseValidationHashes())
+                            {
+                                hashIterator.second->Update(reinterpret_cast<unsigned char*>(dst), static_cast<size_t>(read));
+                            }
+                            if (readLimiter != nullptr)
+                            {
+                                readLimiter->ApplyAndPayForCost(read);
+                            }
+                            auto& receivedHandler = request->GetDataReceivedEventHandler();
+                            if (receivedHandler)
+                            {
+                                receivedHandler(request.get(), response.get(), (long long)read);
+                            }
+                        }
+                        if (!ContinueRequest(*request) || !IsRequestProcessingEnabled())
+                        {
+                            return false;
+                        }
+                    }
+                    return connectionOpen && success && ContinueRequest(*request) && IsRequestProcessingEnabled();
+                };
+        uint64_t numBytesResponseReceived = Aws::Utils::Stream::StreamBufProtectedWriter::WriteToBuffer(response->GetResponseBody(), writerFunc);
+
+        if(!ContinueRequest(*request) || !IsRequestProcessingEnabled())
+        {
+            response->SetClientErrorType(CoreErrors::USER_CANCELLED);
+            response->SetClientErrorMessage("Request processing disabled or continuation cancelled by user's continuation handler.");
+            response->SetResponseCode(Aws::Http::HttpResponseCode::NO_RESPONSE);
+            return false;
+        }
+
+        if (response->GetResponseBody().fail()) {
+            Aws::OStringStream errorMsgStr;
+            errorMsgStr << "Failed to write received response (eof: "
+                        << response->GetResponseBody().eof() << ", bad: " << response->GetResponseBody().bad() << ")";
+
+            Aws::String errorMsg = errorMsgStr.str();
+            AWS_LOGSTREAM_ERROR(GetLogTag(), errorMsg);
+            response->SetClientErrorType(CoreErrors::NETWORK_CONNECTION);
+            response->SetClientErrorMessage(errorMsg);
+            return false;
+        }
+
+        if (request->IsEventStreamRequest() && !response->HasHeader(Aws::Http::X_AMZN_ERROR_TYPE))
+        {
+            response->GetResponseBody().flush();
+            if (response->GetResponseBody().fail()) {
+                const auto& ref = response->GetResponseBody();
+                AWS_LOGSTREAM_ERROR(GetLogTag(), "Failed to flush event response (eof: " << ref.eof() << ", bad: " << ref.bad() << ")");
+                response->SetClientErrorType(CoreErrors::NETWORK_CONNECTION);
+                response->SetClientErrorMessage("Failed to flush event stream event response");
+                return false;
+            }
+        }
+
+        if (response->HasHeader(Aws::Http::CONTENT_LENGTH_HEADER))
         {
             const Aws::String& contentLength = response->GetHeader(Aws::Http::CONTENT_LENGTH_HEADER);
             AWS_LOGSTREAM_TRACE(GetLogTag(), "Response content-length header: " << contentLength);
             AWS_LOGSTREAM_TRACE(GetLogTag(), "Response body length: " << numBytesResponseReceived);
-            if (StringUtils::ConvertToInt64(contentLength.c_str()) != numBytesResponseReceived)
+            if ((uint64_t) StringUtils::ConvertToInt64(contentLength.c_str()) != numBytesResponseReceived)
             {
-                success = false;
                 response->SetClientErrorType(CoreErrors::NETWORK_CONNECTION);
                 response->SetClientErrorMessage("Response body length doesn't match the content-length header.");
                 AWS_LOGSTREAM_ERROR(GetLogTag(), "Response body length doesn't match the content-length header.");
+                return false;
             }
-        }
-
-        if(!success)
-        {
-            return false;
         }
     }
 

--- a/tests/aws-cpp-sdk-logs-integration-tests/CloudWatchLogsTests.cpp
+++ b/tests/aws-cpp-sdk-logs-integration-tests/CloudWatchLogsTests.cpp
@@ -69,6 +69,7 @@ namespace
                 auto cognitoClient = Aws::MakeShared<Aws::CognitoIdentity::CognitoIdentityClient>(ALLOCATION_TAG, config);
                 Aws::AccessManagement::AccessManagementClient accessManagementClient(iamClient, cognitoClient);
                 accountId = accessManagementClient.GetAccountId();
+                assert(!accountId.empty()); // AccountId must be set for this test
             }
             m_accountId = accountId;
         }

--- a/tests/aws-cpp-sdk-transcribestreaming-integ-tests/TranscribeTests.cpp
+++ b/tests/aws-cpp-sdk-transcribestreaming-integ-tests/TranscribeTests.cpp
@@ -557,7 +557,7 @@ unsigned int LevenshteinDistance(Aws::String s1, Aws::String s2)
 TEST_F(TranscribeStreamingTests, TranscribeStreamingCppSdkSample)
 {
   const Aws::Vector<Aws::String> EXPECTED_ALTERNATIVES = {"This is a C plus plus test sample", "This is a C++ test sample"};
-  for(size_t chunkDuration = 50; chunkDuration <= 200; chunkDuration += 25)
+  for(size_t chunkDuration = 50; chunkDuration <= 200; chunkDuration += 50)
   {
     m_testTraces.clear();
     TestTrace(Aws::String("### Starting TranscribeStreamingCppSdkSample with chunks of ") + Aws::Utils::StringUtils::to_string(chunkDuration) + " ms ##");
@@ -582,7 +582,7 @@ TEST_F(TranscribeStreamingTests, TranscribeStreamingKantSample)
   static const char expected[] = "Categorical imperative: Act only according to that maxim whereby you can at the same time will that it should become a universal law. "
                                  "Two things fill the mind with ever-increasing wonder and awe, the more often and the more intensely the mind of thought is drawn to them: "
                                  "the starry heavens above me and the moral law within me.";
-  for(size_t chunkDuration = 50; chunkDuration <= 200; chunkDuration += 25)
+  for(size_t chunkDuration = 50; chunkDuration <= 200; chunkDuration += 50)
   {
     m_testTraces.clear();
     TestTrace(Aws::String("### Starting TranscribeStreamingKantSample with chunks of ") + Aws::Utils::StringUtils::to_string(chunkDuration) + " ms ##");

--- a/tests/benchmark/benchmark.cpp
+++ b/tests/benchmark/benchmark.cpp
@@ -10,6 +10,13 @@
 #include <metric/CloudWatchMetrics.h>
 
 int main(int argc, char *argv[]) {
+    if (1 == argc ||
+        2 == argc && (std::string(argv[1]) == "-h" || std::string(argv[1]) == "--help" ))
+    {
+        Benchmark::Configuration::PrintHelp();
+        return 0;
+    }
+
     Aws::SDKOptions options;
     Aws::InitAPI(options);
     {

--- a/tests/benchmark/include/Configuration.h
+++ b/tests/benchmark/include/Configuration.h
@@ -11,12 +11,14 @@ namespace Benchmark {
         std::string service;
         std::string api;
         long durationMillis;
+        size_t maxRepeats;
         bool shouldReportToCloudWatch;
         std::map<std::string, std::string> dimensions;
     };
 
     class Configuration {
     public:
+        static void PrintHelp();
         static Configuration FromArgs(int argc, char *argv[]);
         inline RunConfiguration GetConfiguration() const { return this->runConfiguration; }
     private:

--- a/tests/benchmark/src/Configuration.cpp
+++ b/tests/benchmark/src/Configuration.cpp
@@ -7,15 +7,25 @@
 #include <algorithm>
 #include <utility>
 #include <vector>
+#include <iostream>
 
 Benchmark::Configuration::Configuration(Benchmark::RunConfiguration runConfiguration) :
     runConfiguration(std::move(runConfiguration)) {}
+
+void Benchmark::Configuration::PrintHelp() {
+
+    std::cout << "usage: benchmark [--service SERVICE] [--api API] [--durationMillis DURATION_MS] [--withMetrics KEY1:VAL1,KEY2:VAL2]\n";
+    std::cout << "\n";
+    std::cout << "example: benchmark --service s3 --api PutObject --durationMillis 1000\n";
+    std::cout << "example: benchmark --service s3 --api PutObject --durationMillis 1000 --dimensions BucketType:S3Express\n";
+}
 
 Benchmark::Configuration Benchmark::Configuration::FromArgs(int argc, char *argv[]) {
     return Benchmark::Configuration({
         Benchmark::Configuration::GetCmdOption(argv, argv + argc, "--service"),
         Benchmark::Configuration::GetCmdOption(argv, argv + argc, "--api"),
         std::stol(Benchmark::Configuration::GetCmdOption(argv, argv + argc, "--durationMillis")),
+        std::stoul(Benchmark::Configuration::GetCmdOption(argv, argv + argc, "--maxRepeats")),
         Benchmark::Configuration::CmdOptionExists(argv, argv + argc, "--withMetrics"),
         Benchmark::Configuration::GetCmdOptions(argv, argv + argc, "--dimensions")
     });
@@ -31,7 +41,7 @@ char *Benchmark::Configuration::GetCmdOption(char **begin, char **end, const std
 
 std::map<std::string, std::string> Benchmark::Configuration::GetCmdOptions(char **begin, char **end, const std::string &option) {
     char **itr = std::find(begin, end, option);
-    auto value = ++itr;
+    auto value = itr != end ? ++itr : itr;
     if (itr != end && value != end) {
         //check to make sure the next entry is not another arg
         std::string nextArg(*value);

--- a/tests/benchmark/src/service/S3GetObject.cpp
+++ b/tests/benchmark/src/service/S3GetObject.cpp
@@ -40,7 +40,19 @@ Benchmark::TestFunction Benchmark::S3GetObject::CreateTestFunction() {
         metricsEmitter->EmitMetricForOp("CreateBucket",
             S3Utils::getMetricDimensions(dimensions, {{"Service", "S3"}, {"Operation", "CreateBucket"}}),
             [&]() -> bool {
-                auto response = s3->CreateBucket(CreateBucketRequest().WithBucket(bucketName));
+                auto request = CreateBucketRequest()
+                        .WithBucket(bucketName);
+                if (dimensions.find("BucketType") != dimensions.end() && dimensions.at("BucketType") == "S3Express") {
+                    request.WithCreateBucketConfiguration(CreateBucketConfiguration()
+                                                                  .WithLocation(LocationInfo()
+                                                                                        .WithType(LocationType::AvailabilityZone)
+                                                                                        .WithName("use1-az2"))
+                                                                  .WithBucket(BucketInfo()
+                                                                                      .WithType(BucketType::Directory)
+                                                                                      .WithDataRedundancy(DataRedundancy::SingleAvailabilityZone)));
+                }
+
+                auto response = s3->CreateBucket(request);
                 if (!response.IsSuccess()) {
                     std::cout << "Create Bucket Failed With: "
                               << response.GetError().GetMessage()
@@ -64,7 +76,7 @@ Benchmark::TestFunction Benchmark::S3GetObject::CreateTestFunction() {
                 if (!response.IsSuccess()) {
                     std::cout << "Put Object Failed With: "
                               << response.GetError().GetMessage()
-                              << "\n";;
+                              << "\n";
                 }
                 return response.IsSuccess();
             });
@@ -72,8 +84,10 @@ Benchmark::TestFunction Benchmark::S3GetObject::CreateTestFunction() {
         // Run GetObject requests
         const auto timeToEnd = duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count() +
                                configuration.GetConfiguration().durationMillis;
+        size_t counter = 0;
+        size_t maxRepeats = configuration.GetConfiguration().maxRepeats;
         auto getObjectRequest = GetObjectRequest().WithBucket(bucketName).WithKey(testObjectKey);
-        while (duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count() < timeToEnd) { ;
+        while (duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count() < timeToEnd) {
             metricsEmitter->EmitMetricForOp(
                 "GetObject",
                 S3Utils::getMetricDimensions(dimensions, {{"Service", "S3"}, {"Operation", "GetObject"}}),
@@ -82,10 +96,14 @@ Benchmark::TestFunction Benchmark::S3GetObject::CreateTestFunction() {
                     if (!response.IsSuccess()) {
                         std::cout << "Get Object Failed With: "
                                   << response.GetError().GetMessage()
-                                  << "\n";;
+                                  << "\n";
                     }
                     return response.IsSuccess();
                 });
+            counter++;
+            if (maxRepeats && counter == maxRepeats) {
+                break;
+            }
         }
 
         // Clean up


### PR DESCRIPTION
*Issue #, if available:*

Unlike in lib curl,

WinHTTP expects a pointer + size to where Windows is going to write us a reply:
```
WINHTTPAPI BOOL WinHttpReadData(
  [in]  HINTERNET hRequest,
  [out] LPVOID    lpBuffer,
  [in]  DWORD     dwNumberOfBytesToRead,
  [out] LPDWORD   lpdwNumberOfBytesRead
);
```
https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpreaddata
while C++'s iostream (it the central point of requests/response handling in the SDK from the initial design) manipulates C++'s streams:
```
// inserts blocks of characters 
basic_ostream& write( const char_type* s, std::streamsize count );
```
https://en.cppreference.com/w/cpp/io/basic_iostream
and can't provide raw pre-allocated buffer that WinHTTP wants.

Should WinHTTP provide std::iostream interface - this would not be an issue.

*Description of changes:*

Create a hack-y class to access raw pointers of the underlying buffer of the streambuffer to perform writes directly to the `pptr` pointer.

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
