### PR TITLE
usage of WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL on old win headers

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
@@ -29,6 +29,14 @@ using namespace Aws::Http::Standard;
 using namespace Aws::Utils;
 using namespace Aws::Utils::Logging;
 
+#ifndef WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL
+    /*
+    * Note: this option was introduced in Windows 10, version 1607. Define it if
+    * it does not exist and let option setting for H2/H3 fail if its not supported.
+    */
+    static const DWORD WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL = 133;
+#endif
+
 DWORD ConvertHttpVersionToWinHttpVersion(const Aws::Http::Version version)
 {
     if (version == Version::HTTP_VERSION_NONE)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
