### PR TITLE
Fix unused private field warn as error in case of imds v1 disabled

### DIFF
--- a/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
+++ b/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
@@ -200,7 +200,11 @@ namespace Aws
             m_tokenRequired(true),
             m_disableIMDSV1(clientConfiguration.disableImdsV1)
         {
-
+#if defined(DISABLE_IMDSV1)
+            AWS_UNREFERENCED_PARAM(m_disableIMDSV1);
+            m_disableIMDSV1 = true;
+            AWS_LOGSTREAM_TRACE(m_logtag.c_str(), "IMDSv1 had been disabled at the SDK build time");
+#endif
         }
 
         EC2MetadataClient::~EC2MetadataClient()


### PR DESCRIPTION
*Issue #, if available:*
on compilers with "unused-private-field" warning implemented, a variable starts to throw a compiler warning as error
*Description of changes:*
add AWS_UNREFERENCED_PARAM and trace
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
