### PR TITLE
fixes s3 copy and move assignment operators

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
@@ -80,7 +80,7 @@ namespace Aws
          * Recreates member that reference self.
          * @param rhs the source object of the copy.
          */
-        S3CrtClient(S3CrtClient &&rhs);
+        S3CrtClient(S3CrtClient &&rhs) noexcept;
 
         /**
          * Assignment move operator for a S3Client. Copies all members that do not reference self.
@@ -88,7 +88,7 @@ namespace Aws
          * @param rhs the source object of the copy.
          * @return the copied client.
          */
-        S3CrtClient& operator=(S3CrtClient &&rhs);
+        S3CrtClient& operator=(S3CrtClient &&rhs) noexcept;
 
         /* Legacy constructors due deprecation */
        /**

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -176,6 +176,10 @@ S3CrtClient::S3CrtClient(const S3CrtClient &rhs) :
     m_identityProvider(rhs.m_identityProvider){}
 
 S3CrtClient& S3CrtClient::operator=(const S3CrtClient &rhs) {
+    if (&rhs == this) {
+      return *this;
+    }
+    BASECLASS::operator=(rhs);
     m_signerProvider = Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
           rhs.GetCredentialsProvider(),
           rhs.m_clientConfiguration.identityProviderSupplier(*this),
@@ -190,7 +194,7 @@ S3CrtClient& S3CrtClient::operator=(const S3CrtClient &rhs) {
     return *this;
 }
 
-S3CrtClient::S3CrtClient(S3CrtClient &&rhs) :
+S3CrtClient::S3CrtClient(S3CrtClient &&rhs) noexcept :
     BASECLASS(rhs.m_clientConfiguration,
         Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
             rhs.GetCredentialsProvider(),
@@ -205,10 +209,11 @@ S3CrtClient::S3CrtClient(S3CrtClient &&rhs) :
     m_executor(std::move(rhs.m_clientConfiguration.executor)),
     m_endpointProvider(std::move(rhs.m_endpointProvider)) {}
 
-S3CrtClient& S3CrtClient::operator=(S3CrtClient &&rhs) {
+S3CrtClient& S3CrtClient::operator=(S3CrtClient &&rhs) noexcept {
   if (&rhs == this) {
     return *this;
   }
+  BASECLASS::operator=(std::move(rhs));
   m_signerProvider = Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
         rhs.GetCredentialsProvider(),
         rhs.m_clientConfiguration.identityProviderSupplier(*this),

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3Client.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3Client.h
@@ -69,7 +69,7 @@ namespace Aws
          * Recreates member that reference self.
          * @param rhs the source object of the copy.
          */
-        S3Client(S3Client &&rhs);
+        S3Client(S3Client &&rhs) noexcept;
 
         /**
          * Assignment move operator for a S3Client. Copies all members that do not reference self.
@@ -77,7 +77,7 @@ namespace Aws
          * @param rhs the source object of the copy.
          * @return the copied client.
          */
-        S3Client& operator=(S3Client &&rhs);
+        S3Client& operator=(S3Client &&rhs) noexcept;
        /**
         * Initializes client to use DefaultCredentialProviderChain, with default http client factory, and optional client config. If client config
         * is not specified, it will be initialized to default values.

--- a/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp
@@ -164,6 +164,7 @@ S3Client& S3Client::operator=(const S3Client &rhs) {
     if (&rhs == this) {
       return *this;
     }
+    BASECLASS::operator=(rhs);
     m_signerProvider = Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
           rhs.GetCredentialsProvider(),
           rhs.m_clientConfiguration.identityProviderSupplier(*this),
@@ -178,7 +179,7 @@ S3Client& S3Client::operator=(const S3Client &rhs) {
     return *this;
 }
 
-S3Client::S3Client(S3Client &&rhs) :
+S3Client::S3Client(S3Client &&rhs) noexcept :
     BASECLASS(rhs.m_clientConfiguration,
         Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
             rhs.GetCredentialsProvider(),
@@ -193,10 +194,11 @@ S3Client::S3Client(S3Client &&rhs) :
     m_executor(std::move(rhs.m_clientConfiguration.executor)),
     m_endpointProvider(std::move(rhs.m_endpointProvider)) {}
 
-S3Client& S3Client::operator=(S3Client &&rhs) {
+S3Client& S3Client::operator=(S3Client &&rhs) noexcept {
   if (&rhs == this) {
     return *this;
   }
+  BASECLASS::operator=(std::move(rhs));
   m_signerProvider = Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
         rhs.GetCredentialsProvider(),
         rhs.m_clientConfiguration.identityProviderSupplier(*this),

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm
@@ -58,7 +58,7 @@
          * Recreates member that reference self.
          * @param rhs the source object of the copy.
          */
-        ${className}(${className} &&rhs);
+        ${className}(${className} &&rhs) noexcept;
 
         /**
          * Assignment move operator for a S3Client. Copies all members that do not reference self.
@@ -66,7 +66,7 @@
          * @param rhs the source object of the copy.
          * @return the copied client.
          */
-        ${className}& operator=(${className} &&rhs);
+        ${className}& operator=(${className} &&rhs) noexcept;
 #end
 #if($serviceModel.endpointRules && $serviceNamespace != "S3Crt")
 #if($serviceModel.hasOnlyBearerAuth())

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm
@@ -101,6 +101,7 @@ ${className}& ${className}::operator=(const ${className} &rhs) {
     if (&rhs == this) {
       return *this;
     }
+    BASECLASS::operator=(rhs);
     m_signerProvider = Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
           rhs.GetCredentialsProvider(),
           rhs.m_clientConfiguration.identityProviderSupplier(*this),
@@ -115,7 +116,7 @@ ${className}& ${className}::operator=(const ${className} &rhs) {
     return *this;
 }
 
-S3Client::S3Client(${className} &&rhs) :
+S3Client::S3Client(${className} &&rhs) noexcept :
     BASECLASS(rhs.m_clientConfiguration,
         Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
             rhs.GetCredentialsProvider(),
@@ -130,10 +131,11 @@ S3Client::S3Client(${className} &&rhs) :
     m_executor(std::move(rhs.m_clientConfiguration.executor)),
     m_endpointProvider(std::move(rhs.m_endpointProvider)) {}
 
-${className}& ${className}::operator=(${className} &&rhs) {
+${className}& ${className}::operator=(${className} &&rhs) noexcept {
   if (&rhs == this) {
     return *this;
   }
+  BASECLASS::operator=(std::move(rhs));
   m_signerProvider = Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
         rhs.GetCredentialsProvider(),
         rhs.m_clientConfiguration.identityProviderSupplier(*this),

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -72,6 +72,10 @@ ${className}::${className}(const ${className} &rhs) :
     m_identityProvider(rhs.m_identityProvider){}
 
 ${className}& ${className}::operator=(const ${className} &rhs) {
+    if (&rhs == this) {
+      return *this;
+    }
+    BASECLASS::operator=(rhs);
     m_signerProvider = Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
           rhs.GetCredentialsProvider(),
           rhs.m_clientConfiguration.identityProviderSupplier(*this),
@@ -86,7 +90,7 @@ ${className}& ${className}::operator=(const ${className} &rhs) {
     return *this;
 }
 
-${className}::${className}(${className} &&rhs) :
+${className}::${className}(${className} &&rhs) noexcept :
     BASECLASS(rhs.m_clientConfiguration,
         Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
             rhs.GetCredentialsProvider(),
@@ -101,10 +105,11 @@ ${className}::${className}(${className} &&rhs) :
     m_executor(std::move(rhs.m_clientConfiguration.executor)),
     m_endpointProvider(std::move(rhs.m_endpointProvider)) {}
 
-${className}& ${className}::operator=(${className} &&rhs) {
+${className}& ${className}::operator=(${className} &&rhs) noexcept {
   if (&rhs == this) {
     return *this;
   }
+  BASECLASS::operator=(std::move(rhs));
   m_signerProvider = Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
         rhs.GetCredentialsProvider(),
         rhs.m_clientConfiguration.identityProviderSupplier(*this),


### PR DESCRIPTION
*Issue #, if available:*

[issues/2972](https://github.com/aws/aws-sdk-cpp/issues/2972)

*Description of changes:*

Fixes base class initialization on copy and move assignment operators.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
