### PR TITLE
fix c++ 20 STD::Allocator Warning

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/memory/stl/AWSAllocator.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/memory/stl/AWSAllocator.h
@@ -71,7 +71,7 @@ namespace Aws
             return reinterpret_cast<Rawpointer>(Malloc("AWSSTL", n * sizeof(T)));
         }
 
-        void deallocate(Rawpointer p, size_type n)
+        void deallocate(RawPointer p, size_type n)
         {
             AWS_UNREFERENCED_PARAM(n);
 

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/memory/stl/AWSAllocator.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/memory/stl/AWSAllocator.h
@@ -62,14 +62,16 @@ namespace Aws
             typedef Allocator<U> other;
         };
 
-        typename Base::pointer allocate(size_type n, const void *hint = nullptr)
+        using RawPointer = typename std::allocator_traitsstd::allocator<T>>::pointer;
+
+        RawPointer allocate(size_type n, const void *hint = nullptr)
         {
             AWS_UNREFERENCED_PARAM(hint);
 
-            return reinterpret_cast<typename Base::pointer>(Malloc("AWSSTL", n * sizeof(T)));
+            return reinterpret_cast<Rawpointer>(Malloc("AWSSTL", n * sizeof(T)));
         }
 
-        void deallocate(typename Base::pointer p, size_type n)
+        void deallocate(Rawpointer p, size_type n)
         {
             AWS_UNREFERENCED_PARAM(n);
 

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/memory/stl/AWSAllocator.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/memory/stl/AWSAllocator.h
@@ -68,7 +68,7 @@ namespace Aws
         {
             AWS_UNREFERENCED_PARAM(hint);
 
-            return reinterpret_cast<Rawpointer>(Malloc("AWSSTL", n * sizeof(T)));
+            return reinterpret_cast<RawPointer>(Malloc("AWSSTL", n * sizeof(T)));
         }
 
         void deallocate(RawPointer p, size_type n)

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/memory/stl/AWSAllocator.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/memory/stl/AWSAllocator.h
@@ -62,7 +62,7 @@ namespace Aws
             typedef Allocator<U> other;
         };
 
-        using RawPointer = typename std::allocator_traitsstd::allocator<T>>::pointer;
+        using RawPointer = typename std::allocator_traits<std::allocator<T>>::pointer;
 
         RawPointer allocate(size_type n, const void *hint = nullptr)
         {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/issues/3001

*Description of changes:*
replace old and deprecated std::allocator. https://github.com/awslabs/aws-crt-cpp/pull/191/files
Similar PR in aws-crt-cpp: https://github.com/awslabs/aws-crt-cpp/pull/191 

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
