### PR TITLE
Fix TSan report around condvar in host resolver

### DIFF
--- a/src/aws-cpp-sdk-core/source/auth/GeneralHTTPCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/GeneralHTTPCredentialsProvider.cpp
@@ -121,7 +121,11 @@ bool GeneralHTTPCredentialsProvider::ShouldCreateGeneralHTTPProvider(const Aws::
                 shouldAllow = !addresses.empty();
                 hostResolved = true;
               }
-              hostResolverCV.notify_one();
+              else
+              {
+                std::unique_lock<std::mutex> lock(hostResolverMutex);
+                hostResolverCV.notify_one();
+              }
             };
           pHostResolver->ResolveHost(authority.c_str(), onHostResolved);
           std::unique_lock<std::mutex> lock(hostResolverMutex);

--- a/src/aws-cpp-sdk-core/source/auth/GeneralHTTPCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/GeneralHTTPCredentialsProvider.cpp
@@ -120,6 +120,7 @@ bool GeneralHTTPCredentialsProvider::ShouldCreateGeneralHTTPProvider(const Aws::
                 std::unique_lock<std::mutex> lock(hostResolverMutex);
                 shouldAllow = !addresses.empty();
                 hostResolved = true;
+                hostResolverCV.notify_one();
               }
               else
               {


### PR DESCRIPTION
*Description of changes:*

The issue was found by the ClickHouse continuous integration system here: https://github.com/ClickHouse/ClickHouse/pull/65362

This change fixes the following TSan report:
```
milovidov@milovidov-pc:~/work/ClickHouse/build_tsan$ AWS_CONTAINER_CREDENTIALS_FULL_URI=http://localhost:1338/latest/meta-data/container/security-credentials programs/clickhouse -q "select * from s3('http://localhost:11111/test/a.tsv')"
==================
WARNING: ThreadSanitizer: data race (pid=244838)
  Write of size 8 at 0x7ffc8aecf000 by main thread:
    #0 pthread_cond_destroy /home/milovidov/work/llvm-project/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1304:3 (clickhouse+0x7042510) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #1 std::__1::__libcpp_condvar_destroy[abi:v15000](pthread_cond_t*) build_tsan/./contrib/llvm-project/libcxx/include/__threading_support:346:10 (clickhouse+0x1ffd1039) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #2 std::__1::condition_variable::~condition_variable() build_tsan/./contrib/llvm-project/libcxx/src/condition_variable_destructor.cpp:42:5 (clickhouse+0x1ffd1039)
    #3 Aws::Auth::GeneralHTTPCredentialsProvider::ShouldCreateGeneralHTTPProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>) <null> (clickhouse+0x1ccae59f) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #4 decltype(std::declval<bool (*&)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>)>()(std::declval<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>(), std::declval<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>(), std::declval<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>())) std::__1::__invoke[abi:v15000]<bool (*&)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>(bool (*&)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x15a47560) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #5 bool std::__1::__invoke_void_return_wrapper<bool, false>::__call<bool (*&)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>(bool (*&)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/invoke.h:470:16 (clickhouse+0x15a47560)
    #6 std::__1::__function::__default_alloc_func<bool (*)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), bool (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>)>::operator()[abi:v15000](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x15a47560)
    #7 bool std::__1::__function::__policy_invoker<bool (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>)>::__call_impl<std::__1::__function::__default_alloc_func<bool (*)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), bool (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>)>>(std::__1::__function::__policy_storage const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x15a47560)
    #8 Aws::Auth::GeneralHTTPCredentialsProvider::GeneralHTTPCredentialsProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, long, std::__1::function<bool (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>)>) <null> (clickhouse+0x1ccaeded) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #9 Aws::Auth::GeneralHTTPCredentialsProvider::GeneralHTTPCredentialsProvider(char const*, char const*, long) build_tsan/./contrib/aws/src/aws-cpp-sdk-core/include/aws/core/auth/GeneralHTTPCredentialsProvider.h:77:17 (clickhouse+0x15a477d5) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #10 Aws::Auth::GeneralHTTPCredentialsProvider* std::__1::construct_at[abi:v15000]<Aws::Auth::GeneralHTTPCredentialsProvider, char const*, char const*, Aws::Auth::GeneralHTTPCredentialsProvider*>(Aws::Auth::GeneralHTTPCredentialsProvider*, char const*&&, char const*&&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:35:48 (clickhouse+0x15a3e39e) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #11 void std::__1::allocator_traits<std::__1::allocator<Aws::Auth::GeneralHTTPCredentialsProvider>>::construct[abi:v15000]<Aws::Auth::GeneralHTTPCredentialsProvider, char const*, char const*, void, void>(std::__1::allocator<Aws::Auth::GeneralHTTPCredentialsProvider>&, Aws::Auth::GeneralHTTPCredentialsProvider*, char const*&&, char const*&&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/allocator_traits.h:298:9 (clickhouse+0x15a3e39e)
    #12 std::__1::__shared_ptr_emplace<Aws::Auth::GeneralHTTPCredentialsProvider, std::__1::allocator<Aws::Auth::GeneralHTTPCredentialsProvider>>::__shared_ptr_emplace[abi:v15000]<char const*, char const*>(std::__1::allocator<Aws::Auth::GeneralHTTPCredentialsProvider>, char const*&&, char const*&&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:292:9 (clickhouse+0x15a3e39e)
    #13 std::__1::shared_ptr<Aws::Auth::GeneralHTTPCredentialsProvider> std::__1::allocate_shared[abi:v15000]<Aws::Auth::GeneralHTTPCredentialsProvider, std::__1::allocator<Aws::Auth::GeneralHTTPCredentialsProvider>, char const*, char const*, void>(std::__1::allocator<Aws::Auth::GeneralHTTPCredentialsProvider> const&, char const*&&, char const*&&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:953:55 (clickhouse+0x15a3e39e)
    #14 std::__1::shared_ptr<Aws::Auth::GeneralHTTPCredentialsProvider> std::__1::make_shared[abi:v15000]<Aws::Auth::GeneralHTTPCredentialsProvider, char const*, char const*, void>(char const*&&, char const*&&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:962:12 (clickhouse+0x15a3e39e)
    #15 DB::S3::S3CredentialsProviderChain::S3CredentialsProviderChain(DB::S3::PocoHTTPClientConfiguration const&, Aws::Auth::AWSCredentials const&, DB::S3::CredentialsConfiguration) build_tsan/./src/IO/S3/Credentials.cpp:736:25 (clickhouse+0x15a3e39e)
    #16 DB::S3::S3CredentialsProviderChain* std::__1::construct_at[abi:v15000]<DB::S3::S3CredentialsProviderChain, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials, DB::S3::CredentialsConfiguration&, DB::S3::S3CredentialsProviderChain*>(DB::S3::S3CredentialsProviderChain*, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials&&, DB::S3::CredentialsConfiguration&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:35:48 (clickhouse+0x159f6f74) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #17 void std::__1::allocator_traits<std::__1::allocator<DB::S3::S3CredentialsProviderChain>>::construct[abi:v15000]<DB::S3::S3CredentialsProviderChain, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials, DB::S3::CredentialsConfiguration&, void, void>(std::__1::allocator<DB::S3::S3CredentialsProviderChain>&, DB::S3::S3CredentialsProviderChain*, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials&&, DB::S3::CredentialsConfiguration&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/allocator_traits.h:298:9 (clickhouse+0x159f6f74)
    #18 std::__1::__shared_ptr_emplace<DB::S3::S3CredentialsProviderChain, std::__1::allocator<DB::S3::S3CredentialsProviderChain>>::__shared_ptr_emplace[abi:v15000]<DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials, DB::S3::CredentialsConfiguration&>(std::__1::allocator<DB::S3::S3CredentialsProviderChain>, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials&&, DB::S3::CredentialsConfiguration&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:292:9 (clickhouse+0x159f6f74)
    #19 std::__1::shared_ptr<DB::S3::S3CredentialsProviderChain> std::__1::allocate_shared[abi:v15000]<DB::S3::S3CredentialsProviderChain, std::__1::allocator<DB::S3::S3CredentialsProviderChain>, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials, DB::S3::CredentialsConfiguration&, void>(std::__1::allocator<DB::S3::S3CredentialsProviderChain> const&, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials&&, DB::S3::CredentialsConfiguration&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:953:55 (clickhouse+0x159f6f74)
    #20 std::__1::shared_ptr<DB::S3::S3CredentialsProviderChain> std::__1::make_shared[abi:v15000]<DB::S3::S3CredentialsProviderChain, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials, DB::S3::CredentialsConfiguration&, void>(DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials&&, DB::S3::CredentialsConfiguration&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:962:12 (clickhouse+0x159f6f74)
    #21 DB::S3::ClientFactory::create(DB::S3::PocoHTTPClientConfiguration const&, DB::S3::ClientSettings, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, DB::S3::ServerSideEncryptionKMSConfig, std::__1::vector<DB::HTTPHeaderEntry, std::__1::allocator<DB::HTTPHeaderEntry>>, DB::S3::CredentialsConfiguration, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) build_tsan/./src/IO/S3/Client.cpp:930:33 (clickhouse+0x159f6f74)
    #22 DB::getClient(DB::S3::URI const&, DB::S3ObjectStorageSettings const&, std::__1::shared_ptr<DB::Context const>, bool) build_tsan/./src/Disks/ObjectStorages/S3/diskSettings.cpp:130:42 (clickhouse+0x15ac2a8e) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #23 DB::StorageS3Configuration::createObjectStorage(std::__1::shared_ptr<DB::Context const>, bool) build_tsan/./src/Storages/ObjectStorage/S3/Configuration.cpp:129:19 (clickhouse+0x1590c132) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #24 DB::TableFunctionObjectStorage<DB::S3Definition, DB::StorageS3Configuration>::getObjectStorage(std::__1::shared_ptr<DB::Context const> const&, bool) const build_tsan/./src/TableFunctions/TableFunctionObjectStorage.cpp:35:41 (clickhouse+0x14fb003f) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #25 DB::TableFunctionObjectStorage<DB::S3Definition, DB::StorageS3Configuration>::executeImpl(std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::Context const>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, DB::ColumnsDescription, bool) const build_tsan/./src/TableFunctions/TableFunctionObjectStorage.cpp:113:9 (clickhouse+0x14fb003f)
    #26 DB::ITableFunction::execute(std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::Context const>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, DB::ColumnsDescription, bool, bool) const build_tsan/./src/TableFunctions/ITableFunction.cpp:37:16 (clickhouse+0x157cac9d) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #27 DB::Context::executeTableFunction(std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::ITableFunction> const&) build_tsan/./src/Interpreters/Context.cpp:2108:35 (clickhouse+0x168f7520) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #28 DB::QueryAnalyzer::resolveTableFunction(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, DB::QueryExpressionsAliasVisitor&, bool) build_tsan/./src/Analyzer/Resolve/QueryAnalyzer.cpp:4758:69 (clickhouse+0x173c477f) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #29 DB::QueryAnalyzer::resolveQueryJoinTreeNode(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, DB::QueryExpressionsAliasVisitor&) build_tsan/./src/Analyzer/Resolve/QueryAnalyzer.cpp:5099:13 (clickhouse+0x173f38d8) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #30 DB::QueryAnalyzer::resolveQuery(std::__1::shared_ptr<DB::IQueryTreeNode> const&, DB::IdentifierResolveScope&) build_tsan/./src/Analyzer/Resolve/QueryAnalyzer.cpp:5349:9 (clickhouse+0x173b71ef) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #31 DB::QueryAnalyzer::resolve(std::__1::shared_ptr<DB::IQueryTreeNode>&, std::__1::shared_ptr<DB::IQueryTreeNode> const&, std::__1::shared_ptr<DB::Context const>) build_tsan/./src/Analyzer/Resolve/QueryAnalyzer.cpp:133:13 (clickhouse+0x173b6146) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #32 DB::QueryAnalysisPass::run(std::__1::shared_ptr<DB::IQueryTreeNode>&, std::__1::shared_ptr<DB::Context const>) build_tsan/./src/Analyzer/Resolve/QueryAnalysisPass.cpp:18:14 (clickhouse+0x173b5521) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #33 DB::QueryTreePassManager::run(std::__1::shared_ptr<DB::IQueryTreeNode>) build_tsan/./src/Analyzer/QueryTreePassManager.cpp:185:20 (clickhouse+0x173b0386) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #34 DB::(anonymous namespace)::buildQueryTreeAndRunPasses(std::__1::shared_ptr<DB::IAST> const&, DB::SelectQueryOptions const&, std::__1::shared_ptr<DB::Context const> const&, std::__1::shared_ptr<DB::IStorage> const&) build_tsan/./src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:142:33 (clickhouse+0x1784eb26) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #35 DB::InterpreterSelectQueryAnalyzer::InterpreterSelectQueryAnalyzer(std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::Context const> const&, DB::SelectQueryOptions const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) build_tsan/./src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:160:18 (clickhouse+0x1784beff) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #36 std::__1::__unique_if<DB::InterpreterSelectQueryAnalyzer>::__unique_single std::__1::make_unique[abi:v15000]<DB::InterpreterSelectQueryAnalyzer, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::Context> const&, DB::SelectQueryOptions const&>(std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::Context> const&, DB::SelectQueryOptions const&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:714:32 (clickhouse+0x178507cf) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #37 DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0::operator()(DB::InterpreterFactory::Arguments const&) const build_tsan/./src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:270:16 (clickhouse+0x178507cf)
    #38 decltype(std::declval<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&>()(std::declval<DB::InterpreterFactory::Arguments const&>())) std::__1::__invoke[abi:v15000]<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&, DB::InterpreterFactory::Arguments const&>(DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&, DB::InterpreterFactory::Arguments const&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x178507cf)
    #39 std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> std::__1::__invoke_void_return_wrapper<std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>>, false>::__call<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&, DB::InterpreterFactory::Arguments const&>(DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&, DB::InterpreterFactory::Arguments const&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/invoke.h:470:16 (clickhouse+0x178507cf)
    #40 std::__1::__function::__default_alloc_func<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0, std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>::operator()[abi:v15000](DB::InterpreterFactory::Arguments const&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x178507cf)
    #41 std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> std::__1::__function::__policy_invoker<std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>::__call_impl<std::__1::__function::__default_alloc_func<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0, std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>>(std::__1::__function::__policy_storage const*, DB::InterpreterFactory::Arguments const&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x178507cf)
    #42 std::__1::__function::__policy_func<std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>::operator()[abi:v15000](DB::InterpreterFactory::Arguments const&) const build_tsan/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x177bd9ed) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #43 std::__1::function<std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>::operator()(DB::InterpreterFactory::Arguments const&) const build_tsan/./contrib/llvm-project/libcxx/include/__functional/function.h:1187:12 (clickhouse+0x177bd9ed)
    #44 DB::InterpreterFactory::get(std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::Context>, DB::SelectQueryOptions const&) build_tsan/./src/Interpreters/InterpreterFactory.cpp:355:12 (clickhouse+0x177bd9ed)
    #45 DB::executeQueryImpl(char const*, char const*, std::__1::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum, DB::ReadBuffer*) build_tsan/./src/Interpreters/executeQuery.cpp:1161:62 (clickhouse+0x17d9dba4) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #46 DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum) build_tsan/./src/Interpreters/executeQuery.cpp:1391:26 (clickhouse+0x17d99935) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #47 DB::LocalConnection::sendQuery(DB::ConnectionTimeouts const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, DB::Settings const*, DB::ClientInfo const*, bool, std::__1::function<void (DB::Progress const&)>) build_tsan/./src/Client/LocalConnection.cpp:194:21 (clickhouse+0x19496837) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #48 DB::ClientBase::processOrdinaryQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::IAST>) build_tsan/./src/Client/ClientBase.cpp:1079:25 (clickhouse+0x194115ea) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #49 DB::ClientBase::processParsedSingleQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::IAST>, std::__1::optional<bool>, bool) build_tsan/./src/Client/ClientBase.cpp:1998:13 (clickhouse+0x1940fb0c) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #50 DB::ClientBase::processTextAsSingleQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) build_tsan/./src/Client/ClientBase.cpp:957:9 (clickhouse+0x1940e5d6) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #51 DB::ClientBase::processQueryText(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) build_tsan/./src/Client/ClientBase.cpp:2403:9 (clickhouse+0x1941d503) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #52 DB::ClientBase::runNonInteractive() build_tsan/./src/Client/ClientBase.cpp:2722:22 (clickhouse+0x194216ba) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #53 DB::LocalServer::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) build_tsan/./programs/local/LocalServer.cpp:522:9 (clickhouse+0xefb2bb6) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #54 Poco::Util::Application::run() build_tsan/./base/poco/Util/src/Application.cpp:315:8 (clickhouse+0x1cbc593e) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #55 mainEntryClickHouseLocal(int, char**) build_tsan/./programs/local/LocalServer.cpp:906:20 (clickhouse+0xefbf470) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #56 main build_tsan/./programs/main.cpp:502:21 (clickhouse+0x70cc489) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)

  Previous read of size 8 at 0x7ffc8aecf000 by thread T3:
    #0 pthread_cond_signal /home/milovidov/work/llvm-project/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1290:3 (clickhouse+0x70421aa) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #1 std::__1::__libcpp_condvar_signal[abi:v15000](pthread_cond_t*) build_tsan/./contrib/llvm-project/libcxx/include/__threading_support:325:10 (clickhouse+0x1ffd0d39) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #2 std::__1::condition_variable::notify_one() build_tsan/./contrib/llvm-project/libcxx/src/condition_variable.cpp:31:5 (clickhouse+0x1ffd0d39)
    #3 void std::__1::__function::__policy_invoker<void (Aws::Crt::Io::HostResolver&, std::__1::vector<aws_host_address, Aws::Crt::StlAllocator<aws_host_address>> const&, int)>::__call_impl<std::__1::__function::__default_alloc_func<Aws::Auth::GeneralHTTPCredentialsProvider::ShouldCreateGeneralHTTPProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>)::$_0, void (Aws::Crt::Io::HostResolver&, std::__1::vector<aws_host_address, Aws::Crt::StlAllocator<aws_host_address>> const&, int)>>(std::__1::__function::__policy_storage const*, Aws::Crt::Io::HostResolver&, std::__1::vector<aws_host_address, Aws::Crt::StlAllocator<aws_host_address>> const&, int) GeneralHTTPCredentialsProvider.cpp (clickhouse+0x1ccb1e0b) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #4 Aws::Crt::Io::DefaultHostResolver::s_onHostResolved(aws_host_resolver*, aws_string const*, int, aws_array_list const*, void*) <null> (clickhouse+0x1d005b1e) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #5 aws_host_resolver_thread host_resolver.c (clickhouse+0x1d00285c) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #6 thread_fn thread.c (clickhouse+0x1cfa0adc) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)

  Location is stack of main thread.

  Location is global '??' at 0x7ffc8aebf000 ([stack]+0x10000)

  Thread T3 (tid=244842, running) created by main thread at:
    #0 pthread_create /home/milovidov/work/llvm-project/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1023:3 (clickhouse+0x7040be1) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #1 aws_thread_launch <null> (clickhouse+0x1cfa0836) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #2 default_resolve_host host_resolver.c (clickhouse+0x1d00032b) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #3 aws_host_resolver_resolve_host <null> (clickhouse+0x1cffef2f) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #4 Aws::Crt::Io::DefaultHostResolver::ResolveHost(std::__1::basic_string<char, std::__1::char_traits<char>, Aws::Crt::StlAllocator<char>> const&, std::__1::function<void (Aws::Crt::Io::HostResolver&, std::__1::vector<aws_host_address, Aws::Crt::StlAllocator<aws_host_address>> const&, int)> const&) <null> (clickhouse+0x1d00600e) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #5 Aws::Auth::GeneralHTTPCredentialsProvider::ShouldCreateGeneralHTTPProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>) <null> (clickhouse+0x1ccae4e2) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #6 decltype(std::declval<bool (*&)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>)>()(std::declval<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>(), std::declval<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>(), std::declval<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>())) std::__1::__invoke[abi:v15000]<bool (*&)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>(bool (*&)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x15a47560) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #7 bool std::__1::__invoke_void_return_wrapper<bool, false>::__call<bool (*&)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>(bool (*&)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/invoke.h:470:16 (clickhouse+0x15a47560)
    #8 std::__1::__function::__default_alloc_func<bool (*)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), bool (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>)>::operator()[abi:v15000](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x15a47560)
    #9 bool std::__1::__function::__policy_invoker<bool (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>)>::__call_impl<std::__1::__function::__default_alloc_func<bool (*)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), bool (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>)>>(std::__1::__function::__policy_storage const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x15a47560)
    #10 Aws::Auth::GeneralHTTPCredentialsProvider::GeneralHTTPCredentialsProvider(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, long, std::__1::function<bool (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>)>) <null> (clickhouse+0x1ccaeded) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #11 Aws::Auth::GeneralHTTPCredentialsProvider::GeneralHTTPCredentialsProvider(char const*, char const*, long) build_tsan/./contrib/aws/src/aws-cpp-sdk-core/include/aws/core/auth/GeneralHTTPCredentialsProvider.h:77:17 (clickhouse+0x15a477d5) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #12 Aws::Auth::GeneralHTTPCredentialsProvider* std::__1::construct_at[abi:v15000]<Aws::Auth::GeneralHTTPCredentialsProvider, char const*, char const*, Aws::Auth::GeneralHTTPCredentialsProvider*>(Aws::Auth::GeneralHTTPCredentialsProvider*, char const*&&, char const*&&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:35:48 (clickhouse+0x15a3e39e) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #13 void std::__1::allocator_traits<std::__1::allocator<Aws::Auth::GeneralHTTPCredentialsProvider>>::construct[abi:v15000]<Aws::Auth::GeneralHTTPCredentialsProvider, char const*, char const*, void, void>(std::__1::allocator<Aws::Auth::GeneralHTTPCredentialsProvider>&, Aws::Auth::GeneralHTTPCredentialsProvider*, char const*&&, char const*&&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/allocator_traits.h:298:9 (clickhouse+0x15a3e39e)
    #14 std::__1::__shared_ptr_emplace<Aws::Auth::GeneralHTTPCredentialsProvider, std::__1::allocator<Aws::Auth::GeneralHTTPCredentialsProvider>>::__shared_ptr_emplace[abi:v15000]<char const*, char const*>(std::__1::allocator<Aws::Auth::GeneralHTTPCredentialsProvider>, char const*&&, char const*&&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:292:9 (clickhouse+0x15a3e39e)
    #15 std::__1::shared_ptr<Aws::Auth::GeneralHTTPCredentialsProvider> std::__1::allocate_shared[abi:v15000]<Aws::Auth::GeneralHTTPCredentialsProvider, std::__1::allocator<Aws::Auth::GeneralHTTPCredentialsProvider>, char const*, char const*, void>(std::__1::allocator<Aws::Auth::GeneralHTTPCredentialsProvider> const&, char const*&&, char const*&&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:953:55 (clickhouse+0x15a3e39e)
    #16 std::__1::shared_ptr<Aws::Auth::GeneralHTTPCredentialsProvider> std::__1::make_shared[abi:v15000]<Aws::Auth::GeneralHTTPCredentialsProvider, char const*, char const*, void>(char const*&&, char const*&&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:962:12 (clickhouse+0x15a3e39e)
    #17 DB::S3::S3CredentialsProviderChain::S3CredentialsProviderChain(DB::S3::PocoHTTPClientConfiguration const&, Aws::Auth::AWSCredentials const&, DB::S3::CredentialsConfiguration) build_tsan/./src/IO/S3/Credentials.cpp:736:25 (clickhouse+0x15a3e39e)
    #18 DB::S3::S3CredentialsProviderChain* std::__1::construct_at[abi:v15000]<DB::S3::S3CredentialsProviderChain, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials, DB::S3::CredentialsConfiguration&, DB::S3::S3CredentialsProviderChain*>(DB::S3::S3CredentialsProviderChain*, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials&&, DB::S3::CredentialsConfiguration&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:35:48 (clickhouse+0x159f6f74) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #19 void std::__1::allocator_traits<std::__1::allocator<DB::S3::S3CredentialsProviderChain>>::construct[abi:v15000]<DB::S3::S3CredentialsProviderChain, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials, DB::S3::CredentialsConfiguration&, void, void>(std::__1::allocator<DB::S3::S3CredentialsProviderChain>&, DB::S3::S3CredentialsProviderChain*, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials&&, DB::S3::CredentialsConfiguration&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/allocator_traits.h:298:9 (clickhouse+0x159f6f74)
    #20 std::__1::__shared_ptr_emplace<DB::S3::S3CredentialsProviderChain, std::__1::allocator<DB::S3::S3CredentialsProviderChain>>::__shared_ptr_emplace[abi:v15000]<DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials, DB::S3::CredentialsConfiguration&>(std::__1::allocator<DB::S3::S3CredentialsProviderChain>, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials&&, DB::S3::CredentialsConfiguration&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:292:9 (clickhouse+0x159f6f74)
    #21 std::__1::shared_ptr<DB::S3::S3CredentialsProviderChain> std::__1::allocate_shared[abi:v15000]<DB::S3::S3CredentialsProviderChain, std::__1::allocator<DB::S3::S3CredentialsProviderChain>, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials, DB::S3::CredentialsConfiguration&, void>(std::__1::allocator<DB::S3::S3CredentialsProviderChain> const&, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials&&, DB::S3::CredentialsConfiguration&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:953:55 (clickhouse+0x159f6f74)
    #22 std::__1::shared_ptr<DB::S3::S3CredentialsProviderChain> std::__1::make_shared[abi:v15000]<DB::S3::S3CredentialsProviderChain, DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials, DB::S3::CredentialsConfiguration&, void>(DB::S3::PocoHTTPClientConfiguration&, Aws::Auth::AWSCredentials&&, DB::S3::CredentialsConfiguration&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:962:12 (clickhouse+0x159f6f74)
    #23 DB::S3::ClientFactory::create(DB::S3::PocoHTTPClientConfiguration const&, DB::S3::ClientSettings, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, DB::S3::ServerSideEncryptionKMSConfig, std::__1::vector<DB::HTTPHeaderEntry, std::__1::allocator<DB::HTTPHeaderEntry>>, DB::S3::CredentialsConfiguration, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) build_tsan/./src/IO/S3/Client.cpp:930:33 (clickhouse+0x159f6f74)
    #24 DB::getClient(DB::S3::URI const&, DB::S3ObjectStorageSettings const&, std::__1::shared_ptr<DB::Context const>, bool) build_tsan/./src/Disks/ObjectStorages/S3/diskSettings.cpp:130:42 (clickhouse+0x15ac2a8e) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #25 DB::StorageS3Configuration::createObjectStorage(std::__1::shared_ptr<DB::Context const>, bool) build_tsan/./src/Storages/ObjectStorage/S3/Configuration.cpp:129:19 (clickhouse+0x1590c132) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #26 DB::TableFunctionObjectStorage<DB::S3Definition, DB::StorageS3Configuration>::getObjectStorage(std::__1::shared_ptr<DB::Context const> const&, bool) const build_tsan/./src/TableFunctions/TableFunctionObjectStorage.cpp:35:41 (clickhouse+0x14fb003f) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #27 DB::TableFunctionObjectStorage<DB::S3Definition, DB::StorageS3Configuration>::executeImpl(std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::Context const>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, DB::ColumnsDescription, bool) const build_tsan/./src/TableFunctions/TableFunctionObjectStorage.cpp:113:9 (clickhouse+0x14fb003f)
    #28 DB::ITableFunction::execute(std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::Context const>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, DB::ColumnsDescription, bool, bool) const build_tsan/./src/TableFunctions/ITableFunction.cpp:37:16 (clickhouse+0x157cac9d) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #29 DB::Context::executeTableFunction(std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::ITableFunction> const&) build_tsan/./src/Interpreters/Context.cpp:2108:35 (clickhouse+0x168f7520) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #30 DB::QueryAnalyzer::resolveTableFunction(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, DB::QueryExpressionsAliasVisitor&, bool) build_tsan/./src/Analyzer/Resolve/QueryAnalyzer.cpp:4758:69 (clickhouse+0x173c477f) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #31 DB::QueryAnalyzer::resolveQueryJoinTreeNode(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, DB::QueryExpressionsAliasVisitor&) build_tsan/./src/Analyzer/Resolve/QueryAnalyzer.cpp:5099:13 (clickhouse+0x173f38d8) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #32 DB::QueryAnalyzer::resolveQuery(std::__1::shared_ptr<DB::IQueryTreeNode> const&, DB::IdentifierResolveScope&) build_tsan/./src/Analyzer/Resolve/QueryAnalyzer.cpp:5349:9 (clickhouse+0x173b71ef) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #33 DB::QueryAnalyzer::resolve(std::__1::shared_ptr<DB::IQueryTreeNode>&, std::__1::shared_ptr<DB::IQueryTreeNode> const&, std::__1::shared_ptr<DB::Context const>) build_tsan/./src/Analyzer/Resolve/QueryAnalyzer.cpp:133:13 (clickhouse+0x173b6146) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #34 DB::QueryAnalysisPass::run(std::__1::shared_ptr<DB::IQueryTreeNode>&, std::__1::shared_ptr<DB::Context const>) build_tsan/./src/Analyzer/Resolve/QueryAnalysisPass.cpp:18:14 (clickhouse+0x173b5521) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #35 DB::QueryTreePassManager::run(std::__1::shared_ptr<DB::IQueryTreeNode>) build_tsan/./src/Analyzer/QueryTreePassManager.cpp:185:20 (clickhouse+0x173b0386) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #36 DB::(anonymous namespace)::buildQueryTreeAndRunPasses(std::__1::shared_ptr<DB::IAST> const&, DB::SelectQueryOptions const&, std::__1::shared_ptr<DB::Context const> const&, std::__1::shared_ptr<DB::IStorage> const&) build_tsan/./src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:142:33 (clickhouse+0x1784eb26) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #37 DB::InterpreterSelectQueryAnalyzer::InterpreterSelectQueryAnalyzer(std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::Context const> const&, DB::SelectQueryOptions const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) build_tsan/./src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:160:18 (clickhouse+0x1784beff) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #38 std::__1::__unique_if<DB::InterpreterSelectQueryAnalyzer>::__unique_single std::__1::make_unique[abi:v15000]<DB::InterpreterSelectQueryAnalyzer, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::Context> const&, DB::SelectQueryOptions const&>(std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::Context> const&, DB::SelectQueryOptions const&) build_tsan/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:714:32 (clickhouse+0x178507cf) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #39 DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0::operator()(DB::InterpreterFactory::Arguments const&) const build_tsan/./src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:270:16 (clickhouse+0x178507cf)
    #40 decltype(std::declval<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&>()(std::declval<DB::InterpreterFactory::Arguments const&>())) std::__1::__invoke[abi:v15000]<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&, DB::InterpreterFactory::Arguments const&>(DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&, DB::InterpreterFactory::Arguments const&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x178507cf)
    #41 std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> std::__1::__invoke_void_return_wrapper<std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>>, false>::__call<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&, DB::InterpreterFactory::Arguments const&>(DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&, DB::InterpreterFactory::Arguments const&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/invoke.h:470:16 (clickhouse+0x178507cf)
    #42 std::__1::__function::__default_alloc_func<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0, std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>::operator()[abi:v15000](DB::InterpreterFactory::Arguments const&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x178507cf)
    #43 std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> std::__1::__function::__policy_invoker<std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>::__call_impl<std::__1::__function::__default_alloc_func<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0, std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>>(std::__1::__function::__policy_storage const*, DB::InterpreterFactory::Arguments const&) build_tsan/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x178507cf)
    #44 std::__1::__function::__policy_func<std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>::operator()[abi:v15000](DB::InterpreterFactory::Arguments const&) const build_tsan/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x177bd9ed) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #45 std::__1::function<std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>::operator()(DB::InterpreterFactory::Arguments const&) const build_tsan/./contrib/llvm-project/libcxx/include/__functional/function.h:1187:12 (clickhouse+0x177bd9ed)
    #46 DB::InterpreterFactory::get(std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::Context>, DB::SelectQueryOptions const&) build_tsan/./src/Interpreters/InterpreterFactory.cpp:355:12 (clickhouse+0x177bd9ed)
    #47 DB::executeQueryImpl(char const*, char const*, std::__1::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum, DB::ReadBuffer*) build_tsan/./src/Interpreters/executeQuery.cpp:1161:62 (clickhouse+0x17d9dba4) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #48 DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum) build_tsan/./src/Interpreters/executeQuery.cpp:1391:26 (clickhouse+0x17d99935) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #49 DB::LocalConnection::sendQuery(DB::ConnectionTimeouts const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, DB::Settings const*, DB::ClientInfo const*, bool, std::__1::function<void (DB::Progress const&)>) build_tsan/./src/Client/LocalConnection.cpp:194:21 (clickhouse+0x19496837) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #50 DB::ClientBase::processOrdinaryQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::IAST>) build_tsan/./src/Client/ClientBase.cpp:1079:25 (clickhouse+0x194115ea) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #51 DB::ClientBase::processParsedSingleQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::IAST>, std::__1::optional<bool>, bool) build_tsan/./src/Client/ClientBase.cpp:1998:13 (clickhouse+0x1940fb0c) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #52 DB::ClientBase::processTextAsSingleQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) build_tsan/./src/Client/ClientBase.cpp:957:9 (clickhouse+0x1940e5d6) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #53 DB::ClientBase::processQueryText(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) build_tsan/./src/Client/ClientBase.cpp:2403:9 (clickhouse+0x1941d503) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #54 DB::ClientBase::runNonInteractive() build_tsan/./src/Client/ClientBase.cpp:2722:22 (clickhouse+0x194216ba) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #55 DB::LocalServer::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) build_tsan/./programs/local/LocalServer.cpp:522:9 (clickhouse+0xefb2bb6) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #56 Poco::Util::Application::run() build_tsan/./base/poco/Util/src/Application.cpp:315:8 (clickhouse+0x1cbc593e) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #57 mainEntryClickHouseLocal(int, char**) build_tsan/./programs/local/LocalServer.cpp:906:20 (clickhouse+0xefbf470) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)
    #58 main build_tsan/./programs/main.cpp:502:21 (clickhouse+0x70cc489) (BuildId: d3f1330967f47c42665b533966f0e0ef20af4e61)

SUMMARY: ThreadSanitizer: data race build_tsan/./contrib/llvm-project/libcxx/include/__threading_support:346:10 in std::__1::__libcpp_condvar_destroy[abi:v15000](pthread_cond_t*)
==================
1       2       3
4       5       6
ThreadSanitizer: reported 1 warnings
```

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
