### PR TITLE
fix shadow warning due to typo

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/Array.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/Array.h
@@ -66,10 +66,10 @@ namespace Aws
              */
             Array(size_t capacity,
                   size_t length,
-                  UniqueArrayPtr<T> m_data)
+                  UniqueArrayPtr<T> data)
                 : m_capacity(capacity),
                   m_length(length),
-                  m_data(std::move(m_data))
+                  m_data(std::move(data))
             {
             }
 


### PR DESCRIPTION
*Description of changes:*

Fixes a shadowed param warning for a typo in a parameter name.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
