### PR TITLE
Update documentation of `DefaultAWSCredentialsProviderChain`.

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProviderChain.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProviderChain.h
@@ -54,14 +54,14 @@ namespace Aws
 
         /**
          * Creates an AWSCredentialsProviderChain which uses in order EnvironmentAWSCredentialsProvider, ProfileConfigFileAWSCredentialsProvider,
-         * and InstanceProfileCredentialsProvider.
+         * ProcessCredentialsProvider, STSAssumeRoleWebIdentityCredentialsProvider and SSOCredentialsProvider.
          */
         class AWS_CORE_API DefaultAWSCredentialsProviderChain : public AWSCredentialsProviderChain
         {
         public:
             /**
              * Initializes the provider chain with EnvironmentAWSCredentialsProvider, ProfileConfigFileAWSCredentialsProvider,
-             * and InstanceProfileCredentialsProvider in that order.
+             * ProcessCredentialsProvider, STSAssumeRoleWebIdentityCredentialsProvider and SSOCredentialsProvider in that order.
              */
             DefaultAWSCredentialsProviderChain();
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR updates the documentation of `DefaultAWSCredentialsProviderChain` to match the credential sources it uses. https://github.com/aws/aws-sdk-cpp/blob/a95671dc38b2c61a18f5398d1e549278e1fbe440/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProviderChain.cpp#L45-L49

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
