### PR TITLE
Re-add #6e8ae64 Avoid concurrent writes in TestingMonitoring

### DIFF
--- a/tests/testing-resources/include/aws/testing/mocks/monitoring/TestingMonitoring.h
+++ b/tests/testing-resources/include/aws/testing/mocks/monitoring/TestingMonitoring.h
@@ -83,6 +83,8 @@ public:
         AWS_UNREFERENCED_PARAM(serviceName);
         AWS_UNREFERENCED_PARAM(requestName);
         AWS_UNREFERENCED_PARAM(context);
+        std::unique_lock<std::mutex> locker(s_lastMutex);
+
         TestingMonitoringMetrics::s_lastUriString = request->GetUri().GetURIString().c_str();
         TestingMonitoringMetrics::s_lastSigningRegion = request->GetSigningRegion().c_str();
         Aws::Vector<Aws::String> authComponents = request->HasAwsAuthorization() ?
@@ -155,6 +157,7 @@ public:
 private:
     static void Init()
     {
+        std::unique_lock<std::mutex> locker(s_lastMutex);
         TestingMonitoringMetrics::Config::s_enablePayload = false;
 
         TestingMonitoringMetrics::s_lastUriString = "";


### PR DESCRIPTION
that accidentally got reverted

*Issue #, if available:*
race condition in testing monitor

*Description of changes:*
Just add a mutex lock.

First fixed in: https://github.com/aws/aws-sdk-cpp/pull/2523
Then accidentally reverted in: https://github.com/aws/aws-sdk-cpp/pull/2930/commits/0b850a96a6f4e762a0f64f23ff7e6e434d1803e8
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
