### PR TITLE
Receive, parse, and present http2 connection headers to the user callback

### DIFF
--- a/generated/src/aws-cpp-sdk-lambda/include/aws/lambda/model/InvokeWithResponseStreamHandler.h
+++ b/generated/src/aws-cpp-sdk-lambda/include/aws/lambda/model/InvokeWithResponseStreamHandler.h
@@ -31,6 +31,7 @@ namespace Model
     class InvokeWithResponseStreamHandler : public Aws::Utils::Event::EventStreamHandler
     {
         typedef std::function<void(const InvokeWithResponseStreamInitialResponse&)> InvokeWithResponseStreamInitialResponseCallback;
+        typedef std::function<void(const InvokeWithResponseStreamInitialResponse&, const Utils::Event::InitialResponseType)> InvokeWithResponseStreamInitialResponseCallbackEx;
         typedef std::function<void(const InvokeResponseStreamUpdate&)> InvokeResponseStreamUpdateCallback;
         typedef std::function<void(const InvokeWithResponseStreamCompleteEvent&)> InvokeWithResponseStreamCompleteEventCallback;
         typedef std::function<void(const Aws::Client::AWSError<LambdaErrors>& error)> ErrorCallback;
@@ -41,17 +42,34 @@ namespace Model
 
         AWS_LAMBDA_API virtual void OnEvent() override;
 
-        inline void SetInitialResponseCallback(const InvokeWithResponseStreamInitialResponseCallback& callback) { m_onInitialResponse = callback; }
+        ///@{
+        /**
+         * Sets an initial response callback. This callback gets called on the initial InvokeWithResponseStream Operation response.
+         *   This can be either "initial-response" decoded event frame or decoded HTTP headers received on connection.
+         *   This callback may get called more than once (i.e. on connection headers received and then on the initial-response event received).
+         * @param callback
+         */
+        inline void SetInitialResponseCallbackEx(const InvokeWithResponseStreamInitialResponseCallbackEx& callback) { m_onInitialResponse = callback; }
+        /**
+         * Sets an initial response callback (a legacy one that does not distinguish whether response originates from headers or from the event).
+         */
+        inline void SetInitialResponseCallback(const InvokeWithResponseStreamInitialResponseCallback& noArgCallback)
+        {
+            m_onInitialResponse = [noArgCallback](const InvokeWithResponseStreamInitialResponse& rs, const Utils::Event::InitialResponseType) { return noArgCallback(rs); };
+        }
+        ///@}
         inline void SetInvokeResponseStreamUpdateCallback(const InvokeResponseStreamUpdateCallback& callback) { m_onInvokeResponseStreamUpdate = callback; }
         inline void SetInvokeWithResponseStreamCompleteEventCallback(const InvokeWithResponseStreamCompleteEventCallback& callback) { m_onInvokeWithResponseStreamCompleteEvent = callback; }
         inline void SetOnErrorCallback(const ErrorCallback& callback) { m_onError = callback; }
+
+        inline InvokeWithResponseStreamInitialResponseCallbackEx& GetInitialResponseCallbackEx() { return m_onInitialResponse; }
 
     private:
         AWS_LAMBDA_API void HandleEventInMessage();
         AWS_LAMBDA_API void HandleErrorInMessage();
         AWS_LAMBDA_API void MarshallError(const Aws::String& errorCode, const Aws::String& errorMessage);
 
-        InvokeWithResponseStreamInitialResponseCallback m_onInitialResponse;
+        InvokeWithResponseStreamInitialResponseCallbackEx m_onInitialResponse;
         InvokeResponseStreamUpdateCallback m_onInvokeResponseStreamUpdate;
         InvokeWithResponseStreamCompleteEventCallback m_onInvokeWithResponseStreamCompleteEvent;
         ErrorCallback m_onError;

--- a/generated/src/aws-cpp-sdk-lambda/include/aws/lambda/model/InvokeWithResponseStreamInitialResponse.h
+++ b/generated/src/aws-cpp-sdk-lambda/include/aws/lambda/model/InvokeWithResponseStreamInitialResponse.h
@@ -6,6 +6,7 @@
 #pragma once
 #include <aws/lambda/Lambda_EXPORTS.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
+#include <aws/core/http/HttpTypes.h>
 #include <utility>
 
 namespace Aws
@@ -29,6 +30,7 @@ namespace Model
     AWS_LAMBDA_API InvokeWithResponseStreamInitialResponse();
     AWS_LAMBDA_API InvokeWithResponseStreamInitialResponse(Aws::Utils::Json::JsonView jsonValue);
     AWS_LAMBDA_API InvokeWithResponseStreamInitialResponse& operator=(Aws::Utils::Json::JsonView jsonValue);
+    AWS_LAMBDA_API InvokeWithResponseStreamInitialResponse(const Http::HeaderValueCollection& responseHeaders);
     AWS_LAMBDA_API Aws::Utils::Json::JsonValue Jsonize() const;
 
 

--- a/generated/src/aws-cpp-sdk-lambda/source/model/InvokeWithResponseStreamInitialResponse.cpp
+++ b/generated/src/aws-cpp-sdk-lambda/source/model/InvokeWithResponseStreamInitialResponse.cpp
@@ -5,6 +5,8 @@
 
 #include <aws/lambda/model/InvokeWithResponseStreamInitialResponse.h>
 #include <aws/core/utils/json/JsonSerializer.h>
+#include <aws/core/utils/StringUtils.h>
+#include <aws/core/utils/UnreferencedParam.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 
 #include <utility>
@@ -37,6 +39,22 @@ InvokeWithResponseStreamInitialResponse& InvokeWithResponseStreamInitialResponse
 {
   AWS_UNREFERENCED_PARAM(jsonValue);
   return *this;
+}
+
+InvokeWithResponseStreamInitialResponse::InvokeWithResponseStreamInitialResponse(const Http::HeaderValueCollection& headers) : InvokeWithResponseStreamInitialResponse()
+{
+  const auto& responseStreamContentTypeIter = headers.find("content-type");
+  if(responseStreamContentTypeIter != headers.end())
+  {
+    m_responseStreamContentType = responseStreamContentTypeIter->second;
+  }
+
+  const auto& executedVersionIter = headers.find("x-amz-executed-version");
+  if(executedVersionIter != headers.end())
+  {
+    m_executedVersion = executedVersionIter->second;
+  }
+
 }
 
 JsonValue InvokeWithResponseStreamInitialResponse::Jsonize() const

--- a/generated/src/aws-cpp-sdk-lambda/source/model/InvokeWithResponseStreamRequest.cpp
+++ b/generated/src/aws-cpp-sdk-lambda/source/model/InvokeWithResponseStreamRequest.cpp
@@ -27,6 +27,13 @@ InvokeWithResponseStreamRequest::InvokeWithResponseStreamRequest() :
     m_qualifierHasBeenSet(false),
     m_handler(), m_decoder(Aws::Utils::Event::EventStreamDecoder(&m_handler))
 {
+    AmazonWebServiceRequest::SetHeadersReceivedEventHandler([this](const Http::HttpRequest*, Http::HttpResponse* response)
+    {
+        auto& initialResponseHandler = m_handler.GetInitialResponseCallbackEx();
+        if (initialResponseHandler) {
+            initialResponseHandler(InvokeWithResponseStreamInitialResponse(response->GetHeaders()), Utils::Event::InitialResponseType::ON_RESPONSE);
+        }
+    });
 }
 
 

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/SelectObjectContentHandler.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/SelectObjectContentHandler.h
@@ -35,6 +35,7 @@ namespace Model
     class SelectObjectContentHandler : public Aws::Utils::Event::EventStreamHandler
     {
         typedef std::function<void(const SelectObjectContentInitialResponse&)> SelectObjectContentInitialResponseCallback;
+        typedef std::function<void(const SelectObjectContentInitialResponse&, const Utils::Event::InitialResponseType)> SelectObjectContentInitialResponseCallbackEx;
         typedef std::function<void(const RecordsEvent&)> RecordsEventCallback;
         typedef std::function<void(const StatsEvent&)> StatsEventCallback;
         typedef std::function<void(const ProgressEvent&)> ProgressEventCallback;
@@ -48,7 +49,22 @@ namespace Model
 
         AWS_S3CRT_API virtual void OnEvent() override;
 
-        inline void SetInitialResponseCallback(const SelectObjectContentInitialResponseCallback& callback) { m_onInitialResponse = callback; }
+        ///@{
+        /**
+         * Sets an initial response callback. This callback gets called on the initial SelectObjectContent Operation response.
+         *   This can be either "initial-response" decoded event frame or decoded HTTP headers received on connection.
+         *   This callback may get called more than once (i.e. on connection headers received and then on the initial-response event received).
+         * @param callback
+         */
+        inline void SetInitialResponseCallbackEx(const SelectObjectContentInitialResponseCallbackEx& callback) { m_onInitialResponse = callback; }
+        /**
+         * Sets an initial response callback (a legacy one that does not distinguish whether response originates from headers or from the event).
+         */
+        inline void SetInitialResponseCallback(const SelectObjectContentInitialResponseCallback& noArgCallback)
+        {
+            m_onInitialResponse = [noArgCallback](const SelectObjectContentInitialResponse& rs, const Utils::Event::InitialResponseType) { return noArgCallback(rs); };
+        }
+        ///@}
         inline void SetRecordsEventCallback(const RecordsEventCallback& callback) { m_onRecordsEvent = callback; }
         inline void SetStatsEventCallback(const StatsEventCallback& callback) { m_onStatsEvent = callback; }
         inline void SetProgressEventCallback(const ProgressEventCallback& callback) { m_onProgressEvent = callback; }
@@ -56,12 +72,14 @@ namespace Model
         inline void SetEndEventCallback(const EndEventCallback& callback) { m_onEndEvent = callback; }
         inline void SetOnErrorCallback(const ErrorCallback& callback) { m_onError = callback; }
 
+        inline SelectObjectContentInitialResponseCallbackEx& GetInitialResponseCallbackEx() { return m_onInitialResponse; }
+
     private:
         AWS_S3CRT_API void HandleEventInMessage();
         AWS_S3CRT_API void HandleErrorInMessage();
         AWS_S3CRT_API void MarshallError(const Aws::String& errorCode, const Aws::String& errorMessage);
 
-        SelectObjectContentInitialResponseCallback m_onInitialResponse;
+        SelectObjectContentInitialResponseCallbackEx m_onInitialResponse;
         RecordsEventCallback m_onRecordsEvent;
         StatsEventCallback m_onStatsEvent;
         ProgressEventCallback m_onProgressEvent;

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/SelectObjectContentInitialResponse.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/SelectObjectContentInitialResponse.h
@@ -5,6 +5,7 @@
 
 #pragma once
 #include <aws/s3-crt/S3Crt_EXPORTS.h>
+#include <aws/core/http/HttpTypes.h>
 
 namespace Aws
 {

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateMultipartUploadResult.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateMultipartUploadResult.cpp
@@ -58,7 +58,7 @@ CreateMultipartUploadResult& CreateMultipartUploadResult::operator =(const Aws::
   const auto& abortDateIter = headers.find("x-amz-abort-date");
   if(abortDateIter != headers.end())
   {
-    m_abortDate = DateTime(abortDateIter->second, Aws::Utils::DateFormat::RFC822);
+    m_abortDate = DateTime(abortDateIter->second.c_str(), Aws::Utils::DateFormat::RFC822);
     if(!m_abortDate.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3Crt::CreateMultipartUploadResult", "Failed to parse abortDate header as an RFC822 timestamp: " << abortDateIter->second.c_str());

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectAttributesResult.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectAttributesResult.cpp
@@ -74,7 +74,7 @@ GetObjectAttributesResult& GetObjectAttributesResult::operator =(const Aws::Amaz
   const auto& lastModifiedIter = headers.find("last-modified");
   if(lastModifiedIter != headers.end())
   {
-    m_lastModified = DateTime(lastModifiedIter->second, Aws::Utils::DateFormat::RFC822);
+    m_lastModified = DateTime(lastModifiedIter->second.c_str(), Aws::Utils::DateFormat::RFC822);
     if(!m_lastModified.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3Crt::GetObjectAttributesResult", "Failed to parse lastModified header as an RFC822 timestamp: " << lastModifiedIter->second.c_str());

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectResult.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/GetObjectResult.cpp
@@ -163,7 +163,7 @@ GetObjectResult& GetObjectResult::operator =(Aws::AmazonWebServiceResult<Respons
   const auto& lastModifiedIter = headers.find("last-modified");
   if(lastModifiedIter != headers.end())
   {
-    m_lastModified = DateTime(lastModifiedIter->second, Aws::Utils::DateFormat::RFC822);
+    m_lastModified = DateTime(lastModifiedIter->second.c_str(), Aws::Utils::DateFormat::RFC822);
     if(!m_lastModified.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3Crt::GetObjectResult", "Failed to parse lastModified header as an RFC822 timestamp: " << lastModifiedIter->second.c_str());
@@ -257,7 +257,7 @@ GetObjectResult& GetObjectResult::operator =(Aws::AmazonWebServiceResult<Respons
   const auto& expiresIter = headers.find("expires");
   if(expiresIter != headers.end())
   {
-    m_expires = DateTime(expiresIter->second, Aws::Utils::DateFormat::RFC822);
+    m_expires = DateTime(expiresIter->second.c_str(), Aws::Utils::DateFormat::RFC822);
     if(!m_expires.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3Crt::GetObjectResult", "Failed to parse expires header as an RFC822 timestamp: " << expiresIter->second.c_str());
@@ -350,7 +350,7 @@ GetObjectResult& GetObjectResult::operator =(Aws::AmazonWebServiceResult<Respons
   const auto& objectLockRetainUntilDateIter = headers.find("x-amz-object-lock-retain-until-date");
   if(objectLockRetainUntilDateIter != headers.end())
   {
-    m_objectLockRetainUntilDate = DateTime(objectLockRetainUntilDateIter->second, Aws::Utils::DateFormat::ISO_8601);
+    m_objectLockRetainUntilDate = DateTime(objectLockRetainUntilDateIter->second.c_str(), Aws::Utils::DateFormat::ISO_8601);
     if(!m_objectLockRetainUntilDate.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3Crt::GetObjectResult", "Failed to parse objectLockRetainUntilDate header as an ISO_8601 timestamp: " << objectLockRetainUntilDateIter->second.c_str());

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/HeadObjectResult.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/HeadObjectResult.cpp
@@ -81,7 +81,7 @@ HeadObjectResult& HeadObjectResult::operator =(const Aws::AmazonWebServiceResult
   const auto& lastModifiedIter = headers.find("last-modified");
   if(lastModifiedIter != headers.end())
   {
-    m_lastModified = DateTime(lastModifiedIter->second, Aws::Utils::DateFormat::RFC822);
+    m_lastModified = DateTime(lastModifiedIter->second.c_str(), Aws::Utils::DateFormat::RFC822);
     if(!m_lastModified.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3Crt::HeadObjectResult", "Failed to parse lastModified header as an RFC822 timestamp: " << lastModifiedIter->second.c_str());
@@ -169,7 +169,7 @@ HeadObjectResult& HeadObjectResult::operator =(const Aws::AmazonWebServiceResult
   const auto& expiresIter = headers.find("expires");
   if(expiresIter != headers.end())
   {
-    m_expires = DateTime(expiresIter->second, Aws::Utils::DateFormat::RFC822);
+    m_expires = DateTime(expiresIter->second.c_str(), Aws::Utils::DateFormat::RFC822);
     if(!m_expires.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3Crt::HeadObjectResult", "Failed to parse expires header as an RFC822 timestamp: " << expiresIter->second.c_str());
@@ -256,7 +256,7 @@ HeadObjectResult& HeadObjectResult::operator =(const Aws::AmazonWebServiceResult
   const auto& objectLockRetainUntilDateIter = headers.find("x-amz-object-lock-retain-until-date");
   if(objectLockRetainUntilDateIter != headers.end())
   {
-    m_objectLockRetainUntilDate = DateTime(objectLockRetainUntilDateIter->second, Aws::Utils::DateFormat::ISO_8601);
+    m_objectLockRetainUntilDate = DateTime(objectLockRetainUntilDateIter->second.c_str(), Aws::Utils::DateFormat::ISO_8601);
     if(!m_objectLockRetainUntilDate.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3Crt::HeadObjectResult", "Failed to parse objectLockRetainUntilDate header as an ISO_8601 timestamp: " << objectLockRetainUntilDateIter->second.c_str());

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/ListPartsResult.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/ListPartsResult.cpp
@@ -112,7 +112,7 @@ ListPartsResult& ListPartsResult::operator =(const Aws::AmazonWebServiceResult<X
   const auto& abortDateIter = headers.find("x-amz-abort-date");
   if(abortDateIter != headers.end())
   {
-    m_abortDate = DateTime(abortDateIter->second, Aws::Utils::DateFormat::RFC822);
+    m_abortDate = DateTime(abortDateIter->second.c_str(), Aws::Utils::DateFormat::RFC822);
     if(!m_abortDate.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3Crt::ListPartsResult", "Failed to parse abortDate header as an RFC822 timestamp: " << abortDateIter->second.c_str());

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/SelectObjectContentHandler.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/SelectObjectContentHandler.cpp
@@ -26,10 +26,11 @@ namespace Model
 
     SelectObjectContentHandler::SelectObjectContentHandler() : EventStreamHandler()
     {
-        m_onInitialResponse = [&](const SelectObjectContentInitialResponse&)
+        m_onInitialResponse = [&](const SelectObjectContentInitialResponse&, const Utils::Event::InitialResponseType eventType)
         {
             AWS_LOGSTREAM_TRACE(SELECTOBJECTCONTENT_HANDLER_CLASS_TAG,
-                "SelectObjectContent initial response received.");
+                "SelectObjectContent initial response received from "
+                << (eventType == Utils::Event::InitialResponseType::ON_EVENT ? "event" : "http headers"));
         };
 
         m_onRecordsEvent = [&](const RecordsEvent&)
@@ -112,7 +113,7 @@ namespace Model
         switch (SelectObjectContentEventMapper::GetSelectObjectContentEventTypeForName(eventTypeHeaderIter->second.GetEventHeaderValueAsString()))
         {
 
-        case SelectObjectContentEventType::INITIAL_RESPONSE: 
+        case SelectObjectContentEventType::INITIAL_RESPONSE:
         {
             auto xmlDoc = XmlDocument::CreateFromXmlString(GetEventPayloadAsString());
             if (!xmlDoc.WasParseSuccessful())
@@ -121,7 +122,7 @@ namespace Model
                 break;
             }
             SelectObjectContentInitialResponse event(xmlDoc.GetRootElement());
-            m_onInitialResponse(event);
+            m_onInitialResponse(event, Utils::Event::InitialResponseType::ON_EVENT);
             break;
         }   
         case SelectObjectContentEventType::RECORDS:

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/SelectObjectContentHandler.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/SelectObjectContentHandler.h
@@ -35,6 +35,7 @@ namespace Model
     class SelectObjectContentHandler : public Aws::Utils::Event::EventStreamHandler
     {
         typedef std::function<void(const SelectObjectContentInitialResponse&)> SelectObjectContentInitialResponseCallback;
+        typedef std::function<void(const SelectObjectContentInitialResponse&, const Utils::Event::InitialResponseType)> SelectObjectContentInitialResponseCallbackEx;
         typedef std::function<void(const RecordsEvent&)> RecordsEventCallback;
         typedef std::function<void(const StatsEvent&)> StatsEventCallback;
         typedef std::function<void(const ProgressEvent&)> ProgressEventCallback;
@@ -48,7 +49,22 @@ namespace Model
 
         AWS_S3_API virtual void OnEvent() override;
 
-        inline void SetInitialResponseCallback(const SelectObjectContentInitialResponseCallback& callback) { m_onInitialResponse = callback; }
+        ///@{
+        /**
+         * Sets an initial response callback. This callback gets called on the initial SelectObjectContent Operation response.
+         *   This can be either "initial-response" decoded event frame or decoded HTTP headers received on connection.
+         *   This callback may get called more than once (i.e. on connection headers received and then on the initial-response event received).
+         * @param callback
+         */
+        inline void SetInitialResponseCallbackEx(const SelectObjectContentInitialResponseCallbackEx& callback) { m_onInitialResponse = callback; }
+        /**
+         * Sets an initial response callback (a legacy one that does not distinguish whether response originates from headers or from the event).
+         */
+        inline void SetInitialResponseCallback(const SelectObjectContentInitialResponseCallback& noArgCallback)
+        {
+            m_onInitialResponse = [noArgCallback](const SelectObjectContentInitialResponse& rs, const Utils::Event::InitialResponseType) { return noArgCallback(rs); };
+        }
+        ///@}
         inline void SetRecordsEventCallback(const RecordsEventCallback& callback) { m_onRecordsEvent = callback; }
         inline void SetStatsEventCallback(const StatsEventCallback& callback) { m_onStatsEvent = callback; }
         inline void SetProgressEventCallback(const ProgressEventCallback& callback) { m_onProgressEvent = callback; }
@@ -56,12 +72,14 @@ namespace Model
         inline void SetEndEventCallback(const EndEventCallback& callback) { m_onEndEvent = callback; }
         inline void SetOnErrorCallback(const ErrorCallback& callback) { m_onError = callback; }
 
+        inline SelectObjectContentInitialResponseCallbackEx& GetInitialResponseCallbackEx() { return m_onInitialResponse; }
+
     private:
         AWS_S3_API void HandleEventInMessage();
         AWS_S3_API void HandleErrorInMessage();
         AWS_S3_API void MarshallError(const Aws::String& errorCode, const Aws::String& errorMessage);
 
-        SelectObjectContentInitialResponseCallback m_onInitialResponse;
+        SelectObjectContentInitialResponseCallbackEx m_onInitialResponse;
         RecordsEventCallback m_onRecordsEvent;
         StatsEventCallback m_onStatsEvent;
         ProgressEventCallback m_onProgressEvent;

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/SelectObjectContentInitialResponse.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/SelectObjectContentInitialResponse.h
@@ -5,6 +5,7 @@
 
 #pragma once
 #include <aws/s3/S3_EXPORTS.h>
+#include <aws/core/http/HttpTypes.h>
 
 namespace Aws
 {

--- a/generated/src/aws-cpp-sdk-s3/source/model/CreateMultipartUploadResult.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/CreateMultipartUploadResult.cpp
@@ -58,7 +58,7 @@ CreateMultipartUploadResult& CreateMultipartUploadResult::operator =(const Aws::
   const auto& abortDateIter = headers.find("x-amz-abort-date");
   if(abortDateIter != headers.end())
   {
-    m_abortDate = DateTime(abortDateIter->second, Aws::Utils::DateFormat::RFC822);
+    m_abortDate = DateTime(abortDateIter->second.c_str(), Aws::Utils::DateFormat::RFC822);
     if(!m_abortDate.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3::CreateMultipartUploadResult", "Failed to parse abortDate header as an RFC822 timestamp: " << abortDateIter->second.c_str());

--- a/generated/src/aws-cpp-sdk-s3/source/model/GetObjectAttributesResult.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/GetObjectAttributesResult.cpp
@@ -74,7 +74,7 @@ GetObjectAttributesResult& GetObjectAttributesResult::operator =(const Aws::Amaz
   const auto& lastModifiedIter = headers.find("last-modified");
   if(lastModifiedIter != headers.end())
   {
-    m_lastModified = DateTime(lastModifiedIter->second, Aws::Utils::DateFormat::RFC822);
+    m_lastModified = DateTime(lastModifiedIter->second.c_str(), Aws::Utils::DateFormat::RFC822);
     if(!m_lastModified.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3::GetObjectAttributesResult", "Failed to parse lastModified header as an RFC822 timestamp: " << lastModifiedIter->second.c_str());

--- a/generated/src/aws-cpp-sdk-s3/source/model/GetObjectResult.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/GetObjectResult.cpp
@@ -163,7 +163,7 @@ GetObjectResult& GetObjectResult::operator =(Aws::AmazonWebServiceResult<Respons
   const auto& lastModifiedIter = headers.find("last-modified");
   if(lastModifiedIter != headers.end())
   {
-    m_lastModified = DateTime(lastModifiedIter->second, Aws::Utils::DateFormat::RFC822);
+    m_lastModified = DateTime(lastModifiedIter->second.c_str(), Aws::Utils::DateFormat::RFC822);
     if(!m_lastModified.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3::GetObjectResult", "Failed to parse lastModified header as an RFC822 timestamp: " << lastModifiedIter->second.c_str());
@@ -257,7 +257,7 @@ GetObjectResult& GetObjectResult::operator =(Aws::AmazonWebServiceResult<Respons
   const auto& expiresIter = headers.find("expires");
   if(expiresIter != headers.end())
   {
-    m_expires = DateTime(expiresIter->second, Aws::Utils::DateFormat::RFC822);
+    m_expires = DateTime(expiresIter->second.c_str(), Aws::Utils::DateFormat::RFC822);
     if(!m_expires.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3::GetObjectResult", "Failed to parse expires header as an RFC822 timestamp: " << expiresIter->second.c_str());
@@ -350,7 +350,7 @@ GetObjectResult& GetObjectResult::operator =(Aws::AmazonWebServiceResult<Respons
   const auto& objectLockRetainUntilDateIter = headers.find("x-amz-object-lock-retain-until-date");
   if(objectLockRetainUntilDateIter != headers.end())
   {
-    m_objectLockRetainUntilDate = DateTime(objectLockRetainUntilDateIter->second, Aws::Utils::DateFormat::ISO_8601);
+    m_objectLockRetainUntilDate = DateTime(objectLockRetainUntilDateIter->second.c_str(), Aws::Utils::DateFormat::ISO_8601);
     if(!m_objectLockRetainUntilDate.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3::GetObjectResult", "Failed to parse objectLockRetainUntilDate header as an ISO_8601 timestamp: " << objectLockRetainUntilDateIter->second.c_str());

--- a/generated/src/aws-cpp-sdk-s3/source/model/HeadObjectResult.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/HeadObjectResult.cpp
@@ -81,7 +81,7 @@ HeadObjectResult& HeadObjectResult::operator =(const Aws::AmazonWebServiceResult
   const auto& lastModifiedIter = headers.find("last-modified");
   if(lastModifiedIter != headers.end())
   {
-    m_lastModified = DateTime(lastModifiedIter->second, Aws::Utils::DateFormat::RFC822);
+    m_lastModified = DateTime(lastModifiedIter->second.c_str(), Aws::Utils::DateFormat::RFC822);
     if(!m_lastModified.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3::HeadObjectResult", "Failed to parse lastModified header as an RFC822 timestamp: " << lastModifiedIter->second.c_str());
@@ -169,7 +169,7 @@ HeadObjectResult& HeadObjectResult::operator =(const Aws::AmazonWebServiceResult
   const auto& expiresIter = headers.find("expires");
   if(expiresIter != headers.end())
   {
-    m_expires = DateTime(expiresIter->second, Aws::Utils::DateFormat::RFC822);
+    m_expires = DateTime(expiresIter->second.c_str(), Aws::Utils::DateFormat::RFC822);
     if(!m_expires.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3::HeadObjectResult", "Failed to parse expires header as an RFC822 timestamp: " << expiresIter->second.c_str());
@@ -256,7 +256,7 @@ HeadObjectResult& HeadObjectResult::operator =(const Aws::AmazonWebServiceResult
   const auto& objectLockRetainUntilDateIter = headers.find("x-amz-object-lock-retain-until-date");
   if(objectLockRetainUntilDateIter != headers.end())
   {
-    m_objectLockRetainUntilDate = DateTime(objectLockRetainUntilDateIter->second, Aws::Utils::DateFormat::ISO_8601);
+    m_objectLockRetainUntilDate = DateTime(objectLockRetainUntilDateIter->second.c_str(), Aws::Utils::DateFormat::ISO_8601);
     if(!m_objectLockRetainUntilDate.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3::HeadObjectResult", "Failed to parse objectLockRetainUntilDate header as an ISO_8601 timestamp: " << objectLockRetainUntilDateIter->second.c_str());

--- a/generated/src/aws-cpp-sdk-s3/source/model/ListPartsResult.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/ListPartsResult.cpp
@@ -112,7 +112,7 @@ ListPartsResult& ListPartsResult::operator =(const Aws::AmazonWebServiceResult<X
   const auto& abortDateIter = headers.find("x-amz-abort-date");
   if(abortDateIter != headers.end())
   {
-    m_abortDate = DateTime(abortDateIter->second, Aws::Utils::DateFormat::RFC822);
+    m_abortDate = DateTime(abortDateIter->second.c_str(), Aws::Utils::DateFormat::RFC822);
     if(!m_abortDate.WasParseSuccessful())
     {
       AWS_LOGSTREAM_WARN("S3::ListPartsResult", "Failed to parse abortDate header as an RFC822 timestamp: " << abortDateIter->second.c_str());

--- a/generated/src/aws-cpp-sdk-s3/source/model/SelectObjectContentHandler.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/SelectObjectContentHandler.cpp
@@ -26,10 +26,11 @@ namespace Model
 
     SelectObjectContentHandler::SelectObjectContentHandler() : EventStreamHandler()
     {
-        m_onInitialResponse = [&](const SelectObjectContentInitialResponse&)
+        m_onInitialResponse = [&](const SelectObjectContentInitialResponse&, const Utils::Event::InitialResponseType eventType)
         {
             AWS_LOGSTREAM_TRACE(SELECTOBJECTCONTENT_HANDLER_CLASS_TAG,
-                "SelectObjectContent initial response received.");
+                "SelectObjectContent initial response received from "
+                << (eventType == Utils::Event::InitialResponseType::ON_EVENT ? "event" : "http headers"));
         };
 
         m_onRecordsEvent = [&](const RecordsEvent&)
@@ -112,7 +113,7 @@ namespace Model
         switch (SelectObjectContentEventMapper::GetSelectObjectContentEventTypeForName(eventTypeHeaderIter->second.GetEventHeaderValueAsString()))
         {
 
-        case SelectObjectContentEventType::INITIAL_RESPONSE: 
+        case SelectObjectContentEventType::INITIAL_RESPONSE:
         {
             auto xmlDoc = XmlDocument::CreateFromXmlString(GetEventPayloadAsString());
             if (!xmlDoc.WasParseSuccessful())
@@ -121,7 +122,7 @@ namespace Model
                 break;
             }
             SelectObjectContentInitialResponse event(xmlDoc.GetRootElement());
-            m_onInitialResponse(event);
+            m_onInitialResponse(event, Utils::Event::InitialResponseType::ON_EVENT);
             break;
         }   
         case SelectObjectContentEventType::RECORDS:

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartCallAnalyticsStreamTranscriptionHandler.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartCallAnalyticsStreamTranscriptionHandler.h
@@ -31,6 +31,7 @@ namespace Model
     class StartCallAnalyticsStreamTranscriptionHandler : public Aws::Utils::Event::EventStreamHandler
     {
         typedef std::function<void(const StartCallAnalyticsStreamTranscriptionInitialResponse&)> StartCallAnalyticsStreamTranscriptionInitialResponseCallback;
+        typedef std::function<void(const StartCallAnalyticsStreamTranscriptionInitialResponse&, const Utils::Event::InitialResponseType)> StartCallAnalyticsStreamTranscriptionInitialResponseCallbackEx;
         typedef std::function<void(const UtteranceEvent&)> UtteranceEventCallback;
         typedef std::function<void(const CategoryEvent&)> CategoryEventCallback;
         typedef std::function<void(const Aws::Client::AWSError<TranscribeStreamingServiceErrors>& error)> ErrorCallback;
@@ -41,17 +42,34 @@ namespace Model
 
         AWS_TRANSCRIBESTREAMINGSERVICE_API virtual void OnEvent() override;
 
-        inline void SetInitialResponseCallback(const StartCallAnalyticsStreamTranscriptionInitialResponseCallback& callback) { m_onInitialResponse = callback; }
+        ///@{
+        /**
+         * Sets an initial response callback. This callback gets called on the initial StartCallAnalyticsStreamTranscription Operation response.
+         *   This can be either "initial-response" decoded event frame or decoded HTTP headers received on connection.
+         *   This callback may get called more than once (i.e. on connection headers received and then on the initial-response event received).
+         * @param callback
+         */
+        inline void SetInitialResponseCallbackEx(const StartCallAnalyticsStreamTranscriptionInitialResponseCallbackEx& callback) { m_onInitialResponse = callback; }
+        /**
+         * Sets an initial response callback (a legacy one that does not distinguish whether response originates from headers or from the event).
+         */
+        inline void SetInitialResponseCallback(const StartCallAnalyticsStreamTranscriptionInitialResponseCallback& noArgCallback)
+        {
+            m_onInitialResponse = [noArgCallback](const StartCallAnalyticsStreamTranscriptionInitialResponse& rs, const Utils::Event::InitialResponseType) { return noArgCallback(rs); };
+        }
+        ///@}
         inline void SetUtteranceEventCallback(const UtteranceEventCallback& callback) { m_onUtteranceEvent = callback; }
         inline void SetCategoryEventCallback(const CategoryEventCallback& callback) { m_onCategoryEvent = callback; }
         inline void SetOnErrorCallback(const ErrorCallback& callback) { m_onError = callback; }
+
+        inline StartCallAnalyticsStreamTranscriptionInitialResponseCallbackEx& GetInitialResponseCallbackEx() { return m_onInitialResponse; }
 
     private:
         AWS_TRANSCRIBESTREAMINGSERVICE_API void HandleEventInMessage();
         AWS_TRANSCRIBESTREAMINGSERVICE_API void HandleErrorInMessage();
         AWS_TRANSCRIBESTREAMINGSERVICE_API void MarshallError(const Aws::String& errorCode, const Aws::String& errorMessage);
 
-        StartCallAnalyticsStreamTranscriptionInitialResponseCallback m_onInitialResponse;
+        StartCallAnalyticsStreamTranscriptionInitialResponseCallbackEx m_onInitialResponse;
         UtteranceEventCallback m_onUtteranceEvent;
         CategoryEventCallback m_onCategoryEvent;
         ErrorCallback m_onError;

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartCallAnalyticsStreamTranscriptionInitialResponse.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartCallAnalyticsStreamTranscriptionInitialResponse.h
@@ -12,6 +12,7 @@
 #include <aws/transcribestreaming/model/ContentRedactionType.h>
 #include <aws/transcribestreaming/model/ContentIdentificationType.h>
 #include <aws/transcribestreaming/model/VocabularyFilterMethod.h>
+#include <aws/core/http/HttpTypes.h>
 #include <utility>
 
 namespace Aws
@@ -35,6 +36,7 @@ namespace Model
     AWS_TRANSCRIBESTREAMINGSERVICE_API StartCallAnalyticsStreamTranscriptionInitialResponse();
     AWS_TRANSCRIBESTREAMINGSERVICE_API StartCallAnalyticsStreamTranscriptionInitialResponse(Aws::Utils::Json::JsonView jsonValue);
     AWS_TRANSCRIBESTREAMINGSERVICE_API StartCallAnalyticsStreamTranscriptionInitialResponse& operator=(Aws::Utils::Json::JsonView jsonValue);
+    AWS_TRANSCRIBESTREAMINGSERVICE_API StartCallAnalyticsStreamTranscriptionInitialResponse(const Http::HeaderValueCollection& responseHeaders);
     AWS_TRANSCRIBESTREAMINGSERVICE_API Aws::Utils::Json::JsonValue Jsonize() const;
 
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartMedicalStreamTranscriptionHandler.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartMedicalStreamTranscriptionHandler.h
@@ -29,6 +29,7 @@ namespace Model
     class StartMedicalStreamTranscriptionHandler : public Aws::Utils::Event::EventStreamHandler
     {
         typedef std::function<void(const StartMedicalStreamTranscriptionInitialResponse&)> StartMedicalStreamTranscriptionInitialResponseCallback;
+        typedef std::function<void(const StartMedicalStreamTranscriptionInitialResponse&, const Utils::Event::InitialResponseType)> StartMedicalStreamTranscriptionInitialResponseCallbackEx;
         typedef std::function<void(const MedicalTranscriptEvent&)> MedicalTranscriptEventCallback;
         typedef std::function<void(const Aws::Client::AWSError<TranscribeStreamingServiceErrors>& error)> ErrorCallback;
 
@@ -38,16 +39,33 @@ namespace Model
 
         AWS_TRANSCRIBESTREAMINGSERVICE_API virtual void OnEvent() override;
 
-        inline void SetInitialResponseCallback(const StartMedicalStreamTranscriptionInitialResponseCallback& callback) { m_onInitialResponse = callback; }
+        ///@{
+        /**
+         * Sets an initial response callback. This callback gets called on the initial StartMedicalStreamTranscription Operation response.
+         *   This can be either "initial-response" decoded event frame or decoded HTTP headers received on connection.
+         *   This callback may get called more than once (i.e. on connection headers received and then on the initial-response event received).
+         * @param callback
+         */
+        inline void SetInitialResponseCallbackEx(const StartMedicalStreamTranscriptionInitialResponseCallbackEx& callback) { m_onInitialResponse = callback; }
+        /**
+         * Sets an initial response callback (a legacy one that does not distinguish whether response originates from headers or from the event).
+         */
+        inline void SetInitialResponseCallback(const StartMedicalStreamTranscriptionInitialResponseCallback& noArgCallback)
+        {
+            m_onInitialResponse = [noArgCallback](const StartMedicalStreamTranscriptionInitialResponse& rs, const Utils::Event::InitialResponseType) { return noArgCallback(rs); };
+        }
+        ///@}
         inline void SetMedicalTranscriptEventCallback(const MedicalTranscriptEventCallback& callback) { m_onMedicalTranscriptEvent = callback; }
         inline void SetOnErrorCallback(const ErrorCallback& callback) { m_onError = callback; }
+
+        inline StartMedicalStreamTranscriptionInitialResponseCallbackEx& GetInitialResponseCallbackEx() { return m_onInitialResponse; }
 
     private:
         AWS_TRANSCRIBESTREAMINGSERVICE_API void HandleEventInMessage();
         AWS_TRANSCRIBESTREAMINGSERVICE_API void HandleErrorInMessage();
         AWS_TRANSCRIBESTREAMINGSERVICE_API void MarshallError(const Aws::String& errorCode, const Aws::String& errorMessage);
 
-        StartMedicalStreamTranscriptionInitialResponseCallback m_onInitialResponse;
+        StartMedicalStreamTranscriptionInitialResponseCallbackEx m_onInitialResponse;
         MedicalTranscriptEventCallback m_onMedicalTranscriptEvent;
         ErrorCallback m_onError;
     };

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartMedicalStreamTranscriptionInitialResponse.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartMedicalStreamTranscriptionInitialResponse.h
@@ -11,6 +11,7 @@
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/transcribestreaming/model/MedicalContentIdentificationType.h>
 #include <aws/transcribestreaming/model/MediaEncoding.h>
+#include <aws/core/http/HttpTypes.h>
 #include <utility>
 
 namespace Aws
@@ -34,6 +35,7 @@ namespace Model
     AWS_TRANSCRIBESTREAMINGSERVICE_API StartMedicalStreamTranscriptionInitialResponse();
     AWS_TRANSCRIBESTREAMINGSERVICE_API StartMedicalStreamTranscriptionInitialResponse(Aws::Utils::Json::JsonView jsonValue);
     AWS_TRANSCRIBESTREAMINGSERVICE_API StartMedicalStreamTranscriptionInitialResponse& operator=(Aws::Utils::Json::JsonView jsonValue);
+    AWS_TRANSCRIBESTREAMINGSERVICE_API StartMedicalStreamTranscriptionInitialResponse(const Http::HeaderValueCollection& responseHeaders);
     AWS_TRANSCRIBESTREAMINGSERVICE_API Aws::Utils::Json::JsonValue Jsonize() const;
 
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartStreamTranscriptionHandler.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartStreamTranscriptionHandler.h
@@ -29,6 +29,7 @@ namespace Model
     class StartStreamTranscriptionHandler : public Aws::Utils::Event::EventStreamHandler
     {
         typedef std::function<void(const StartStreamTranscriptionInitialResponse&)> StartStreamTranscriptionInitialResponseCallback;
+        typedef std::function<void(const StartStreamTranscriptionInitialResponse&, const Utils::Event::InitialResponseType)> StartStreamTranscriptionInitialResponseCallbackEx;
         typedef std::function<void(const TranscriptEvent&)> TranscriptEventCallback;
         typedef std::function<void(const Aws::Client::AWSError<TranscribeStreamingServiceErrors>& error)> ErrorCallback;
 
@@ -38,16 +39,33 @@ namespace Model
 
         AWS_TRANSCRIBESTREAMINGSERVICE_API virtual void OnEvent() override;
 
-        inline void SetInitialResponseCallback(const StartStreamTranscriptionInitialResponseCallback& callback) { m_onInitialResponse = callback; }
+        ///@{
+        /**
+         * Sets an initial response callback. This callback gets called on the initial StartStreamTranscription Operation response.
+         *   This can be either "initial-response" decoded event frame or decoded HTTP headers received on connection.
+         *   This callback may get called more than once (i.e. on connection headers received and then on the initial-response event received).
+         * @param callback
+         */
+        inline void SetInitialResponseCallbackEx(const StartStreamTranscriptionInitialResponseCallbackEx& callback) { m_onInitialResponse = callback; }
+        /**
+         * Sets an initial response callback (a legacy one that does not distinguish whether response originates from headers or from the event).
+         */
+        inline void SetInitialResponseCallback(const StartStreamTranscriptionInitialResponseCallback& noArgCallback)
+        {
+            m_onInitialResponse = [noArgCallback](const StartStreamTranscriptionInitialResponse& rs, const Utils::Event::InitialResponseType) { return noArgCallback(rs); };
+        }
+        ///@}
         inline void SetTranscriptEventCallback(const TranscriptEventCallback& callback) { m_onTranscriptEvent = callback; }
         inline void SetOnErrorCallback(const ErrorCallback& callback) { m_onError = callback; }
+
+        inline StartStreamTranscriptionInitialResponseCallbackEx& GetInitialResponseCallbackEx() { return m_onInitialResponse; }
 
     private:
         AWS_TRANSCRIBESTREAMINGSERVICE_API void HandleEventInMessage();
         AWS_TRANSCRIBESTREAMINGSERVICE_API void HandleErrorInMessage();
         AWS_TRANSCRIBESTREAMINGSERVICE_API void MarshallError(const Aws::String& errorCode, const Aws::String& errorMessage);
 
-        StartStreamTranscriptionInitialResponseCallback m_onInitialResponse;
+        StartStreamTranscriptionInitialResponseCallbackEx m_onInitialResponse;
         TranscriptEventCallback m_onTranscriptEvent;
         ErrorCallback m_onError;
     };

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartStreamTranscriptionInitialResponse.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartStreamTranscriptionInitialResponse.h
@@ -12,6 +12,7 @@
 #include <aws/transcribestreaming/model/ContentRedactionType.h>
 #include <aws/transcribestreaming/model/ContentIdentificationType.h>
 #include <aws/transcribestreaming/model/VocabularyFilterMethod.h>
+#include <aws/core/http/HttpTypes.h>
 #include <utility>
 
 namespace Aws
@@ -35,6 +36,7 @@ namespace Model
     AWS_TRANSCRIBESTREAMINGSERVICE_API StartStreamTranscriptionInitialResponse();
     AWS_TRANSCRIBESTREAMINGSERVICE_API StartStreamTranscriptionInitialResponse(Aws::Utils::Json::JsonView jsonValue);
     AWS_TRANSCRIBESTREAMINGSERVICE_API StartStreamTranscriptionInitialResponse& operator=(Aws::Utils::Json::JsonView jsonValue);
+    AWS_TRANSCRIBESTREAMINGSERVICE_API StartStreamTranscriptionInitialResponse(const Http::HeaderValueCollection& responseHeaders);
     AWS_TRANSCRIBESTREAMINGSERVICE_API Aws::Utils::Json::JsonValue Jsonize() const;
 
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartCallAnalyticsStreamTranscriptionHandler.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartCallAnalyticsStreamTranscriptionHandler.cpp
@@ -29,10 +29,11 @@ namespace Model
 
     StartCallAnalyticsStreamTranscriptionHandler::StartCallAnalyticsStreamTranscriptionHandler() : EventStreamHandler()
     {
-        m_onInitialResponse = [&](const StartCallAnalyticsStreamTranscriptionInitialResponse&)
+        m_onInitialResponse = [&](const StartCallAnalyticsStreamTranscriptionInitialResponse&, const Utils::Event::InitialResponseType eventType)
         {
             AWS_LOGSTREAM_TRACE(STARTCALLANALYTICSSTREAMTRANSCRIPTION_HANDLER_CLASS_TAG,
-                "StartCallAnalyticsStreamTranscription initial response received.");
+                "StartCallAnalyticsStreamTranscription initial response received from "
+                << (eventType == Utils::Event::InitialResponseType::ON_EVENT ? "event" : "http headers"));
         };
 
         m_onUtteranceEvent = [&](const UtteranceEvent&)
@@ -99,18 +100,11 @@ namespace Model
         }
         switch (StartCallAnalyticsStreamTranscriptionEventMapper::GetStartCallAnalyticsStreamTranscriptionEventTypeForName(eventTypeHeaderIter->second.GetEventHeaderValueAsString()))
         {
-        
-        case StartCallAnalyticsStreamTranscriptionEventType::INITIAL_RESPONSE: 
-        {
-            JsonValue json(GetEventPayloadAsString());
-            if (!json.WasParseSuccessful())
-            {
-                AWS_LOGSTREAM_WARN(STARTCALLANALYTICSSTREAMTRANSCRIPTION_HANDLER_CLASS_TAG, "Unable to generate a proper StartCallAnalyticsStreamTranscriptionInitialResponse object from the response in JSON format.");
-                break;
-            }
 
-            StartCallAnalyticsStreamTranscriptionInitialResponse event(json.View());
-            m_onInitialResponse(event);
+        case StartCallAnalyticsStreamTranscriptionEventType::INITIAL_RESPONSE:
+        {
+            StartCallAnalyticsStreamTranscriptionInitialResponse event(GetEventHeadersAsHttpHeaders());
+            m_onInitialResponse(event, Utils::Event::InitialResponseType::ON_EVENT);
             break;
         }   
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartCallAnalyticsStreamTranscriptionInitialResponse.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartCallAnalyticsStreamTranscriptionInitialResponse.cpp
@@ -5,6 +5,8 @@
 
 #include <aws/transcribestreaming/model/StartCallAnalyticsStreamTranscriptionInitialResponse.h>
 #include <aws/core/utils/json/JsonSerializer.h>
+#include <aws/core/utils/StringUtils.h>
+#include <aws/core/utils/UnreferencedParam.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 
 #include <utility>
@@ -55,6 +57,94 @@ StartCallAnalyticsStreamTranscriptionInitialResponse& StartCallAnalyticsStreamTr
 {
   AWS_UNREFERENCED_PARAM(jsonValue);
   return *this;
+}
+
+StartCallAnalyticsStreamTranscriptionInitialResponse::StartCallAnalyticsStreamTranscriptionInitialResponse(const Http::HeaderValueCollection& headers) : StartCallAnalyticsStreamTranscriptionInitialResponse()
+{
+  const auto& languageModelNameIter = headers.find("x-amzn-transcribe-language-model-name");
+  if(languageModelNameIter != headers.end())
+  {
+    m_languageModelName = languageModelNameIter->second;
+  }
+
+  const auto& requestIdIter = headers.find("x-amzn-request-id");
+  if(requestIdIter != headers.end())
+  {
+    m_requestId = requestIdIter->second;
+  }
+
+  const auto& vocabularyFilterNameIter = headers.find("x-amzn-transcribe-vocabulary-filter-name");
+  if(vocabularyFilterNameIter != headers.end())
+  {
+    m_vocabularyFilterName = vocabularyFilterNameIter->second;
+  }
+
+  const auto& mediaSampleRateHertzIter = headers.find("x-amzn-transcribe-sample-rate");
+  if(mediaSampleRateHertzIter != headers.end())
+  {
+     m_mediaSampleRateHertz = StringUtils::ConvertToInt32(mediaSampleRateHertzIter->second.c_str());
+  }
+
+  const auto& mediaEncodingIter = headers.find("x-amzn-transcribe-media-encoding");
+  if(mediaEncodingIter != headers.end())
+  {
+    m_mediaEncoding = MediaEncodingMapper::GetMediaEncodingForName(mediaEncodingIter->second);
+  }
+
+  const auto& partialResultsStabilityIter = headers.find("x-amzn-transcribe-partial-results-stability");
+  if(partialResultsStabilityIter != headers.end())
+  {
+    m_partialResultsStability = PartialResultsStabilityMapper::GetPartialResultsStabilityForName(partialResultsStabilityIter->second);
+  }
+
+  const auto& languageCodeIter = headers.find("x-amzn-transcribe-language-code");
+  if(languageCodeIter != headers.end())
+  {
+    m_languageCode = CallAnalyticsLanguageCodeMapper::GetCallAnalyticsLanguageCodeForName(languageCodeIter->second);
+  }
+
+  const auto& enablePartialResultsStabilizationIter = headers.find("x-amzn-transcribe-enable-partial-results-stabilization");
+  if(enablePartialResultsStabilizationIter != headers.end())
+  {
+     m_enablePartialResultsStabilization = StringUtils::ConvertToBool(enablePartialResultsStabilizationIter->second.c_str());
+  }
+
+  const auto& vocabularyNameIter = headers.find("x-amzn-transcribe-vocabulary-name");
+  if(vocabularyNameIter != headers.end())
+  {
+    m_vocabularyName = vocabularyNameIter->second;
+  }
+
+  const auto& contentRedactionTypeIter = headers.find("x-amzn-transcribe-content-redaction-type");
+  if(contentRedactionTypeIter != headers.end())
+  {
+    m_contentRedactionType = ContentRedactionTypeMapper::GetContentRedactionTypeForName(contentRedactionTypeIter->second);
+  }
+
+  const auto& contentIdentificationTypeIter = headers.find("x-amzn-transcribe-content-identification-type");
+  if(contentIdentificationTypeIter != headers.end())
+  {
+    m_contentIdentificationType = ContentIdentificationTypeMapper::GetContentIdentificationTypeForName(contentIdentificationTypeIter->second);
+  }
+
+  const auto& piiEntityTypesIter = headers.find("x-amzn-transcribe-pii-entity-types");
+  if(piiEntityTypesIter != headers.end())
+  {
+    m_piiEntityTypes = piiEntityTypesIter->second;
+  }
+
+  const auto& vocabularyFilterMethodIter = headers.find("x-amzn-transcribe-vocabulary-filter-method");
+  if(vocabularyFilterMethodIter != headers.end())
+  {
+    m_vocabularyFilterMethod = VocabularyFilterMethodMapper::GetVocabularyFilterMethodForName(vocabularyFilterMethodIter->second);
+  }
+
+  const auto& sessionIdIter = headers.find("x-amzn-transcribe-session-id");
+  if(sessionIdIter != headers.end())
+  {
+    m_sessionId = sessionIdIter->second;
+  }
+
 }
 
 JsonValue StartCallAnalyticsStreamTranscriptionInitialResponse::Jsonize() const

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartCallAnalyticsStreamTranscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartCallAnalyticsStreamTranscriptionRequest.cpp
@@ -38,6 +38,13 @@ StartCallAnalyticsStreamTranscriptionRequest::StartCallAnalyticsStreamTranscript
     m_piiEntityTypesHasBeenSet(false),
     m_handler(), m_decoder(Aws::Utils::Event::EventStreamDecoder(&m_handler))
 {
+    AmazonWebServiceRequest::SetHeadersReceivedEventHandler([this](const Http::HttpRequest*, Http::HttpResponse* response)
+    {
+        auto& initialResponseHandler = m_handler.GetInitialResponseCallbackEx();
+        if (initialResponseHandler) {
+            initialResponseHandler(StartCallAnalyticsStreamTranscriptionInitialResponse(response->GetHeaders()), Utils::Event::InitialResponseType::ON_RESPONSE);
+        }
+    });
 }
 
 std::shared_ptr<Aws::IOStream> StartCallAnalyticsStreamTranscriptionRequest::GetBody() const

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartMedicalStreamTranscriptionHandler.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartMedicalStreamTranscriptionHandler.cpp
@@ -29,10 +29,11 @@ namespace Model
 
     StartMedicalStreamTranscriptionHandler::StartMedicalStreamTranscriptionHandler() : EventStreamHandler()
     {
-        m_onInitialResponse = [&](const StartMedicalStreamTranscriptionInitialResponse&)
+        m_onInitialResponse = [&](const StartMedicalStreamTranscriptionInitialResponse&, const Utils::Event::InitialResponseType eventType)
         {
             AWS_LOGSTREAM_TRACE(STARTMEDICALSTREAMTRANSCRIPTION_HANDLER_CLASS_TAG,
-                "StartMedicalStreamTranscription initial response received.");
+                "StartMedicalStreamTranscription initial response received from "
+                << (eventType == Utils::Event::InitialResponseType::ON_EVENT ? "event" : "http headers"));
         };
 
         m_onMedicalTranscriptEvent = [&](const MedicalTranscriptEvent&)
@@ -94,18 +95,11 @@ namespace Model
         }
         switch (StartMedicalStreamTranscriptionEventMapper::GetStartMedicalStreamTranscriptionEventTypeForName(eventTypeHeaderIter->second.GetEventHeaderValueAsString()))
         {
-        
-        case StartMedicalStreamTranscriptionEventType::INITIAL_RESPONSE: 
-        {
-            JsonValue json(GetEventPayloadAsString());
-            if (!json.WasParseSuccessful())
-            {
-                AWS_LOGSTREAM_WARN(STARTMEDICALSTREAMTRANSCRIPTION_HANDLER_CLASS_TAG, "Unable to generate a proper StartMedicalStreamTranscriptionInitialResponse object from the response in JSON format.");
-                break;
-            }
 
-            StartMedicalStreamTranscriptionInitialResponse event(json.View());
-            m_onInitialResponse(event);
+        case StartMedicalStreamTranscriptionEventType::INITIAL_RESPONSE:
+        {
+            StartMedicalStreamTranscriptionInitialResponse event(GetEventHeadersAsHttpHeaders());
+            m_onInitialResponse(event, Utils::Event::InitialResponseType::ON_EVENT);
             break;
         }   
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartMedicalStreamTranscriptionInitialResponse.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartMedicalStreamTranscriptionInitialResponse.cpp
@@ -5,6 +5,8 @@
 
 #include <aws/transcribestreaming/model/StartMedicalStreamTranscriptionInitialResponse.h>
 #include <aws/core/utils/json/JsonSerializer.h>
+#include <aws/core/utils/StringUtils.h>
+#include <aws/core/utils/UnreferencedParam.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 
 #include <utility>
@@ -54,6 +56,82 @@ StartMedicalStreamTranscriptionInitialResponse& StartMedicalStreamTranscriptionI
 {
   AWS_UNREFERENCED_PARAM(jsonValue);
   return *this;
+}
+
+StartMedicalStreamTranscriptionInitialResponse::StartMedicalStreamTranscriptionInitialResponse(const Http::HeaderValueCollection& headers) : StartMedicalStreamTranscriptionInitialResponse()
+{
+  const auto& specialtyIter = headers.find("x-amzn-transcribe-specialty");
+  if(specialtyIter != headers.end())
+  {
+    m_specialty = SpecialtyMapper::GetSpecialtyForName(specialtyIter->second);
+  }
+
+  const auto& languageCodeIter = headers.find("x-amzn-transcribe-language-code");
+  if(languageCodeIter != headers.end())
+  {
+    m_languageCode = LanguageCodeMapper::GetLanguageCodeForName(languageCodeIter->second);
+  }
+
+  const auto& typeIter = headers.find("x-amzn-transcribe-type");
+  if(typeIter != headers.end())
+  {
+    m_type = TypeMapper::GetTypeForName(typeIter->second);
+  }
+
+  const auto& vocabularyNameIter = headers.find("x-amzn-transcribe-vocabulary-name");
+  if(vocabularyNameIter != headers.end())
+  {
+    m_vocabularyName = vocabularyNameIter->second;
+  }
+
+  const auto& requestIdIter = headers.find("x-amzn-request-id");
+  if(requestIdIter != headers.end())
+  {
+    m_requestId = requestIdIter->second;
+  }
+
+  const auto& showSpeakerLabelIter = headers.find("x-amzn-transcribe-show-speaker-label");
+  if(showSpeakerLabelIter != headers.end())
+  {
+     m_showSpeakerLabel = StringUtils::ConvertToBool(showSpeakerLabelIter->second.c_str());
+  }
+
+  const auto& contentIdentificationTypeIter = headers.find("x-amzn-transcribe-content-identification-type");
+  if(contentIdentificationTypeIter != headers.end())
+  {
+    m_contentIdentificationType = MedicalContentIdentificationTypeMapper::GetMedicalContentIdentificationTypeForName(contentIdentificationTypeIter->second);
+  }
+
+  const auto& mediaSampleRateHertzIter = headers.find("x-amzn-transcribe-sample-rate");
+  if(mediaSampleRateHertzIter != headers.end())
+  {
+     m_mediaSampleRateHertz = StringUtils::ConvertToInt32(mediaSampleRateHertzIter->second.c_str());
+  }
+
+  const auto& enableChannelIdentificationIter = headers.find("x-amzn-transcribe-enable-channel-identification");
+  if(enableChannelIdentificationIter != headers.end())
+  {
+     m_enableChannelIdentification = StringUtils::ConvertToBool(enableChannelIdentificationIter->second.c_str());
+  }
+
+  const auto& mediaEncodingIter = headers.find("x-amzn-transcribe-media-encoding");
+  if(mediaEncodingIter != headers.end())
+  {
+    m_mediaEncoding = MediaEncodingMapper::GetMediaEncodingForName(mediaEncodingIter->second);
+  }
+
+  const auto& numberOfChannelsIter = headers.find("x-amzn-transcribe-number-of-channels");
+  if(numberOfChannelsIter != headers.end())
+  {
+     m_numberOfChannels = StringUtils::ConvertToInt32(numberOfChannelsIter->second.c_str());
+  }
+
+  const auto& sessionIdIter = headers.find("x-amzn-transcribe-session-id");
+  if(sessionIdIter != headers.end())
+  {
+    m_sessionId = sessionIdIter->second;
+  }
+
 }
 
 JsonValue StartMedicalStreamTranscriptionInitialResponse::Jsonize() const

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartMedicalStreamTranscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartMedicalStreamTranscriptionRequest.cpp
@@ -37,6 +37,13 @@ StartMedicalStreamTranscriptionRequest::StartMedicalStreamTranscriptionRequest()
     m_contentIdentificationTypeHasBeenSet(false),
     m_handler(), m_decoder(Aws::Utils::Event::EventStreamDecoder(&m_handler))
 {
+    AmazonWebServiceRequest::SetHeadersReceivedEventHandler([this](const Http::HttpRequest*, Http::HttpResponse* response)
+    {
+        auto& initialResponseHandler = m_handler.GetInitialResponseCallbackEx();
+        if (initialResponseHandler) {
+            initialResponseHandler(StartMedicalStreamTranscriptionInitialResponse(response->GetHeaders()), Utils::Event::InitialResponseType::ON_RESPONSE);
+        }
+    });
 }
 
 std::shared_ptr<Aws::IOStream> StartMedicalStreamTranscriptionRequest::GetBody() const

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartStreamTranscriptionInitialResponse.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartStreamTranscriptionInitialResponse.cpp
@@ -5,6 +5,8 @@
 
 #include <aws/transcribestreaming/model/StartStreamTranscriptionInitialResponse.h>
 #include <aws/core/utils/json/JsonSerializer.h>
+#include <aws/core/utils/StringUtils.h>
+#include <aws/core/utils/UnreferencedParam.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 
 #include <utility>
@@ -70,6 +72,148 @@ StartStreamTranscriptionInitialResponse& StartStreamTranscriptionInitialResponse
 {
   AWS_UNREFERENCED_PARAM(jsonValue);
   return *this;
+}
+
+StartStreamTranscriptionInitialResponse::StartStreamTranscriptionInitialResponse(const Http::HeaderValueCollection& headers) : StartStreamTranscriptionInitialResponse()
+{
+  const auto& identifyMultipleLanguagesIter = headers.find("x-amzn-transcribe-identify-multiple-languages");
+  if(identifyMultipleLanguagesIter != headers.end())
+  {
+     m_identifyMultipleLanguages = StringUtils::ConvertToBool(identifyMultipleLanguagesIter->second.c_str());
+  }
+
+  const auto& vocabularyNamesIter = headers.find("x-amzn-transcribe-vocabulary-names");
+  if(vocabularyNamesIter != headers.end())
+  {
+    m_vocabularyNames = vocabularyNamesIter->second;
+  }
+
+  const auto& languageModelNameIter = headers.find("x-amzn-transcribe-language-model-name");
+  if(languageModelNameIter != headers.end())
+  {
+    m_languageModelName = languageModelNameIter->second;
+  }
+
+  const auto& requestIdIter = headers.find("x-amzn-request-id");
+  if(requestIdIter != headers.end())
+  {
+    m_requestId = requestIdIter->second;
+  }
+
+  const auto& vocabularyFilterNameIter = headers.find("x-amzn-transcribe-vocabulary-filter-name");
+  if(vocabularyFilterNameIter != headers.end())
+  {
+    m_vocabularyFilterName = vocabularyFilterNameIter->second;
+  }
+
+  const auto& mediaSampleRateHertzIter = headers.find("x-amzn-transcribe-sample-rate");
+  if(mediaSampleRateHertzIter != headers.end())
+  {
+     m_mediaSampleRateHertz = StringUtils::ConvertToInt32(mediaSampleRateHertzIter->second.c_str());
+  }
+
+  const auto& mediaEncodingIter = headers.find("x-amzn-transcribe-media-encoding");
+  if(mediaEncodingIter != headers.end())
+  {
+    m_mediaEncoding = MediaEncodingMapper::GetMediaEncodingForName(mediaEncodingIter->second);
+  }
+
+  const auto& identifyLanguageIter = headers.find("x-amzn-transcribe-identify-language");
+  if(identifyLanguageIter != headers.end())
+  {
+     m_identifyLanguage = StringUtils::ConvertToBool(identifyLanguageIter->second.c_str());
+  }
+
+  const auto& partialResultsStabilityIter = headers.find("x-amzn-transcribe-partial-results-stability");
+  if(partialResultsStabilityIter != headers.end())
+  {
+    m_partialResultsStability = PartialResultsStabilityMapper::GetPartialResultsStabilityForName(partialResultsStabilityIter->second);
+  }
+
+  const auto& languageOptionsIter = headers.find("x-amzn-transcribe-language-options");
+  if(languageOptionsIter != headers.end())
+  {
+    m_languageOptions = languageOptionsIter->second;
+  }
+
+  const auto& vocabularyFilterNamesIter = headers.find("x-amzn-transcribe-vocabulary-filter-names");
+  if(vocabularyFilterNamesIter != headers.end())
+  {
+    m_vocabularyFilterNames = vocabularyFilterNamesIter->second;
+  }
+
+  const auto& languageCodeIter = headers.find("x-amzn-transcribe-language-code");
+  if(languageCodeIter != headers.end())
+  {
+    m_languageCode = LanguageCodeMapper::GetLanguageCodeForName(languageCodeIter->second);
+  }
+
+  const auto& enablePartialResultsStabilizationIter = headers.find("x-amzn-transcribe-enable-partial-results-stabilization");
+  if(enablePartialResultsStabilizationIter != headers.end())
+  {
+     m_enablePartialResultsStabilization = StringUtils::ConvertToBool(enablePartialResultsStabilizationIter->second.c_str());
+  }
+
+  const auto& vocabularyNameIter = headers.find("x-amzn-transcribe-vocabulary-name");
+  if(vocabularyNameIter != headers.end())
+  {
+    m_vocabularyName = vocabularyNameIter->second;
+  }
+
+  const auto& contentRedactionTypeIter = headers.find("x-amzn-transcribe-content-redaction-type");
+  if(contentRedactionTypeIter != headers.end())
+  {
+    m_contentRedactionType = ContentRedactionTypeMapper::GetContentRedactionTypeForName(contentRedactionTypeIter->second);
+  }
+
+  const auto& showSpeakerLabelIter = headers.find("x-amzn-transcribe-show-speaker-label");
+  if(showSpeakerLabelIter != headers.end())
+  {
+     m_showSpeakerLabel = StringUtils::ConvertToBool(showSpeakerLabelIter->second.c_str());
+  }
+
+  const auto& contentIdentificationTypeIter = headers.find("x-amzn-transcribe-content-identification-type");
+  if(contentIdentificationTypeIter != headers.end())
+  {
+    m_contentIdentificationType = ContentIdentificationTypeMapper::GetContentIdentificationTypeForName(contentIdentificationTypeIter->second);
+  }
+
+  const auto& piiEntityTypesIter = headers.find("x-amzn-transcribe-pii-entity-types");
+  if(piiEntityTypesIter != headers.end())
+  {
+    m_piiEntityTypes = piiEntityTypesIter->second;
+  }
+
+  const auto& preferredLanguageIter = headers.find("x-amzn-transcribe-preferred-language");
+  if(preferredLanguageIter != headers.end())
+  {
+    m_preferredLanguage = LanguageCodeMapper::GetLanguageCodeForName(preferredLanguageIter->second);
+  }
+
+  const auto& enableChannelIdentificationIter = headers.find("x-amzn-transcribe-enable-channel-identification");
+  if(enableChannelIdentificationIter != headers.end())
+  {
+     m_enableChannelIdentification = StringUtils::ConvertToBool(enableChannelIdentificationIter->second.c_str());
+  }
+
+  const auto& vocabularyFilterMethodIter = headers.find("x-amzn-transcribe-vocabulary-filter-method");
+  if(vocabularyFilterMethodIter != headers.end())
+  {
+    m_vocabularyFilterMethod = VocabularyFilterMethodMapper::GetVocabularyFilterMethodForName(vocabularyFilterMethodIter->second);
+  }
+
+  const auto& numberOfChannelsIter = headers.find("x-amzn-transcribe-number-of-channels");
+  if(numberOfChannelsIter != headers.end())
+  {
+     m_numberOfChannels = StringUtils::ConvertToInt32(numberOfChannelsIter->second.c_str());
+  }
+
+  const auto& sessionIdIter = headers.find("x-amzn-transcribe-session-id");
+  if(sessionIdIter != headers.end())
+  {
+    m_sessionId = sessionIdIter->second;
+  }
+
 }
 
 JsonValue StartStreamTranscriptionInitialResponse::Jsonize() const

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartStreamTranscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartStreamTranscriptionRequest.cpp
@@ -53,6 +53,13 @@ StartStreamTranscriptionRequest::StartStreamTranscriptionRequest() :
     m_vocabularyFilterNamesHasBeenSet(false),
     m_handler(), m_decoder(Aws::Utils::Event::EventStreamDecoder(&m_handler))
 {
+    AmazonWebServiceRequest::SetHeadersReceivedEventHandler([this](const Http::HttpRequest*, Http::HttpResponse* response)
+    {
+        auto& initialResponseHandler = m_handler.GetInitialResponseCallbackEx();
+        if (initialResponseHandler) {
+            initialResponseHandler(StartStreamTranscriptionInitialResponse(response->GetHeaders()), Utils::Event::InitialResponseType::ON_RESPONSE);
+        }
+    });
 }
 
 std::shared_ptr<Aws::IOStream> StartStreamTranscriptionRequest::GetBody() const

--- a/src/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceRequest.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceRequest.h
@@ -119,38 +119,51 @@ namespace Aws
          * Set the response stream factory.
          */
         void SetResponseStreamFactory(const Aws::IOStreamFactory& factory) { m_responseStreamFactory = factory; }
+
+        ///@{
+        /**
+         * Sets the closure for headers received event.
+         */
+        inline virtual void SetHeadersReceivedEventHandler(const Aws::Http::HeadersReceivedEventHandler& headersReceivedEventHandler) { m_onHeadersReceived = headersReceivedEventHandler; }
+        inline virtual void SetHeadersReceivedEventHandler(Aws::Http::HeadersReceivedEventHandler&& headersReceivedEventHandler) { m_onHeadersReceived = std::move(headersReceivedEventHandler); }
+        ///@}
+
+        ///@{
         /**
          * Register closure for data received event.
          */
         inline virtual void SetDataReceivedEventHandler(const Aws::Http::DataReceivedEventHandler& dataReceivedEventHandler) { m_onDataReceived = dataReceivedEventHandler; }
+        inline virtual void SetDataReceivedEventHandler(Aws::Http::DataReceivedEventHandler&& dataReceivedEventHandler) { m_onDataReceived = std::move(dataReceivedEventHandler); }
+        ///@}
+
+        ///@{
         /**
-         * register closure for data sent event
+         * Register closure for data sent event
          */
         inline virtual void SetDataSentEventHandler(const Aws::Http::DataSentEventHandler& dataSentEventHandler) { m_onDataSent = dataSentEventHandler; }
+        inline virtual void SetDataSentEventHandler(Aws::Http::DataSentEventHandler&& dataSentEventHandler) { m_onDataSent = std::move(dataSentEventHandler); }
+        ///@}
+
+        ///@{
         /**
          * Register closure for  handling whether or not to continue a request.
          */
         inline virtual void SetContinueRequestHandler(const Aws::Http::ContinueRequestHandler& continueRequestHandler) { m_continueRequest = continueRequestHandler; }
-        /**
-         * Register closure for data received event.
-         */
-        inline virtual void SetDataReceivedEventHandler(Aws::Http::DataReceivedEventHandler&& dataReceivedEventHandler) { m_onDataReceived = std::move(dataReceivedEventHandler); }
-        /**
-         * register closure for data sent event
-         */
-        inline virtual void SetDataSentEventHandler(Aws::Http::DataSentEventHandler&& dataSentEventHandler) { m_onDataSent = std::move(dataSentEventHandler); }
-        /**
-         * Register closure for handling whether or not to cancel a request.
-         */
         inline virtual void SetContinueRequestHandler(Aws::Http::ContinueRequestHandler&& continueRequestHandler) { m_continueRequest = std::move(continueRequestHandler); }
+        ///@}
+
+        ///@{
         /**
          * Register closure for notification that a request is being retried
          */
         inline virtual void SetRequestRetryHandler(const RequestRetryHandler& handler) { m_requestRetryHandler = handler; }
-        /**
-         * Register closure for notification that a request is being retried
-         */
         inline virtual void SetRequestRetryHandler(RequestRetryHandler&& handler) { m_requestRetryHandler = std::move(handler); }
+        ///@}
+
+        /**
+         * get closure for headers received event.
+         */
+        inline virtual const Aws::Http::HeadersReceivedEventHandler& GetHeadersReceivedEventHandler() const { return m_onHeadersReceived; }
         /**
          * get closure for data received event.
          */
@@ -201,6 +214,7 @@ namespace Aws
     private:
         Aws::IOStreamFactory m_responseStreamFactory;
 
+        Aws::Http::HeadersReceivedEventHandler m_onHeadersReceived;
         Aws::Http::DataReceivedEventHandler m_onDataReceived;
         Aws::Http::DataSentEventHandler m_onDataSent;
         Aws::Http::ContinueRequestHandler m_continueRequest;

--- a/src/aws-cpp-sdk-core/include/aws/core/http/HttpRequest.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/HttpRequest.h
@@ -68,6 +68,10 @@ namespace Aws
         class HttpResponse;
 
         /**
+         * closure type for receiving notifications that headers have been received.
+         */
+        typedef std::function<void(const HttpRequest*, HttpResponse*)> HeadersReceivedEventHandler;
+        /**
          * closure type for receiving notifications that data has been received.
          */
         typedef std::function<void(const HttpRequest*, HttpResponse*, long long)> DataReceivedEventHandler;
@@ -111,14 +115,14 @@ namespace Aws
              * Get the value for a Header based on its name. (in default StandardHttpRequest implementation, an empty string will be returned if headerName doesn't exist)
              */
             virtual const Aws::String& GetHeaderValue(const char* headerName) const = 0;
+            ///@{
             /**
              * Add a header pair
              */
             virtual void SetHeaderValue(const char* headerName, const Aws::String& headerValue) = 0;
-            /**
-             * Creates a shared_ptr of HttpRequest with uri, method, and closure for how to create a response stream.
-             */
             virtual void SetHeaderValue(const Aws::String& headerName, const Aws::String& headerValue) = 0;
+            ///@}
+
             /**
              * Deletes a header from the request by name.
              */
@@ -472,31 +476,42 @@ namespace Aws
                 SetHeaderValue(API_VERSION_HEADER, value);
             }
 
+            ///@{
+            /**
+             * Sets the closure for receiving events when headers are received from the server.
+             */
+            inline void SetHeadersReceivedEventHandler(const HeadersReceivedEventHandler& headersReceivedEventHandler) { m_onHeadersReceived = headersReceivedEventHandler; }
+            inline void SetHeadersReceivedEventHandler(HeadersReceivedEventHandler&& headersReceivedEventHandler) { m_onHeadersReceived = std::move(headersReceivedEventHandler); }
+            ///@}
+
+            ///@{
             /**
              * Sets the closure for receiving events when data is received from the server.
              */
             inline void SetDataReceivedEventHandler(const DataReceivedEventHandler& dataReceivedEventHandler) { m_onDataReceived = dataReceivedEventHandler; }
-            /**
-             * Sets the closure for receiving events when data is received from the server.
-             */
             inline void SetDataReceivedEventHandler(DataReceivedEventHandler&& dataReceivedEventHandler) { m_onDataReceived = std::move(dataReceivedEventHandler); }
+            ///@}
+
+            ///@{
             /**
              * Sets the closure for receiving events when data is sent to the server.
              */
             inline void SetDataSentEventHandler(const DataSentEventHandler& dataSentEventHandler) { m_onDataSent = dataSentEventHandler; }
-            /**
-             * Sets the closure for receiving events when data is sent to the server.
-             */
             inline void SetDataSentEventHandler(DataSentEventHandler&& dataSentEventHandler) { m_onDataSent = std::move(dataSentEventHandler); }
+            ///@}
+
+            ///@{
             /**
              * Sets the closure for handling whether or not to cancel a request.
              */
             inline void SetContinueRequestHandle(const ContinueRequestHandler& continueRequestHandler) { m_continueRequest = continueRequestHandler; }
-            /**
-             * Sets the closure for handling whether or not to cancel a request.
-             */
             inline void SetContinueRequestHandle(ContinueRequestHandler&& continueRequestHandler) { m_continueRequest = std::move(continueRequestHandler); }
+            ///@}
 
+            /**
+             * Gets the closure for receiving events when headers are received from the server.
+             */
+            inline const HeadersReceivedEventHandler & GetHeadersReceivedEventHandler() const { return m_onHeadersReceived; }
             /**
              * Gets the closure for receiving events when data is received from the server.
              */
@@ -576,7 +591,8 @@ namespace Aws
         private:
             URI m_uri;
             HttpMethod m_method;
-            bool m_isEvenStreamRequest;
+            bool m_isEvenStreamRequest = false;
+            HeadersReceivedEventHandler m_onHeadersReceived;
             DataReceivedEventHandler m_onDataReceived;
             DataSentEventHandler m_onDataSent;
             ContinueRequestHandler m_continueRequest;

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/event/EventHeader.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/event/EventHeader.h
@@ -6,11 +6,13 @@
 #pragma once
 
 #include <aws/core/Core_EXPORTS.h>
-#include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/utils/Array.h>
-#include <aws/core/utils/memory/stl/AWSMap.h>
+#include <aws/core/utils/DateTime.h>
+#include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/UUID.h>
 #include <aws/core/utils/logging/LogMacros.h>
+#include <aws/core/utils/memory/stl/AWSMap.h>
+#include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/event-stream/event_stream.h>
 #include <cassert>
 
@@ -297,6 +299,36 @@ namespace Aws
                 inline const ByteBuffer& GetUnderlyingBuffer() const
                 {
                     return m_eventHeaderVariableLengthValue;
+                }
+
+                inline Aws::String ToString() const
+                {
+                    switch (m_eventHeaderType)
+                    {
+                        case EventHeaderType::BOOL_TRUE:
+                        case EventHeaderType::BOOL_FALSE:
+                            return Utils::StringUtils::to_string(GetEventHeaderValueAsBoolean());
+                        case EventHeaderType::BYTE:
+                            return Utils::StringUtils::to_string(GetEventHeaderValueAsByte());
+                        case EventHeaderType::INT16:
+                            return Utils::StringUtils::to_string(GetEventHeaderValueAsInt16());
+                        case EventHeaderType::INT32:
+                            return Utils::StringUtils::to_string(GetEventHeaderValueAsInt32());
+                        case EventHeaderType::INT64:
+                            return Utils::StringUtils::to_string(GetEventHeaderValueAsInt64());
+                        case EventHeaderType::BYTE_BUF:
+                            return Aws::String(reinterpret_cast<char*>(GetEventHeaderValueAsBytebuf().GetUnderlyingData()), GetEventHeaderValueAsBytebuf().GetLength());
+                        case EventHeaderType::STRING:
+                            return GetEventHeaderValueAsString();
+                        case EventHeaderType::TIMESTAMP:
+                            return Aws::Utils::DateTime(GetEventHeaderValueAsTimestamp()).ToGmtString(Aws::Utils::DateFormat::RFC822);
+                        case EventHeaderType::UUID:
+                            return GetEventHeaderValueAsUuid();
+                        case EventHeaderType::UNKNOWN:
+                        default:
+                            AWS_LOGSTREAM_ERROR(CLASS_TAG, "Cannot transform EventHeader value to string: type is unknown");
+                            return {};
+                    }
                 }
 
             private:

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/event/EventStreamHandler.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/event/EventStreamHandler.h
@@ -21,6 +21,12 @@ namespace Aws
     {
         namespace Event
         {
+            enum class InitialResponseType
+            {
+                ON_EVENT,
+                ON_RESPONSE
+            };
+
             /**
              * Handler of event stream.
              * Includes context and callback function while scanning the event stream.
@@ -128,6 +134,20 @@ namespace Aws
                 }
 
                 inline virtual const Aws::Utils::Event::EventHeaderValueCollection& GetEventHeaders() { return m_message.GetEventHeaders(); }
+
+                inline virtual const Http::HeaderValueCollection GetEventHeadersAsHttpHeaders() const
+                {
+                    Http::HeaderValueCollection output;
+                    using SrcT = Aws::Utils::Event::EventHeaderValueCollection::value_type;
+                    using DstT = Http::HeaderValueCollection::value_type;
+                    std::transform(m_message.GetEventHeaders().cbegin(), m_message.GetEventHeaders().cend(),
+                                   std::inserter(output, output.end()),
+                                   [](const SrcT& src)
+                                   {
+                                       return DstT(src.first, src.second.ToString());
+                                   });
+                    return output;
+                }
 
                 /**
                  * Entry point of all callback functions.

--- a/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -1017,6 +1017,7 @@ void AWSClient::BuildHttpRequest(const Aws::AmazonWebServiceRequest& request, co
 
     AddChecksumToRequest(httpRequest, request);
     // Pass along handlers for processing data sent/received in bytes
+    httpRequest->SetHeadersReceivedEventHandler(request.GetHeadersReceivedEventHandler());
     httpRequest->SetDataReceivedEventHandler(request.GetDataReceivedEventHandler());
     httpRequest->SetDataSentEventHandler(request.GetDataSentEventHandler());
     httpRequest->SetContinueRequestHandle(request.GetContinueRequestHandler());

--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -191,6 +191,12 @@ static size_t WriteData(char* ptr, size_t size, size_t nmemb, void* userdata)
         }
 
         HttpResponse* response = context->m_response;
+        auto& headersHandler = context->m_request->GetHeadersReceivedEventHandler();
+        if (context->m_numBytesResponseReceived == 0 && headersHandler)
+        {
+            headersHandler(context->m_request, context->m_response);
+        }
+
         size_t sizeToWrite = size * nmemb;
         if (context->m_rateLimiter)
         {

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/ServiceModel.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/ServiceModel.java
@@ -61,6 +61,16 @@ public class ServiceModel {
         return operations.values().parallelStream().allMatch(operation -> operation.getSignerName().equals("Aws::Auth::BEARER_SIGNER"));
     }
 
+    public Operation getOperationForRequestShapeName(String requestShapeName) {
+        for (Map.Entry<String, Operation> opEntry : operations.entrySet()) {
+            Operation op = opEntry.getValue();
+            if (op.getRequest() != null && op.getRequest().getShape().getName() == requestShapeName) {
+                return op;
+            }
+        }
+        return null;
+    }
+
     String endpointRules;
     EndpointTests endpointTests;
     ClientContextParams clientContextParams;

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
@@ -317,6 +317,9 @@ public class CppViewHelper {
             }
         }
 
+        if(shape.isEvent() && shape.getName().endsWith("InitialResponse")) {
+            headers.add("<aws/core/http/HttpTypes.h>");
+        }
         if(includeUtilityHeader) {
             headers.add("<utility>");
         }

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/CppClientGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/CppClientGenerator.java
@@ -363,13 +363,7 @@ public abstract class CppClientGenerator implements ClientGenerator {
         }
 
         if (shape.isRequest()) {
-            for (Map.Entry<String, Operation> opEntry : serviceModel.getOperations().entrySet()) {
-                Operation op = opEntry.getValue();
-                if (op.getRequest() != null && op.getRequest().getShape().getName() == shape.getName()) {
-                    context.put("operation", op);
-                    break;
-                }
-            }
+            context.put("operation", serviceModel.getOperationForRequestShapeName(shape.getName()));
         }
 
         return null;

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/JsonCppClientGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/JsonCppClientGenerator.java
@@ -134,14 +134,7 @@ public class JsonCppClientGenerator extends CppClientGenerator {
                 template = velocityEngine.getTemplate("/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonSubObjectSource.vm", StandardCharsets.UTF_8.name());
             }
 
-            for (Map.Entry<String, Operation> opEntry : serviceModel.getOperations().entrySet()) {
-                Operation op = opEntry.getValue();
-                if (op.getRequest() != null && op.getRequest().getShape().getName() == shape.getName()) {
-                    context.put("operation", op);
-                    break;
-                }
-            }
-
+            context.put("operation", serviceModel.getOperationForRequestShapeName(shape.getName()));
             context.put("shape", shape);
             context.put("typeInfo", new CppShapeInformation(shape, serviceModel));
             context.put("CppViewHelper", CppViewHelper.class);

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/RestXmlCppClientGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/RestXmlCppClientGenerator.java
@@ -134,14 +134,7 @@ public class RestXmlCppClientGenerator  extends CppClientGenerator {
                 (shape.isResult() && shape.hasEventStreamMembers()))) {
             Template template = null;
             VelocityContext context = createContext(serviceModel);
-
-            for (Map.Entry<String, Operation> opEntry : serviceModel.getOperations().entrySet()) {
-                Operation op = opEntry.getValue();
-                if (op.getRequest() != null && op.getRequest().getShape().getName() == shape.getName()) {
-                    context.put("operation", op);
-                    break;
-                }
-            }
+            context.put("operation", serviceModel.getOperationForRequestShapeName(shape.getName()));
 
             if (shape.isRequest() && shape.hasStreamMembers()) {
                 template = velocityEngine.getTemplate("/com/amazonaws/util/awsclientgenerator/velocity/cpp/StreamRequestSource.vm", StandardCharsets.UTF_8.name());

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/s3/S3RestXmlCppClientGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/s3/S3RestXmlCppClientGenerator.java
@@ -459,15 +459,7 @@ public class S3RestXmlCppClientGenerator extends RestXmlCppClientGenerator {
         Shape shape = shapeEntry.getValue();
         VelocityContext context = createContext(serviceModel);
         context.put("shape", shape);
-        if (shape.isRequest()) {
-            for (Map.Entry<String, Operation> opEntry : serviceModel.getOperations().entrySet()) {
-                Operation op = opEntry.getValue();
-                if (op.getRequest() != null && op.getRequest().getShape().getName() == shape.getName()) {
-                    context.put("operation", op);
-                    break;
-                }
-            }
-        }
+        context.put("operation", serviceModel.getOperationForRequestShapeName(shape.getName()));
         context.put("typeInfo", new CppShapeInformation(shape, serviceModel));
         context.put("CppViewHelper", CppViewHelper.class);
         return makeFile(template, context, fileName, true);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/RequestEventStreamHandlerHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/RequestEventStreamHandlerHeader.vm
@@ -39,6 +39,7 @@ namespace Model
     class ${operation.name}Handler : public Aws::Utils::Event::EventStreamHandler
     {
         typedef std::function<void(const ${operation.name}InitialResponse&)> ${operation.name}InitialResponseCallback;
+        typedef std::function<void(const ${operation.name}InitialResponse&, const Utils::Event::InitialResponseType)> ${operation.name}InitialResponseCallbackEx;
 #foreach($eventMemberEntry in $eventStreamShape.members.entrySet())
 #set($eventShape = $eventMemberEntry.value.shape)
 #if($eventShape.isException())
@@ -59,7 +60,22 @@ namespace Model
 
         ${exportMacro} virtual void OnEvent() override;
 
-        inline void SetInitialResponseCallback(const ${operation.name}InitialResponseCallback& callback) { m_onInitialResponse = callback; }
+        ///@{
+        /**
+         * Sets an initial response callback. This callback gets called on the initial ${operation.name} Operation response.
+         *   This can be either "initial-response" decoded event frame or decoded HTTP headers received on connection.
+         *   This callback may get called more than once (i.e. on connection headers received and then on the initial-response event received).
+         * @param callback
+         */
+        inline void SetInitialResponseCallbackEx(const ${operation.name}InitialResponseCallbackEx& callback) { m_onInitialResponse = callback; }
+        /**
+         * Sets an initial response callback (a legacy one that does not distinguish whether response originates from headers or from the event).
+         */
+        inline void SetInitialResponseCallback(const ${operation.name}InitialResponseCallback& noArgCallback)
+        {
+            m_onInitialResponse = [noArgCallback](const ${operation.name}InitialResponse& rs, const Utils::Event::InitialResponseType) { return noArgCallback(rs); };
+        }
+        ///@}
 #foreach($eventMemberEntry in $eventStreamShape.members.entrySet())
 #if(!$eventMemberEntry.value.shape.isException())
 #set($eventShapeName = $eventMemberEntry.value.shape.name)
@@ -68,12 +84,14 @@ namespace Model
 #end
         inline void SetOnErrorCallback(const ErrorCallback& callback) { m_onError = callback; }
 
+        inline ${operation.name}InitialResponseCallbackEx& GetInitialResponseCallbackEx() { return m_onInitialResponse; }
+
     private:
         ${exportMacro} void HandleEventInMessage();
         ${exportMacro} void HandleErrorInMessage();
         ${exportMacro} void MarshallError(const Aws::String& errorCode, const Aws::String& errorMessage);
 
-        ${operation.name}InitialResponseCallback m_onInitialResponse;
+        ${operation.name}InitialResponseCallbackEx m_onInitialResponse;
 #foreach($eventMemberEntry in $eventStreamShape.members.entrySet())
 #set($eventShapeName = $eventMemberEntry.value.shape.name)
 #if(!$eventMemberEntry.value.shape.isException())

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/StreamRequestSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/StreamRequestSource.vm
@@ -29,6 +29,15 @@ using namespace Aws;
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassMembersGenerateInitializers.vm")
 ${typeInfo.className}::${typeInfo.className}()$initializers
 {
+#if ($typeInfo.shape.isRequest() && $operation.result && $operation.result.shape.hasEventStreamMembers())
+    AmazonWebServiceRequest::SetHeadersReceivedEventHandler([this](const Http::HttpRequest*, Http::HttpResponse* response)
+    {
+        auto& initialResponseHandler = m_handler.GetInitialResponseCallbackEx();
+        if (initialResponseHandler) {
+            initialResponseHandler(${operation.name}InitialResponse(response->GetHeaders()), Utils::Event::InitialResponseType::ON_RESPONSE);
+        }
+    });
+#end
 }
 
 #if($shape.hasEventStreamMembers())

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/StreamResultSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/StreamResultSource.vm
@@ -61,49 +61,7 @@ ${typeInfo.className}& ${typeInfo.className}::operator =(Aws::AmazonWebServiceRe
 {
   ${CppViewHelper.computeMemberVariableName($shape.payload)} = result.TakeOwnershipOfPayload();
 
-#if($shape.hasHeaderMembers())
-  const auto& headers = result.GetHeaderValueCollection();
-#foreach($memberEntry in $shape.members.entrySet())
-#set($varName = $CppViewHelper.computeVariableName($memberEntry.key))
-#set($memberVarName = $CppViewHelper.computeMemberVariableName($memberEntry.key))
-#if($memberEntry.value.usedForHeader)
-#if($memberEntry.value.shape.map)
-  std::size_t prefixSize = sizeof("${memberEntry.value.locationName}") - 1; //subtract the NULL terminator out
-  for(const auto& item : headers)
-  {
-    std::size_t foundPrefix = item.first.find("${memberEntry.value.locationName}");
-
-    if(foundPrefix != std::string::npos)
-    {
-      ${memberVarName}[item.first.substr(prefixSize)] = item.second;
-    }
-  }
-
-#else
-  const auto& ${varName}Iter = headers.find("${memberEntry.value.locationName}");
-  if(${varName}Iter != headers.end())
-  {
-#if($memberEntry.value.shape.string)
-    ${memberVarName} = ${varName}Iter->second;
-#elseif($memberEntry.value.shape.enum)
-    ${memberVarName} = ${memberEntry.value.shape.name}Mapper::Get${memberEntry.value.shape.name}ForName(${varName}Iter->second);
-#elseif($memberEntry.value.shape.timeStamp)
-    ${memberVarName} = DateTime(${varName}Iter->second, Aws::Utils::DateFormat::$CppViewHelper.computeTimestampFormatInHeader($memberEntry.value.shape));
-    if(!${memberVarName}.WasParseSuccessful())
-    {
-      AWS_LOGSTREAM_WARN("${serviceNamespace}::${typeInfo.className}", "Failed to parse ${varName} header as an $CppViewHelper.computeTimestampFormatInHeader($memberEntry.value.shape) timestamp: " << ${varName}Iter->second.c_str());
-    }
-#elseif($memberEntry.value.shape.blob)
-    ${memberVarName} = HashingUtils::Base64Decode(StringUtils::Trim(${varName}Iter->second.c_str()));
-#elseif($memberEntry.value.shape.primitive)
-     ${memberVarName} = ${CppViewHelper.computeXmlConversionMethodName($memberEntry.value.shape)}(${varName}Iter->second.c_str());
-#end
-  }
-
-#end
-#end
-#end
-#end
+#parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ResultClassHeadersDeserialize.vm")
 #if($shape.hasStatusCodeMembers())
 #foreach($memberEntry in $shape.members.entrySet())
 #if($memberEntry.value.usedForHttpStatusCode)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ResultClassHeadersDeserialize.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ResultClassHeadersDeserialize.vm
@@ -1,0 +1,51 @@
+#if(!$shape.hasHeaderMembers() && $ResultClassHeadersDeserializeDoNotGetHeaders)
+  AWS_UNREFERENCED_PARAM(headers);
+#end
+#if($shape.hasHeaderMembers())
+#if(!$ResultClassHeadersDeserializeDoNotGetHeaders)
+  const auto& headers = result.GetHeaderValueCollection();
+#end
+#foreach($memberEntry in $shape.members.entrySet())
+#set($varName = $CppViewHelper.computeVariableName($memberEntry.key))
+#set($memberVarName = $CppViewHelper.computeMemberVariableName($memberEntry.key))
+#if($memberEntry.value.usedForHeader)
+#if($memberEntry.value.shape.map)
+  std::size_t prefixSize = sizeof("${memberEntry.value.locationName}") - 1; //subtract the NULL terminator out
+  for(const auto& item : headers)
+  {
+    std::size_t foundPrefix = item.first.find("${memberEntry.value.locationName}");
+
+    if(foundPrefix != std::string::npos)
+    {
+      ${memberVarName}[item.first.substr(prefixSize)] = item.second;
+    }
+  }
+
+#else
+  const auto& ${varName}Iter = headers.find("${memberEntry.value.locationName}");
+  if(${varName}Iter != headers.end())
+  {
+#if($memberEntry.value.shape.string)
+    ${memberVarName} = ${varName}Iter->second;
+#elseif($memberEntry.value.shape.timeStamp)
+    ${memberVarName} = DateTime(${varName}Iter->second.c_str(), Aws::Utils::DateFormat::$CppViewHelper.computeTimestampFormatInHeader($memberEntry.value.shape));
+    if(!${memberVarName}.WasParseSuccessful())
+    {
+      AWS_LOGSTREAM_WARN("${serviceNamespace}::${typeInfo.className}", "Failed to parse ${varName} header as an $CppViewHelper.computeTimestampFormatInHeader($memberEntry.value.shape) timestamp: " << ${varName}Iter->second.c_str());
+    }
+#elseif($memberEntry.value.shape.enum)
+    ${memberVarName} = ${memberEntry.value.shape.name}Mapper::Get${memberEntry.value.shape.name}ForName(${varName}Iter->second);
+#elseif($memberEntry.value.shape.blob)
+    ${memberVarName} = HashingUtils::Base64Decode(StringUtils::Trim(${varName}Iter->second.c_str()));
+#elseif($memberEntry.value.shape.primitive)
+     ${memberVarName} = ${CppViewHelper.computeXmlConversionMethodName($memberEntry.value.shape)}(${varName}Iter->second.c_str());
+#elseif($metadata.awsQueryCompatible && $memberEntry.value.shape.structure && $memberEntry.value.shape.name == 'ResponseMetadata')
+     // for backward compatibility for customers used to an old XML Client interface
+     m_responseMetadata.SetRequestId(${varName}Iter->second);
+#end
+  }
+
+#end
+#end
+#end
+#end

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonEventStreamHandlerSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonEventStreamHandlerSource.vm
@@ -29,10 +29,11 @@ namespace Model
 
     ${operation.name}Handler::${operation.name}Handler() : EventStreamHandler()
     {
-        m_onInitialResponse = [&](const ${operation.name}InitialResponse&)
+        m_onInitialResponse = [&](const ${operation.name}InitialResponse&, const Utils::Event::InitialResponseType eventType)
         {
             AWS_LOGSTREAM_TRACE(${operation.name.toUpperCase()}_HANDLER_CLASS_TAG,
-                "${operation.name} initial response received.");
+                "${operation.name} initial response received from "
+                << (eventType == Utils::Event::InitialResponseType::ON_EVENT ? "event" : "http headers"));
         };
 
 #foreach($eventMemberEntry in $eventStreamShape.members.entrySet())
@@ -108,18 +109,11 @@ namespace Model
         }
         switch (${operation.name}EventMapper::Get${operation.name}EventTypeForName(eventTypeHeaderIter->second.GetEventHeaderValueAsString()))
         {
-        
-        case ${operation.name}EventType::INITIAL_RESPONSE: 
-        {
-            JsonValue json(GetEventPayloadAsString());
-            if (!json.WasParseSuccessful())
-            {
-                AWS_LOGSTREAM_WARN(${operation.name.toUpperCase()}_HANDLER_CLASS_TAG, "Unable to generate a proper ${operation.name}InitialResponse object from the response in JSON format.");
-                break;
-            }
 
-            ${operation.name}InitialResponse event(json.View());
-            m_onInitialResponse(event);
+        case ${operation.name}EventType::INITIAL_RESPONSE:
+        {
+            ${operation.name}InitialResponse event(GetEventHeadersAsHttpHeaders());
+            m_onInitialResponse(event, Utils::Event::InitialResponseType::ON_EVENT);
             break;
         }   
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonResultSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonResultSource.vm
@@ -43,46 +43,7 @@ ${typeInfo.className}& ${typeInfo.className}::operator =(const Aws::AmazonWebSer
 #set($useRequiredField = false)
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/json/ModelClassMembersDeserializeJson.vm")
 
-#if($shape.hasHeaderMembers())
-  const auto& headers = result.GetHeaderValueCollection();
-#foreach($memberEntry in $shape.members.entrySet())
-#set($varName = $CppViewHelper.computeVariableName($memberEntry.key))
-#set($memberVarName = $CppViewHelper.computeMemberVariableName($memberEntry.key))
-#if($memberEntry.value.usedForHeader)
-#if($memberEntry.value.shape.map)
-  std::size_t prefixSize = sizeof("${memberEntry.value.locationName}") - 1; //subtract the NULL terminator out
-  for(const auto& item : headers)
-  {
-    std::size_t foundPrefix = item.first.find("${memberEntry.value.locationName}");
-
-    if(foundPrefix != std::string::npos)
-    {
-      ${memberVarName}[item.first.substr(prefixSize)] = item.second;
-    }
-  }
-
-#else
-  const auto& ${varName}Iter = headers.find("${memberEntry.value.locationName}");
-  if(${varName}Iter != headers.end())
-  {
-#if($memberEntry.value.shape.string)
-    ${memberVarName} = ${varName}Iter->second;
-#elseif($memberEntry.value.shape.enum)
-    ${memberVarName} = ${memberEntry.value.shape.name}Mapper::Get${memberEntry.value.shape.name}ForName(${varName}Iter->second);
-#elseif($memberEntry.value.shape.timeStamp)
-    ${memberVarName} = DateTime(${varName}Iter->second.c_str(), Aws::Utils::DateFormat::$CppViewHelper.computeTimestampFormatInHeader($memberEntry.value.shape));
-#elseif($memberEntry.value.shape.primitive)
-     ${memberVarName} = ${CppViewHelper.computeXmlConversionMethodName($memberEntry.value.shape)}(${varName}Iter->second.c_str());
-#elseif($metadata.awsQueryCompatible && $memberEntry.value.shape.structure && $memberEntry.value.shape.name == 'ResponseMetadata')
-     // for backward compatibility for customers used to an old XML Client interface
-     m_responseMetadata.SetRequestId(${varName}Iter->second);
-#end
-  }
-
-#end
-#end
-#end
-#end
+#parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ResultClassHeadersDeserialize.vm")
 
 #if($shape.hasStatusCodeMembers())
 #foreach($memberEntry in $shape.members.entrySet())

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonSubObjectHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonSubObjectHeader.vm
@@ -45,6 +45,9 @@ namespace Model
     ${exportMacro} ${typeInfo.className}();
     ${exportMacro} ${typeInfo.className}(${typeInfo.jsonViewType} jsonValue);
     ${exportMacro} ${classNameRef} operator=(${typeInfo.jsonViewType} jsonValue);
+#if ($typeInfo.shape.isEvent() && $typeInfo.className.endsWith("InitialResponse"))
+    ${exportMacro} ${typeInfo.className}(const Http::HeaderValueCollection& responseHeaders);
+#end
     ${exportMacro} ${typeInfo.jsonType} Jsonize() const;
 
 #set($useRequiredField = true)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonSubObjectSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonSubObjectSource.vm
@@ -5,6 +5,10 @@
 #set($serviceNamespace = $metadata.namespace)
 \#include <aws/${metadata.projectName}/model/${typeInfo.className}.h>
 \#include <aws/core/utils/json/JsonSerializer.h>
+#if ($typeInfo.shape.isEvent() && $typeInfo.className.endsWith("InitialResponse"))
+\#include <aws/core/utils/StringUtils.h>
+\#include <aws/core/utils/UnreferencedParam.h>
+#end
 #foreach($header in $typeInfo.sourceIncludes)
 \#include $header
 #end
@@ -46,6 +50,14 @@ ${typeInfo.className}& ${typeInfo.className}::operator =(JsonView jsonValue)
   return *this;
 }
 
+#if ($typeInfo.shape.isEvent() && $typeInfo.className.endsWith("InitialResponse"))
+${typeInfo.className}::${typeInfo.className}(const Http::HeaderValueCollection& headers) : ${typeInfo.className}()
+{
+#set($ResultClassHeadersDeserializeDoNotGetHeaders = true)
+#parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ResultClassHeadersDeserialize.vm")
+}
+
+#end
 JsonValue ${typeInfo.className}::Jsonize() const
 {
   JsonValue payload;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/queryxml/QueryXmlResultSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/queryxml/QueryXmlResultSource.vm
@@ -63,47 +63,7 @@ ${typeInfo.className}& ${typeInfo.className}::operator =(const Aws::AmazonWebSer
 #end
     AWS_LOGSTREAM_DEBUG("Aws::${metadata.namespace}::Model::${typeInfo.className}", "x-amzn-request-id: " << m_responseMetadata.GetRequestId() );
   }
-#if($shape.hasHeaderMembers())
-  const auto& headers = result.GetHeaderValueCollection();
-#foreach($memberEntry in $shape.members.entrySet())
-#set($varName = $CppViewHelper.computeVariableName($memberEntry.key))
-#set($memberVarName = $CppViewHelper.computeMemberVariableName($memberEntry.key))
-#if($memberEntry.value.usedForHeader)
-#if($memberEntry.value.shape.map)
-  std::size_t prefixSize = sizeof("${memberEntry.value.locationName}") - 1; //subtract the NULL terminator out
-  for(const auto& item : headers)
-  {
-    std::size_t foundPrefix = item.first.find("${memberEntry.value.locationName}");
-
-    if(foundPrefix != std::string::npos)
-    {
-      ${memberVarName}[item.first.substr(prefixSize)] = item.second;
-    }
-  }
-
-#else
-  const auto& ${varName}Iter = headers.find("${memberEntry.value.locationName}");
-  if(${varName}Iter != headers.end())
-  {
-#if($memberEntry.value.shape.string)
-    ${memberVarName} = ${varName}Iter->second;
-#elseif($memberEntry.value.shape.timeStamp)
-    ${memberVarName} = DateTime(${varName}Iter->second.c_str(), Aws::Utils::DateFormat::$CppViewHelper.computeTimestampFormatInHeader($memberEntry.value.shape));
-    if(!${memberVarName}.WasParseSuccessful())
-    {
-      AWS_LOGSTREAM_WARN("${serviceNamespace}::${typeInfo.className}", "Failed to parse ${varName} header as an $CppViewHelper.computeTimestampFormatInHeader($memberEntry.value.shape) timestamp: " << ${varName}Iter->second.c_str());
-    }
-#elseif($memberEntry.value.shape.enum)
-    ${memberVarName} = ${memberEntry.value.shape.name}Mapper::Get${memberEntry.value.shape.name}ForName(${varName}Iter->second);
-#elseif($memberEntry.value.shape.primitive)
-     ${memberVarName} = ${CppViewHelper.computeXmlConversionMethodName($memberEntry.value.shape)}(${varName}Iter->second.c_str());
-#end
-  }
-
-#end
-#end
-#end
-#end
+#parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ResultClassHeadersDeserialize.vm")
 #if($shape.hasStatusCodeMembers())
 #foreach($memberEntry in $shape.members.entrySet())
 #if($memberEntry.value.usedForHttpStatusCode)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlRequestEventStreamHandlerSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlRequestEventStreamHandlerSource.vm
@@ -26,10 +26,11 @@ namespace Model
 
     ${operation.name}Handler::${operation.name}Handler() : EventStreamHandler()
     {
-        m_onInitialResponse = [&](const ${operation.name}InitialResponse&)
+        m_onInitialResponse = [&](const ${operation.name}InitialResponse&, const Utils::Event::InitialResponseType eventType)
         {
             AWS_LOGSTREAM_TRACE(${operation.name.toUpperCase()}_HANDLER_CLASS_TAG,
-                "${operation.name} initial response received.");
+                "${operation.name} initial response received from "
+                << (eventType == Utils::Event::InitialResponseType::ON_EVENT ? "event" : "http headers"));
         };
 
 #foreach($eventMemberEntry in $eventStreamShape.members.entrySet())
@@ -106,7 +107,7 @@ namespace Model
         switch (${operation.name}EventMapper::Get${operation.name}EventTypeForName(eventTypeHeaderIter->second.GetEventHeaderValueAsString()))
         {
 
-        case ${operation.name}EventType::INITIAL_RESPONSE: 
+        case ${operation.name}EventType::INITIAL_RESPONSE:
         {
             auto xmlDoc = XmlDocument::CreateFromXmlString(GetEventPayloadAsString());
             if (!xmlDoc.WasParseSuccessful())
@@ -115,7 +116,7 @@ namespace Model
                 break;
             }
             ${operation.name}InitialResponse event(xmlDoc.GetRootElement());
-            m_onInitialResponse(event);
+            m_onInitialResponse(event, Utils::Event::InitialResponseType::ON_EVENT);
             break;
         }   
 #foreach($eventMemberEntry in $eventStreamShape.members.entrySet())

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/rest/RestXmlResultSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/rest/RestXmlResultSource.vm
@@ -44,47 +44,7 @@ ${typeInfo.className}& ${typeInfo.className}::operator =(const Aws::AmazonWebSer
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/ModelClassMembersDeserializeXml.vm")
   }
 
-#if($shape.hasHeaderMembers())
-  const auto& headers = result.GetHeaderValueCollection();
-#foreach($memberEntry in $shape.members.entrySet())
-#set($varName = $CppViewHelper.computeVariableName($memberEntry.key))
-#set($memberVarName = $CppViewHelper.computeMemberVariableName($memberEntry.key))
-#if($memberEntry.value.usedForHeader)
-#if($memberEntry.value.shape.map)
-  std::size_t prefixSize = sizeof("${memberEntry.value.locationName}") - 1; //subtract the NULL terminator out
-  for(const auto& item : headers)
-  {
-    std::size_t foundPrefix = item.first.find("${memberEntry.value.locationName}");
-
-    if(foundPrefix != std::string::npos)
-    {
-      ${memberVarName}[item.first.substr(prefixSize)] = item.second;
-    }
-  }
-
-#else
-  const auto& ${varName}Iter = headers.find("${memberEntry.value.locationName}");
-  if(${varName}Iter != headers.end())
-  {
-#if($memberEntry.value.shape.string)
-    ${memberVarName} = ${varName}Iter->second;
-#elseif($memberEntry.value.shape.timeStamp)
-    ${memberVarName} = DateTime(${varName}Iter->second, Aws::Utils::DateFormat::$CppViewHelper.computeTimestampFormatInHeader($memberEntry.value.shape));
-    if(!${memberVarName}.WasParseSuccessful())
-    {
-      AWS_LOGSTREAM_WARN("${serviceNamespace}::${typeInfo.className}", "Failed to parse ${varName} header as an $CppViewHelper.computeTimestampFormatInHeader($memberEntry.value.shape) timestamp: " << ${varName}Iter->second.c_str());
-    }
-#elseif($memberEntry.value.shape.enum)
-    ${memberVarName} = ${memberEntry.value.shape.name}Mapper::Get${memberEntry.value.shape.name}ForName(${varName}Iter->second);
-#elseif($memberEntry.value.shape.primitive)
-     ${memberVarName} = ${CppViewHelper.computeXmlConversionMethodName($memberEntry.value.shape)}(${varName}Iter->second.c_str());
-#end
-  }
-
-#end
-#end
-#end
-#end
+#parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ResultClassHeadersDeserialize.vm")
 #if($shape.hasStatusCodeMembers())
 #foreach($memberEntry in $shape.members.entrySet())
 #if($memberEntry.value.usedForHttpStatusCode)


### PR DESCRIPTION
*Issue #, if available:*
impossible to receive Session Id from Transcribe streaming session
*Description of changes:*
After HTTP Client has received headers for a connection
Call user handler on "headersReceived"
Add a default "headersReceived" handler to event stream operation requests and handlers to parse headers as "initial-response" event.

Also small refactoring on code gen headers de-serialization to a model object.
pending CIs and full code regen checks.
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
