### PR TITLE
include aws_use_package for all cmake paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,9 +214,7 @@ if (LEGACY_BUILD)
     if (BUILD_DEPS)
         set(CMAKE_INSTALL_RPATH "$ORIGIN")
         list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/crt/aws-crt-cpp/crt/aws-c-common/cmake")
-
         include(AwsFindPackage)
-
         set(IN_SOURCE_BUILD ON)
         set(BUILD_TESTING_PREV ${BUILD_TESTING})
         set(BUILD_TESTING OFF CACHE BOOL "Disable all tests in dependencies.")
@@ -230,6 +228,7 @@ if (LEGACY_BUILD)
         string(REPLACE ";" "${AWS_MODULE_DIR};" AWS_MODULE_PATH "${CMAKE_PREFIX_PATH}${AWS_MODULE_DIR}")
         # Append that generated list to the module search path
         list(APPEND CMAKE_MODULE_PATH ${AWS_MODULE_PATH})
+        include(AwsFindPackage)
         set(IN_SOURCE_BUILD OFF)
     endif ()
     aws_use_package(aws-crt-cpp)


### PR DESCRIPTION
*Description of changes:*

In a recent change for removing the direct crypto dependency in favor of the c-cal interface, this included some cmake changed that inadvertently broke the cmake arg `BUILD_DEPS` when removing `include(AwsFindPackage)` from both branches of the path. this adds that include back for both.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
