### PR TITLE
Add fallback to std::getenv in Aws::Environment::GetEnv for Windows

### DIFF
--- a/src/aws-cpp-sdk-core/source/platform/windows/Environment.cpp
+++ b/src/aws-cpp-sdk-core/source/platform/windows/Environment.cpp
@@ -16,9 +16,12 @@ namespace Environment
 /*
 using std::getenv generates a warning on windows so we use _dupenv_s instead.  The character array returned by this function is our responsibility to clean up, so rather than returning raw strings
 that would need to be manually freed in all the client functions, just copy it into a Aws::String instead, freeing it here.
+
+since _dupenv_s is a non-standard function, on non-Microsoft compilers we will fall back to using std::getenv instead.
 */
 Aws::String GetEnv(const char *variableName)
 {
+#ifdef _MSC_VER    
     char* variableValue = nullptr;
     std::size_t valueSize = 0;
     auto queryResult = _dupenv_s(&variableValue, &valueSize, variableName);
@@ -31,6 +34,10 @@ Aws::String GetEnv(const char *variableName)
     }
 
     return result;
+#else
+    auto variableValue = std::getenv(variableName);
+    return Aws::String( variableValue ? variableValue : "" );
+#endif
 }
 
 } // namespace Environment


### PR DESCRIPTION
*Description of changes:*
In order to avoid a warning in Visual Studio, on Windows the GetEnv implementation that uses `_dupenv_s` to read environment variables. `_dupenv_s` is a non-standard function that does not exist in non-Microsoft compilers, like GCC and clang compiling against MinGW for example.

This PR adds a fallback for non-Microsoft compilers that uses `std::getenv` instead. 

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Since this is an alternative implementation that gets selected at compile time, compiling any existing tests with an applicable toolchain will exercise this fallback method already.

*Check which platforms you have built SDK on to verify the correctness of this PR:*

- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [x] Other Platforms

Compiled on MinGW as well using GCC and clang.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
