### PR TITLE
Add appId to the ClientConfiguration structure

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -355,6 +355,16 @@ namespace Aws
             bool disableImdsV1 = false;
 
             /**
+             * AppId is an optional application specific identifier that can be set.
+             * When set it will be appended to the User-Agent header of every request
+             * in the form of App/{AppId}. This variable is sourced from environment
+             * variable AWS_SDK_UA_APP_ID or the shared config profile attribute sdk_ua_app_id.
+             * See https://docs.aws.amazon.com/sdkref/latest/guide/settings-reference.html for
+             * more information on environment variables and shared config settings.
+             */
+            Aws::String appId;
+
+            /**
              * A helper function to read config value from env variable or aws profile config
              */
             static Aws::String LoadConfigFromEnvOrProfile(const Aws::String& envKey,


### PR DESCRIPTION
*Issue #, if available:*
n/a
*Description of changes:*
a minor update to allow to configure the app id also by the configuration
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
