### PR TITLE
Avoid setting Cache-Control on WinHttp client; fix setting empty headers

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
@@ -538,8 +538,11 @@ void* WinHttpSyncHttpClient::OpenRequest(const std::shared_ptr<HttpRequest>& req
 {
     LPCWSTR accept[2] = { nullptr, nullptr };
 
-    DWORD requestFlags = WINHTTP_FLAG_REFRESH |
-        (request->GetUri().GetScheme() == Scheme::HTTPS && m_verifySSL ? WINHTTP_FLAG_SECURE : 0);
+    DWORD requestFlags = request->GetUri().GetScheme() == Scheme::HTTPS && m_verifySSL ? WINHTTP_FLAG_SECURE : 0;
+    if (m_usingProxy) {
+        // Avoid force adding "Cache-Control: no-cache" header.
+        requestFlags |= WINHTTP_FLAG_REFRESH;
+    }
 
     Aws::WString acceptHeader(L"*/*");
 

--- a/src/aws-cpp-sdk-core/source/http/windows/WinSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinSyncHttpClient.cpp
@@ -80,8 +80,8 @@ void WinSyncHttpClient::AddHeadersToRequest(const std::shared_ptr<HttpRequest>& 
             }
             else
             {
-                // WinHttp does not accept empty header key or value
-                AWS_LOGSTREAM_DEBUG(GetLogTag(), "Empty header is ignored: " << header.first << ": " << header.second);
+                // DOUBLE SPACE after COLON, thanks, WinHTTP!
+                ss << header.first << ":  " << "\r\n";
             }
         }
 

--- a/tests/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/tests/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp
@@ -590,6 +590,7 @@ namespace
         GetObjectOutcome getObjectOutcome = Client->GetObject(getObjectRequest);
         AWS_ASSERT_SUCCESS(getObjectOutcome);
         ASSERT_EQ(contentLength, getObjectOutcome.GetResult().GetContentLength());
+        EXPECT_TRUE(getObjectOutcome.GetResult().GetCacheControl().empty());
 
         // GET with range
         getObjectRequest.SetRange("bytes=128-1024");

--- a/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
@@ -961,6 +961,7 @@ namespace
         ss.str("");
         ss << getObjectOutcome.GetResult().GetBody().rdbuf();
         ASSERT_STREQ("Test Object", ss.str().c_str());
+        EXPECT_TRUE(getObjectOutcome.GetResult().GetCacheControl().empty());
 
         HeadObjectRequest headObjectRequest;
         headObjectRequest.SetBucket(fullBucketName);


### PR DESCRIPTION
*Issue #, if available:*
Cache-Control is always set to `no-cache` by WinHTTP client
https://github.com/aws/aws-sdk-cpp/issues/2603
*Description of changes:*
Do not set `WINHTTP_FLAG_REFRESH` if proxy is not used.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
