### PR TITLE
Aes update

### DIFF
--- a/prefetch_crt_dependency.sh
+++ b/prefetch_crt_dependency.sh
@@ -3,21 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 CRT_URI_PREFIX=https://codeload.github.com/awslabs
-CRT_URI=${CRT_URI_PREFIX}/aws-crt-cpp/zip/c5f770b59e27fdf62b599f24bfbe6d135820a07f  # v0.26.9
+CRT_URI=${CRT_URI_PREFIX}/aws-crt-cpp/zip/4d78af94182f39123f8b384158f143485906ea82  # v0.27.0
 
-AWS_C_AUTH_URI=${CRT_URI_PREFIX}/aws-c-auth/zip/0d2aa00ae70c699fcb14d0338c1b07a58b9eb24b  # v0.7.16
-AWS_C_CAL_URI=${CRT_URI_PREFIX}/aws-c-cal/zip/96c47e339d030d1fa4eaca201be948bc4442510d  # v0.6.14
-AWS_C_COMMON_URI=${CRT_URI_PREFIX}/aws-c-common/zip/ae7b067d9274d2d3faa1d3ae42d489a6986661f7  # v0.9.15
+AWS_C_AUTH_URI=${CRT_URI_PREFIX}/aws-c-auth/zip/53a31bacf2918e848e00b052d2e25cba0be069d9  # v0.7.22
+AWS_C_CAL_URI=${CRT_URI_PREFIX}/aws-c-cal/zip/11fc68445b2b4993656ed720fc2788f3c4c7c20f  # v0.7.0
+AWS_C_COMMON_URI=${CRT_URI_PREFIX}/aws-c-common/zip/4f874cea50a70bc6ebcd85c6ce1c6c0016b5aff4  # v0.9.21
 AWS_C_COMPRESSION_URI=${CRT_URI_PREFIX}/aws-c-compression/zip/ea1d421a421ad83a540309a94c38d50b6a5d836b  # v0.2.18
 AWS_C_EVENT_STREAM_URI=${CRT_URI_PREFIX}/aws-c-event-stream/zip/1a70c50f78a6e706f1f91a4ed138478271b6d9d3  # v0.4.2
-AWS_C_HTTP_URI=${CRT_URI_PREFIX}/aws-c-http/zip/98ec73ad0c18b78ba08d40b4e60d97abf794f24d  # v0.8.1
-AWS_C_IO_URI=${CRT_URI_PREFIX}/aws-c-io/zip/bf2d72230727f02eddb5b16c4e6c5ac5a3f203a7  # v0.14.7
-AWS_C_MQTT_URI=${CRT_URI_PREFIX}/aws-c-mqtt/zip/74da9cadfa9dfd2179479fdc445617f5da3261ba  # v0.10.3
-AWS_C_S3_URI=${CRT_URI_PREFIX}/aws-c-s3/zip/0ce756ec29b251cd81f6937ccf856a3878c5edd3  # v0.5.5
-AWS_C_SDKUTILS_URI=${CRT_URI_PREFIX}/aws-c-sdkutils/zip/638fdd6548df85c599f82db7ea70fd9e44917ef5  # v0.1.15
+AWS_C_HTTP_URI=${CRT_URI_PREFIX}/aws-c-http/zip/d83f8d70143ddce5ab4e479175fbd44ba994211b  # v0.8.2
+AWS_C_IO_URI=${CRT_URI_PREFIX}/aws-c-io/zip/878b4fa027bda4041493f06e0562d5e98bb3deb8  # v0.14.9
+AWS_C_MQTT_URI=${CRT_URI_PREFIX}/aws-c-mqtt/zip/ed7bbd68c03d7022c915a2924740ab7992ad2311  # v0.10.4
+AWS_C_S3_URI=${CRT_URI_PREFIX}/aws-c-s3/zip/6588f9a714ee7a8be1bddd63ea5ea1ea224d00b4  # v0.5.10
+AWS_C_SDKUTILS_URI=${CRT_URI_PREFIX}/aws-c-sdkutils/zip/8c7af71f91ed5b9d2a043d51f120495f43723f80  # v0.1.16
 AWS_CHECKSUMS_URI=${CRT_URI_PREFIX}/aws-checksums/zip/aac442a2dbbb5e72d0a3eca8313cf65e7e1cac2f  # v0.1.18
-AWS_LC_URI=${CRT_URI_PREFIX}/aws-lc/zip/4e690737e0a386f8c5eb9a0a88becc7985b5d24e  # v1.23.0
-S2N_URI=${CRT_URI_PREFIX}/s2n/zip/171c96a232eb2bf45415340378b55b3bb6dd29cd  # v1.4.11
+AWS_LC_URI=${CRT_URI_PREFIX}/aws-lc/zip/4e54dd8363396f257d7a2317c48101e18170e6fb  # v1.29.0
+S2N_URI=${CRT_URI_PREFIX}/s2n/zip/114ccab0ff2cde491203ac841837d0d39b767412  # v1.4.16
 
 
 echo "Removing CRT"

--- a/src/aws-cpp-sdk-core/source/utils/crypto/crt/CRTSymmetricCipher.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/crypto/crt/CRTSymmetricCipher.cpp
@@ -85,7 +85,9 @@ namespace Aws
 
             void CRTSymmetricCipher::Reset()
             {
+                m_lastFetchedTag = GetTag();
                 m_cipher.Reset();
+                m_cipher.SetTag(Crt::ByteCursorFromArray(m_lastFetchedTag.GetUnderlyingData(), m_lastFetchedTag.GetLength()));
             }
 
             bool CRTSymmetricCipher::Good() const

--- a/tests/aws-cpp-sdk-cloudfront-integration-tests/CloudfrontKeyValueStoreTest.cpp
+++ b/tests/aws-cpp-sdk-cloudfront-integration-tests/CloudfrontKeyValueStoreTest.cpp
@@ -15,7 +15,8 @@
 
 #define TEST_PREFIX "IntegrationTest_"
 
-class CloudfrontKeyValueStoreTest : public ::testing::Test
+//Test takes ~15 minutes, it is a manual test.
+class DISABLED_CloudfrontKeyValueStoreTest : public ::testing::Test
 {
 
 public:
@@ -30,9 +31,8 @@ protected:
     }
 };
 
-TEST_F(CloudfrontKeyValueStoreTest, TestListKeysUsesSigV4A)
+TEST_F(DISABLED_CloudfrontKeyValueStoreTest, TestListKeysUsesSigV4A)
 {
-  GTEST_SKIP() << "Test takes ~15 minutes, it is a manual test.";
 
   Aws::String kvsArn;
 

--- a/tests/aws-cpp-sdk-core-tests/utils/crypto/SymmetricCiphersTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/crypto/SymmetricCiphersTest.cpp
@@ -270,10 +270,10 @@ TEST_F(AES_GCM_TEST, TestBadTagCausesFailure)
     ASSERT_TRUE(*cipher);
 
     const_cast<CryptoBuffer&>(cipher->GetTag())[8] = 0;
-
     cipher->Reset();
     auto decryptResult = cipher->DecryptBuffer(encryptedResult);
     auto finalDecryptBuffer = cipher->FinalizeDecryption();
+    ASSERT_FALSE(*cipher);
     ASSERT_EQ(0u, finalDecryptBuffer.GetLength());
 }
 


### PR DESCRIPTION
*Issue #, if available:*

[issues/3012](https://github.com/aws/aws-sdk-cpp/issues/3012)

*Description of changes:*

The CRT made changes to c-cal and CRT for stability and correctness that were not backwards compatible, this updates the call pattern.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
