### PR TITLE
Fixed 'aws-c-common' dependency subdirectory in main AWS CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,7 @@ if (LEGACY_BUILD)
         set(BUILD_TESTING OFF CACHE BOOL "Disable all tests in dependencies.")
         # TODO: Use same BUILD_SHARED_LIBS for Aws Common Runtime dependencies.
         set(CRT_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
-        add_subdirectory(crt/aws-crt-cpp)
+        add_subdirectory(crt/aws-crt-cpp/crt/aws-c-common)
         set(BUILD_TESTING ${BUILD_TESTING_PREV})
     else ()
         # This is required in order to append /lib/cmake to each element in CMAKE_PREFIX_PATH


### PR DESCRIPTION
*Description of changes:*

The wrong path was used to add the 'aws-c-common' dependency since the currently used sub directory path for the 'aws-c-common' was missing the 'CMakeLists.txt' after cloning and downloading the 'aws-c-common' dependency. Let's also highlight the inconsistency with the previous list append command in line 216, so we maintained the path hierarchy from the list command and consider the add_subdirectory command an incomplete path for this command.

*Check all that applies:*
- [y] Did a review by yourself.
- [y] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [n] Checked if this PR is a breaking (APIs have been changed) change.
- [n] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [n] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [n] Linux
- [x] Windows
- [n] Android
- [n] MacOS
- [n] IOS
- [n] Other Platforms

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
