### PR TITLE
fixes more shapes that cause codegen naming conflicts

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
@@ -115,7 +115,8 @@ public class C2jModelToGeneratorModelTransformer {
 
     private static final Map<String, MemberMapping> RESERVED_REQUEST_MEMBER_MAPPING = ImmutableMap.of(
         "body", new MemberMapping("requestBody", ImmutableSet.of("amplifyuibuilder", "apigateway", "apigateway2", "bedrock-runtime", "glacier", "repostspace")),
-        "headers", new MemberMapping("headerValues", ImmutableSet.of("apigateway"))
+        "headers", new MemberMapping("headerValues", ImmutableSet.of("apigateway")),
+        "Headers", new MemberMapping("headerValues", ImmutableSet.of())
     );
 
     /**


### PR DESCRIPTION
*Description of changes:*

follow up to [pull/2792](https://github.com/aws/aws-sdk-cpp/pull/2792). there was another issue when requests have the member shape `Headers` as the logic treats that as a different shape than `headers` (capitalization).

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
