### PR TITLE
cmake install to strip rpath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,9 +154,6 @@ if (LEGACY_BUILD)
         set(STATIC_CRT ON)
     endif ()
 
-    # Add Linker search paths to RPATH so as to fix the problem where some linkers can't find cross-compiled dependent libraries in customer paths when linking executables.
-    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
-
     # build the sdk targets
     project("aws-cpp-sdk-all" VERSION "${PROJECT_VERSION}" LANGUAGES CXX)
 


### PR DESCRIPTION
*Issue #, if available:*
cmake does not strip RPATH

the original intent of having this "feature" was to fix cross-compilation:
>When doing cross-compilation, linkers can link shared SDK with cross-compiled libraries (like libssl.so) from specified customer search paths.
But these customer search paths are not written to SDK library as RPATH. Some linkers then don't know where to link libssl.so when linking an executable.
This path fixes this specific problem.

From the original description, it seems to be our classic "FindCrypto" class of problems.
Now that "FindCrypto" is fixed by removing the crypto (and using crypto methods from/through CRT library), this hack is not necessary anymore. Even more, it was and is harmful as it goes against regular development practices.

*Description of changes:*
cmake to strip RPATH how it is typically expected.
Issues with "some linkers" should be fixed in the environments where these "some linkers" exist and not pollute the generic expected way of things.
> to fix the problem where some linkers can't find cross-compiled dependent libraries in customer paths when linking executables.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
