### PR TITLE
curl: Log SSL_DATA_{IN,OUT} with trace level rather than debug

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -574,7 +574,7 @@ int CurlDebugCallback(CURL *handle, curl_infotype type, char *data, size_t size,
 
     if(type == CURLINFO_SSL_DATA_IN || type == CURLINFO_SSL_DATA_OUT)
     {
-        AWS_LOGSTREAM_DEBUG("CURL", "(" << CurlInfoTypeToString(type) << ") " << size << " bytes");
+        AWS_LOGSTREAM_TRACE("CURL", "(" << CurlInfoTypeToString(type) << ") " << size << " bytes");
     }
     else if (type == CURLINFO_DATA_IN || type == CURLINFO_DATA_OUT)
     {


### PR DESCRIPTION
Consider the following sample from some s3 client debug logs: the SSLDataIn and SSLDataOut messages occupy a large amount of space among the otherwise potentially useful debug output. We should bump it to the trace level instead.

<details>
<summary> Spammy logs </summary>

```
AWS: [DEBUG] 2024-06-15 07:10:34.397 CurlHandleContainer [132987362911616] Attempting to acquire curl connection.
AWS: [DEBUG] 2024-06-15 07:10:34.397 CurlHandleContainer [132987362911616] No current connections available in pool. Attempting to create new connections
.
AWS: [DEBUG] 2024-06-15 07:10:34.397 CurlHandleContainer [132987362911616] attempting to grow pool size by 2
AWS: [INFO] 2024-06-15 07:10:34.397 CurlHandleContainer [132987362911616] Pool grown by 2
AWS: [DEBUG] 2024-06-15 07:10:34.397 CurlHandleContainer [132987362911616] Connection has been released. Continuing.
AWS: [DEBUG] 2024-06-15 07:10:34.397 CurlHandleContainer [132987362911616] Returning connection handle 0x5fb8e8584d20
AWS: [DEBUG] 2024-06-15 07:10:34.397 CurlHttpClient [132987362911616] Obtained connection handle 0x5fb8e8584d20
AWS: [DEBUG] 2024-06-15 07:10:34.398 CURL [132987362911616] (Text) Host <redacted> was resolved.
AWS: [DEBUG] 2024-06-15 07:10:34.398 CURL [132987362911616] (Text) IPv6: 0000:000:0000:000::000
AWS: [DEBUG] 2024-06-15 07:10:34.398 CURL [132987362911616] (Text) IPv4: 000.000.00.000
AWS: [DEBUG] 2024-06-15 07:10:34.398 CURL [132987362911616] (Text)   Trying 000.000.00.000:443...
AWS: [DEBUG] 2024-06-15 07:10:34.544 CURL [132987362911616] (Text) Connected to <redacted> port 443
AWS: [DEBUG] 2024-06-15 07:10:34.544 CURL [132987362911616] (Text) ALPN: curl offers h2,http/1.1
AWS: [DEBUG] 2024-06-15 07:10:34.544 CURL [132987362911616] (SSLDataOut) 5 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.544 CURL [132987362911616] (Text) TLSv1.3 (OUT), TLS handshake, Client hello (1):
AWS: [DEBUG] 2024-06-15 07:10:34.544 CURL [132987362911616] (SSLDataOut) 512 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.564 CURL [132987362911616] (Text)  CAfile: /etc/ssl/certs/ca-certificates.crt
AWS: [DEBUG] 2024-06-15 07:10:34.564 CURL [132987362911616] (Text)  CApath: none
AWS: [DEBUG] 2024-06-15 07:10:34.704 CURL [132987362911616] (SSLDataIn) 5 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.704 CURL [132987362911616] (Text) TLSv1.3 (IN), TLS handshake, Server hello (2):
AWS: [DEBUG] 2024-06-15 07:10:34.704 CURL [132987362911616] (SSLDataIn) 122 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.704 CURL [132987362911616] (SSLDataIn) 5 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.704 CURL [132987362911616] (SSLDataIn) 5 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.704 CURL [132987362911616] (SSLDataIn) 1 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.704 CURL [132987362911616] (Text) TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
AWS: [DEBUG] 2024-06-15 07:10:34.704 CURL [132987362911616] (SSLDataIn) 19 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.704 CURL [132987362911616] (SSLDataIn) 5 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.704 CURL [132987362911616] (SSLDataIn) 1 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.704 CURL [132987362911616] (Text) TLSv1.3 (IN), TLS handshake, Certificate (11):
AWS: [DEBUG] 2024-06-15 07:10:34.704 CURL [132987362911616] (SSLDataIn) 2473 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.705 CURL [132987362911616] (SSLDataIn) 5 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.705 CURL [132987362911616] (SSLDataIn) 1 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.705 CURL [132987362911616] (Text) TLSv1.3 (IN), TLS handshake, CERT verify (15):
AWS: [DEBUG] 2024-06-15 07:10:34.705 CURL [132987362911616] (SSLDataIn) 79 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.705 CURL [132987362911616] (SSLDataIn) 5 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.848 CURL [132987362911616] (SSLDataIn) 1 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.848 CURL [132987362911616] (Text) TLSv1.3 (IN), TLS handshake, Finished (20):
AWS: [DEBUG] 2024-06-15 07:10:34.848 CURL [132987362911616] (SSLDataIn) 52 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.848 CURL [132987362911616] (SSLDataOut) 5 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.848 CURL [132987362911616] (Text) TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
AWS: [DEBUG] 2024-06-15 07:10:34.848 CURL [132987362911616] (SSLDataOut) 1 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.848 CURL [132987362911616] (SSLDataOut) 5 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.848 CURL [132987362911616] (SSLDataOut) 1 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.848 CURL [132987362911616] (Text) TLSv1.3 (OUT), TLS handshake, Finished (20):
AWS: [DEBUG] 2024-06-15 07:10:34.848 CURL [132987362911616] (SSLDataOut) 52 bytes
AWS: [DEBUG] 2024-06-15 07:10:34.848 CURL [132987362911616] (Text) SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / X25519 / id-ecPublicKey
```

</details>

*Issue #, if available:*

*Description of changes:* Simply changed the log level of SSL_DATA_{IN,OUT} to match DATA_{IN,OUT}

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.) I would be stunned if this were tested to begin with; it's just log output.
- [x] Checked if this PR is a breaking (APIs have been changed) change. No.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior. No.
- [x] Checked if this PR would require a ReadMe/Wiki update. No

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
