### PR TITLE
Fix emptylist aws query

### DIFF
--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/AttachInstancesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/AttachInstancesRequest.cpp
@@ -22,12 +22,19 @@ Aws::String AttachInstancesRequest::SerializePayload() const
   ss << "Action=AttachInstances&";
   if(m_instanceIdsHasBeenSet)
   {
-    unsigned instanceIdsCount = 1;
-    for(auto& item : m_instanceIds)
+    if (m_instanceIds.empty())
     {
-      ss << "InstanceIds.member." << instanceIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      instanceIdsCount++;
+      ss << "InstanceIds=&";
+    }
+    else
+    {
+      unsigned instanceIdsCount = 1;
+      for(auto& item : m_instanceIds)
+      {
+        ss << "InstanceIds.member." << instanceIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        instanceIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/AttachLoadBalancerTargetGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/AttachLoadBalancerTargetGroupsRequest.cpp
@@ -27,12 +27,19 @@ Aws::String AttachLoadBalancerTargetGroupsRequest::SerializePayload() const
 
   if(m_targetGroupARNsHasBeenSet)
   {
-    unsigned targetGroupARNsCount = 1;
-    for(auto& item : m_targetGroupARNs)
+    if (m_targetGroupARNs.empty())
     {
-      ss << "TargetGroupARNs.member." << targetGroupARNsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      targetGroupARNsCount++;
+      ss << "TargetGroupARNs=&";
+    }
+    else
+    {
+      unsigned targetGroupARNsCount = 1;
+      for(auto& item : m_targetGroupARNs)
+      {
+        ss << "TargetGroupARNs.member." << targetGroupARNsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        targetGroupARNsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/AttachLoadBalancersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/AttachLoadBalancersRequest.cpp
@@ -27,12 +27,19 @@ Aws::String AttachLoadBalancersRequest::SerializePayload() const
 
   if(m_loadBalancerNamesHasBeenSet)
   {
-    unsigned loadBalancerNamesCount = 1;
-    for(auto& item : m_loadBalancerNames)
+    if (m_loadBalancerNames.empty())
     {
-      ss << "LoadBalancerNames.member." << loadBalancerNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      loadBalancerNamesCount++;
+      ss << "LoadBalancerNames=&";
+    }
+    else
+    {
+      unsigned loadBalancerNamesCount = 1;
+      for(auto& item : m_loadBalancerNames)
+      {
+        ss << "LoadBalancerNames.member." << loadBalancerNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        loadBalancerNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/AttachTrafficSourcesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/AttachTrafficSourcesRequest.cpp
@@ -27,11 +27,18 @@ Aws::String AttachTrafficSourcesRequest::SerializePayload() const
 
   if(m_trafficSourcesHasBeenSet)
   {
-    unsigned trafficSourcesCount = 1;
-    for(auto& item : m_trafficSources)
+    if (m_trafficSources.empty())
     {
-      item.OutputToStream(ss, "TrafficSources.member.", trafficSourcesCount, "");
-      trafficSourcesCount++;
+      ss << "TrafficSources=&";
+    }
+    else
+    {
+      unsigned trafficSourcesCount = 1;
+      for(auto& item : m_trafficSources)
+      {
+        item.OutputToStream(ss, "TrafficSources.member.", trafficSourcesCount, "");
+        trafficSourcesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/BatchDeleteScheduledActionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/BatchDeleteScheduledActionRequest.cpp
@@ -27,12 +27,19 @@ Aws::String BatchDeleteScheduledActionRequest::SerializePayload() const
 
   if(m_scheduledActionNamesHasBeenSet)
   {
-    unsigned scheduledActionNamesCount = 1;
-    for(auto& item : m_scheduledActionNames)
+    if (m_scheduledActionNames.empty())
     {
-      ss << "ScheduledActionNames.member." << scheduledActionNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      scheduledActionNamesCount++;
+      ss << "ScheduledActionNames=&";
+    }
+    else
+    {
+      unsigned scheduledActionNamesCount = 1;
+      for(auto& item : m_scheduledActionNames)
+      {
+        ss << "ScheduledActionNames.member." << scheduledActionNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        scheduledActionNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/BatchPutScheduledUpdateGroupActionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/BatchPutScheduledUpdateGroupActionRequest.cpp
@@ -27,11 +27,18 @@ Aws::String BatchPutScheduledUpdateGroupActionRequest::SerializePayload() const
 
   if(m_scheduledUpdateGroupActionsHasBeenSet)
   {
-    unsigned scheduledUpdateGroupActionsCount = 1;
-    for(auto& item : m_scheduledUpdateGroupActions)
+    if (m_scheduledUpdateGroupActions.empty())
     {
-      item.OutputToStream(ss, "ScheduledUpdateGroupActions.member.", scheduledUpdateGroupActionsCount, "");
-      scheduledUpdateGroupActionsCount++;
+      ss << "ScheduledUpdateGroupActions=&";
+    }
+    else
+    {
+      unsigned scheduledUpdateGroupActionsCount = 1;
+      for(auto& item : m_scheduledUpdateGroupActions)
+      {
+        item.OutputToStream(ss, "ScheduledUpdateGroupActions.member.", scheduledUpdateGroupActionsCount, "");
+        scheduledUpdateGroupActionsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/CreateAutoScalingGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/CreateAutoScalingGroupRequest.cpp
@@ -102,34 +102,55 @@ Aws::String CreateAutoScalingGroupRequest::SerializePayload() const
 
   if(m_availabilityZonesHasBeenSet)
   {
-    unsigned availabilityZonesCount = 1;
-    for(auto& item : m_availabilityZones)
+    if (m_availabilityZones.empty())
     {
-      ss << "AvailabilityZones.member." << availabilityZonesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      availabilityZonesCount++;
+      ss << "AvailabilityZones=&";
+    }
+    else
+    {
+      unsigned availabilityZonesCount = 1;
+      for(auto& item : m_availabilityZones)
+      {
+        ss << "AvailabilityZones.member." << availabilityZonesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        availabilityZonesCount++;
+      }
     }
   }
 
   if(m_loadBalancerNamesHasBeenSet)
   {
-    unsigned loadBalancerNamesCount = 1;
-    for(auto& item : m_loadBalancerNames)
+    if (m_loadBalancerNames.empty())
     {
-      ss << "LoadBalancerNames.member." << loadBalancerNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      loadBalancerNamesCount++;
+      ss << "LoadBalancerNames=&";
+    }
+    else
+    {
+      unsigned loadBalancerNamesCount = 1;
+      for(auto& item : m_loadBalancerNames)
+      {
+        ss << "LoadBalancerNames.member." << loadBalancerNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        loadBalancerNamesCount++;
+      }
     }
   }
 
   if(m_targetGroupARNsHasBeenSet)
   {
-    unsigned targetGroupARNsCount = 1;
-    for(auto& item : m_targetGroupARNs)
+    if (m_targetGroupARNs.empty())
     {
-      ss << "TargetGroupARNs.member." << targetGroupARNsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      targetGroupARNsCount++;
+      ss << "TargetGroupARNs=&";
+    }
+    else
+    {
+      unsigned targetGroupARNsCount = 1;
+      for(auto& item : m_targetGroupARNs)
+      {
+        ss << "TargetGroupARNs.member." << targetGroupARNsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        targetGroupARNsCount++;
+      }
     }
   }
 
@@ -155,12 +176,19 @@ Aws::String CreateAutoScalingGroupRequest::SerializePayload() const
 
   if(m_terminationPoliciesHasBeenSet)
   {
-    unsigned terminationPoliciesCount = 1;
-    for(auto& item : m_terminationPolicies)
+    if (m_terminationPolicies.empty())
     {
-      ss << "TerminationPolicies.member." << terminationPoliciesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      terminationPoliciesCount++;
+      ss << "TerminationPolicies=&";
+    }
+    else
+    {
+      unsigned terminationPoliciesCount = 1;
+      for(auto& item : m_terminationPolicies)
+      {
+        ss << "TerminationPolicies.member." << terminationPoliciesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        terminationPoliciesCount++;
+      }
     }
   }
 
@@ -176,21 +204,35 @@ Aws::String CreateAutoScalingGroupRequest::SerializePayload() const
 
   if(m_lifecycleHookSpecificationListHasBeenSet)
   {
-    unsigned lifecycleHookSpecificationListCount = 1;
-    for(auto& item : m_lifecycleHookSpecificationList)
+    if (m_lifecycleHookSpecificationList.empty())
     {
-      item.OutputToStream(ss, "LifecycleHookSpecificationList.member.", lifecycleHookSpecificationListCount, "");
-      lifecycleHookSpecificationListCount++;
+      ss << "LifecycleHookSpecificationList=&";
+    }
+    else
+    {
+      unsigned lifecycleHookSpecificationListCount = 1;
+      for(auto& item : m_lifecycleHookSpecificationList)
+      {
+        item.OutputToStream(ss, "LifecycleHookSpecificationList.member.", lifecycleHookSpecificationListCount, "");
+        lifecycleHookSpecificationListCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -221,11 +263,18 @@ Aws::String CreateAutoScalingGroupRequest::SerializePayload() const
 
   if(m_trafficSourcesHasBeenSet)
   {
-    unsigned trafficSourcesCount = 1;
-    for(auto& item : m_trafficSources)
+    if (m_trafficSources.empty())
     {
-      item.OutputToStream(ss, "TrafficSources.member.", trafficSourcesCount, "");
-      trafficSourcesCount++;
+      ss << "TrafficSources=&";
+    }
+    else
+    {
+      unsigned trafficSourcesCount = 1;
+      for(auto& item : m_trafficSources)
+      {
+        item.OutputToStream(ss, "TrafficSources.member.", trafficSourcesCount, "");
+        trafficSourcesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/CreateLaunchConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/CreateLaunchConfigurationRequest.cpp
@@ -56,12 +56,19 @@ Aws::String CreateLaunchConfigurationRequest::SerializePayload() const
 
   if(m_securityGroupsHasBeenSet)
   {
-    unsigned securityGroupsCount = 1;
-    for(auto& item : m_securityGroups)
+    if (m_securityGroups.empty())
     {
-      ss << "SecurityGroups.member." << securityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      securityGroupsCount++;
+      ss << "SecurityGroups=&";
+    }
+    else
+    {
+      unsigned securityGroupsCount = 1;
+      for(auto& item : m_securityGroups)
+      {
+        ss << "SecurityGroups.member." << securityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        securityGroupsCount++;
+      }
     }
   }
 
@@ -72,12 +79,19 @@ Aws::String CreateLaunchConfigurationRequest::SerializePayload() const
 
   if(m_classicLinkVPCSecurityGroupsHasBeenSet)
   {
-    unsigned classicLinkVPCSecurityGroupsCount = 1;
-    for(auto& item : m_classicLinkVPCSecurityGroups)
+    if (m_classicLinkVPCSecurityGroups.empty())
     {
-      ss << "ClassicLinkVPCSecurityGroups.member." << classicLinkVPCSecurityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      classicLinkVPCSecurityGroupsCount++;
+      ss << "ClassicLinkVPCSecurityGroups=&";
+    }
+    else
+    {
+      unsigned classicLinkVPCSecurityGroupsCount = 1;
+      for(auto& item : m_classicLinkVPCSecurityGroups)
+      {
+        ss << "ClassicLinkVPCSecurityGroups.member." << classicLinkVPCSecurityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        classicLinkVPCSecurityGroupsCount++;
+      }
     }
   }
 
@@ -108,11 +122,18 @@ Aws::String CreateLaunchConfigurationRequest::SerializePayload() const
 
   if(m_blockDeviceMappingsHasBeenSet)
   {
-    unsigned blockDeviceMappingsCount = 1;
-    for(auto& item : m_blockDeviceMappings)
+    if (m_blockDeviceMappings.empty())
     {
-      item.OutputToStream(ss, "BlockDeviceMappings.member.", blockDeviceMappingsCount, "");
-      blockDeviceMappingsCount++;
+      ss << "BlockDeviceMappings=&";
+    }
+    else
+    {
+      unsigned blockDeviceMappingsCount = 1;
+      for(auto& item : m_blockDeviceMappings)
+      {
+        item.OutputToStream(ss, "BlockDeviceMappings.member.", blockDeviceMappingsCount, "");
+        blockDeviceMappingsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/CreateOrUpdateTagsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/CreateOrUpdateTagsRequest.cpp
@@ -21,11 +21,18 @@ Aws::String CreateOrUpdateTagsRequest::SerializePayload() const
   ss << "Action=CreateOrUpdateTags&";
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DeleteTagsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DeleteTagsRequest.cpp
@@ -21,11 +21,18 @@ Aws::String DeleteTagsRequest::SerializePayload() const
   ss << "Action=DeleteTags&";
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeAutoScalingGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeAutoScalingGroupsRequest.cpp
@@ -25,12 +25,19 @@ Aws::String DescribeAutoScalingGroupsRequest::SerializePayload() const
   ss << "Action=DescribeAutoScalingGroups&";
   if(m_autoScalingGroupNamesHasBeenSet)
   {
-    unsigned autoScalingGroupNamesCount = 1;
-    for(auto& item : m_autoScalingGroupNames)
+    if (m_autoScalingGroupNames.empty())
     {
-      ss << "AutoScalingGroupNames.member." << autoScalingGroupNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      autoScalingGroupNamesCount++;
+      ss << "AutoScalingGroupNames=&";
+    }
+    else
+    {
+      unsigned autoScalingGroupNamesCount = 1;
+      for(auto& item : m_autoScalingGroupNames)
+      {
+        ss << "AutoScalingGroupNames.member." << autoScalingGroupNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        autoScalingGroupNamesCount++;
+      }
     }
   }
 
@@ -46,11 +53,18 @@ Aws::String DescribeAutoScalingGroupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeAutoScalingInstancesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeAutoScalingInstancesRequest.cpp
@@ -24,12 +24,19 @@ Aws::String DescribeAutoScalingInstancesRequest::SerializePayload() const
   ss << "Action=DescribeAutoScalingInstances&";
   if(m_instanceIdsHasBeenSet)
   {
-    unsigned instanceIdsCount = 1;
-    for(auto& item : m_instanceIds)
+    if (m_instanceIds.empty())
     {
-      ss << "InstanceIds.member." << instanceIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      instanceIdsCount++;
+      ss << "InstanceIds=&";
+    }
+    else
+    {
+      unsigned instanceIdsCount = 1;
+      for(auto& item : m_instanceIds)
+      {
+        ss << "InstanceIds.member." << instanceIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        instanceIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeInstanceRefreshesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeInstanceRefreshesRequest.cpp
@@ -30,12 +30,19 @@ Aws::String DescribeInstanceRefreshesRequest::SerializePayload() const
 
   if(m_instanceRefreshIdsHasBeenSet)
   {
-    unsigned instanceRefreshIdsCount = 1;
-    for(auto& item : m_instanceRefreshIds)
+    if (m_instanceRefreshIds.empty())
     {
-      ss << "InstanceRefreshIds.member." << instanceRefreshIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      instanceRefreshIdsCount++;
+      ss << "InstanceRefreshIds=&";
+    }
+    else
+    {
+      unsigned instanceRefreshIdsCount = 1;
+      for(auto& item : m_instanceRefreshIds)
+      {
+        ss << "InstanceRefreshIds.member." << instanceRefreshIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        instanceRefreshIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeLaunchConfigurationsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeLaunchConfigurationsRequest.cpp
@@ -24,12 +24,19 @@ Aws::String DescribeLaunchConfigurationsRequest::SerializePayload() const
   ss << "Action=DescribeLaunchConfigurations&";
   if(m_launchConfigurationNamesHasBeenSet)
   {
-    unsigned launchConfigurationNamesCount = 1;
-    for(auto& item : m_launchConfigurationNames)
+    if (m_launchConfigurationNames.empty())
     {
-      ss << "LaunchConfigurationNames.member." << launchConfigurationNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      launchConfigurationNamesCount++;
+      ss << "LaunchConfigurationNames=&";
+    }
+    else
+    {
+      unsigned launchConfigurationNamesCount = 1;
+      for(auto& item : m_launchConfigurationNames)
+      {
+        ss << "LaunchConfigurationNames.member." << launchConfigurationNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        launchConfigurationNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeLifecycleHooksRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeLifecycleHooksRequest.cpp
@@ -27,12 +27,19 @@ Aws::String DescribeLifecycleHooksRequest::SerializePayload() const
 
   if(m_lifecycleHookNamesHasBeenSet)
   {
-    unsigned lifecycleHookNamesCount = 1;
-    for(auto& item : m_lifecycleHookNames)
+    if (m_lifecycleHookNames.empty())
     {
-      ss << "LifecycleHookNames.member." << lifecycleHookNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      lifecycleHookNamesCount++;
+      ss << "LifecycleHookNames=&";
+    }
+    else
+    {
+      unsigned lifecycleHookNamesCount = 1;
+      for(auto& item : m_lifecycleHookNames)
+      {
+        ss << "LifecycleHookNames.member." << lifecycleHookNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        lifecycleHookNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeNotificationConfigurationsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeNotificationConfigurationsRequest.cpp
@@ -24,12 +24,19 @@ Aws::String DescribeNotificationConfigurationsRequest::SerializePayload() const
   ss << "Action=DescribeNotificationConfigurations&";
   if(m_autoScalingGroupNamesHasBeenSet)
   {
-    unsigned autoScalingGroupNamesCount = 1;
-    for(auto& item : m_autoScalingGroupNames)
+    if (m_autoScalingGroupNames.empty())
     {
-      ss << "AutoScalingGroupNames.member." << autoScalingGroupNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      autoScalingGroupNamesCount++;
+      ss << "AutoScalingGroupNames=&";
+    }
+    else
+    {
+      unsigned autoScalingGroupNamesCount = 1;
+      for(auto& item : m_autoScalingGroupNames)
+      {
+        ss << "AutoScalingGroupNames.member." << autoScalingGroupNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        autoScalingGroupNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribePoliciesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribePoliciesRequest.cpp
@@ -31,23 +31,37 @@ Aws::String DescribePoliciesRequest::SerializePayload() const
 
   if(m_policyNamesHasBeenSet)
   {
-    unsigned policyNamesCount = 1;
-    for(auto& item : m_policyNames)
+    if (m_policyNames.empty())
     {
-      ss << "PolicyNames.member." << policyNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      policyNamesCount++;
+      ss << "PolicyNames=&";
+    }
+    else
+    {
+      unsigned policyNamesCount = 1;
+      for(auto& item : m_policyNames)
+      {
+        ss << "PolicyNames.member." << policyNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        policyNamesCount++;
+      }
     }
   }
 
   if(m_policyTypesHasBeenSet)
   {
-    unsigned policyTypesCount = 1;
-    for(auto& item : m_policyTypes)
+    if (m_policyTypes.empty())
     {
-      ss << "PolicyTypes.member." << policyTypesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      policyTypesCount++;
+      ss << "PolicyTypes=&";
+    }
+    else
+    {
+      unsigned policyTypesCount = 1;
+      for(auto& item : m_policyTypes)
+      {
+        ss << "PolicyTypes.member." << policyTypesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        policyTypesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeScalingActivitiesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeScalingActivitiesRequest.cpp
@@ -27,12 +27,19 @@ Aws::String DescribeScalingActivitiesRequest::SerializePayload() const
   ss << "Action=DescribeScalingActivities&";
   if(m_activityIdsHasBeenSet)
   {
-    unsigned activityIdsCount = 1;
-    for(auto& item : m_activityIds)
+    if (m_activityIds.empty())
     {
-      ss << "ActivityIds.member." << activityIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      activityIdsCount++;
+      ss << "ActivityIds=&";
+    }
+    else
+    {
+      unsigned activityIdsCount = 1;
+      for(auto& item : m_activityIds)
+      {
+        ss << "ActivityIds.member." << activityIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        activityIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeScheduledActionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeScheduledActionsRequest.cpp
@@ -32,12 +32,19 @@ Aws::String DescribeScheduledActionsRequest::SerializePayload() const
 
   if(m_scheduledActionNamesHasBeenSet)
   {
-    unsigned scheduledActionNamesCount = 1;
-    for(auto& item : m_scheduledActionNames)
+    if (m_scheduledActionNames.empty())
     {
-      ss << "ScheduledActionNames.member." << scheduledActionNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      scheduledActionNamesCount++;
+      ss << "ScheduledActionNames=&";
+    }
+    else
+    {
+      unsigned scheduledActionNamesCount = 1;
+      for(auto& item : m_scheduledActionNames)
+      {
+        ss << "ScheduledActionNames.member." << scheduledActionNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        scheduledActionNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeTagsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DescribeTagsRequest.cpp
@@ -24,11 +24,18 @@ Aws::String DescribeTagsRequest::SerializePayload() const
   ss << "Action=DescribeTags&";
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DetachInstancesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DetachInstancesRequest.cpp
@@ -24,12 +24,19 @@ Aws::String DetachInstancesRequest::SerializePayload() const
   ss << "Action=DetachInstances&";
   if(m_instanceIdsHasBeenSet)
   {
-    unsigned instanceIdsCount = 1;
-    for(auto& item : m_instanceIds)
+    if (m_instanceIds.empty())
     {
-      ss << "InstanceIds.member." << instanceIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      instanceIdsCount++;
+      ss << "InstanceIds=&";
+    }
+    else
+    {
+      unsigned instanceIdsCount = 1;
+      for(auto& item : m_instanceIds)
+      {
+        ss << "InstanceIds.member." << instanceIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        instanceIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DetachLoadBalancerTargetGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DetachLoadBalancerTargetGroupsRequest.cpp
@@ -27,12 +27,19 @@ Aws::String DetachLoadBalancerTargetGroupsRequest::SerializePayload() const
 
   if(m_targetGroupARNsHasBeenSet)
   {
-    unsigned targetGroupARNsCount = 1;
-    for(auto& item : m_targetGroupARNs)
+    if (m_targetGroupARNs.empty())
     {
-      ss << "TargetGroupARNs.member." << targetGroupARNsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      targetGroupARNsCount++;
+      ss << "TargetGroupARNs=&";
+    }
+    else
+    {
+      unsigned targetGroupARNsCount = 1;
+      for(auto& item : m_targetGroupARNs)
+      {
+        ss << "TargetGroupARNs.member." << targetGroupARNsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        targetGroupARNsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DetachLoadBalancersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DetachLoadBalancersRequest.cpp
@@ -27,12 +27,19 @@ Aws::String DetachLoadBalancersRequest::SerializePayload() const
 
   if(m_loadBalancerNamesHasBeenSet)
   {
-    unsigned loadBalancerNamesCount = 1;
-    for(auto& item : m_loadBalancerNames)
+    if (m_loadBalancerNames.empty())
     {
-      ss << "LoadBalancerNames.member." << loadBalancerNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      loadBalancerNamesCount++;
+      ss << "LoadBalancerNames=&";
+    }
+    else
+    {
+      unsigned loadBalancerNamesCount = 1;
+      for(auto& item : m_loadBalancerNames)
+      {
+        ss << "LoadBalancerNames.member." << loadBalancerNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        loadBalancerNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DetachTrafficSourcesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DetachTrafficSourcesRequest.cpp
@@ -27,11 +27,18 @@ Aws::String DetachTrafficSourcesRequest::SerializePayload() const
 
   if(m_trafficSourcesHasBeenSet)
   {
-    unsigned trafficSourcesCount = 1;
-    for(auto& item : m_trafficSources)
+    if (m_trafficSources.empty())
     {
-      item.OutputToStream(ss, "TrafficSources.member.", trafficSourcesCount, "");
-      trafficSourcesCount++;
+      ss << "TrafficSources=&";
+    }
+    else
+    {
+      unsigned trafficSourcesCount = 1;
+      for(auto& item : m_trafficSources)
+      {
+        item.OutputToStream(ss, "TrafficSources.member.", trafficSourcesCount, "");
+        trafficSourcesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/DisableMetricsCollectionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/DisableMetricsCollectionRequest.cpp
@@ -27,12 +27,19 @@ Aws::String DisableMetricsCollectionRequest::SerializePayload() const
 
   if(m_metricsHasBeenSet)
   {
-    unsigned metricsCount = 1;
-    for(auto& item : m_metrics)
+    if (m_metrics.empty())
     {
-      ss << "Metrics.member." << metricsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      metricsCount++;
+      ss << "Metrics=&";
+    }
+    else
+    {
+      unsigned metricsCount = 1;
+      for(auto& item : m_metrics)
+      {
+        ss << "Metrics.member." << metricsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        metricsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/EnableMetricsCollectionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/EnableMetricsCollectionRequest.cpp
@@ -28,12 +28,19 @@ Aws::String EnableMetricsCollectionRequest::SerializePayload() const
 
   if(m_metricsHasBeenSet)
   {
-    unsigned metricsCount = 1;
-    for(auto& item : m_metrics)
+    if (m_metrics.empty())
     {
-      ss << "Metrics.member." << metricsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      metricsCount++;
+      ss << "Metrics=&";
+    }
+    else
+    {
+      unsigned metricsCount = 1;
+      for(auto& item : m_metrics)
+      {
+        ss << "Metrics.member." << metricsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        metricsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/EnterStandbyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/EnterStandbyRequest.cpp
@@ -24,12 +24,19 @@ Aws::String EnterStandbyRequest::SerializePayload() const
   ss << "Action=EnterStandby&";
   if(m_instanceIdsHasBeenSet)
   {
-    unsigned instanceIdsCount = 1;
-    for(auto& item : m_instanceIds)
+    if (m_instanceIds.empty())
     {
-      ss << "InstanceIds.member." << instanceIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      instanceIdsCount++;
+      ss << "InstanceIds=&";
+    }
+    else
+    {
+      unsigned instanceIdsCount = 1;
+      for(auto& item : m_instanceIds)
+      {
+        ss << "InstanceIds.member." << instanceIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        instanceIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/ExitStandbyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/ExitStandbyRequest.cpp
@@ -22,12 +22,19 @@ Aws::String ExitStandbyRequest::SerializePayload() const
   ss << "Action=ExitStandby&";
   if(m_instanceIdsHasBeenSet)
   {
-    unsigned instanceIdsCount = 1;
-    for(auto& item : m_instanceIds)
+    if (m_instanceIds.empty())
     {
-      ss << "InstanceIds.member." << instanceIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      instanceIdsCount++;
+      ss << "InstanceIds=&";
+    }
+    else
+    {
+      unsigned instanceIdsCount = 1;
+      for(auto& item : m_instanceIds)
+      {
+        ss << "InstanceIds.member." << instanceIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        instanceIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/PutNotificationConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/PutNotificationConfigurationRequest.cpp
@@ -33,12 +33,19 @@ Aws::String PutNotificationConfigurationRequest::SerializePayload() const
 
   if(m_notificationTypesHasBeenSet)
   {
-    unsigned notificationTypesCount = 1;
-    for(auto& item : m_notificationTypes)
+    if (m_notificationTypes.empty())
     {
-      ss << "NotificationTypes.member." << notificationTypesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      notificationTypesCount++;
+      ss << "NotificationTypes=&";
+    }
+    else
+    {
+      unsigned notificationTypesCount = 1;
+      for(auto& item : m_notificationTypes)
+      {
+        ss << "NotificationTypes.member." << notificationTypesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        notificationTypesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/PutScalingPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/PutScalingPolicyRequest.cpp
@@ -85,11 +85,18 @@ Aws::String PutScalingPolicyRequest::SerializePayload() const
 
   if(m_stepAdjustmentsHasBeenSet)
   {
-    unsigned stepAdjustmentsCount = 1;
-    for(auto& item : m_stepAdjustments)
+    if (m_stepAdjustments.empty())
     {
-      item.OutputToStream(ss, "StepAdjustments.member.", stepAdjustmentsCount, "");
-      stepAdjustmentsCount++;
+      ss << "StepAdjustments=&";
+    }
+    else
+    {
+      unsigned stepAdjustmentsCount = 1;
+      for(auto& item : m_stepAdjustments)
+      {
+        item.OutputToStream(ss, "StepAdjustments.member.", stepAdjustmentsCount, "");
+        stepAdjustmentsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/ResumeProcessesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/ResumeProcessesRequest.cpp
@@ -27,12 +27,19 @@ Aws::String ResumeProcessesRequest::SerializePayload() const
 
   if(m_scalingProcessesHasBeenSet)
   {
-    unsigned scalingProcessesCount = 1;
-    for(auto& item : m_scalingProcesses)
+    if (m_scalingProcesses.empty())
     {
-      ss << "ScalingProcesses.member." << scalingProcessesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      scalingProcessesCount++;
+      ss << "ScalingProcesses=&";
+    }
+    else
+    {
+      unsigned scalingProcessesCount = 1;
+      for(auto& item : m_scalingProcesses)
+      {
+        ss << "ScalingProcesses.member." << scalingProcessesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        scalingProcessesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/SetInstanceProtectionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/SetInstanceProtectionRequest.cpp
@@ -24,12 +24,19 @@ Aws::String SetInstanceProtectionRequest::SerializePayload() const
   ss << "Action=SetInstanceProtection&";
   if(m_instanceIdsHasBeenSet)
   {
-    unsigned instanceIdsCount = 1;
-    for(auto& item : m_instanceIds)
+    if (m_instanceIds.empty())
     {
-      ss << "InstanceIds.member." << instanceIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      instanceIdsCount++;
+      ss << "InstanceIds=&";
+    }
+    else
+    {
+      unsigned instanceIdsCount = 1;
+      for(auto& item : m_instanceIds)
+      {
+        ss << "InstanceIds.member." << instanceIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        instanceIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/SuspendProcessesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/SuspendProcessesRequest.cpp
@@ -27,12 +27,19 @@ Aws::String SuspendProcessesRequest::SerializePayload() const
 
   if(m_scalingProcessesHasBeenSet)
   {
-    unsigned scalingProcessesCount = 1;
-    for(auto& item : m_scalingProcesses)
+    if (m_scalingProcesses.empty())
     {
-      ss << "ScalingProcesses.member." << scalingProcessesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      scalingProcessesCount++;
+      ss << "ScalingProcesses=&";
+    }
+    else
+    {
+      unsigned scalingProcessesCount = 1;
+      for(auto& item : m_scalingProcesses)
+      {
+        ss << "ScalingProcesses.member." << scalingProcessesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        scalingProcessesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/model/UpdateAutoScalingGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/model/UpdateAutoScalingGroupRequest.cpp
@@ -91,12 +91,19 @@ Aws::String UpdateAutoScalingGroupRequest::SerializePayload() const
 
   if(m_availabilityZonesHasBeenSet)
   {
-    unsigned availabilityZonesCount = 1;
-    for(auto& item : m_availabilityZones)
+    if (m_availabilityZones.empty())
     {
-      ss << "AvailabilityZones.member." << availabilityZonesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      availabilityZonesCount++;
+      ss << "AvailabilityZones=&";
+    }
+    else
+    {
+      unsigned availabilityZonesCount = 1;
+      for(auto& item : m_availabilityZones)
+      {
+        ss << "AvailabilityZones.member." << availabilityZonesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        availabilityZonesCount++;
+      }
     }
   }
 
@@ -122,12 +129,19 @@ Aws::String UpdateAutoScalingGroupRequest::SerializePayload() const
 
   if(m_terminationPoliciesHasBeenSet)
   {
-    unsigned terminationPoliciesCount = 1;
-    for(auto& item : m_terminationPolicies)
+    if (m_terminationPolicies.empty())
     {
-      ss << "TerminationPolicies.member." << terminationPoliciesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      terminationPoliciesCount++;
+      ss << "TerminationPolicies=&";
+    }
+    else
+    {
+      unsigned terminationPoliciesCount = 1;
+      for(auto& item : m_terminationPolicies)
+      {
+        ss << "TerminationPolicies.member." << terminationPoliciesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        terminationPoliciesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/BatchDescribeTypeConfigurationsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/BatchDescribeTypeConfigurationsRequest.cpp
@@ -21,11 +21,18 @@ Aws::String BatchDescribeTypeConfigurationsRequest::SerializePayload() const
   ss << "Action=BatchDescribeTypeConfigurations&";
   if(m_typeConfigurationIdentifiersHasBeenSet)
   {
-    unsigned typeConfigurationIdentifiersCount = 1;
-    for(auto& item : m_typeConfigurationIdentifiers)
+    if (m_typeConfigurationIdentifiers.empty())
     {
-      item.OutputToStream(ss, "TypeConfigurationIdentifiers.member.", typeConfigurationIdentifiersCount, "");
-      typeConfigurationIdentifiersCount++;
+      ss << "TypeConfigurationIdentifiers=&";
+    }
+    else
+    {
+      unsigned typeConfigurationIdentifiersCount = 1;
+      for(auto& item : m_typeConfigurationIdentifiers)
+      {
+        item.OutputToStream(ss, "TypeConfigurationIdentifiers.member.", typeConfigurationIdentifiersCount, "");
+        typeConfigurationIdentifiersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/ContinueUpdateRollbackRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/ContinueUpdateRollbackRequest.cpp
@@ -34,12 +34,19 @@ Aws::String ContinueUpdateRollbackRequest::SerializePayload() const
 
   if(m_resourcesToSkipHasBeenSet)
   {
-    unsigned resourcesToSkipCount = 1;
-    for(auto& item : m_resourcesToSkip)
+    if (m_resourcesToSkip.empty())
     {
-      ss << "ResourcesToSkip.member." << resourcesToSkipCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      resourcesToSkipCount++;
+      ss << "ResourcesToSkip=&";
+    }
+    else
+    {
+      unsigned resourcesToSkipCount = 1;
+      for(auto& item : m_resourcesToSkip)
+      {
+        ss << "ResourcesToSkip.member." << resourcesToSkipCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        resourcesToSkipCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/CreateChangeSetRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/CreateChangeSetRequest.cpp
@@ -64,33 +64,54 @@ Aws::String CreateChangeSetRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 
   if(m_capabilitiesHasBeenSet)
   {
-    unsigned capabilitiesCount = 1;
-    for(auto& item : m_capabilities)
+    if (m_capabilities.empty())
     {
-      ss << "Capabilities.member." << capabilitiesCount << "="
-          << StringUtils::URLEncode(CapabilityMapper::GetNameForCapability(item).c_str()) << "&";
-      capabilitiesCount++;
+      ss << "Capabilities=&";
+    }
+    else
+    {
+      unsigned capabilitiesCount = 1;
+      for(auto& item : m_capabilities)
+      {
+        ss << "Capabilities.member." << capabilitiesCount << "="
+            << StringUtils::URLEncode(CapabilityMapper::GetNameForCapability(item).c_str()) << "&";
+        capabilitiesCount++;
+      }
     }
   }
 
   if(m_resourceTypesHasBeenSet)
   {
-    unsigned resourceTypesCount = 1;
-    for(auto& item : m_resourceTypes)
+    if (m_resourceTypes.empty())
     {
-      ss << "ResourceTypes.member." << resourceTypesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      resourceTypesCount++;
+      ss << "ResourceTypes=&";
+    }
+    else
+    {
+      unsigned resourceTypesCount = 1;
+      for(auto& item : m_resourceTypes)
+      {
+        ss << "ResourceTypes.member." << resourceTypesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        resourceTypesCount++;
+      }
     }
   }
 
@@ -106,22 +127,36 @@ Aws::String CreateChangeSetRequest::SerializePayload() const
 
   if(m_notificationARNsHasBeenSet)
   {
-    unsigned notificationARNsCount = 1;
-    for(auto& item : m_notificationARNs)
+    if (m_notificationARNs.empty())
     {
-      ss << "NotificationARNs.member." << notificationARNsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      notificationARNsCount++;
+      ss << "NotificationARNs=&";
+    }
+    else
+    {
+      unsigned notificationARNsCount = 1;
+      for(auto& item : m_notificationARNs)
+      {
+        ss << "NotificationARNs.member." << notificationARNsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        notificationARNsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -147,11 +182,18 @@ Aws::String CreateChangeSetRequest::SerializePayload() const
 
   if(m_resourcesToImportHasBeenSet)
   {
-    unsigned resourcesToImportCount = 1;
-    for(auto& item : m_resourcesToImport)
+    if (m_resourcesToImport.empty())
     {
-      item.OutputToStream(ss, "ResourcesToImport.member.", resourcesToImportCount, "");
-      resourcesToImportCount++;
+      ss << "ResourcesToImport=&";
+    }
+    else
+    {
+      unsigned resourcesToImportCount = 1;
+      for(auto& item : m_resourcesToImport)
+      {
+        item.OutputToStream(ss, "ResourcesToImport.member.", resourcesToImportCount, "");
+        resourcesToImportCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/CreateGeneratedTemplateRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/CreateGeneratedTemplateRequest.cpp
@@ -24,11 +24,18 @@ Aws::String CreateGeneratedTemplateRequest::SerializePayload() const
   ss << "Action=CreateGeneratedTemplate&";
   if(m_resourcesHasBeenSet)
   {
-    unsigned resourcesCount = 1;
-    for(auto& item : m_resources)
+    if (m_resources.empty())
     {
-      item.OutputToStream(ss, "Resources.member.", resourcesCount, "");
-      resourcesCount++;
+      ss << "Resources=&";
+    }
+    else
+    {
+      unsigned resourcesCount = 1;
+      for(auto& item : m_resources)
+      {
+        item.OutputToStream(ss, "Resources.member.", resourcesCount, "");
+        resourcesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/CreateStackInstancesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/CreateStackInstancesRequest.cpp
@@ -35,12 +35,19 @@ Aws::String CreateStackInstancesRequest::SerializePayload() const
 
   if(m_accountsHasBeenSet)
   {
-    unsigned accountsCount = 1;
-    for(auto& item : m_accounts)
+    if (m_accounts.empty())
     {
-      ss << "Accounts.member." << accountsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      accountsCount++;
+      ss << "Accounts=&";
+    }
+    else
+    {
+      unsigned accountsCount = 1;
+      for(auto& item : m_accounts)
+      {
+        ss << "Accounts.member." << accountsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        accountsCount++;
+      }
     }
   }
 
@@ -51,22 +58,36 @@ Aws::String CreateStackInstancesRequest::SerializePayload() const
 
   if(m_regionsHasBeenSet)
   {
-    unsigned regionsCount = 1;
-    for(auto& item : m_regions)
+    if (m_regions.empty())
     {
-      ss << "Regions.member." << regionsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      regionsCount++;
+      ss << "Regions=&";
+    }
+    else
+    {
+      unsigned regionsCount = 1;
+      for(auto& item : m_regions)
+      {
+        ss << "Regions.member." << regionsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        regionsCount++;
+      }
     }
   }
 
   if(m_parameterOverridesHasBeenSet)
   {
-    unsigned parameterOverridesCount = 1;
-    for(auto& item : m_parameterOverrides)
+    if (m_parameterOverrides.empty())
     {
-      item.OutputToStream(ss, "ParameterOverrides.member.", parameterOverridesCount, "");
-      parameterOverridesCount++;
+      ss << "ParameterOverrides=&";
+    }
+    else
+    {
+      unsigned parameterOverridesCount = 1;
+      for(auto& item : m_parameterOverrides)
+      {
+        item.OutputToStream(ss, "ParameterOverrides.member.", parameterOverridesCount, "");
+        parameterOverridesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/CreateStackRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/CreateStackRequest.cpp
@@ -58,11 +58,18 @@ Aws::String CreateStackRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 
@@ -83,34 +90,55 @@ Aws::String CreateStackRequest::SerializePayload() const
 
   if(m_notificationARNsHasBeenSet)
   {
-    unsigned notificationARNsCount = 1;
-    for(auto& item : m_notificationARNs)
+    if (m_notificationARNs.empty())
     {
-      ss << "NotificationARNs.member." << notificationARNsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      notificationARNsCount++;
+      ss << "NotificationARNs=&";
+    }
+    else
+    {
+      unsigned notificationARNsCount = 1;
+      for(auto& item : m_notificationARNs)
+      {
+        ss << "NotificationARNs.member." << notificationARNsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        notificationARNsCount++;
+      }
     }
   }
 
   if(m_capabilitiesHasBeenSet)
   {
-    unsigned capabilitiesCount = 1;
-    for(auto& item : m_capabilities)
+    if (m_capabilities.empty())
     {
-      ss << "Capabilities.member." << capabilitiesCount << "="
-          << StringUtils::URLEncode(CapabilityMapper::GetNameForCapability(item).c_str()) << "&";
-      capabilitiesCount++;
+      ss << "Capabilities=&";
+    }
+    else
+    {
+      unsigned capabilitiesCount = 1;
+      for(auto& item : m_capabilities)
+      {
+        ss << "Capabilities.member." << capabilitiesCount << "="
+            << StringUtils::URLEncode(CapabilityMapper::GetNameForCapability(item).c_str()) << "&";
+        capabilitiesCount++;
+      }
     }
   }
 
   if(m_resourceTypesHasBeenSet)
   {
-    unsigned resourceTypesCount = 1;
-    for(auto& item : m_resourceTypes)
+    if (m_resourceTypes.empty())
     {
-      ss << "ResourceTypes.member." << resourceTypesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      resourceTypesCount++;
+      ss << "ResourceTypes=&";
+    }
+    else
+    {
+      unsigned resourceTypesCount = 1;
+      for(auto& item : m_resourceTypes)
+      {
+        ss << "ResourceTypes.member." << resourceTypesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        resourceTypesCount++;
+      }
     }
   }
 
@@ -136,11 +164,18 @@ Aws::String CreateStackRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/CreateStackSetRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/CreateStackSetRequest.cpp
@@ -63,32 +63,53 @@ Aws::String CreateStackSetRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 
   if(m_capabilitiesHasBeenSet)
   {
-    unsigned capabilitiesCount = 1;
-    for(auto& item : m_capabilities)
+    if (m_capabilities.empty())
     {
-      ss << "Capabilities.member." << capabilitiesCount << "="
-          << StringUtils::URLEncode(CapabilityMapper::GetNameForCapability(item).c_str()) << "&";
-      capabilitiesCount++;
+      ss << "Capabilities=&";
+    }
+    else
+    {
+      unsigned capabilitiesCount = 1;
+      for(auto& item : m_capabilities)
+      {
+        ss << "Capabilities.member." << capabilitiesCount << "="
+            << StringUtils::URLEncode(CapabilityMapper::GetNameForCapability(item).c_str()) << "&";
+        capabilitiesCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/DeleteStackInstancesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/DeleteStackInstancesRequest.cpp
@@ -36,12 +36,19 @@ Aws::String DeleteStackInstancesRequest::SerializePayload() const
 
   if(m_accountsHasBeenSet)
   {
-    unsigned accountsCount = 1;
-    for(auto& item : m_accounts)
+    if (m_accounts.empty())
     {
-      ss << "Accounts.member." << accountsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      accountsCount++;
+      ss << "Accounts=&";
+    }
+    else
+    {
+      unsigned accountsCount = 1;
+      for(auto& item : m_accounts)
+      {
+        ss << "Accounts.member." << accountsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        accountsCount++;
+      }
     }
   }
 
@@ -52,12 +59,19 @@ Aws::String DeleteStackInstancesRequest::SerializePayload() const
 
   if(m_regionsHasBeenSet)
   {
-    unsigned regionsCount = 1;
-    for(auto& item : m_regions)
+    if (m_regions.empty())
     {
-      ss << "Regions.member." << regionsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      regionsCount++;
+      ss << "Regions=&";
+    }
+    else
+    {
+      unsigned regionsCount = 1;
+      for(auto& item : m_regions)
+      {
+        ss << "Regions.member." << regionsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        regionsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/DeleteStackRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/DeleteStackRequest.cpp
@@ -31,12 +31,19 @@ Aws::String DeleteStackRequest::SerializePayload() const
 
   if(m_retainResourcesHasBeenSet)
   {
-    unsigned retainResourcesCount = 1;
-    for(auto& item : m_retainResources)
+    if (m_retainResources.empty())
     {
-      ss << "RetainResources.member." << retainResourcesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      retainResourcesCount++;
+      ss << "RetainResources=&";
+    }
+    else
+    {
+      unsigned retainResourcesCount = 1;
+      for(auto& item : m_retainResources)
+      {
+        ss << "RetainResources.member." << retainResourcesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        retainResourcesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/DescribeStackResourceDriftsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/DescribeStackResourceDriftsRequest.cpp
@@ -30,12 +30,19 @@ Aws::String DescribeStackResourceDriftsRequest::SerializePayload() const
 
   if(m_stackResourceDriftStatusFiltersHasBeenSet)
   {
-    unsigned stackResourceDriftStatusFiltersCount = 1;
-    for(auto& item : m_stackResourceDriftStatusFilters)
+    if (m_stackResourceDriftStatusFilters.empty())
     {
-      ss << "StackResourceDriftStatusFilters.member." << stackResourceDriftStatusFiltersCount << "="
-          << StringUtils::URLEncode(StackResourceDriftStatusMapper::GetNameForStackResourceDriftStatus(item).c_str()) << "&";
-      stackResourceDriftStatusFiltersCount++;
+      ss << "StackResourceDriftStatusFilters=&";
+    }
+    else
+    {
+      unsigned stackResourceDriftStatusFiltersCount = 1;
+      for(auto& item : m_stackResourceDriftStatusFilters)
+      {
+        ss << "StackResourceDriftStatusFilters.member." << stackResourceDriftStatusFiltersCount << "="
+            << StringUtils::URLEncode(StackResourceDriftStatusMapper::GetNameForStackResourceDriftStatus(item).c_str()) << "&";
+        stackResourceDriftStatusFiltersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/DetectStackDriftRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/DetectStackDriftRequest.cpp
@@ -27,12 +27,19 @@ Aws::String DetectStackDriftRequest::SerializePayload() const
 
   if(m_logicalResourceIdsHasBeenSet)
   {
-    unsigned logicalResourceIdsCount = 1;
-    for(auto& item : m_logicalResourceIds)
+    if (m_logicalResourceIds.empty())
     {
-      ss << "LogicalResourceIds.member." << logicalResourceIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      logicalResourceIdsCount++;
+      ss << "LogicalResourceIds=&";
+    }
+    else
+    {
+      unsigned logicalResourceIdsCount = 1;
+      for(auto& item : m_logicalResourceIds)
+      {
+        ss << "LogicalResourceIds.member." << logicalResourceIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        logicalResourceIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/EstimateTemplateCostRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/EstimateTemplateCostRequest.cpp
@@ -33,11 +33,18 @@ Aws::String EstimateTemplateCostRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/ImportStacksToStackSetRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/ImportStacksToStackSetRequest.cpp
@@ -34,12 +34,19 @@ Aws::String ImportStacksToStackSetRequest::SerializePayload() const
 
   if(m_stackIdsHasBeenSet)
   {
-    unsigned stackIdsCount = 1;
-    for(auto& item : m_stackIds)
+    if (m_stackIds.empty())
     {
-      ss << "StackIds.member." << stackIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      stackIdsCount++;
+      ss << "StackIds=&";
+    }
+    else
+    {
+      unsigned stackIdsCount = 1;
+      for(auto& item : m_stackIds)
+      {
+        ss << "StackIds.member." << stackIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        stackIdsCount++;
+      }
     }
   }
 
@@ -50,12 +57,19 @@ Aws::String ImportStacksToStackSetRequest::SerializePayload() const
 
   if(m_organizationalUnitIdsHasBeenSet)
   {
-    unsigned organizationalUnitIdsCount = 1;
-    for(auto& item : m_organizationalUnitIds)
+    if (m_organizationalUnitIds.empty())
     {
-      ss << "OrganizationalUnitIds.member." << organizationalUnitIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      organizationalUnitIdsCount++;
+      ss << "OrganizationalUnitIds=&";
+    }
+    else
+    {
+      unsigned organizationalUnitIdsCount = 1;
+      for(auto& item : m_organizationalUnitIds)
+      {
+        ss << "OrganizationalUnitIds.member." << organizationalUnitIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        organizationalUnitIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/ListResourceScanRelatedResourcesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/ListResourceScanRelatedResourcesRequest.cpp
@@ -30,11 +30,18 @@ Aws::String ListResourceScanRelatedResourcesRequest::SerializePayload() const
 
   if(m_resourcesHasBeenSet)
   {
-    unsigned resourcesCount = 1;
-    for(auto& item : m_resources)
+    if (m_resources.empty())
     {
-      item.OutputToStream(ss, "Resources.member.", resourcesCount, "");
-      resourcesCount++;
+      ss << "Resources=&";
+    }
+    else
+    {
+      unsigned resourcesCount = 1;
+      for(auto& item : m_resources)
+      {
+        item.OutputToStream(ss, "Resources.member.", resourcesCount, "");
+        resourcesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/ListStackInstanceResourceDriftsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/ListStackInstanceResourceDriftsRequest.cpp
@@ -45,12 +45,19 @@ Aws::String ListStackInstanceResourceDriftsRequest::SerializePayload() const
 
   if(m_stackInstanceResourceDriftStatusesHasBeenSet)
   {
-    unsigned stackInstanceResourceDriftStatusesCount = 1;
-    for(auto& item : m_stackInstanceResourceDriftStatuses)
+    if (m_stackInstanceResourceDriftStatuses.empty())
     {
-      ss << "StackInstanceResourceDriftStatuses.member." << stackInstanceResourceDriftStatusesCount << "="
-          << StringUtils::URLEncode(StackResourceDriftStatusMapper::GetNameForStackResourceDriftStatus(item).c_str()) << "&";
-      stackInstanceResourceDriftStatusesCount++;
+      ss << "StackInstanceResourceDriftStatuses=&";
+    }
+    else
+    {
+      unsigned stackInstanceResourceDriftStatusesCount = 1;
+      for(auto& item : m_stackInstanceResourceDriftStatuses)
+      {
+        ss << "StackInstanceResourceDriftStatuses.member." << stackInstanceResourceDriftStatusesCount << "="
+            << StringUtils::URLEncode(StackResourceDriftStatusMapper::GetNameForStackResourceDriftStatus(item).c_str()) << "&";
+        stackInstanceResourceDriftStatusesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/ListStackInstancesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/ListStackInstancesRequest.cpp
@@ -44,11 +44,18 @@ Aws::String ListStackInstancesRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/ListStackSetOperationResultsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/ListStackSetOperationResultsRequest.cpp
@@ -53,11 +53,18 @@ Aws::String ListStackSetOperationResultsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/ListStacksRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/ListStacksRequest.cpp
@@ -27,12 +27,19 @@ Aws::String ListStacksRequest::SerializePayload() const
 
   if(m_stackStatusFilterHasBeenSet)
   {
-    unsigned stackStatusFilterCount = 1;
-    for(auto& item : m_stackStatusFilter)
+    if (m_stackStatusFilter.empty())
     {
-      ss << "StackStatusFilter.member." << stackStatusFilterCount << "="
-          << StringUtils::URLEncode(StackStatusMapper::GetNameForStackStatus(item).c_str()) << "&";
-      stackStatusFilterCount++;
+      ss << "StackStatusFilter=&";
+    }
+    else
+    {
+      unsigned stackStatusFilterCount = 1;
+      for(auto& item : m_stackStatusFilter)
+      {
+        ss << "StackStatusFilter.member." << stackStatusFilterCount << "="
+            << StringUtils::URLEncode(StackStatusMapper::GetNameForStackStatus(item).c_str()) << "&";
+        stackStatusFilterCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/UpdateGeneratedTemplateRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/UpdateGeneratedTemplateRequest.cpp
@@ -37,22 +37,36 @@ Aws::String UpdateGeneratedTemplateRequest::SerializePayload() const
 
   if(m_addResourcesHasBeenSet)
   {
-    unsigned addResourcesCount = 1;
-    for(auto& item : m_addResources)
+    if (m_addResources.empty())
     {
-      item.OutputToStream(ss, "AddResources.member.", addResourcesCount, "");
-      addResourcesCount++;
+      ss << "AddResources=&";
+    }
+    else
+    {
+      unsigned addResourcesCount = 1;
+      for(auto& item : m_addResources)
+      {
+        item.OutputToStream(ss, "AddResources.member.", addResourcesCount, "");
+        addResourcesCount++;
+      }
     }
   }
 
   if(m_removeResourcesHasBeenSet)
   {
-    unsigned removeResourcesCount = 1;
-    for(auto& item : m_removeResources)
+    if (m_removeResources.empty())
     {
-      ss << "RemoveResources.member." << removeResourcesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      removeResourcesCount++;
+      ss << "RemoveResources=&";
+    }
+    else
+    {
+      unsigned removeResourcesCount = 1;
+      for(auto& item : m_removeResources)
+      {
+        ss << "RemoveResources.member." << removeResourcesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        removeResourcesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/UpdateStackInstancesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/UpdateStackInstancesRequest.cpp
@@ -35,12 +35,19 @@ Aws::String UpdateStackInstancesRequest::SerializePayload() const
 
   if(m_accountsHasBeenSet)
   {
-    unsigned accountsCount = 1;
-    for(auto& item : m_accounts)
+    if (m_accounts.empty())
     {
-      ss << "Accounts.member." << accountsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      accountsCount++;
+      ss << "Accounts=&";
+    }
+    else
+    {
+      unsigned accountsCount = 1;
+      for(auto& item : m_accounts)
+      {
+        ss << "Accounts.member." << accountsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        accountsCount++;
+      }
     }
   }
 
@@ -51,22 +58,36 @@ Aws::String UpdateStackInstancesRequest::SerializePayload() const
 
   if(m_regionsHasBeenSet)
   {
-    unsigned regionsCount = 1;
-    for(auto& item : m_regions)
+    if (m_regions.empty())
     {
-      ss << "Regions.member." << regionsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      regionsCount++;
+      ss << "Regions=&";
+    }
+    else
+    {
+      unsigned regionsCount = 1;
+      for(auto& item : m_regions)
+      {
+        ss << "Regions.member." << regionsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        regionsCount++;
+      }
     }
   }
 
   if(m_parameterOverridesHasBeenSet)
   {
-    unsigned parameterOverridesCount = 1;
-    for(auto& item : m_parameterOverrides)
+    if (m_parameterOverrides.empty())
     {
-      item.OutputToStream(ss, "ParameterOverrides.member.", parameterOverridesCount, "");
-      parameterOverridesCount++;
+      ss << "ParameterOverrides=&";
+    }
+    else
+    {
+      unsigned parameterOverridesCount = 1;
+      for(auto& item : m_parameterOverrides)
+      {
+        item.OutputToStream(ss, "ParameterOverrides.member.", parameterOverridesCount, "");
+        parameterOverridesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/UpdateStackRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/UpdateStackRequest.cpp
@@ -71,33 +71,54 @@ Aws::String UpdateStackRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 
   if(m_capabilitiesHasBeenSet)
   {
-    unsigned capabilitiesCount = 1;
-    for(auto& item : m_capabilities)
+    if (m_capabilities.empty())
     {
-      ss << "Capabilities.member." << capabilitiesCount << "="
-          << StringUtils::URLEncode(CapabilityMapper::GetNameForCapability(item).c_str()) << "&";
-      capabilitiesCount++;
+      ss << "Capabilities=&";
+    }
+    else
+    {
+      unsigned capabilitiesCount = 1;
+      for(auto& item : m_capabilities)
+      {
+        ss << "Capabilities.member." << capabilitiesCount << "="
+            << StringUtils::URLEncode(CapabilityMapper::GetNameForCapability(item).c_str()) << "&";
+        capabilitiesCount++;
+      }
     }
   }
 
   if(m_resourceTypesHasBeenSet)
   {
-    unsigned resourceTypesCount = 1;
-    for(auto& item : m_resourceTypes)
+    if (m_resourceTypes.empty())
     {
-      ss << "ResourceTypes.member." << resourceTypesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      resourceTypesCount++;
+      ss << "ResourceTypes=&";
+    }
+    else
+    {
+      unsigned resourceTypesCount = 1;
+      for(auto& item : m_resourceTypes)
+      {
+        ss << "ResourceTypes.member." << resourceTypesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        resourceTypesCount++;
+      }
     }
   }
 
@@ -123,22 +144,36 @@ Aws::String UpdateStackRequest::SerializePayload() const
 
   if(m_notificationARNsHasBeenSet)
   {
-    unsigned notificationARNsCount = 1;
-    for(auto& item : m_notificationARNs)
+    if (m_notificationARNs.empty())
     {
-      ss << "NotificationARNs.member." << notificationARNsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      notificationARNsCount++;
+      ss << "NotificationARNs=&";
+    }
+    else
+    {
+      unsigned notificationARNsCount = 1;
+      for(auto& item : m_notificationARNs)
+      {
+        ss << "NotificationARNs.member." << notificationARNsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        notificationARNsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/model/UpdateStackSetRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/model/UpdateStackSetRequest.cpp
@@ -68,32 +68,53 @@ Aws::String UpdateStackSetRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 
   if(m_capabilitiesHasBeenSet)
   {
-    unsigned capabilitiesCount = 1;
-    for(auto& item : m_capabilities)
+    if (m_capabilities.empty())
     {
-      ss << "Capabilities.member." << capabilitiesCount << "="
-          << StringUtils::URLEncode(CapabilityMapper::GetNameForCapability(item).c_str()) << "&";
-      capabilitiesCount++;
+      ss << "Capabilities=&";
+    }
+    else
+    {
+      unsigned capabilitiesCount = 1;
+      for(auto& item : m_capabilities)
+      {
+        ss << "Capabilities.member." << capabilitiesCount << "="
+            << StringUtils::URLEncode(CapabilityMapper::GetNameForCapability(item).c_str()) << "&";
+        capabilitiesCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -134,23 +155,37 @@ Aws::String UpdateStackSetRequest::SerializePayload() const
 
   if(m_accountsHasBeenSet)
   {
-    unsigned accountsCount = 1;
-    for(auto& item : m_accounts)
+    if (m_accounts.empty())
     {
-      ss << "Accounts.member." << accountsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      accountsCount++;
+      ss << "Accounts=&";
+    }
+    else
+    {
+      unsigned accountsCount = 1;
+      for(auto& item : m_accounts)
+      {
+        ss << "Accounts.member." << accountsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        accountsCount++;
+      }
     }
   }
 
   if(m_regionsHasBeenSet)
   {
-    unsigned regionsCount = 1;
-    for(auto& item : m_regions)
+    if (m_regions.empty())
     {
-      ss << "Regions.member." << regionsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      regionsCount++;
+      ss << "Regions=&";
+    }
+    else
+    {
+      unsigned regionsCount = 1;
+      for(auto& item : m_regions)
+      {
+        ss << "Regions.member." << regionsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        regionsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudsearch/source/model/DescribeAnalysisSchemesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudsearch/source/model/DescribeAnalysisSchemesRequest.cpp
@@ -29,12 +29,19 @@ Aws::String DescribeAnalysisSchemesRequest::SerializePayload() const
 
   if(m_analysisSchemeNamesHasBeenSet)
   {
-    unsigned analysisSchemeNamesCount = 1;
-    for(auto& item : m_analysisSchemeNames)
+    if (m_analysisSchemeNames.empty())
     {
-      ss << "AnalysisSchemeNames.member." << analysisSchemeNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      analysisSchemeNamesCount++;
+      ss << "AnalysisSchemeNames=&";
+    }
+    else
+    {
+      unsigned analysisSchemeNamesCount = 1;
+      for(auto& item : m_analysisSchemeNames)
+      {
+        ss << "AnalysisSchemeNames.member." << analysisSchemeNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        analysisSchemeNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudsearch/source/model/DescribeDomainsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudsearch/source/model/DescribeDomainsRequest.cpp
@@ -21,12 +21,19 @@ Aws::String DescribeDomainsRequest::SerializePayload() const
   ss << "Action=DescribeDomains&";
   if(m_domainNamesHasBeenSet)
   {
-    unsigned domainNamesCount = 1;
-    for(auto& item : m_domainNames)
+    if (m_domainNames.empty())
     {
-      ss << "DomainNames.member." << domainNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      domainNamesCount++;
+      ss << "DomainNames=&";
+    }
+    else
+    {
+      unsigned domainNamesCount = 1;
+      for(auto& item : m_domainNames)
+      {
+        ss << "DomainNames.member." << domainNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        domainNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudsearch/source/model/DescribeExpressionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudsearch/source/model/DescribeExpressionsRequest.cpp
@@ -29,12 +29,19 @@ Aws::String DescribeExpressionsRequest::SerializePayload() const
 
   if(m_expressionNamesHasBeenSet)
   {
-    unsigned expressionNamesCount = 1;
-    for(auto& item : m_expressionNames)
+    if (m_expressionNames.empty())
     {
-      ss << "ExpressionNames.member." << expressionNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      expressionNamesCount++;
+      ss << "ExpressionNames=&";
+    }
+    else
+    {
+      unsigned expressionNamesCount = 1;
+      for(auto& item : m_expressionNames)
+      {
+        ss << "ExpressionNames.member." << expressionNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        expressionNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudsearch/source/model/DescribeIndexFieldsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudsearch/source/model/DescribeIndexFieldsRequest.cpp
@@ -29,12 +29,19 @@ Aws::String DescribeIndexFieldsRequest::SerializePayload() const
 
   if(m_fieldNamesHasBeenSet)
   {
-    unsigned fieldNamesCount = 1;
-    for(auto& item : m_fieldNames)
+    if (m_fieldNames.empty())
     {
-      ss << "FieldNames.member." << fieldNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      fieldNamesCount++;
+      ss << "FieldNames=&";
+    }
+    else
+    {
+      unsigned fieldNamesCount = 1;
+      for(auto& item : m_fieldNames)
+      {
+        ss << "FieldNames.member." << fieldNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        fieldNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-cloudsearch/source/model/DescribeSuggestersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-cloudsearch/source/model/DescribeSuggestersRequest.cpp
@@ -29,12 +29,19 @@ Aws::String DescribeSuggestersRequest::SerializePayload() const
 
   if(m_suggesterNamesHasBeenSet)
   {
-    unsigned suggesterNamesCount = 1;
-    for(auto& item : m_suggesterNames)
+    if (m_suggesterNames.empty())
     {
-      ss << "SuggesterNames.member." << suggesterNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      suggesterNamesCount++;
+      ss << "SuggesterNames=&";
+    }
+    else
+    {
+      unsigned suggesterNamesCount = 1;
+      for(auto& item : m_suggesterNames)
+      {
+        ss << "SuggesterNames.member." << suggesterNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        suggesterNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/AddTagsToResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/AddTagsToResourceRequest.cpp
@@ -27,11 +27,18 @@ Aws::String AddTagsToResourceRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/CopyDBClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/CopyDBClusterParameterGroupRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CopyDBClusterParameterGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/CopyDBClusterSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/CopyDBClusterSnapshotRequest.cpp
@@ -53,11 +53,18 @@ Aws::String CopyDBClusterSnapshotRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/CreateDBClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/CreateDBClusterParameterGroupRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CreateDBClusterParameterGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/CreateDBClusterRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/CreateDBClusterRequest.cpp
@@ -46,12 +46,19 @@ Aws::String CreateDBClusterRequest::SerializePayload() const
   ss << "Action=CreateDBCluster&";
   if(m_availabilityZonesHasBeenSet)
   {
-    unsigned availabilityZonesCount = 1;
-    for(auto& item : m_availabilityZones)
+    if (m_availabilityZones.empty())
     {
-      ss << "AvailabilityZones.member." << availabilityZonesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      availabilityZonesCount++;
+      ss << "AvailabilityZones=&";
+    }
+    else
+    {
+      unsigned availabilityZonesCount = 1;
+      for(auto& item : m_availabilityZones)
+      {
+        ss << "AvailabilityZones.member." << availabilityZonesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        availabilityZonesCount++;
+      }
     }
   }
 
@@ -72,12 +79,19 @@ Aws::String CreateDBClusterRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -123,11 +137,18 @@ Aws::String CreateDBClusterRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -148,12 +169,19 @@ Aws::String CreateDBClusterRequest::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/CreateDBClusterSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/CreateDBClusterSnapshotRequest.cpp
@@ -33,11 +33,18 @@ Aws::String CreateDBClusterSnapshotRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/CreateDBInstanceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/CreateDBInstanceRequest.cpp
@@ -67,11 +67,18 @@ Aws::String CreateDBInstanceRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/CreateDBSubnetGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/CreateDBSubnetGroupRequest.cpp
@@ -34,22 +34,36 @@ Aws::String CreateDBSubnetGroupRequest::SerializePayload() const
 
   if(m_subnetIdsHasBeenSet)
   {
-    unsigned subnetIdsCount = 1;
-    for(auto& item : m_subnetIds)
+    if (m_subnetIds.empty())
     {
-      ss << "SubnetIds.member." << subnetIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetIdsCount++;
+      ss << "SubnetIds=&";
+    }
+    else
+    {
+      unsigned subnetIdsCount = 1;
+      for(auto& item : m_subnetIds)
+      {
+        ss << "SubnetIds.member." << subnetIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetIdsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/CreateEventSubscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/CreateEventSubscriptionRequest.cpp
@@ -43,23 +43,37 @@ Aws::String CreateEventSubscriptionRequest::SerializePayload() const
 
   if(m_eventCategoriesHasBeenSet)
   {
-    unsigned eventCategoriesCount = 1;
-    for(auto& item : m_eventCategories)
+    if (m_eventCategories.empty())
     {
-      ss << "EventCategories.member." << eventCategoriesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      eventCategoriesCount++;
+      ss << "EventCategories=&";
+    }
+    else
+    {
+      unsigned eventCategoriesCount = 1;
+      for(auto& item : m_eventCategories)
+      {
+        ss << "EventCategories.member." << eventCategoriesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        eventCategoriesCount++;
+      }
     }
   }
 
   if(m_sourceIdsHasBeenSet)
   {
-    unsigned sourceIdsCount = 1;
-    for(auto& item : m_sourceIds)
+    if (m_sourceIds.empty())
     {
-      ss << "SourceIds.member." << sourceIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      sourceIdsCount++;
+      ss << "SourceIds=&";
+    }
+    else
+    {
+      unsigned sourceIdsCount = 1;
+      for(auto& item : m_sourceIds)
+      {
+        ss << "SourceIds.member." << sourceIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        sourceIdsCount++;
+      }
     }
   }
 
@@ -70,11 +84,18 @@ Aws::String CreateEventSubscriptionRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribeCertificatesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribeCertificatesRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeCertificatesRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribeDBClusterParameterGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribeDBClusterParameterGroupsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBClusterParameterGroupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribeDBClusterParametersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribeDBClusterParametersRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeDBClusterParametersRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribeDBClusterSnapshotsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribeDBClusterSnapshotsRequest.cpp
@@ -46,11 +46,18 @@ Aws::String DescribeDBClusterSnapshotsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribeDBClustersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribeDBClustersRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBClustersRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribeDBEngineVersionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribeDBEngineVersionsRequest.cpp
@@ -48,11 +48,18 @@ Aws::String DescribeDBEngineVersionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribeDBInstancesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribeDBInstancesRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBInstancesRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribeDBSubnetGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribeDBSubnetGroupsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBSubnetGroupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribeEngineDefaultClusterParametersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribeEngineDefaultClusterParametersRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeEngineDefaultClusterParametersRequest::SerializePayload() co
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribeEventCategoriesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribeEventCategoriesRequest.cpp
@@ -27,11 +27,18 @@ Aws::String DescribeEventCategoriesRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribeEventSubscriptionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribeEventSubscriptionsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeEventSubscriptionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribeEventsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribeEventsRequest.cpp
@@ -57,22 +57,36 @@ Aws::String DescribeEventsRequest::SerializePayload() const
 
   if(m_eventCategoriesHasBeenSet)
   {
-    unsigned eventCategoriesCount = 1;
-    for(auto& item : m_eventCategories)
+    if (m_eventCategories.empty())
     {
-      ss << "EventCategories.member." << eventCategoriesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      eventCategoriesCount++;
+      ss << "EventCategories=&";
+    }
+    else
+    {
+      unsigned eventCategoriesCount = 1;
+      for(auto& item : m_eventCategories)
+      {
+        ss << "EventCategories.member." << eventCategoriesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        eventCategoriesCount++;
+      }
     }
   }
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribeGlobalClustersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribeGlobalClustersRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeGlobalClustersRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribeOrderableDBInstanceOptionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribeOrderableDBInstanceOptionsRequest.cpp
@@ -55,11 +55,18 @@ Aws::String DescribeOrderableDBInstanceOptionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/DescribePendingMaintenanceActionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/DescribePendingMaintenanceActionsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribePendingMaintenanceActionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/ListTagsForResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/ListTagsForResourceRequest.cpp
@@ -27,11 +27,18 @@ Aws::String ListTagsForResourceRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/ModifyDBClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/ModifyDBClusterParameterGroupRequest.cpp
@@ -27,11 +27,18 @@ Aws::String ModifyDBClusterParameterGroupRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/ModifyDBClusterRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/ModifyDBClusterRequest.cpp
@@ -65,12 +65,19 @@ Aws::String ModifyDBClusterRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/ModifyDBClusterSnapshotAttributeRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/ModifyDBClusterSnapshotAttributeRequest.cpp
@@ -34,23 +34,37 @@ Aws::String ModifyDBClusterSnapshotAttributeRequest::SerializePayload() const
 
   if(m_valuesToAddHasBeenSet)
   {
-    unsigned valuesToAddCount = 1;
-    for(auto& item : m_valuesToAdd)
+    if (m_valuesToAdd.empty())
     {
-      ss << "ValuesToAdd.member." << valuesToAddCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      valuesToAddCount++;
+      ss << "ValuesToAdd=&";
+    }
+    else
+    {
+      unsigned valuesToAddCount = 1;
+      for(auto& item : m_valuesToAdd)
+      {
+        ss << "ValuesToAdd.member." << valuesToAddCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        valuesToAddCount++;
+      }
     }
   }
 
   if(m_valuesToRemoveHasBeenSet)
   {
-    unsigned valuesToRemoveCount = 1;
-    for(auto& item : m_valuesToRemove)
+    if (m_valuesToRemove.empty())
     {
-      ss << "ValuesToRemove.member." << valuesToRemoveCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      valuesToRemoveCount++;
+      ss << "ValuesToRemove=&";
+    }
+    else
+    {
+      unsigned valuesToRemoveCount = 1;
+      for(auto& item : m_valuesToRemove)
+      {
+        ss << "ValuesToRemove.member." << valuesToRemoveCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        valuesToRemoveCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/ModifyDBSubnetGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/ModifyDBSubnetGroupRequest.cpp
@@ -33,12 +33,19 @@ Aws::String ModifyDBSubnetGroupRequest::SerializePayload() const
 
   if(m_subnetIdsHasBeenSet)
   {
-    unsigned subnetIdsCount = 1;
-    for(auto& item : m_subnetIds)
+    if (m_subnetIds.empty())
     {
-      ss << "SubnetIds.member." << subnetIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetIdsCount++;
+      ss << "SubnetIds=&";
+    }
+    else
+    {
+      unsigned subnetIdsCount = 1;
+      for(auto& item : m_subnetIds)
+      {
+        ss << "SubnetIds.member." << subnetIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/ModifyEventSubscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/ModifyEventSubscriptionRequest.cpp
@@ -41,12 +41,19 @@ Aws::String ModifyEventSubscriptionRequest::SerializePayload() const
 
   if(m_eventCategoriesHasBeenSet)
   {
-    unsigned eventCategoriesCount = 1;
-    for(auto& item : m_eventCategories)
+    if (m_eventCategories.empty())
     {
-      ss << "EventCategories.member." << eventCategoriesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      eventCategoriesCount++;
+      ss << "EventCategories=&";
+    }
+    else
+    {
+      unsigned eventCategoriesCount = 1;
+      for(auto& item : m_eventCategories)
+      {
+        ss << "EventCategories.member." << eventCategoriesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        eventCategoriesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/RemoveTagsFromResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/RemoveTagsFromResourceRequest.cpp
@@ -27,12 +27,19 @@ Aws::String RemoveTagsFromResourceRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/ResetDBClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/ResetDBClusterParameterGroupRequest.cpp
@@ -34,11 +34,18 @@ Aws::String ResetDBClusterParameterGroupRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/RestoreDBClusterFromSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/RestoreDBClusterFromSnapshotRequest.cpp
@@ -36,12 +36,19 @@ Aws::String RestoreDBClusterFromSnapshotRequest::SerializePayload() const
   ss << "Action=RestoreDBClusterFromSnapshot&";
   if(m_availabilityZonesHasBeenSet)
   {
-    unsigned availabilityZonesCount = 1;
-    for(auto& item : m_availabilityZones)
+    if (m_availabilityZones.empty())
     {
-      ss << "AvailabilityZones.member." << availabilityZonesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      availabilityZonesCount++;
+      ss << "AvailabilityZones=&";
+    }
+    else
+    {
+      unsigned availabilityZonesCount = 1;
+      for(auto& item : m_availabilityZones)
+      {
+        ss << "AvailabilityZones.member." << availabilityZonesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        availabilityZonesCount++;
+      }
     }
   }
 
@@ -77,22 +84,36 @@ Aws::String RestoreDBClusterFromSnapshotRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -103,12 +124,19 @@ Aws::String RestoreDBClusterFromSnapshotRequest::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/model/RestoreDBClusterToPointInTimeRequest.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/model/RestoreDBClusterToPointInTimeRequest.cpp
@@ -71,22 +71,36 @@ Aws::String RestoreDBClusterToPointInTimeRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -97,12 +111,19 @@ Aws::String RestoreDBClusterToPointInTimeRequest::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/AddTagsToResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/AddTagsToResourceRequest.cpp
@@ -27,11 +27,18 @@ Aws::String AddTagsToResourceRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/BatchApplyUpdateActionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/BatchApplyUpdateActionRequest.cpp
@@ -23,23 +23,37 @@ Aws::String BatchApplyUpdateActionRequest::SerializePayload() const
   ss << "Action=BatchApplyUpdateAction&";
   if(m_replicationGroupIdsHasBeenSet)
   {
-    unsigned replicationGroupIdsCount = 1;
-    for(auto& item : m_replicationGroupIds)
+    if (m_replicationGroupIds.empty())
     {
-      ss << "ReplicationGroupIds.member." << replicationGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      replicationGroupIdsCount++;
+      ss << "ReplicationGroupIds=&";
+    }
+    else
+    {
+      unsigned replicationGroupIdsCount = 1;
+      for(auto& item : m_replicationGroupIds)
+      {
+        ss << "ReplicationGroupIds.member." << replicationGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        replicationGroupIdsCount++;
+      }
     }
   }
 
   if(m_cacheClusterIdsHasBeenSet)
   {
-    unsigned cacheClusterIdsCount = 1;
-    for(auto& item : m_cacheClusterIds)
+    if (m_cacheClusterIds.empty())
     {
-      ss << "CacheClusterIds.member." << cacheClusterIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      cacheClusterIdsCount++;
+      ss << "CacheClusterIds=&";
+    }
+    else
+    {
+      unsigned cacheClusterIdsCount = 1;
+      for(auto& item : m_cacheClusterIds)
+      {
+        ss << "CacheClusterIds.member." << cacheClusterIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        cacheClusterIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/BatchStopUpdateActionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/BatchStopUpdateActionRequest.cpp
@@ -23,23 +23,37 @@ Aws::String BatchStopUpdateActionRequest::SerializePayload() const
   ss << "Action=BatchStopUpdateAction&";
   if(m_replicationGroupIdsHasBeenSet)
   {
-    unsigned replicationGroupIdsCount = 1;
-    for(auto& item : m_replicationGroupIds)
+    if (m_replicationGroupIds.empty())
     {
-      ss << "ReplicationGroupIds.member." << replicationGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      replicationGroupIdsCount++;
+      ss << "ReplicationGroupIds=&";
+    }
+    else
+    {
+      unsigned replicationGroupIdsCount = 1;
+      for(auto& item : m_replicationGroupIds)
+      {
+        ss << "ReplicationGroupIds.member." << replicationGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        replicationGroupIdsCount++;
+      }
     }
   }
 
   if(m_cacheClusterIdsHasBeenSet)
   {
-    unsigned cacheClusterIdsCount = 1;
-    for(auto& item : m_cacheClusterIds)
+    if (m_cacheClusterIds.empty())
     {
-      ss << "CacheClusterIds.member." << cacheClusterIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      cacheClusterIdsCount++;
+      ss << "CacheClusterIds=&";
+    }
+    else
+    {
+      unsigned cacheClusterIdsCount = 1;
+      for(auto& item : m_cacheClusterIds)
+      {
+        ss << "CacheClusterIds.member." << cacheClusterIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        cacheClusterIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/CopyServerlessCacheSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/CopyServerlessCacheSnapshotRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CopyServerlessCacheSnapshotRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/CopySnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/CopySnapshotRequest.cpp
@@ -45,11 +45,18 @@ Aws::String CopySnapshotRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/CreateCacheClusterRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/CreateCacheClusterRequest.cpp
@@ -79,12 +79,19 @@ Aws::String CreateCacheClusterRequest::SerializePayload() const
 
   if(m_preferredAvailabilityZonesHasBeenSet)
   {
-    unsigned preferredAvailabilityZonesCount = 1;
-    for(auto& item : m_preferredAvailabilityZones)
+    if (m_preferredAvailabilityZones.empty())
     {
-      ss << "PreferredAvailabilityZones.member." << preferredAvailabilityZonesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      preferredAvailabilityZonesCount++;
+      ss << "PreferredAvailabilityZones=&";
+    }
+    else
+    {
+      unsigned preferredAvailabilityZonesCount = 1;
+      for(auto& item : m_preferredAvailabilityZones)
+      {
+        ss << "PreferredAvailabilityZones.member." << preferredAvailabilityZonesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        preferredAvailabilityZonesCount++;
+      }
     }
   }
 
@@ -120,44 +127,72 @@ Aws::String CreateCacheClusterRequest::SerializePayload() const
 
   if(m_cacheSecurityGroupNamesHasBeenSet)
   {
-    unsigned cacheSecurityGroupNamesCount = 1;
-    for(auto& item : m_cacheSecurityGroupNames)
+    if (m_cacheSecurityGroupNames.empty())
     {
-      ss << "CacheSecurityGroupNames.member." << cacheSecurityGroupNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      cacheSecurityGroupNamesCount++;
+      ss << "CacheSecurityGroupNames=&";
+    }
+    else
+    {
+      unsigned cacheSecurityGroupNamesCount = 1;
+      for(auto& item : m_cacheSecurityGroupNames)
+      {
+        ss << "CacheSecurityGroupNames.member." << cacheSecurityGroupNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        cacheSecurityGroupNamesCount++;
+      }
     }
   }
 
   if(m_securityGroupIdsHasBeenSet)
   {
-    unsigned securityGroupIdsCount = 1;
-    for(auto& item : m_securityGroupIds)
+    if (m_securityGroupIds.empty())
     {
-      ss << "SecurityGroupIds.member." << securityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      securityGroupIdsCount++;
+      ss << "SecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned securityGroupIdsCount = 1;
+      for(auto& item : m_securityGroupIds)
+      {
+        ss << "SecurityGroupIds.member." << securityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        securityGroupIdsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
   if(m_snapshotArnsHasBeenSet)
   {
-    unsigned snapshotArnsCount = 1;
-    for(auto& item : m_snapshotArns)
+    if (m_snapshotArns.empty())
     {
-      ss << "SnapshotArns.member." << snapshotArnsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      snapshotArnsCount++;
+      ss << "SnapshotArns=&";
+    }
+    else
+    {
+      unsigned snapshotArnsCount = 1;
+      for(auto& item : m_snapshotArns)
+      {
+        ss << "SnapshotArns.member." << snapshotArnsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        snapshotArnsCount++;
+      }
     }
   }
 
@@ -213,22 +248,36 @@ Aws::String CreateCacheClusterRequest::SerializePayload() const
 
   if(m_preferredOutpostArnsHasBeenSet)
   {
-    unsigned preferredOutpostArnsCount = 1;
-    for(auto& item : m_preferredOutpostArns)
+    if (m_preferredOutpostArns.empty())
     {
-      ss << "PreferredOutpostArns.member." << preferredOutpostArnsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      preferredOutpostArnsCount++;
+      ss << "PreferredOutpostArns=&";
+    }
+    else
+    {
+      unsigned preferredOutpostArnsCount = 1;
+      for(auto& item : m_preferredOutpostArns)
+      {
+        ss << "PreferredOutpostArns.member." << preferredOutpostArnsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        preferredOutpostArnsCount++;
+      }
     }
   }
 
   if(m_logDeliveryConfigurationsHasBeenSet)
   {
-    unsigned logDeliveryConfigurationsCount = 1;
-    for(auto& item : m_logDeliveryConfigurations)
+    if (m_logDeliveryConfigurations.empty())
     {
-      item.OutputToStream(ss, "LogDeliveryConfigurations.member.", logDeliveryConfigurationsCount, "");
-      logDeliveryConfigurationsCount++;
+      ss << "LogDeliveryConfigurations=&";
+    }
+    else
+    {
+      unsigned logDeliveryConfigurationsCount = 1;
+      for(auto& item : m_logDeliveryConfigurations)
+      {
+        item.OutputToStream(ss, "LogDeliveryConfigurations.member.", logDeliveryConfigurationsCount, "");
+        logDeliveryConfigurationsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/CreateCacheParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/CreateCacheParameterGroupRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CreateCacheParameterGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/CreateCacheSecurityGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/CreateCacheSecurityGroupRequest.cpp
@@ -33,11 +33,18 @@ Aws::String CreateCacheSecurityGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/CreateCacheSubnetGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/CreateCacheSubnetGroupRequest.cpp
@@ -34,22 +34,36 @@ Aws::String CreateCacheSubnetGroupRequest::SerializePayload() const
 
   if(m_subnetIdsHasBeenSet)
   {
-    unsigned subnetIdsCount = 1;
-    for(auto& item : m_subnetIds)
+    if (m_subnetIds.empty())
     {
-      ss << "SubnetIds.member." << subnetIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetIdsCount++;
+      ss << "SubnetIds=&";
+    }
+    else
+    {
+      unsigned subnetIdsCount = 1;
+      for(auto& item : m_subnetIds)
+      {
+        ss << "SubnetIds.member." << subnetIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetIdsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/CreateReplicationGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/CreateReplicationGroupRequest.cpp
@@ -109,12 +109,19 @@ Aws::String CreateReplicationGroupRequest::SerializePayload() const
 
   if(m_preferredCacheClusterAZsHasBeenSet)
   {
-    unsigned preferredCacheClusterAZsCount = 1;
-    for(auto& item : m_preferredCacheClusterAZs)
+    if (m_preferredCacheClusterAZs.empty())
     {
-      ss << "PreferredCacheClusterAZs.member." << preferredCacheClusterAZsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      preferredCacheClusterAZsCount++;
+      ss << "PreferredCacheClusterAZs=&";
+    }
+    else
+    {
+      unsigned preferredCacheClusterAZsCount = 1;
+      for(auto& item : m_preferredCacheClusterAZs)
+      {
+        ss << "PreferredCacheClusterAZs.member." << preferredCacheClusterAZsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        preferredCacheClusterAZsCount++;
+      }
     }
   }
 
@@ -130,11 +137,18 @@ Aws::String CreateReplicationGroupRequest::SerializePayload() const
 
   if(m_nodeGroupConfigurationHasBeenSet)
   {
-    unsigned nodeGroupConfigurationCount = 1;
-    for(auto& item : m_nodeGroupConfiguration)
+    if (m_nodeGroupConfiguration.empty())
     {
-      item.OutputToStream(ss, "NodeGroupConfiguration.member.", nodeGroupConfigurationCount, "");
-      nodeGroupConfigurationCount++;
+      ss << "NodeGroupConfiguration=&";
+    }
+    else
+    {
+      unsigned nodeGroupConfigurationCount = 1;
+      for(auto& item : m_nodeGroupConfiguration)
+      {
+        item.OutputToStream(ss, "NodeGroupConfiguration.member.", nodeGroupConfigurationCount, "");
+        nodeGroupConfigurationCount++;
+      }
     }
   }
 
@@ -165,44 +179,72 @@ Aws::String CreateReplicationGroupRequest::SerializePayload() const
 
   if(m_cacheSecurityGroupNamesHasBeenSet)
   {
-    unsigned cacheSecurityGroupNamesCount = 1;
-    for(auto& item : m_cacheSecurityGroupNames)
+    if (m_cacheSecurityGroupNames.empty())
     {
-      ss << "CacheSecurityGroupNames.member." << cacheSecurityGroupNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      cacheSecurityGroupNamesCount++;
+      ss << "CacheSecurityGroupNames=&";
+    }
+    else
+    {
+      unsigned cacheSecurityGroupNamesCount = 1;
+      for(auto& item : m_cacheSecurityGroupNames)
+      {
+        ss << "CacheSecurityGroupNames.member." << cacheSecurityGroupNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        cacheSecurityGroupNamesCount++;
+      }
     }
   }
 
   if(m_securityGroupIdsHasBeenSet)
   {
-    unsigned securityGroupIdsCount = 1;
-    for(auto& item : m_securityGroupIds)
+    if (m_securityGroupIds.empty())
     {
-      ss << "SecurityGroupIds.member." << securityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      securityGroupIdsCount++;
+      ss << "SecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned securityGroupIdsCount = 1;
+      for(auto& item : m_securityGroupIds)
+      {
+        ss << "SecurityGroupIds.member." << securityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        securityGroupIdsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
   if(m_snapshotArnsHasBeenSet)
   {
-    unsigned snapshotArnsCount = 1;
-    for(auto& item : m_snapshotArns)
+    if (m_snapshotArns.empty())
     {
-      ss << "SnapshotArns.member." << snapshotArnsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      snapshotArnsCount++;
+      ss << "SnapshotArns=&";
+    }
+    else
+    {
+      unsigned snapshotArnsCount = 1;
+      for(auto& item : m_snapshotArns)
+      {
+        ss << "SnapshotArns.member." << snapshotArnsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        snapshotArnsCount++;
+      }
     }
   }
 
@@ -263,22 +305,36 @@ Aws::String CreateReplicationGroupRequest::SerializePayload() const
 
   if(m_userGroupIdsHasBeenSet)
   {
-    unsigned userGroupIdsCount = 1;
-    for(auto& item : m_userGroupIds)
+    if (m_userGroupIds.empty())
     {
-      ss << "UserGroupIds.member." << userGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      userGroupIdsCount++;
+      ss << "UserGroupIds=&";
+    }
+    else
+    {
+      unsigned userGroupIdsCount = 1;
+      for(auto& item : m_userGroupIds)
+      {
+        ss << "UserGroupIds.member." << userGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        userGroupIdsCount++;
+      }
     }
   }
 
   if(m_logDeliveryConfigurationsHasBeenSet)
   {
-    unsigned logDeliveryConfigurationsCount = 1;
-    for(auto& item : m_logDeliveryConfigurations)
+    if (m_logDeliveryConfigurations.empty())
     {
-      item.OutputToStream(ss, "LogDeliveryConfigurations.member.", logDeliveryConfigurationsCount, "");
-      logDeliveryConfigurationsCount++;
+      ss << "LogDeliveryConfigurations=&";
+    }
+    else
+    {
+      unsigned logDeliveryConfigurationsCount = 1;
+      for(auto& item : m_logDeliveryConfigurations)
+      {
+        item.OutputToStream(ss, "LogDeliveryConfigurations.member.", logDeliveryConfigurationsCount, "");
+        logDeliveryConfigurationsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/CreateServerlessCacheRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/CreateServerlessCacheRequest.cpp
@@ -64,33 +64,54 @@ Aws::String CreateServerlessCacheRequest::SerializePayload() const
 
   if(m_securityGroupIdsHasBeenSet)
   {
-    unsigned securityGroupIdsCount = 1;
-    for(auto& item : m_securityGroupIds)
+    if (m_securityGroupIds.empty())
     {
-      ss << "SecurityGroupIds.member." << securityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      securityGroupIdsCount++;
+      ss << "SecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned securityGroupIdsCount = 1;
+      for(auto& item : m_securityGroupIds)
+      {
+        ss << "SecurityGroupIds.member." << securityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        securityGroupIdsCount++;
+      }
     }
   }
 
   if(m_snapshotArnsToRestoreHasBeenSet)
   {
-    unsigned snapshotArnsToRestoreCount = 1;
-    for(auto& item : m_snapshotArnsToRestore)
+    if (m_snapshotArnsToRestore.empty())
     {
-      ss << "SnapshotArnsToRestore.member." << snapshotArnsToRestoreCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      snapshotArnsToRestoreCount++;
+      ss << "SnapshotArnsToRestore=&";
+    }
+    else
+    {
+      unsigned snapshotArnsToRestoreCount = 1;
+      for(auto& item : m_snapshotArnsToRestore)
+      {
+        ss << "SnapshotArnsToRestore.member." << snapshotArnsToRestoreCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        snapshotArnsToRestoreCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -101,12 +122,19 @@ Aws::String CreateServerlessCacheRequest::SerializePayload() const
 
   if(m_subnetIdsHasBeenSet)
   {
-    unsigned subnetIdsCount = 1;
-    for(auto& item : m_subnetIds)
+    if (m_subnetIds.empty())
     {
-      ss << "SubnetIds.member." << subnetIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetIdsCount++;
+      ss << "SubnetIds=&";
+    }
+    else
+    {
+      unsigned subnetIdsCount = 1;
+      for(auto& item : m_subnetIds)
+      {
+        ss << "SubnetIds.member." << subnetIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/CreateServerlessCacheSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/CreateServerlessCacheSnapshotRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CreateServerlessCacheSnapshotRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/CreateSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/CreateSnapshotRequest.cpp
@@ -45,11 +45,18 @@ Aws::String CreateSnapshotRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/CreateUserGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/CreateUserGroupRequest.cpp
@@ -34,22 +34,36 @@ Aws::String CreateUserGroupRequest::SerializePayload() const
 
   if(m_userIdsHasBeenSet)
   {
-    unsigned userIdsCount = 1;
-    for(auto& item : m_userIds)
+    if (m_userIds.empty())
     {
-      ss << "UserIds.member." << userIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      userIdsCount++;
+      ss << "UserIds=&";
+    }
+    else
+    {
+      unsigned userIdsCount = 1;
+      for(auto& item : m_userIds)
+      {
+        ss << "UserIds.member." << userIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        userIdsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/CreateUserRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/CreateUserRequest.cpp
@@ -44,12 +44,19 @@ Aws::String CreateUserRequest::SerializePayload() const
 
   if(m_passwordsHasBeenSet)
   {
-    unsigned passwordsCount = 1;
-    for(auto& item : m_passwords)
+    if (m_passwords.empty())
     {
-      ss << "Passwords.member." << passwordsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      passwordsCount++;
+      ss << "Passwords=&";
+    }
+    else
+    {
+      unsigned passwordsCount = 1;
+      for(auto& item : m_passwords)
+      {
+        ss << "Passwords.member." << passwordsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        passwordsCount++;
+      }
     }
   }
 
@@ -65,11 +72,18 @@ Aws::String CreateUserRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/DecreaseNodeGroupsInGlobalReplicationGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/DecreaseNodeGroupsInGlobalReplicationGroupRequest.cpp
@@ -37,23 +37,37 @@ Aws::String DecreaseNodeGroupsInGlobalReplicationGroupRequest::SerializePayload(
 
   if(m_globalNodeGroupsToRemoveHasBeenSet)
   {
-    unsigned globalNodeGroupsToRemoveCount = 1;
-    for(auto& item : m_globalNodeGroupsToRemove)
+    if (m_globalNodeGroupsToRemove.empty())
     {
-      ss << "GlobalNodeGroupsToRemove.member." << globalNodeGroupsToRemoveCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      globalNodeGroupsToRemoveCount++;
+      ss << "GlobalNodeGroupsToRemove=&";
+    }
+    else
+    {
+      unsigned globalNodeGroupsToRemoveCount = 1;
+      for(auto& item : m_globalNodeGroupsToRemove)
+      {
+        ss << "GlobalNodeGroupsToRemove.member." << globalNodeGroupsToRemoveCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        globalNodeGroupsToRemoveCount++;
+      }
     }
   }
 
   if(m_globalNodeGroupsToRetainHasBeenSet)
   {
-    unsigned globalNodeGroupsToRetainCount = 1;
-    for(auto& item : m_globalNodeGroupsToRetain)
+    if (m_globalNodeGroupsToRetain.empty())
     {
-      ss << "GlobalNodeGroupsToRetain.member." << globalNodeGroupsToRetainCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      globalNodeGroupsToRetainCount++;
+      ss << "GlobalNodeGroupsToRetain=&";
+    }
+    else
+    {
+      unsigned globalNodeGroupsToRetainCount = 1;
+      for(auto& item : m_globalNodeGroupsToRetain)
+      {
+        ss << "GlobalNodeGroupsToRetain.member." << globalNodeGroupsToRetainCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        globalNodeGroupsToRetainCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/DecreaseReplicaCountRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/DecreaseReplicaCountRequest.cpp
@@ -37,22 +37,36 @@ Aws::String DecreaseReplicaCountRequest::SerializePayload() const
 
   if(m_replicaConfigurationHasBeenSet)
   {
-    unsigned replicaConfigurationCount = 1;
-    for(auto& item : m_replicaConfiguration)
+    if (m_replicaConfiguration.empty())
     {
-      item.OutputToStream(ss, "ReplicaConfiguration.member.", replicaConfigurationCount, "");
-      replicaConfigurationCount++;
+      ss << "ReplicaConfiguration=&";
+    }
+    else
+    {
+      unsigned replicaConfigurationCount = 1;
+      for(auto& item : m_replicaConfiguration)
+      {
+        item.OutputToStream(ss, "ReplicaConfiguration.member.", replicaConfigurationCount, "");
+        replicaConfigurationCount++;
+      }
     }
   }
 
   if(m_replicasToRemoveHasBeenSet)
   {
-    unsigned replicasToRemoveCount = 1;
-    for(auto& item : m_replicasToRemove)
+    if (m_replicasToRemove.empty())
     {
-      ss << "ReplicasToRemove.member." << replicasToRemoveCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      replicasToRemoveCount++;
+      ss << "ReplicasToRemove=&";
+    }
+    else
+    {
+      unsigned replicasToRemoveCount = 1;
+      for(auto& item : m_replicasToRemove)
+      {
+        ss << "ReplicasToRemove.member." << replicasToRemoveCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        replicasToRemoveCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/DescribeServiceUpdatesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/DescribeServiceUpdatesRequest.cpp
@@ -30,12 +30,19 @@ Aws::String DescribeServiceUpdatesRequest::SerializePayload() const
 
   if(m_serviceUpdateStatusHasBeenSet)
   {
-    unsigned serviceUpdateStatusCount = 1;
-    for(auto& item : m_serviceUpdateStatus)
+    if (m_serviceUpdateStatus.empty())
     {
-      ss << "ServiceUpdateStatus.member." << serviceUpdateStatusCount << "="
-          << StringUtils::URLEncode(ServiceUpdateStatusMapper::GetNameForServiceUpdateStatus(item).c_str()) << "&";
-      serviceUpdateStatusCount++;
+      ss << "ServiceUpdateStatus=&";
+    }
+    else
+    {
+      unsigned serviceUpdateStatusCount = 1;
+      for(auto& item : m_serviceUpdateStatus)
+      {
+        ss << "ServiceUpdateStatus.member." << serviceUpdateStatusCount << "="
+            << StringUtils::URLEncode(ServiceUpdateStatusMapper::GetNameForServiceUpdateStatus(item).c_str()) << "&";
+        serviceUpdateStatusCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/DescribeUpdateActionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/DescribeUpdateActionsRequest.cpp
@@ -37,23 +37,37 @@ Aws::String DescribeUpdateActionsRequest::SerializePayload() const
 
   if(m_replicationGroupIdsHasBeenSet)
   {
-    unsigned replicationGroupIdsCount = 1;
-    for(auto& item : m_replicationGroupIds)
+    if (m_replicationGroupIds.empty())
     {
-      ss << "ReplicationGroupIds.member." << replicationGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      replicationGroupIdsCount++;
+      ss << "ReplicationGroupIds=&";
+    }
+    else
+    {
+      unsigned replicationGroupIdsCount = 1;
+      for(auto& item : m_replicationGroupIds)
+      {
+        ss << "ReplicationGroupIds.member." << replicationGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        replicationGroupIdsCount++;
+      }
     }
   }
 
   if(m_cacheClusterIdsHasBeenSet)
   {
-    unsigned cacheClusterIdsCount = 1;
-    for(auto& item : m_cacheClusterIds)
+    if (m_cacheClusterIds.empty())
     {
-      ss << "CacheClusterIds.member." << cacheClusterIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      cacheClusterIdsCount++;
+      ss << "CacheClusterIds=&";
+    }
+    else
+    {
+      unsigned cacheClusterIdsCount = 1;
+      for(auto& item : m_cacheClusterIds)
+      {
+        ss << "CacheClusterIds.member." << cacheClusterIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        cacheClusterIdsCount++;
+      }
     }
   }
 
@@ -64,12 +78,19 @@ Aws::String DescribeUpdateActionsRequest::SerializePayload() const
 
   if(m_serviceUpdateStatusHasBeenSet)
   {
-    unsigned serviceUpdateStatusCount = 1;
-    for(auto& item : m_serviceUpdateStatus)
+    if (m_serviceUpdateStatus.empty())
     {
-      ss << "ServiceUpdateStatus.member." << serviceUpdateStatusCount << "="
-          << StringUtils::URLEncode(ServiceUpdateStatusMapper::GetNameForServiceUpdateStatus(item).c_str()) << "&";
-      serviceUpdateStatusCount++;
+      ss << "ServiceUpdateStatus=&";
+    }
+    else
+    {
+      unsigned serviceUpdateStatusCount = 1;
+      for(auto& item : m_serviceUpdateStatus)
+      {
+        ss << "ServiceUpdateStatus.member." << serviceUpdateStatusCount << "="
+            << StringUtils::URLEncode(ServiceUpdateStatusMapper::GetNameForServiceUpdateStatus(item).c_str()) << "&";
+        serviceUpdateStatusCount++;
+      }
     }
   }
 
@@ -80,12 +101,19 @@ Aws::String DescribeUpdateActionsRequest::SerializePayload() const
 
   if(m_updateActionStatusHasBeenSet)
   {
-    unsigned updateActionStatusCount = 1;
-    for(auto& item : m_updateActionStatus)
+    if (m_updateActionStatus.empty())
     {
-      ss << "UpdateActionStatus.member." << updateActionStatusCount << "="
-          << StringUtils::URLEncode(UpdateActionStatusMapper::GetNameForUpdateActionStatus(item).c_str()) << "&";
-      updateActionStatusCount++;
+      ss << "UpdateActionStatus=&";
+    }
+    else
+    {
+      unsigned updateActionStatusCount = 1;
+      for(auto& item : m_updateActionStatus)
+      {
+        ss << "UpdateActionStatus.member." << updateActionStatusCount << "="
+            << StringUtils::URLEncode(UpdateActionStatusMapper::GetNameForUpdateActionStatus(item).c_str()) << "&";
+        updateActionStatusCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/DescribeUsersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/DescribeUsersRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeUsersRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/IncreaseNodeGroupsInGlobalReplicationGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/IncreaseNodeGroupsInGlobalReplicationGroupRequest.cpp
@@ -36,11 +36,18 @@ Aws::String IncreaseNodeGroupsInGlobalReplicationGroupRequest::SerializePayload(
 
   if(m_regionalConfigurationsHasBeenSet)
   {
-    unsigned regionalConfigurationsCount = 1;
-    for(auto& item : m_regionalConfigurations)
+    if (m_regionalConfigurations.empty())
     {
-      item.OutputToStream(ss, "RegionalConfigurations.member.", regionalConfigurationsCount, "");
-      regionalConfigurationsCount++;
+      ss << "RegionalConfigurations=&";
+    }
+    else
+    {
+      unsigned regionalConfigurationsCount = 1;
+      for(auto& item : m_regionalConfigurations)
+      {
+        item.OutputToStream(ss, "RegionalConfigurations.member.", regionalConfigurationsCount, "");
+        regionalConfigurationsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/IncreaseReplicaCountRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/IncreaseReplicaCountRequest.cpp
@@ -36,11 +36,18 @@ Aws::String IncreaseReplicaCountRequest::SerializePayload() const
 
   if(m_replicaConfigurationHasBeenSet)
   {
-    unsigned replicaConfigurationCount = 1;
-    for(auto& item : m_replicaConfiguration)
+    if (m_replicaConfiguration.empty())
     {
-      item.OutputToStream(ss, "ReplicaConfiguration.member.", replicaConfigurationCount, "");
-      replicaConfigurationCount++;
+      ss << "ReplicaConfiguration=&";
+    }
+    else
+    {
+      unsigned replicaConfigurationCount = 1;
+      for(auto& item : m_replicaConfiguration)
+      {
+        item.OutputToStream(ss, "ReplicaConfiguration.member.", replicaConfigurationCount, "");
+        replicaConfigurationCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyCacheClusterRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyCacheClusterRequest.cpp
@@ -58,12 +58,19 @@ Aws::String ModifyCacheClusterRequest::SerializePayload() const
 
   if(m_cacheNodeIdsToRemoveHasBeenSet)
   {
-    unsigned cacheNodeIdsToRemoveCount = 1;
-    for(auto& item : m_cacheNodeIdsToRemove)
+    if (m_cacheNodeIdsToRemove.empty())
     {
-      ss << "CacheNodeIdsToRemove.member." << cacheNodeIdsToRemoveCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      cacheNodeIdsToRemoveCount++;
+      ss << "CacheNodeIdsToRemove=&";
+    }
+    else
+    {
+      unsigned cacheNodeIdsToRemoveCount = 1;
+      for(auto& item : m_cacheNodeIdsToRemove)
+      {
+        ss << "CacheNodeIdsToRemove.member." << cacheNodeIdsToRemoveCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        cacheNodeIdsToRemoveCount++;
+      }
     }
   }
 
@@ -74,34 +81,55 @@ Aws::String ModifyCacheClusterRequest::SerializePayload() const
 
   if(m_newAvailabilityZonesHasBeenSet)
   {
-    unsigned newAvailabilityZonesCount = 1;
-    for(auto& item : m_newAvailabilityZones)
+    if (m_newAvailabilityZones.empty())
     {
-      ss << "NewAvailabilityZones.member." << newAvailabilityZonesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      newAvailabilityZonesCount++;
+      ss << "NewAvailabilityZones=&";
+    }
+    else
+    {
+      unsigned newAvailabilityZonesCount = 1;
+      for(auto& item : m_newAvailabilityZones)
+      {
+        ss << "NewAvailabilityZones.member." << newAvailabilityZonesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        newAvailabilityZonesCount++;
+      }
     }
   }
 
   if(m_cacheSecurityGroupNamesHasBeenSet)
   {
-    unsigned cacheSecurityGroupNamesCount = 1;
-    for(auto& item : m_cacheSecurityGroupNames)
+    if (m_cacheSecurityGroupNames.empty())
     {
-      ss << "CacheSecurityGroupNames.member." << cacheSecurityGroupNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      cacheSecurityGroupNamesCount++;
+      ss << "CacheSecurityGroupNames=&";
+    }
+    else
+    {
+      unsigned cacheSecurityGroupNamesCount = 1;
+      for(auto& item : m_cacheSecurityGroupNames)
+      {
+        ss << "CacheSecurityGroupNames.member." << cacheSecurityGroupNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        cacheSecurityGroupNamesCount++;
+      }
     }
   }
 
   if(m_securityGroupIdsHasBeenSet)
   {
-    unsigned securityGroupIdsCount = 1;
-    for(auto& item : m_securityGroupIds)
+    if (m_securityGroupIds.empty())
     {
-      ss << "SecurityGroupIds.member." << securityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      securityGroupIdsCount++;
+      ss << "SecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned securityGroupIdsCount = 1;
+      for(auto& item : m_securityGroupIds)
+      {
+        ss << "SecurityGroupIds.member." << securityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        securityGroupIdsCount++;
+      }
     }
   }
 
@@ -167,11 +195,18 @@ Aws::String ModifyCacheClusterRequest::SerializePayload() const
 
   if(m_logDeliveryConfigurationsHasBeenSet)
   {
-    unsigned logDeliveryConfigurationsCount = 1;
-    for(auto& item : m_logDeliveryConfigurations)
+    if (m_logDeliveryConfigurations.empty())
     {
-      item.OutputToStream(ss, "LogDeliveryConfigurations.member.", logDeliveryConfigurationsCount, "");
-      logDeliveryConfigurationsCount++;
+      ss << "LogDeliveryConfigurations=&";
+    }
+    else
+    {
+      unsigned logDeliveryConfigurationsCount = 1;
+      for(auto& item : m_logDeliveryConfigurations)
+      {
+        item.OutputToStream(ss, "LogDeliveryConfigurations.member.", logDeliveryConfigurationsCount, "");
+        logDeliveryConfigurationsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyCacheParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyCacheParameterGroupRequest.cpp
@@ -27,11 +27,18 @@ Aws::String ModifyCacheParameterGroupRequest::SerializePayload() const
 
   if(m_parameterNameValuesHasBeenSet)
   {
-    unsigned parameterNameValuesCount = 1;
-    for(auto& item : m_parameterNameValues)
+    if (m_parameterNameValues.empty())
     {
-      item.OutputToStream(ss, "ParameterNameValues.member.", parameterNameValuesCount, "");
-      parameterNameValuesCount++;
+      ss << "ParameterNameValues=&";
+    }
+    else
+    {
+      unsigned parameterNameValuesCount = 1;
+      for(auto& item : m_parameterNameValues)
+      {
+        item.OutputToStream(ss, "ParameterNameValues.member.", parameterNameValuesCount, "");
+        parameterNameValuesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyCacheSubnetGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyCacheSubnetGroupRequest.cpp
@@ -33,12 +33,19 @@ Aws::String ModifyCacheSubnetGroupRequest::SerializePayload() const
 
   if(m_subnetIdsHasBeenSet)
   {
-    unsigned subnetIdsCount = 1;
-    for(auto& item : m_subnetIds)
+    if (m_subnetIds.empty())
     {
-      ss << "SubnetIds.member." << subnetIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetIdsCount++;
+      ss << "SubnetIds=&";
+    }
+    else
+    {
+      unsigned subnetIdsCount = 1;
+      for(auto& item : m_subnetIds)
+      {
+        ss << "SubnetIds.member." << subnetIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyReplicationGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyReplicationGroupRequest.cpp
@@ -89,23 +89,37 @@ Aws::String ModifyReplicationGroupRequest::SerializePayload() const
 
   if(m_cacheSecurityGroupNamesHasBeenSet)
   {
-    unsigned cacheSecurityGroupNamesCount = 1;
-    for(auto& item : m_cacheSecurityGroupNames)
+    if (m_cacheSecurityGroupNames.empty())
     {
-      ss << "CacheSecurityGroupNames.member." << cacheSecurityGroupNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      cacheSecurityGroupNamesCount++;
+      ss << "CacheSecurityGroupNames=&";
+    }
+    else
+    {
+      unsigned cacheSecurityGroupNamesCount = 1;
+      for(auto& item : m_cacheSecurityGroupNames)
+      {
+        ss << "CacheSecurityGroupNames.member." << cacheSecurityGroupNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        cacheSecurityGroupNamesCount++;
+      }
     }
   }
 
   if(m_securityGroupIdsHasBeenSet)
   {
-    unsigned securityGroupIdsCount = 1;
-    for(auto& item : m_securityGroupIds)
+    if (m_securityGroupIds.empty())
     {
-      ss << "SecurityGroupIds.member." << securityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      securityGroupIdsCount++;
+      ss << "SecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned securityGroupIdsCount = 1;
+      for(auto& item : m_securityGroupIds)
+      {
+        ss << "SecurityGroupIds.member." << securityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        securityGroupIdsCount++;
+      }
     }
   }
 
@@ -171,23 +185,37 @@ Aws::String ModifyReplicationGroupRequest::SerializePayload() const
 
   if(m_userGroupIdsToAddHasBeenSet)
   {
-    unsigned userGroupIdsToAddCount = 1;
-    for(auto& item : m_userGroupIdsToAdd)
+    if (m_userGroupIdsToAdd.empty())
     {
-      ss << "UserGroupIdsToAdd.member." << userGroupIdsToAddCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      userGroupIdsToAddCount++;
+      ss << "UserGroupIdsToAdd=&";
+    }
+    else
+    {
+      unsigned userGroupIdsToAddCount = 1;
+      for(auto& item : m_userGroupIdsToAdd)
+      {
+        ss << "UserGroupIdsToAdd.member." << userGroupIdsToAddCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        userGroupIdsToAddCount++;
+      }
     }
   }
 
   if(m_userGroupIdsToRemoveHasBeenSet)
   {
-    unsigned userGroupIdsToRemoveCount = 1;
-    for(auto& item : m_userGroupIdsToRemove)
+    if (m_userGroupIdsToRemove.empty())
     {
-      ss << "UserGroupIdsToRemove.member." << userGroupIdsToRemoveCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      userGroupIdsToRemoveCount++;
+      ss << "UserGroupIdsToRemove=&";
+    }
+    else
+    {
+      unsigned userGroupIdsToRemoveCount = 1;
+      for(auto& item : m_userGroupIdsToRemove)
+      {
+        ss << "UserGroupIdsToRemove.member." << userGroupIdsToRemoveCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        userGroupIdsToRemoveCount++;
+      }
     }
   }
 
@@ -198,11 +226,18 @@ Aws::String ModifyReplicationGroupRequest::SerializePayload() const
 
   if(m_logDeliveryConfigurationsHasBeenSet)
   {
-    unsigned logDeliveryConfigurationsCount = 1;
-    for(auto& item : m_logDeliveryConfigurations)
+    if (m_logDeliveryConfigurations.empty())
     {
-      item.OutputToStream(ss, "LogDeliveryConfigurations.member.", logDeliveryConfigurationsCount, "");
-      logDeliveryConfigurationsCount++;
+      ss << "LogDeliveryConfigurations=&";
+    }
+    else
+    {
+      unsigned logDeliveryConfigurationsCount = 1;
+      for(auto& item : m_logDeliveryConfigurations)
+      {
+        item.OutputToStream(ss, "LogDeliveryConfigurations.member.", logDeliveryConfigurationsCount, "");
+        logDeliveryConfigurationsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyReplicationGroupShardConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyReplicationGroupShardConfigurationRequest.cpp
@@ -43,33 +43,54 @@ Aws::String ModifyReplicationGroupShardConfigurationRequest::SerializePayload() 
 
   if(m_reshardingConfigurationHasBeenSet)
   {
-    unsigned reshardingConfigurationCount = 1;
-    for(auto& item : m_reshardingConfiguration)
+    if (m_reshardingConfiguration.empty())
     {
-      item.OutputToStream(ss, "ReshardingConfiguration.member.", reshardingConfigurationCount, "");
-      reshardingConfigurationCount++;
+      ss << "ReshardingConfiguration=&";
+    }
+    else
+    {
+      unsigned reshardingConfigurationCount = 1;
+      for(auto& item : m_reshardingConfiguration)
+      {
+        item.OutputToStream(ss, "ReshardingConfiguration.member.", reshardingConfigurationCount, "");
+        reshardingConfigurationCount++;
+      }
     }
   }
 
   if(m_nodeGroupsToRemoveHasBeenSet)
   {
-    unsigned nodeGroupsToRemoveCount = 1;
-    for(auto& item : m_nodeGroupsToRemove)
+    if (m_nodeGroupsToRemove.empty())
     {
-      ss << "NodeGroupsToRemove.member." << nodeGroupsToRemoveCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      nodeGroupsToRemoveCount++;
+      ss << "NodeGroupsToRemove=&";
+    }
+    else
+    {
+      unsigned nodeGroupsToRemoveCount = 1;
+      for(auto& item : m_nodeGroupsToRemove)
+      {
+        ss << "NodeGroupsToRemove.member." << nodeGroupsToRemoveCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        nodeGroupsToRemoveCount++;
+      }
     }
   }
 
   if(m_nodeGroupsToRetainHasBeenSet)
   {
-    unsigned nodeGroupsToRetainCount = 1;
-    for(auto& item : m_nodeGroupsToRetain)
+    if (m_nodeGroupsToRetain.empty())
     {
-      ss << "NodeGroupsToRetain.member." << nodeGroupsToRetainCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      nodeGroupsToRetainCount++;
+      ss << "NodeGroupsToRetain=&";
+    }
+    else
+    {
+      unsigned nodeGroupsToRetainCount = 1;
+      for(auto& item : m_nodeGroupsToRetain)
+      {
+        ss << "NodeGroupsToRetain.member." << nodeGroupsToRetainCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        nodeGroupsToRetainCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyServerlessCacheRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyServerlessCacheRequest.cpp
@@ -55,12 +55,19 @@ Aws::String ModifyServerlessCacheRequest::SerializePayload() const
 
   if(m_securityGroupIdsHasBeenSet)
   {
-    unsigned securityGroupIdsCount = 1;
-    for(auto& item : m_securityGroupIds)
+    if (m_securityGroupIds.empty())
     {
-      ss << "SecurityGroupIds.member." << securityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      securityGroupIdsCount++;
+      ss << "SecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned securityGroupIdsCount = 1;
+      for(auto& item : m_securityGroupIds)
+      {
+        ss << "SecurityGroupIds.member." << securityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        securityGroupIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyUserGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyUserGroupRequest.cpp
@@ -28,23 +28,37 @@ Aws::String ModifyUserGroupRequest::SerializePayload() const
 
   if(m_userIdsToAddHasBeenSet)
   {
-    unsigned userIdsToAddCount = 1;
-    for(auto& item : m_userIdsToAdd)
+    if (m_userIdsToAdd.empty())
     {
-      ss << "UserIdsToAdd.member." << userIdsToAddCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      userIdsToAddCount++;
+      ss << "UserIdsToAdd=&";
+    }
+    else
+    {
+      unsigned userIdsToAddCount = 1;
+      for(auto& item : m_userIdsToAdd)
+      {
+        ss << "UserIdsToAdd.member." << userIdsToAddCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        userIdsToAddCount++;
+      }
     }
   }
 
   if(m_userIdsToRemoveHasBeenSet)
   {
-    unsigned userIdsToRemoveCount = 1;
-    for(auto& item : m_userIdsToRemove)
+    if (m_userIdsToRemove.empty())
     {
-      ss << "UserIdsToRemove.member." << userIdsToRemoveCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      userIdsToRemoveCount++;
+      ss << "UserIdsToRemove=&";
+    }
+    else
+    {
+      unsigned userIdsToRemoveCount = 1;
+      for(auto& item : m_userIdsToRemove)
+      {
+        ss << "UserIdsToRemove.member." << userIdsToRemoveCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        userIdsToRemoveCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyUserRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/ModifyUserRequest.cpp
@@ -42,12 +42,19 @@ Aws::String ModifyUserRequest::SerializePayload() const
 
   if(m_passwordsHasBeenSet)
   {
-    unsigned passwordsCount = 1;
-    for(auto& item : m_passwords)
+    if (m_passwords.empty())
     {
-      ss << "Passwords.member." << passwordsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      passwordsCount++;
+      ss << "Passwords=&";
+    }
+    else
+    {
+      unsigned passwordsCount = 1;
+      for(auto& item : m_passwords)
+      {
+        ss << "Passwords.member." << passwordsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        passwordsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/PurchaseReservedCacheNodesOfferingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/PurchaseReservedCacheNodesOfferingRequest.cpp
@@ -40,11 +40,18 @@ Aws::String PurchaseReservedCacheNodesOfferingRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/RebootCacheClusterRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/RebootCacheClusterRequest.cpp
@@ -27,12 +27,19 @@ Aws::String RebootCacheClusterRequest::SerializePayload() const
 
   if(m_cacheNodeIdsToRebootHasBeenSet)
   {
-    unsigned cacheNodeIdsToRebootCount = 1;
-    for(auto& item : m_cacheNodeIdsToReboot)
+    if (m_cacheNodeIdsToReboot.empty())
     {
-      ss << "CacheNodeIdsToReboot.member." << cacheNodeIdsToRebootCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      cacheNodeIdsToRebootCount++;
+      ss << "CacheNodeIdsToReboot=&";
+    }
+    else
+    {
+      unsigned cacheNodeIdsToRebootCount = 1;
+      for(auto& item : m_cacheNodeIdsToReboot)
+      {
+        ss << "CacheNodeIdsToReboot.member." << cacheNodeIdsToRebootCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        cacheNodeIdsToRebootCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/RemoveTagsFromResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/RemoveTagsFromResourceRequest.cpp
@@ -27,12 +27,19 @@ Aws::String RemoveTagsFromResourceRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/ResetCacheParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/ResetCacheParameterGroupRequest.cpp
@@ -34,11 +34,18 @@ Aws::String ResetCacheParameterGroupRequest::SerializePayload() const
 
   if(m_parameterNameValuesHasBeenSet)
   {
-    unsigned parameterNameValuesCount = 1;
-    for(auto& item : m_parameterNameValues)
+    if (m_parameterNameValues.empty())
     {
-      item.OutputToStream(ss, "ParameterNameValues.member.", parameterNameValuesCount, "");
-      parameterNameValuesCount++;
+      ss << "ParameterNameValues=&";
+    }
+    else
+    {
+      unsigned parameterNameValuesCount = 1;
+      for(auto& item : m_parameterNameValues)
+      {
+        item.OutputToStream(ss, "ParameterNameValues.member.", parameterNameValuesCount, "");
+        parameterNameValuesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/StartMigrationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/StartMigrationRequest.cpp
@@ -27,11 +27,18 @@ Aws::String StartMigrationRequest::SerializePayload() const
 
   if(m_customerNodeEndpointListHasBeenSet)
   {
-    unsigned customerNodeEndpointListCount = 1;
-    for(auto& item : m_customerNodeEndpointList)
+    if (m_customerNodeEndpointList.empty())
     {
-      item.OutputToStream(ss, "CustomerNodeEndpointList.member.", customerNodeEndpointListCount, "");
-      customerNodeEndpointListCount++;
+      ss << "CustomerNodeEndpointList=&";
+    }
+    else
+    {
+      unsigned customerNodeEndpointListCount = 1;
+      for(auto& item : m_customerNodeEndpointList)
+      {
+        item.OutputToStream(ss, "CustomerNodeEndpointList.member.", customerNodeEndpointListCount, "");
+        customerNodeEndpointListCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/model/TestMigrationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/model/TestMigrationRequest.cpp
@@ -27,11 +27,18 @@ Aws::String TestMigrationRequest::SerializePayload() const
 
   if(m_customerNodeEndpointListHasBeenSet)
   {
-    unsigned customerNodeEndpointListCount = 1;
-    for(auto& item : m_customerNodeEndpointList)
+    if (m_customerNodeEndpointList.empty())
     {
-      item.OutputToStream(ss, "CustomerNodeEndpointList.member.", customerNodeEndpointListCount, "");
-      customerNodeEndpointListCount++;
+      ss << "CustomerNodeEndpointList=&";
+    }
+    else
+    {
+      unsigned customerNodeEndpointListCount = 1;
+      for(auto& item : m_customerNodeEndpointList)
+      {
+        item.OutputToStream(ss, "CustomerNodeEndpointList.member.", customerNodeEndpointListCount, "");
+        customerNodeEndpointListCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/ComposeEnvironmentsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/ComposeEnvironmentsRequest.cpp
@@ -33,12 +33,19 @@ Aws::String ComposeEnvironmentsRequest::SerializePayload() const
 
   if(m_versionLabelsHasBeenSet)
   {
-    unsigned versionLabelsCount = 1;
-    for(auto& item : m_versionLabels)
+    if (m_versionLabels.empty())
     {
-      ss << "VersionLabels.member." << versionLabelsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      versionLabelsCount++;
+      ss << "VersionLabels=&";
+    }
+    else
+    {
+      unsigned versionLabelsCount = 1;
+      for(auto& item : m_versionLabels)
+      {
+        ss << "VersionLabels.member." << versionLabelsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        versionLabelsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/CreateApplicationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/CreateApplicationRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CreateApplicationRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/CreateApplicationVersionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/CreateApplicationVersionRequest.cpp
@@ -71,11 +71,18 @@ Aws::String CreateApplicationVersionRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/CreateConfigurationTemplateRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/CreateConfigurationTemplateRequest.cpp
@@ -64,21 +64,35 @@ Aws::String CreateConfigurationTemplateRequest::SerializePayload() const
 
   if(m_optionSettingsHasBeenSet)
   {
-    unsigned optionSettingsCount = 1;
-    for(auto& item : m_optionSettings)
+    if (m_optionSettings.empty())
     {
-      item.OutputToStream(ss, "OptionSettings.member.", optionSettingsCount, "");
-      optionSettingsCount++;
+      ss << "OptionSettings=&";
+    }
+    else
+    {
+      unsigned optionSettingsCount = 1;
+      for(auto& item : m_optionSettings)
+      {
+        item.OutputToStream(ss, "OptionSettings.member.", optionSettingsCount, "");
+        optionSettingsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/CreateEnvironmentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/CreateEnvironmentRequest.cpp
@@ -64,11 +64,18 @@ Aws::String CreateEnvironmentRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -94,21 +101,35 @@ Aws::String CreateEnvironmentRequest::SerializePayload() const
 
   if(m_optionSettingsHasBeenSet)
   {
-    unsigned optionSettingsCount = 1;
-    for(auto& item : m_optionSettings)
+    if (m_optionSettings.empty())
     {
-      item.OutputToStream(ss, "OptionSettings.member.", optionSettingsCount, "");
-      optionSettingsCount++;
+      ss << "OptionSettings=&";
+    }
+    else
+    {
+      unsigned optionSettingsCount = 1;
+      for(auto& item : m_optionSettings)
+      {
+        item.OutputToStream(ss, "OptionSettings.member.", optionSettingsCount, "");
+        optionSettingsCount++;
+      }
     }
   }
 
   if(m_optionsToRemoveHasBeenSet)
   {
-    unsigned optionsToRemoveCount = 1;
-    for(auto& item : m_optionsToRemove)
+    if (m_optionsToRemove.empty())
     {
-      item.OutputToStream(ss, "OptionsToRemove.member.", optionsToRemoveCount, "");
-      optionsToRemoveCount++;
+      ss << "OptionsToRemove=&";
+    }
+    else
+    {
+      unsigned optionsToRemoveCount = 1;
+      for(auto& item : m_optionsToRemove)
+      {
+        item.OutputToStream(ss, "OptionsToRemove.member.", optionsToRemoveCount, "");
+        optionsToRemoveCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/CreatePlatformVersionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/CreatePlatformVersionRequest.cpp
@@ -46,21 +46,35 @@ Aws::String CreatePlatformVersionRequest::SerializePayload() const
 
   if(m_optionSettingsHasBeenSet)
   {
-    unsigned optionSettingsCount = 1;
-    for(auto& item : m_optionSettings)
+    if (m_optionSettings.empty())
     {
-      item.OutputToStream(ss, "OptionSettings.member.", optionSettingsCount, "");
-      optionSettingsCount++;
+      ss << "OptionSettings=&";
+    }
+    else
+    {
+      unsigned optionSettingsCount = 1;
+      for(auto& item : m_optionSettings)
+      {
+        item.OutputToStream(ss, "OptionSettings.member.", optionSettingsCount, "");
+        optionSettingsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/DescribeApplicationVersionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/DescribeApplicationVersionsRequest.cpp
@@ -30,12 +30,19 @@ Aws::String DescribeApplicationVersionsRequest::SerializePayload() const
 
   if(m_versionLabelsHasBeenSet)
   {
-    unsigned versionLabelsCount = 1;
-    for(auto& item : m_versionLabels)
+    if (m_versionLabels.empty())
     {
-      ss << "VersionLabels.member." << versionLabelsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      versionLabelsCount++;
+      ss << "VersionLabels=&";
+    }
+    else
+    {
+      unsigned versionLabelsCount = 1;
+      for(auto& item : m_versionLabels)
+      {
+        ss << "VersionLabels.member." << versionLabelsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        versionLabelsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/DescribeApplicationsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/DescribeApplicationsRequest.cpp
@@ -21,12 +21,19 @@ Aws::String DescribeApplicationsRequest::SerializePayload() const
   ss << "Action=DescribeApplications&";
   if(m_applicationNamesHasBeenSet)
   {
-    unsigned applicationNamesCount = 1;
-    for(auto& item : m_applicationNames)
+    if (m_applicationNames.empty())
     {
-      ss << "ApplicationNames.member." << applicationNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      applicationNamesCount++;
+      ss << "ApplicationNames=&";
+    }
+    else
+    {
+      unsigned applicationNamesCount = 1;
+      for(auto& item : m_applicationNames)
+      {
+        ss << "ApplicationNames.member." << applicationNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        applicationNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/DescribeConfigurationOptionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/DescribeConfigurationOptionsRequest.cpp
@@ -51,11 +51,18 @@ Aws::String DescribeConfigurationOptionsRequest::SerializePayload() const
 
   if(m_optionsHasBeenSet)
   {
-    unsigned optionsCount = 1;
-    for(auto& item : m_options)
+    if (m_options.empty())
     {
-      item.OutputToStream(ss, "Options.member.", optionsCount, "");
-      optionsCount++;
+      ss << "Options=&";
+    }
+    else
+    {
+      unsigned optionsCount = 1;
+      for(auto& item : m_options)
+      {
+        item.OutputToStream(ss, "Options.member.", optionsCount, "");
+        optionsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/DescribeEnvironmentHealthRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/DescribeEnvironmentHealthRequest.cpp
@@ -33,12 +33,19 @@ Aws::String DescribeEnvironmentHealthRequest::SerializePayload() const
 
   if(m_attributeNamesHasBeenSet)
   {
-    unsigned attributeNamesCount = 1;
-    for(auto& item : m_attributeNames)
+    if (m_attributeNames.empty())
     {
-      ss << "AttributeNames.member." << attributeNamesCount << "="
-          << StringUtils::URLEncode(EnvironmentHealthAttributeMapper::GetNameForEnvironmentHealthAttribute(item).c_str()) << "&";
-      attributeNamesCount++;
+      ss << "AttributeNames=&";
+    }
+    else
+    {
+      unsigned attributeNamesCount = 1;
+      for(auto& item : m_attributeNames)
+      {
+        ss << "AttributeNames.member." << attributeNamesCount << "="
+            << StringUtils::URLEncode(EnvironmentHealthAttributeMapper::GetNameForEnvironmentHealthAttribute(item).c_str()) << "&";
+        attributeNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/DescribeEnvironmentsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/DescribeEnvironmentsRequest.cpp
@@ -40,23 +40,37 @@ Aws::String DescribeEnvironmentsRequest::SerializePayload() const
 
   if(m_environmentIdsHasBeenSet)
   {
-    unsigned environmentIdsCount = 1;
-    for(auto& item : m_environmentIds)
+    if (m_environmentIds.empty())
     {
-      ss << "EnvironmentIds.member." << environmentIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      environmentIdsCount++;
+      ss << "EnvironmentIds=&";
+    }
+    else
+    {
+      unsigned environmentIdsCount = 1;
+      for(auto& item : m_environmentIds)
+      {
+        ss << "EnvironmentIds.member." << environmentIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        environmentIdsCount++;
+      }
     }
   }
 
   if(m_environmentNamesHasBeenSet)
   {
-    unsigned environmentNamesCount = 1;
-    for(auto& item : m_environmentNames)
+    if (m_environmentNames.empty())
     {
-      ss << "EnvironmentNames.member." << environmentNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      environmentNamesCount++;
+      ss << "EnvironmentNames=&";
+    }
+    else
+    {
+      unsigned environmentNamesCount = 1;
+      for(auto& item : m_environmentNames)
+      {
+        ss << "EnvironmentNames.member." << environmentNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        environmentNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/DescribeInstancesHealthRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/DescribeInstancesHealthRequest.cpp
@@ -34,12 +34,19 @@ Aws::String DescribeInstancesHealthRequest::SerializePayload() const
 
   if(m_attributeNamesHasBeenSet)
   {
-    unsigned attributeNamesCount = 1;
-    for(auto& item : m_attributeNames)
+    if (m_attributeNames.empty())
     {
-      ss << "AttributeNames.member." << attributeNamesCount << "="
-          << StringUtils::URLEncode(InstancesHealthAttributeMapper::GetNameForInstancesHealthAttribute(item).c_str()) << "&";
-      attributeNamesCount++;
+      ss << "AttributeNames=&";
+    }
+    else
+    {
+      unsigned attributeNamesCount = 1;
+      for(auto& item : m_attributeNames)
+      {
+        ss << "AttributeNames.member." << attributeNamesCount << "="
+            << StringUtils::URLEncode(InstancesHealthAttributeMapper::GetNameForInstancesHealthAttribute(item).c_str()) << "&";
+        attributeNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/ListPlatformBranchesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/ListPlatformBranchesRequest.cpp
@@ -24,11 +24,18 @@ Aws::String ListPlatformBranchesRequest::SerializePayload() const
   ss << "Action=ListPlatformBranches&";
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/ListPlatformVersionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/ListPlatformVersionsRequest.cpp
@@ -24,11 +24,18 @@ Aws::String ListPlatformVersionsRequest::SerializePayload() const
   ss << "Action=ListPlatformVersions&";
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/UpdateConfigurationTemplateRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/UpdateConfigurationTemplateRequest.cpp
@@ -40,21 +40,35 @@ Aws::String UpdateConfigurationTemplateRequest::SerializePayload() const
 
   if(m_optionSettingsHasBeenSet)
   {
-    unsigned optionSettingsCount = 1;
-    for(auto& item : m_optionSettings)
+    if (m_optionSettings.empty())
     {
-      item.OutputToStream(ss, "OptionSettings.member.", optionSettingsCount, "");
-      optionSettingsCount++;
+      ss << "OptionSettings=&";
+    }
+    else
+    {
+      unsigned optionSettingsCount = 1;
+      for(auto& item : m_optionSettings)
+      {
+        item.OutputToStream(ss, "OptionSettings.member.", optionSettingsCount, "");
+        optionSettingsCount++;
+      }
     }
   }
 
   if(m_optionsToRemoveHasBeenSet)
   {
-    unsigned optionsToRemoveCount = 1;
-    for(auto& item : m_optionsToRemove)
+    if (m_optionsToRemove.empty())
     {
-      item.OutputToStream(ss, "OptionsToRemove.member.", optionsToRemoveCount, "");
-      optionsToRemoveCount++;
+      ss << "OptionsToRemove=&";
+    }
+    else
+    {
+      unsigned optionsToRemoveCount = 1;
+      for(auto& item : m_optionsToRemove)
+      {
+        item.OutputToStream(ss, "OptionsToRemove.member.", optionsToRemoveCount, "");
+        optionsToRemoveCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/UpdateEnvironmentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/UpdateEnvironmentRequest.cpp
@@ -82,21 +82,35 @@ Aws::String UpdateEnvironmentRequest::SerializePayload() const
 
   if(m_optionSettingsHasBeenSet)
   {
-    unsigned optionSettingsCount = 1;
-    for(auto& item : m_optionSettings)
+    if (m_optionSettings.empty())
     {
-      item.OutputToStream(ss, "OptionSettings.member.", optionSettingsCount, "");
-      optionSettingsCount++;
+      ss << "OptionSettings=&";
+    }
+    else
+    {
+      unsigned optionSettingsCount = 1;
+      for(auto& item : m_optionSettings)
+      {
+        item.OutputToStream(ss, "OptionSettings.member.", optionSettingsCount, "");
+        optionSettingsCount++;
+      }
     }
   }
 
   if(m_optionsToRemoveHasBeenSet)
   {
-    unsigned optionsToRemoveCount = 1;
-    for(auto& item : m_optionsToRemove)
+    if (m_optionsToRemove.empty())
     {
-      item.OutputToStream(ss, "OptionsToRemove.member.", optionsToRemoveCount, "");
-      optionsToRemoveCount++;
+      ss << "OptionsToRemove=&";
+    }
+    else
+    {
+      unsigned optionsToRemoveCount = 1;
+      for(auto& item : m_optionsToRemove)
+      {
+        item.OutputToStream(ss, "OptionsToRemove.member.", optionsToRemoveCount, "");
+        optionsToRemoveCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/UpdateTagsForResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/UpdateTagsForResourceRequest.cpp
@@ -28,22 +28,36 @@ Aws::String UpdateTagsForResourceRequest::SerializePayload() const
 
   if(m_tagsToAddHasBeenSet)
   {
-    unsigned tagsToAddCount = 1;
-    for(auto& item : m_tagsToAdd)
+    if (m_tagsToAdd.empty())
     {
-      item.OutputToStream(ss, "TagsToAdd.member.", tagsToAddCount, "");
-      tagsToAddCount++;
+      ss << "TagsToAdd=&";
+    }
+    else
+    {
+      unsigned tagsToAddCount = 1;
+      for(auto& item : m_tagsToAdd)
+      {
+        item.OutputToStream(ss, "TagsToAdd.member.", tagsToAddCount, "");
+        tagsToAddCount++;
+      }
     }
   }
 
   if(m_tagsToRemoveHasBeenSet)
   {
-    unsigned tagsToRemoveCount = 1;
-    for(auto& item : m_tagsToRemove)
+    if (m_tagsToRemove.empty())
     {
-      ss << "TagsToRemove.member." << tagsToRemoveCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagsToRemoveCount++;
+      ss << "TagsToRemove=&";
+    }
+    else
+    {
+      unsigned tagsToRemoveCount = 1;
+      for(auto& item : m_tagsToRemove)
+      {
+        ss << "TagsToRemove.member." << tagsToRemoveCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagsToRemoveCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/ValidateConfigurationSettingsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/model/ValidateConfigurationSettingsRequest.cpp
@@ -39,11 +39,18 @@ Aws::String ValidateConfigurationSettingsRequest::SerializePayload() const
 
   if(m_optionSettingsHasBeenSet)
   {
-    unsigned optionSettingsCount = 1;
-    for(auto& item : m_optionSettings)
+    if (m_optionSettings.empty())
     {
-      item.OutputToStream(ss, "OptionSettings.member.", optionSettingsCount, "");
-      optionSettingsCount++;
+      ss << "OptionSettings=&";
+    }
+    else
+    {
+      unsigned optionSettingsCount = 1;
+      for(auto& item : m_optionSettings)
+      {
+        item.OutputToStream(ss, "OptionSettings.member.", optionSettingsCount, "");
+        optionSettingsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/AddTagsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/AddTagsRequest.cpp
@@ -22,22 +22,36 @@ Aws::String AddTagsRequest::SerializePayload() const
   ss << "Action=AddTags&";
   if(m_loadBalancerNamesHasBeenSet)
   {
-    unsigned loadBalancerNamesCount = 1;
-    for(auto& item : m_loadBalancerNames)
+    if (m_loadBalancerNames.empty())
     {
-      ss << "LoadBalancerNames.member." << loadBalancerNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      loadBalancerNamesCount++;
+      ss << "LoadBalancerNames=&";
+    }
+    else
+    {
+      unsigned loadBalancerNamesCount = 1;
+      for(auto& item : m_loadBalancerNames)
+      {
+        ss << "LoadBalancerNames.member." << loadBalancerNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        loadBalancerNamesCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/ApplySecurityGroupsToLoadBalancerRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/ApplySecurityGroupsToLoadBalancerRequest.cpp
@@ -27,12 +27,19 @@ Aws::String ApplySecurityGroupsToLoadBalancerRequest::SerializePayload() const
 
   if(m_securityGroupsHasBeenSet)
   {
-    unsigned securityGroupsCount = 1;
-    for(auto& item : m_securityGroups)
+    if (m_securityGroups.empty())
     {
-      ss << "SecurityGroups.member." << securityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      securityGroupsCount++;
+      ss << "SecurityGroups=&";
+    }
+    else
+    {
+      unsigned securityGroupsCount = 1;
+      for(auto& item : m_securityGroups)
+      {
+        ss << "SecurityGroups.member." << securityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        securityGroupsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/AttachLoadBalancerToSubnetsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/AttachLoadBalancerToSubnetsRequest.cpp
@@ -27,12 +27,19 @@ Aws::String AttachLoadBalancerToSubnetsRequest::SerializePayload() const
 
   if(m_subnetsHasBeenSet)
   {
-    unsigned subnetsCount = 1;
-    for(auto& item : m_subnets)
+    if (m_subnets.empty())
     {
-      ss << "Subnets.member." << subnetsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetsCount++;
+      ss << "Subnets=&";
+    }
+    else
+    {
+      unsigned subnetsCount = 1;
+      for(auto& item : m_subnets)
+      {
+        ss << "Subnets.member." << subnetsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/CreateLoadBalancerListenersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/CreateLoadBalancerListenersRequest.cpp
@@ -27,11 +27,18 @@ Aws::String CreateLoadBalancerListenersRequest::SerializePayload() const
 
   if(m_listenersHasBeenSet)
   {
-    unsigned listenersCount = 1;
-    for(auto& item : m_listeners)
+    if (m_listeners.empty())
     {
-      item.OutputToStream(ss, "Listeners.member.", listenersCount, "");
-      listenersCount++;
+      ss << "Listeners=&";
+    }
+    else
+    {
+      unsigned listenersCount = 1;
+      for(auto& item : m_listeners)
+      {
+        item.OutputToStream(ss, "Listeners.member.", listenersCount, "");
+        listenersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/CreateLoadBalancerPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/CreateLoadBalancerPolicyRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CreateLoadBalancerPolicyRequest::SerializePayload() const
 
   if(m_policyAttributesHasBeenSet)
   {
-    unsigned policyAttributesCount = 1;
-    for(auto& item : m_policyAttributes)
+    if (m_policyAttributes.empty())
     {
-      item.OutputToStream(ss, "PolicyAttributes.member.", policyAttributesCount, "");
-      policyAttributesCount++;
+      ss << "PolicyAttributes=&";
+    }
+    else
+    {
+      unsigned policyAttributesCount = 1;
+      for(auto& item : m_policyAttributes)
+      {
+        item.OutputToStream(ss, "PolicyAttributes.member.", policyAttributesCount, "");
+        policyAttributesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/CreateLoadBalancerRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/CreateLoadBalancerRequest.cpp
@@ -32,44 +32,72 @@ Aws::String CreateLoadBalancerRequest::SerializePayload() const
 
   if(m_listenersHasBeenSet)
   {
-    unsigned listenersCount = 1;
-    for(auto& item : m_listeners)
+    if (m_listeners.empty())
     {
-      item.OutputToStream(ss, "Listeners.member.", listenersCount, "");
-      listenersCount++;
+      ss << "Listeners=&";
+    }
+    else
+    {
+      unsigned listenersCount = 1;
+      for(auto& item : m_listeners)
+      {
+        item.OutputToStream(ss, "Listeners.member.", listenersCount, "");
+        listenersCount++;
+      }
     }
   }
 
   if(m_availabilityZonesHasBeenSet)
   {
-    unsigned availabilityZonesCount = 1;
-    for(auto& item : m_availabilityZones)
+    if (m_availabilityZones.empty())
     {
-      ss << "AvailabilityZones.member." << availabilityZonesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      availabilityZonesCount++;
+      ss << "AvailabilityZones=&";
+    }
+    else
+    {
+      unsigned availabilityZonesCount = 1;
+      for(auto& item : m_availabilityZones)
+      {
+        ss << "AvailabilityZones.member." << availabilityZonesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        availabilityZonesCount++;
+      }
     }
   }
 
   if(m_subnetsHasBeenSet)
   {
-    unsigned subnetsCount = 1;
-    for(auto& item : m_subnets)
+    if (m_subnets.empty())
     {
-      ss << "Subnets.member." << subnetsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetsCount++;
+      ss << "Subnets=&";
+    }
+    else
+    {
+      unsigned subnetsCount = 1;
+      for(auto& item : m_subnets)
+      {
+        ss << "Subnets.member." << subnetsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetsCount++;
+      }
     }
   }
 
   if(m_securityGroupsHasBeenSet)
   {
-    unsigned securityGroupsCount = 1;
-    for(auto& item : m_securityGroups)
+    if (m_securityGroups.empty())
     {
-      ss << "SecurityGroups.member." << securityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      securityGroupsCount++;
+      ss << "SecurityGroups=&";
+    }
+    else
+    {
+      unsigned securityGroupsCount = 1;
+      for(auto& item : m_securityGroups)
+      {
+        ss << "SecurityGroups.member." << securityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        securityGroupsCount++;
+      }
     }
   }
 
@@ -80,11 +108,18 @@ Aws::String CreateLoadBalancerRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DeleteLoadBalancerListenersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DeleteLoadBalancerListenersRequest.cpp
@@ -27,12 +27,19 @@ Aws::String DeleteLoadBalancerListenersRequest::SerializePayload() const
 
   if(m_loadBalancerPortsHasBeenSet)
   {
-    unsigned loadBalancerPortsCount = 1;
-    for(auto& item : m_loadBalancerPorts)
+    if (m_loadBalancerPorts.empty())
     {
-      ss << "LoadBalancerPorts.member." << loadBalancerPortsCount << "="
-          << item << "&";
-      loadBalancerPortsCount++;
+      ss << "LoadBalancerPorts=&";
+    }
+    else
+    {
+      unsigned loadBalancerPortsCount = 1;
+      for(auto& item : m_loadBalancerPorts)
+      {
+        ss << "LoadBalancerPorts.member." << loadBalancerPortsCount << "="
+            << item << "&";
+        loadBalancerPortsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DeregisterInstancesFromLoadBalancerRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DeregisterInstancesFromLoadBalancerRequest.cpp
@@ -27,11 +27,18 @@ Aws::String DeregisterInstancesFromLoadBalancerRequest::SerializePayload() const
 
   if(m_instancesHasBeenSet)
   {
-    unsigned instancesCount = 1;
-    for(auto& item : m_instances)
+    if (m_instances.empty())
     {
-      item.OutputToStream(ss, "Instances.member.", instancesCount, "");
-      instancesCount++;
+      ss << "Instances=&";
+    }
+    else
+    {
+      unsigned instancesCount = 1;
+      for(auto& item : m_instances)
+      {
+        item.OutputToStream(ss, "Instances.member.", instancesCount, "");
+        instancesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DescribeInstanceHealthRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DescribeInstanceHealthRequest.cpp
@@ -27,11 +27,18 @@ Aws::String DescribeInstanceHealthRequest::SerializePayload() const
 
   if(m_instancesHasBeenSet)
   {
-    unsigned instancesCount = 1;
-    for(auto& item : m_instances)
+    if (m_instances.empty())
     {
-      item.OutputToStream(ss, "Instances.member.", instancesCount, "");
-      instancesCount++;
+      ss << "Instances=&";
+    }
+    else
+    {
+      unsigned instancesCount = 1;
+      for(auto& item : m_instances)
+      {
+        item.OutputToStream(ss, "Instances.member.", instancesCount, "");
+        instancesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DescribeLoadBalancerPoliciesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DescribeLoadBalancerPoliciesRequest.cpp
@@ -27,12 +27,19 @@ Aws::String DescribeLoadBalancerPoliciesRequest::SerializePayload() const
 
   if(m_policyNamesHasBeenSet)
   {
-    unsigned policyNamesCount = 1;
-    for(auto& item : m_policyNames)
+    if (m_policyNames.empty())
     {
-      ss << "PolicyNames.member." << policyNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      policyNamesCount++;
+      ss << "PolicyNames=&";
+    }
+    else
+    {
+      unsigned policyNamesCount = 1;
+      for(auto& item : m_policyNames)
+      {
+        ss << "PolicyNames.member." << policyNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        policyNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DescribeLoadBalancerPolicyTypesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DescribeLoadBalancerPolicyTypesRequest.cpp
@@ -21,12 +21,19 @@ Aws::String DescribeLoadBalancerPolicyTypesRequest::SerializePayload() const
   ss << "Action=DescribeLoadBalancerPolicyTypes&";
   if(m_policyTypeNamesHasBeenSet)
   {
-    unsigned policyTypeNamesCount = 1;
-    for(auto& item : m_policyTypeNames)
+    if (m_policyTypeNames.empty())
     {
-      ss << "PolicyTypeNames.member." << policyTypeNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      policyTypeNamesCount++;
+      ss << "PolicyTypeNames=&";
+    }
+    else
+    {
+      unsigned policyTypeNamesCount = 1;
+      for(auto& item : m_policyTypeNames)
+      {
+        ss << "PolicyTypeNames.member." << policyTypeNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        policyTypeNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DescribeLoadBalancersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DescribeLoadBalancersRequest.cpp
@@ -24,12 +24,19 @@ Aws::String DescribeLoadBalancersRequest::SerializePayload() const
   ss << "Action=DescribeLoadBalancers&";
   if(m_loadBalancerNamesHasBeenSet)
   {
-    unsigned loadBalancerNamesCount = 1;
-    for(auto& item : m_loadBalancerNames)
+    if (m_loadBalancerNames.empty())
     {
-      ss << "LoadBalancerNames.member." << loadBalancerNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      loadBalancerNamesCount++;
+      ss << "LoadBalancerNames=&";
+    }
+    else
+    {
+      unsigned loadBalancerNamesCount = 1;
+      for(auto& item : m_loadBalancerNames)
+      {
+        ss << "LoadBalancerNames.member." << loadBalancerNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        loadBalancerNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DescribeTagsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DescribeTagsRequest.cpp
@@ -21,12 +21,19 @@ Aws::String DescribeTagsRequest::SerializePayload() const
   ss << "Action=DescribeTags&";
   if(m_loadBalancerNamesHasBeenSet)
   {
-    unsigned loadBalancerNamesCount = 1;
-    for(auto& item : m_loadBalancerNames)
+    if (m_loadBalancerNames.empty())
     {
-      ss << "LoadBalancerNames.member." << loadBalancerNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      loadBalancerNamesCount++;
+      ss << "LoadBalancerNames=&";
+    }
+    else
+    {
+      unsigned loadBalancerNamesCount = 1;
+      for(auto& item : m_loadBalancerNames)
+      {
+        ss << "LoadBalancerNames.member." << loadBalancerNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        loadBalancerNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DetachLoadBalancerFromSubnetsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DetachLoadBalancerFromSubnetsRequest.cpp
@@ -27,12 +27,19 @@ Aws::String DetachLoadBalancerFromSubnetsRequest::SerializePayload() const
 
   if(m_subnetsHasBeenSet)
   {
-    unsigned subnetsCount = 1;
-    for(auto& item : m_subnets)
+    if (m_subnets.empty())
     {
-      ss << "Subnets.member." << subnetsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetsCount++;
+      ss << "Subnets=&";
+    }
+    else
+    {
+      unsigned subnetsCount = 1;
+      for(auto& item : m_subnets)
+      {
+        ss << "Subnets.member." << subnetsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DisableAvailabilityZonesForLoadBalancerRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/DisableAvailabilityZonesForLoadBalancerRequest.cpp
@@ -27,12 +27,19 @@ Aws::String DisableAvailabilityZonesForLoadBalancerRequest::SerializePayload() c
 
   if(m_availabilityZonesHasBeenSet)
   {
-    unsigned availabilityZonesCount = 1;
-    for(auto& item : m_availabilityZones)
+    if (m_availabilityZones.empty())
     {
-      ss << "AvailabilityZones.member." << availabilityZonesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      availabilityZonesCount++;
+      ss << "AvailabilityZones=&";
+    }
+    else
+    {
+      unsigned availabilityZonesCount = 1;
+      for(auto& item : m_availabilityZones)
+      {
+        ss << "AvailabilityZones.member." << availabilityZonesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        availabilityZonesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/EnableAvailabilityZonesForLoadBalancerRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/EnableAvailabilityZonesForLoadBalancerRequest.cpp
@@ -27,12 +27,19 @@ Aws::String EnableAvailabilityZonesForLoadBalancerRequest::SerializePayload() co
 
   if(m_availabilityZonesHasBeenSet)
   {
-    unsigned availabilityZonesCount = 1;
-    for(auto& item : m_availabilityZones)
+    if (m_availabilityZones.empty())
     {
-      ss << "AvailabilityZones.member." << availabilityZonesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      availabilityZonesCount++;
+      ss << "AvailabilityZones=&";
+    }
+    else
+    {
+      unsigned availabilityZonesCount = 1;
+      for(auto& item : m_availabilityZones)
+      {
+        ss << "AvailabilityZones.member." << availabilityZonesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        availabilityZonesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/RegisterInstancesWithLoadBalancerRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/RegisterInstancesWithLoadBalancerRequest.cpp
@@ -27,11 +27,18 @@ Aws::String RegisterInstancesWithLoadBalancerRequest::SerializePayload() const
 
   if(m_instancesHasBeenSet)
   {
-    unsigned instancesCount = 1;
-    for(auto& item : m_instances)
+    if (m_instances.empty())
     {
-      item.OutputToStream(ss, "Instances.member.", instancesCount, "");
-      instancesCount++;
+      ss << "Instances=&";
+    }
+    else
+    {
+      unsigned instancesCount = 1;
+      for(auto& item : m_instances)
+      {
+        item.OutputToStream(ss, "Instances.member.", instancesCount, "");
+        instancesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/RemoveTagsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/RemoveTagsRequest.cpp
@@ -22,22 +22,36 @@ Aws::String RemoveTagsRequest::SerializePayload() const
   ss << "Action=RemoveTags&";
   if(m_loadBalancerNamesHasBeenSet)
   {
-    unsigned loadBalancerNamesCount = 1;
-    for(auto& item : m_loadBalancerNames)
+    if (m_loadBalancerNames.empty())
     {
-      ss << "LoadBalancerNames.member." << loadBalancerNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      loadBalancerNamesCount++;
+      ss << "LoadBalancerNames=&";
+    }
+    else
+    {
+      unsigned loadBalancerNamesCount = 1;
+      for(auto& item : m_loadBalancerNames)
+      {
+        ss << "LoadBalancerNames.member." << loadBalancerNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        loadBalancerNamesCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/SetLoadBalancerPoliciesForBackendServerRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/SetLoadBalancerPoliciesForBackendServerRequest.cpp
@@ -34,12 +34,19 @@ Aws::String SetLoadBalancerPoliciesForBackendServerRequest::SerializePayload() c
 
   if(m_policyNamesHasBeenSet)
   {
-    unsigned policyNamesCount = 1;
-    for(auto& item : m_policyNames)
+    if (m_policyNames.empty())
     {
-      ss << "PolicyNames.member." << policyNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      policyNamesCount++;
+      ss << "PolicyNames=&";
+    }
+    else
+    {
+      unsigned policyNamesCount = 1;
+      for(auto& item : m_policyNames)
+      {
+        ss << "PolicyNames.member." << policyNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        policyNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/SetLoadBalancerPoliciesOfListenerRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/model/SetLoadBalancerPoliciesOfListenerRequest.cpp
@@ -34,12 +34,19 @@ Aws::String SetLoadBalancerPoliciesOfListenerRequest::SerializePayload() const
 
   if(m_policyNamesHasBeenSet)
   {
-    unsigned policyNamesCount = 1;
-    for(auto& item : m_policyNames)
+    if (m_policyNames.empty())
     {
-      ss << "PolicyNames.member." << policyNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      policyNamesCount++;
+      ss << "PolicyNames=&";
+    }
+    else
+    {
+      unsigned policyNamesCount = 1;
+      for(auto& item : m_policyNames)
+      {
+        ss << "PolicyNames.member." << policyNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        policyNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/AddListenerCertificatesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/AddListenerCertificatesRequest.cpp
@@ -27,11 +27,18 @@ Aws::String AddListenerCertificatesRequest::SerializePayload() const
 
   if(m_certificatesHasBeenSet)
   {
-    unsigned certificatesCount = 1;
-    for(auto& item : m_certificates)
+    if (m_certificates.empty())
     {
-      item.OutputToStream(ss, "Certificates.member.", certificatesCount, "");
-      certificatesCount++;
+      ss << "Certificates=&";
+    }
+    else
+    {
+      unsigned certificatesCount = 1;
+      for(auto& item : m_certificates)
+      {
+        item.OutputToStream(ss, "Certificates.member.", certificatesCount, "");
+        certificatesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/AddTagsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/AddTagsRequest.cpp
@@ -22,22 +22,36 @@ Aws::String AddTagsRequest::SerializePayload() const
   ss << "Action=AddTags&";
   if(m_resourceArnsHasBeenSet)
   {
-    unsigned resourceArnsCount = 1;
-    for(auto& item : m_resourceArns)
+    if (m_resourceArns.empty())
     {
-      ss << "ResourceArns.member." << resourceArnsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      resourceArnsCount++;
+      ss << "ResourceArns=&";
+    }
+    else
+    {
+      unsigned resourceArnsCount = 1;
+      for(auto& item : m_resourceArns)
+      {
+        ss << "ResourceArns.member." << resourceArnsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        resourceArnsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/AddTrustStoreRevocationsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/AddTrustStoreRevocationsRequest.cpp
@@ -27,11 +27,18 @@ Aws::String AddTrustStoreRevocationsRequest::SerializePayload() const
 
   if(m_revocationContentsHasBeenSet)
   {
-    unsigned revocationContentsCount = 1;
-    for(auto& item : m_revocationContents)
+    if (m_revocationContents.empty())
     {
-      item.OutputToStream(ss, "RevocationContents.member.", revocationContentsCount, "");
-      revocationContentsCount++;
+      ss << "RevocationContents=&";
+    }
+    else
+    {
+      unsigned revocationContentsCount = 1;
+      for(auto& item : m_revocationContents)
+      {
+        item.OutputToStream(ss, "RevocationContents.member.", revocationContentsCount, "");
+        revocationContentsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/CreateListenerRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/CreateListenerRequest.cpp
@@ -51,42 +51,70 @@ Aws::String CreateListenerRequest::SerializePayload() const
 
   if(m_certificatesHasBeenSet)
   {
-    unsigned certificatesCount = 1;
-    for(auto& item : m_certificates)
+    if (m_certificates.empty())
     {
-      item.OutputToStream(ss, "Certificates.member.", certificatesCount, "");
-      certificatesCount++;
+      ss << "Certificates=&";
+    }
+    else
+    {
+      unsigned certificatesCount = 1;
+      for(auto& item : m_certificates)
+      {
+        item.OutputToStream(ss, "Certificates.member.", certificatesCount, "");
+        certificatesCount++;
+      }
     }
   }
 
   if(m_defaultActionsHasBeenSet)
   {
-    unsigned defaultActionsCount = 1;
-    for(auto& item : m_defaultActions)
+    if (m_defaultActions.empty())
     {
-      item.OutputToStream(ss, "DefaultActions.member.", defaultActionsCount, "");
-      defaultActionsCount++;
+      ss << "DefaultActions=&";
+    }
+    else
+    {
+      unsigned defaultActionsCount = 1;
+      for(auto& item : m_defaultActions)
+      {
+        item.OutputToStream(ss, "DefaultActions.member.", defaultActionsCount, "");
+        defaultActionsCount++;
+      }
     }
   }
 
   if(m_alpnPolicyHasBeenSet)
   {
-    unsigned alpnPolicyCount = 1;
-    for(auto& item : m_alpnPolicy)
+    if (m_alpnPolicy.empty())
     {
-      ss << "AlpnPolicy.member." << alpnPolicyCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      alpnPolicyCount++;
+      ss << "AlpnPolicy=&";
+    }
+    else
+    {
+      unsigned alpnPolicyCount = 1;
+      for(auto& item : m_alpnPolicy)
+      {
+        ss << "AlpnPolicy.member." << alpnPolicyCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        alpnPolicyCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/CreateLoadBalancerRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/CreateLoadBalancerRequest.cpp
@@ -37,33 +37,54 @@ Aws::String CreateLoadBalancerRequest::SerializePayload() const
 
   if(m_subnetsHasBeenSet)
   {
-    unsigned subnetsCount = 1;
-    for(auto& item : m_subnets)
+    if (m_subnets.empty())
     {
-      ss << "Subnets.member." << subnetsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetsCount++;
+      ss << "Subnets=&";
+    }
+    else
+    {
+      unsigned subnetsCount = 1;
+      for(auto& item : m_subnets)
+      {
+        ss << "Subnets.member." << subnetsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetsCount++;
+      }
     }
   }
 
   if(m_subnetMappingsHasBeenSet)
   {
-    unsigned subnetMappingsCount = 1;
-    for(auto& item : m_subnetMappings)
+    if (m_subnetMappings.empty())
     {
-      item.OutputToStream(ss, "SubnetMappings.member.", subnetMappingsCount, "");
-      subnetMappingsCount++;
+      ss << "SubnetMappings=&";
+    }
+    else
+    {
+      unsigned subnetMappingsCount = 1;
+      for(auto& item : m_subnetMappings)
+      {
+        item.OutputToStream(ss, "SubnetMappings.member.", subnetMappingsCount, "");
+        subnetMappingsCount++;
+      }
     }
   }
 
   if(m_securityGroupsHasBeenSet)
   {
-    unsigned securityGroupsCount = 1;
-    for(auto& item : m_securityGroups)
+    if (m_securityGroups.empty())
     {
-      ss << "SecurityGroups.member." << securityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      securityGroupsCount++;
+      ss << "SecurityGroups=&";
+    }
+    else
+    {
+      unsigned securityGroupsCount = 1;
+      for(auto& item : m_securityGroups)
+      {
+        ss << "SecurityGroups.member." << securityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        securityGroupsCount++;
+      }
     }
   }
 
@@ -74,11 +95,18 @@ Aws::String CreateLoadBalancerRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/CreateRuleRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/CreateRuleRequest.cpp
@@ -31,11 +31,18 @@ Aws::String CreateRuleRequest::SerializePayload() const
 
   if(m_conditionsHasBeenSet)
   {
-    unsigned conditionsCount = 1;
-    for(auto& item : m_conditions)
+    if (m_conditions.empty())
     {
-      item.OutputToStream(ss, "Conditions.member.", conditionsCount, "");
-      conditionsCount++;
+      ss << "Conditions=&";
+    }
+    else
+    {
+      unsigned conditionsCount = 1;
+      for(auto& item : m_conditions)
+      {
+        item.OutputToStream(ss, "Conditions.member.", conditionsCount, "");
+        conditionsCount++;
+      }
     }
   }
 
@@ -46,21 +53,35 @@ Aws::String CreateRuleRequest::SerializePayload() const
 
   if(m_actionsHasBeenSet)
   {
-    unsigned actionsCount = 1;
-    for(auto& item : m_actions)
+    if (m_actions.empty())
     {
-      item.OutputToStream(ss, "Actions.member.", actionsCount, "");
-      actionsCount++;
+      ss << "Actions=&";
+    }
+    else
+    {
+      unsigned actionsCount = 1;
+      for(auto& item : m_actions)
+      {
+        item.OutputToStream(ss, "Actions.member.", actionsCount, "");
+        actionsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/CreateTargetGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/CreateTargetGroupRequest.cpp
@@ -122,11 +122,18 @@ Aws::String CreateTargetGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/CreateTrustStoreRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/CreateTrustStoreRequest.cpp
@@ -45,11 +45,18 @@ Aws::String CreateTrustStoreRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DeregisterTargetsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DeregisterTargetsRequest.cpp
@@ -27,11 +27,18 @@ Aws::String DeregisterTargetsRequest::SerializePayload() const
 
   if(m_targetsHasBeenSet)
   {
-    unsigned targetsCount = 1;
-    for(auto& item : m_targets)
+    if (m_targets.empty())
     {
-      item.OutputToStream(ss, "Targets.member.", targetsCount, "");
-      targetsCount++;
+      ss << "Targets=&";
+    }
+    else
+    {
+      unsigned targetsCount = 1;
+      for(auto& item : m_targets)
+      {
+        item.OutputToStream(ss, "Targets.member.", targetsCount, "");
+        targetsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeListenersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeListenersRequest.cpp
@@ -30,12 +30,19 @@ Aws::String DescribeListenersRequest::SerializePayload() const
 
   if(m_listenerArnsHasBeenSet)
   {
-    unsigned listenerArnsCount = 1;
-    for(auto& item : m_listenerArns)
+    if (m_listenerArns.empty())
     {
-      ss << "ListenerArns.member." << listenerArnsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      listenerArnsCount++;
+      ss << "ListenerArns=&";
+    }
+    else
+    {
+      unsigned listenerArnsCount = 1;
+      for(auto& item : m_listenerArns)
+      {
+        ss << "ListenerArns.member." << listenerArnsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        listenerArnsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeLoadBalancersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeLoadBalancersRequest.cpp
@@ -25,23 +25,37 @@ Aws::String DescribeLoadBalancersRequest::SerializePayload() const
   ss << "Action=DescribeLoadBalancers&";
   if(m_loadBalancerArnsHasBeenSet)
   {
-    unsigned loadBalancerArnsCount = 1;
-    for(auto& item : m_loadBalancerArns)
+    if (m_loadBalancerArns.empty())
     {
-      ss << "LoadBalancerArns.member." << loadBalancerArnsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      loadBalancerArnsCount++;
+      ss << "LoadBalancerArns=&";
+    }
+    else
+    {
+      unsigned loadBalancerArnsCount = 1;
+      for(auto& item : m_loadBalancerArns)
+      {
+        ss << "LoadBalancerArns.member." << loadBalancerArnsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        loadBalancerArnsCount++;
+      }
     }
   }
 
   if(m_namesHasBeenSet)
   {
-    unsigned namesCount = 1;
-    for(auto& item : m_names)
+    if (m_names.empty())
     {
-      ss << "Names.member." << namesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      namesCount++;
+      ss << "Names=&";
+    }
+    else
+    {
+      unsigned namesCount = 1;
+      for(auto& item : m_names)
+      {
+        ss << "Names.member." << namesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        namesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeRulesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeRulesRequest.cpp
@@ -30,12 +30,19 @@ Aws::String DescribeRulesRequest::SerializePayload() const
 
   if(m_ruleArnsHasBeenSet)
   {
-    unsigned ruleArnsCount = 1;
-    for(auto& item : m_ruleArns)
+    if (m_ruleArns.empty())
     {
-      ss << "RuleArns.member." << ruleArnsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      ruleArnsCount++;
+      ss << "RuleArns=&";
+    }
+    else
+    {
+      unsigned ruleArnsCount = 1;
+      for(auto& item : m_ruleArns)
+      {
+        ss << "RuleArns.member." << ruleArnsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        ruleArnsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeSSLPoliciesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeSSLPoliciesRequest.cpp
@@ -26,12 +26,19 @@ Aws::String DescribeSSLPoliciesRequest::SerializePayload() const
   ss << "Action=DescribeSSLPolicies&";
   if(m_namesHasBeenSet)
   {
-    unsigned namesCount = 1;
-    for(auto& item : m_names)
+    if (m_names.empty())
     {
-      ss << "Names.member." << namesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      namesCount++;
+      ss << "Names=&";
+    }
+    else
+    {
+      unsigned namesCount = 1;
+      for(auto& item : m_names)
+      {
+        ss << "Names.member." << namesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        namesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeTagsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeTagsRequest.cpp
@@ -21,12 +21,19 @@ Aws::String DescribeTagsRequest::SerializePayload() const
   ss << "Action=DescribeTags&";
   if(m_resourceArnsHasBeenSet)
   {
-    unsigned resourceArnsCount = 1;
-    for(auto& item : m_resourceArns)
+    if (m_resourceArns.empty())
     {
-      ss << "ResourceArns.member." << resourceArnsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      resourceArnsCount++;
+      ss << "ResourceArns=&";
+    }
+    else
+    {
+      unsigned resourceArnsCount = 1;
+      for(auto& item : m_resourceArns)
+      {
+        ss << "ResourceArns.member." << resourceArnsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        resourceArnsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeTargetGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeTargetGroupsRequest.cpp
@@ -31,23 +31,37 @@ Aws::String DescribeTargetGroupsRequest::SerializePayload() const
 
   if(m_targetGroupArnsHasBeenSet)
   {
-    unsigned targetGroupArnsCount = 1;
-    for(auto& item : m_targetGroupArns)
+    if (m_targetGroupArns.empty())
     {
-      ss << "TargetGroupArns.member." << targetGroupArnsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      targetGroupArnsCount++;
+      ss << "TargetGroupArns=&";
+    }
+    else
+    {
+      unsigned targetGroupArnsCount = 1;
+      for(auto& item : m_targetGroupArns)
+      {
+        ss << "TargetGroupArns.member." << targetGroupArnsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        targetGroupArnsCount++;
+      }
     }
   }
 
   if(m_namesHasBeenSet)
   {
-    unsigned namesCount = 1;
-    for(auto& item : m_names)
+    if (m_names.empty())
     {
-      ss << "Names.member." << namesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      namesCount++;
+      ss << "Names=&";
+    }
+    else
+    {
+      unsigned namesCount = 1;
+      for(auto& item : m_names)
+      {
+        ss << "Names.member." << namesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        namesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeTargetHealthRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeTargetHealthRequest.cpp
@@ -28,22 +28,36 @@ Aws::String DescribeTargetHealthRequest::SerializePayload() const
 
   if(m_targetsHasBeenSet)
   {
-    unsigned targetsCount = 1;
-    for(auto& item : m_targets)
+    if (m_targets.empty())
     {
-      item.OutputToStream(ss, "Targets.member.", targetsCount, "");
-      targetsCount++;
+      ss << "Targets=&";
+    }
+    else
+    {
+      unsigned targetsCount = 1;
+      for(auto& item : m_targets)
+      {
+        item.OutputToStream(ss, "Targets.member.", targetsCount, "");
+        targetsCount++;
+      }
     }
   }
 
   if(m_includeHasBeenSet)
   {
-    unsigned includeCount = 1;
-    for(auto& item : m_include)
+    if (m_include.empty())
     {
-      ss << "Include.member." << includeCount << "="
-          << StringUtils::URLEncode(DescribeTargetHealthInputIncludeEnumMapper::GetNameForDescribeTargetHealthInputIncludeEnum(item).c_str()) << "&";
-      includeCount++;
+      ss << "Include=&";
+    }
+    else
+    {
+      unsigned includeCount = 1;
+      for(auto& item : m_include)
+      {
+        ss << "Include.member." << includeCount << "="
+            << StringUtils::URLEncode(DescribeTargetHealthInputIncludeEnumMapper::GetNameForDescribeTargetHealthInputIncludeEnum(item).c_str()) << "&";
+        includeCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeTrustStoreRevocationsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeTrustStoreRevocationsRequest.cpp
@@ -30,12 +30,19 @@ Aws::String DescribeTrustStoreRevocationsRequest::SerializePayload() const
 
   if(m_revocationIdsHasBeenSet)
   {
-    unsigned revocationIdsCount = 1;
-    for(auto& item : m_revocationIds)
+    if (m_revocationIds.empty())
     {
-      ss << "RevocationIds.member." << revocationIdsCount << "="
-          << item << "&";
-      revocationIdsCount++;
+      ss << "RevocationIds=&";
+    }
+    else
+    {
+      unsigned revocationIdsCount = 1;
+      for(auto& item : m_revocationIds)
+      {
+        ss << "RevocationIds.member." << revocationIdsCount << "="
+            << item << "&";
+        revocationIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeTrustStoresRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/DescribeTrustStoresRequest.cpp
@@ -25,23 +25,37 @@ Aws::String DescribeTrustStoresRequest::SerializePayload() const
   ss << "Action=DescribeTrustStores&";
   if(m_trustStoreArnsHasBeenSet)
   {
-    unsigned trustStoreArnsCount = 1;
-    for(auto& item : m_trustStoreArns)
+    if (m_trustStoreArns.empty())
     {
-      ss << "TrustStoreArns.member." << trustStoreArnsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      trustStoreArnsCount++;
+      ss << "TrustStoreArns=&";
+    }
+    else
+    {
+      unsigned trustStoreArnsCount = 1;
+      for(auto& item : m_trustStoreArns)
+      {
+        ss << "TrustStoreArns.member." << trustStoreArnsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        trustStoreArnsCount++;
+      }
     }
   }
 
   if(m_namesHasBeenSet)
   {
-    unsigned namesCount = 1;
-    for(auto& item : m_names)
+    if (m_names.empty())
     {
-      ss << "Names.member." << namesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      namesCount++;
+      ss << "Names=&";
+    }
+    else
+    {
+      unsigned namesCount = 1;
+      for(auto& item : m_names)
+      {
+        ss << "Names.member." << namesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        namesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/ModifyListenerRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/ModifyListenerRequest.cpp
@@ -50,32 +50,53 @@ Aws::String ModifyListenerRequest::SerializePayload() const
 
   if(m_certificatesHasBeenSet)
   {
-    unsigned certificatesCount = 1;
-    for(auto& item : m_certificates)
+    if (m_certificates.empty())
     {
-      item.OutputToStream(ss, "Certificates.member.", certificatesCount, "");
-      certificatesCount++;
+      ss << "Certificates=&";
+    }
+    else
+    {
+      unsigned certificatesCount = 1;
+      for(auto& item : m_certificates)
+      {
+        item.OutputToStream(ss, "Certificates.member.", certificatesCount, "");
+        certificatesCount++;
+      }
     }
   }
 
   if(m_defaultActionsHasBeenSet)
   {
-    unsigned defaultActionsCount = 1;
-    for(auto& item : m_defaultActions)
+    if (m_defaultActions.empty())
     {
-      item.OutputToStream(ss, "DefaultActions.member.", defaultActionsCount, "");
-      defaultActionsCount++;
+      ss << "DefaultActions=&";
+    }
+    else
+    {
+      unsigned defaultActionsCount = 1;
+      for(auto& item : m_defaultActions)
+      {
+        item.OutputToStream(ss, "DefaultActions.member.", defaultActionsCount, "");
+        defaultActionsCount++;
+      }
     }
   }
 
   if(m_alpnPolicyHasBeenSet)
   {
-    unsigned alpnPolicyCount = 1;
-    for(auto& item : m_alpnPolicy)
+    if (m_alpnPolicy.empty())
     {
-      ss << "AlpnPolicy.member." << alpnPolicyCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      alpnPolicyCount++;
+      ss << "AlpnPolicy=&";
+    }
+    else
+    {
+      unsigned alpnPolicyCount = 1;
+      for(auto& item : m_alpnPolicy)
+      {
+        ss << "AlpnPolicy.member." << alpnPolicyCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        alpnPolicyCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/ModifyLoadBalancerAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/ModifyLoadBalancerAttributesRequest.cpp
@@ -27,11 +27,18 @@ Aws::String ModifyLoadBalancerAttributesRequest::SerializePayload() const
 
   if(m_attributesHasBeenSet)
   {
-    unsigned attributesCount = 1;
-    for(auto& item : m_attributes)
+    if (m_attributes.empty())
     {
-      item.OutputToStream(ss, "Attributes.member.", attributesCount, "");
-      attributesCount++;
+      ss << "Attributes=&";
+    }
+    else
+    {
+      unsigned attributesCount = 1;
+      for(auto& item : m_attributes)
+      {
+        item.OutputToStream(ss, "Attributes.member.", attributesCount, "");
+        attributesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/ModifyRuleRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/ModifyRuleRequest.cpp
@@ -28,21 +28,35 @@ Aws::String ModifyRuleRequest::SerializePayload() const
 
   if(m_conditionsHasBeenSet)
   {
-    unsigned conditionsCount = 1;
-    for(auto& item : m_conditions)
+    if (m_conditions.empty())
     {
-      item.OutputToStream(ss, "Conditions.member.", conditionsCount, "");
-      conditionsCount++;
+      ss << "Conditions=&";
+    }
+    else
+    {
+      unsigned conditionsCount = 1;
+      for(auto& item : m_conditions)
+      {
+        item.OutputToStream(ss, "Conditions.member.", conditionsCount, "");
+        conditionsCount++;
+      }
     }
   }
 
   if(m_actionsHasBeenSet)
   {
-    unsigned actionsCount = 1;
-    for(auto& item : m_actions)
+    if (m_actions.empty())
     {
-      item.OutputToStream(ss, "Actions.member.", actionsCount, "");
-      actionsCount++;
+      ss << "Actions=&";
+    }
+    else
+    {
+      unsigned actionsCount = 1;
+      for(auto& item : m_actions)
+      {
+        item.OutputToStream(ss, "Actions.member.", actionsCount, "");
+        actionsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/ModifyTargetGroupAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/ModifyTargetGroupAttributesRequest.cpp
@@ -27,11 +27,18 @@ Aws::String ModifyTargetGroupAttributesRequest::SerializePayload() const
 
   if(m_attributesHasBeenSet)
   {
-    unsigned attributesCount = 1;
-    for(auto& item : m_attributes)
+    if (m_attributes.empty())
     {
-      item.OutputToStream(ss, "Attributes.member.", attributesCount, "");
-      attributesCount++;
+      ss << "Attributes=&";
+    }
+    else
+    {
+      unsigned attributesCount = 1;
+      for(auto& item : m_attributes)
+      {
+        item.OutputToStream(ss, "Attributes.member.", attributesCount, "");
+        attributesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/RegisterTargetsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/RegisterTargetsRequest.cpp
@@ -27,11 +27,18 @@ Aws::String RegisterTargetsRequest::SerializePayload() const
 
   if(m_targetsHasBeenSet)
   {
-    unsigned targetsCount = 1;
-    for(auto& item : m_targets)
+    if (m_targets.empty())
     {
-      item.OutputToStream(ss, "Targets.member.", targetsCount, "");
-      targetsCount++;
+      ss << "Targets=&";
+    }
+    else
+    {
+      unsigned targetsCount = 1;
+      for(auto& item : m_targets)
+      {
+        item.OutputToStream(ss, "Targets.member.", targetsCount, "");
+        targetsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/RemoveListenerCertificatesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/RemoveListenerCertificatesRequest.cpp
@@ -27,11 +27,18 @@ Aws::String RemoveListenerCertificatesRequest::SerializePayload() const
 
   if(m_certificatesHasBeenSet)
   {
-    unsigned certificatesCount = 1;
-    for(auto& item : m_certificates)
+    if (m_certificates.empty())
     {
-      item.OutputToStream(ss, "Certificates.member.", certificatesCount, "");
-      certificatesCount++;
+      ss << "Certificates=&";
+    }
+    else
+    {
+      unsigned certificatesCount = 1;
+      for(auto& item : m_certificates)
+      {
+        item.OutputToStream(ss, "Certificates.member.", certificatesCount, "");
+        certificatesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/RemoveTagsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/RemoveTagsRequest.cpp
@@ -22,23 +22,37 @@ Aws::String RemoveTagsRequest::SerializePayload() const
   ss << "Action=RemoveTags&";
   if(m_resourceArnsHasBeenSet)
   {
-    unsigned resourceArnsCount = 1;
-    for(auto& item : m_resourceArns)
+    if (m_resourceArns.empty())
     {
-      ss << "ResourceArns.member." << resourceArnsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      resourceArnsCount++;
+      ss << "ResourceArns=&";
+    }
+    else
+    {
+      unsigned resourceArnsCount = 1;
+      for(auto& item : m_resourceArns)
+      {
+        ss << "ResourceArns.member." << resourceArnsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        resourceArnsCount++;
+      }
     }
   }
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/RemoveTrustStoreRevocationsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/RemoveTrustStoreRevocationsRequest.cpp
@@ -27,12 +27,19 @@ Aws::String RemoveTrustStoreRevocationsRequest::SerializePayload() const
 
   if(m_revocationIdsHasBeenSet)
   {
-    unsigned revocationIdsCount = 1;
-    for(auto& item : m_revocationIds)
+    if (m_revocationIds.empty())
     {
-      ss << "RevocationIds.member." << revocationIdsCount << "="
-          << item << "&";
-      revocationIdsCount++;
+      ss << "RevocationIds=&";
+    }
+    else
+    {
+      unsigned revocationIdsCount = 1;
+      for(auto& item : m_revocationIds)
+      {
+        ss << "RevocationIds.member." << revocationIdsCount << "="
+            << item << "&";
+        revocationIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/SetRulePrioritiesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/SetRulePrioritiesRequest.cpp
@@ -21,11 +21,18 @@ Aws::String SetRulePrioritiesRequest::SerializePayload() const
   ss << "Action=SetRulePriorities&";
   if(m_rulePrioritiesHasBeenSet)
   {
-    unsigned rulePrioritiesCount = 1;
-    for(auto& item : m_rulePriorities)
+    if (m_rulePriorities.empty())
     {
-      item.OutputToStream(ss, "RulePriorities.member.", rulePrioritiesCount, "");
-      rulePrioritiesCount++;
+      ss << "RulePriorities=&";
+    }
+    else
+    {
+      unsigned rulePrioritiesCount = 1;
+      for(auto& item : m_rulePriorities)
+      {
+        item.OutputToStream(ss, "RulePriorities.member.", rulePrioritiesCount, "");
+        rulePrioritiesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/SetSecurityGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/SetSecurityGroupsRequest.cpp
@@ -29,12 +29,19 @@ Aws::String SetSecurityGroupsRequest::SerializePayload() const
 
   if(m_securityGroupsHasBeenSet)
   {
-    unsigned securityGroupsCount = 1;
-    for(auto& item : m_securityGroups)
+    if (m_securityGroups.empty())
     {
-      ss << "SecurityGroups.member." << securityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      securityGroupsCount++;
+      ss << "SecurityGroups=&";
+    }
+    else
+    {
+      unsigned securityGroupsCount = 1;
+      for(auto& item : m_securityGroups)
+      {
+        ss << "SecurityGroups.member." << securityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        securityGroupsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/SetSubnetsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/model/SetSubnetsRequest.cpp
@@ -30,22 +30,36 @@ Aws::String SetSubnetsRequest::SerializePayload() const
 
   if(m_subnetsHasBeenSet)
   {
-    unsigned subnetsCount = 1;
-    for(auto& item : m_subnets)
+    if (m_subnets.empty())
     {
-      ss << "Subnets.member." << subnetsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetsCount++;
+      ss << "Subnets=&";
+    }
+    else
+    {
+      unsigned subnetsCount = 1;
+      for(auto& item : m_subnets)
+      {
+        ss << "Subnets.member." << subnetsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetsCount++;
+      }
     }
   }
 
   if(m_subnetMappingsHasBeenSet)
   {
-    unsigned subnetMappingsCount = 1;
-    for(auto& item : m_subnetMappings)
+    if (m_subnetMappings.empty())
     {
-      item.OutputToStream(ss, "SubnetMappings.member.", subnetMappingsCount, "");
-      subnetMappingsCount++;
+      ss << "SubnetMappings=&";
+    }
+    else
+    {
+      unsigned subnetMappingsCount = 1;
+      for(auto& item : m_subnetMappings)
+      {
+        item.OutputToStream(ss, "SubnetMappings.member.", subnetMappingsCount, "");
+        subnetMappingsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-email/source/model/DescribeConfigurationSetRequest.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/model/DescribeConfigurationSetRequest.cpp
@@ -27,12 +27,19 @@ Aws::String DescribeConfigurationSetRequest::SerializePayload() const
 
   if(m_configurationSetAttributeNamesHasBeenSet)
   {
-    unsigned configurationSetAttributeNamesCount = 1;
-    for(auto& item : m_configurationSetAttributeNames)
+    if (m_configurationSetAttributeNames.empty())
     {
-      ss << "ConfigurationSetAttributeNames.member." << configurationSetAttributeNamesCount << "="
-          << StringUtils::URLEncode(ConfigurationSetAttributeMapper::GetNameForConfigurationSetAttribute(item).c_str()) << "&";
-      configurationSetAttributeNamesCount++;
+      ss << "ConfigurationSetAttributeNames=&";
+    }
+    else
+    {
+      unsigned configurationSetAttributeNamesCount = 1;
+      for(auto& item : m_configurationSetAttributeNames)
+      {
+        ss << "ConfigurationSetAttributeNames.member." << configurationSetAttributeNamesCount << "="
+            << StringUtils::URLEncode(ConfigurationSetAttributeMapper::GetNameForConfigurationSetAttribute(item).c_str()) << "&";
+        configurationSetAttributeNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-email/source/model/GetIdentityDkimAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/model/GetIdentityDkimAttributesRequest.cpp
@@ -21,12 +21,19 @@ Aws::String GetIdentityDkimAttributesRequest::SerializePayload() const
   ss << "Action=GetIdentityDkimAttributes&";
   if(m_identitiesHasBeenSet)
   {
-    unsigned identitiesCount = 1;
-    for(auto& item : m_identities)
+    if (m_identities.empty())
     {
-      ss << "Identities.member." << identitiesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      identitiesCount++;
+      ss << "Identities=&";
+    }
+    else
+    {
+      unsigned identitiesCount = 1;
+      for(auto& item : m_identities)
+      {
+        ss << "Identities.member." << identitiesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        identitiesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-email/source/model/GetIdentityMailFromDomainAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/model/GetIdentityMailFromDomainAttributesRequest.cpp
@@ -21,12 +21,19 @@ Aws::String GetIdentityMailFromDomainAttributesRequest::SerializePayload() const
   ss << "Action=GetIdentityMailFromDomainAttributes&";
   if(m_identitiesHasBeenSet)
   {
-    unsigned identitiesCount = 1;
-    for(auto& item : m_identities)
+    if (m_identities.empty())
     {
-      ss << "Identities.member." << identitiesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      identitiesCount++;
+      ss << "Identities=&";
+    }
+    else
+    {
+      unsigned identitiesCount = 1;
+      for(auto& item : m_identities)
+      {
+        ss << "Identities.member." << identitiesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        identitiesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-email/source/model/GetIdentityNotificationAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/model/GetIdentityNotificationAttributesRequest.cpp
@@ -21,12 +21,19 @@ Aws::String GetIdentityNotificationAttributesRequest::SerializePayload() const
   ss << "Action=GetIdentityNotificationAttributes&";
   if(m_identitiesHasBeenSet)
   {
-    unsigned identitiesCount = 1;
-    for(auto& item : m_identities)
+    if (m_identities.empty())
     {
-      ss << "Identities.member." << identitiesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      identitiesCount++;
+      ss << "Identities=&";
+    }
+    else
+    {
+      unsigned identitiesCount = 1;
+      for(auto& item : m_identities)
+      {
+        ss << "Identities.member." << identitiesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        identitiesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-email/source/model/GetIdentityPoliciesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/model/GetIdentityPoliciesRequest.cpp
@@ -27,12 +27,19 @@ Aws::String GetIdentityPoliciesRequest::SerializePayload() const
 
   if(m_policyNamesHasBeenSet)
   {
-    unsigned policyNamesCount = 1;
-    for(auto& item : m_policyNames)
+    if (m_policyNames.empty())
     {
-      ss << "PolicyNames.member." << policyNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      policyNamesCount++;
+      ss << "PolicyNames=&";
+    }
+    else
+    {
+      unsigned policyNamesCount = 1;
+      for(auto& item : m_policyNames)
+      {
+        ss << "PolicyNames.member." << policyNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        policyNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-email/source/model/GetIdentityVerificationAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/model/GetIdentityVerificationAttributesRequest.cpp
@@ -21,12 +21,19 @@ Aws::String GetIdentityVerificationAttributesRequest::SerializePayload() const
   ss << "Action=GetIdentityVerificationAttributes&";
   if(m_identitiesHasBeenSet)
   {
-    unsigned identitiesCount = 1;
-    for(auto& item : m_identities)
+    if (m_identities.empty())
     {
-      ss << "Identities.member." << identitiesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      identitiesCount++;
+      ss << "Identities=&";
+    }
+    else
+    {
+      unsigned identitiesCount = 1;
+      for(auto& item : m_identities)
+      {
+        ss << "Identities.member." << identitiesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        identitiesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-email/source/model/ReorderReceiptRuleSetRequest.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/model/ReorderReceiptRuleSetRequest.cpp
@@ -27,12 +27,19 @@ Aws::String ReorderReceiptRuleSetRequest::SerializePayload() const
 
   if(m_ruleNamesHasBeenSet)
   {
-    unsigned ruleNamesCount = 1;
-    for(auto& item : m_ruleNames)
+    if (m_ruleNames.empty())
     {
-      ss << "RuleNames.member." << ruleNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      ruleNamesCount++;
+      ss << "RuleNames=&";
+    }
+    else
+    {
+      unsigned ruleNamesCount = 1;
+      for(auto& item : m_ruleNames)
+      {
+        ss << "RuleNames.member." << ruleNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        ruleNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-email/source/model/SendBounceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/model/SendBounceRequest.cpp
@@ -46,11 +46,18 @@ Aws::String SendBounceRequest::SerializePayload() const
 
   if(m_bouncedRecipientInfoListHasBeenSet)
   {
-    unsigned bouncedRecipientInfoListCount = 1;
-    for(auto& item : m_bouncedRecipientInfoList)
+    if (m_bouncedRecipientInfoList.empty())
     {
-      item.OutputToStream(ss, "BouncedRecipientInfoList.member.", bouncedRecipientInfoListCount, "");
-      bouncedRecipientInfoListCount++;
+      ss << "BouncedRecipientInfoList=&";
+    }
+    else
+    {
+      unsigned bouncedRecipientInfoListCount = 1;
+      for(auto& item : m_bouncedRecipientInfoList)
+      {
+        item.OutputToStream(ss, "BouncedRecipientInfoList.member.", bouncedRecipientInfoListCount, "");
+        bouncedRecipientInfoListCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-email/source/model/SendBulkTemplatedEmailRequest.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/model/SendBulkTemplatedEmailRequest.cpp
@@ -41,12 +41,19 @@ Aws::String SendBulkTemplatedEmailRequest::SerializePayload() const
 
   if(m_replyToAddressesHasBeenSet)
   {
-    unsigned replyToAddressesCount = 1;
-    for(auto& item : m_replyToAddresses)
+    if (m_replyToAddresses.empty())
     {
-      ss << "ReplyToAddresses.member." << replyToAddressesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      replyToAddressesCount++;
+      ss << "ReplyToAddresses=&";
+    }
+    else
+    {
+      unsigned replyToAddressesCount = 1;
+      for(auto& item : m_replyToAddresses)
+      {
+        ss << "ReplyToAddresses.member." << replyToAddressesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        replyToAddressesCount++;
+      }
     }
   }
 
@@ -67,11 +74,18 @@ Aws::String SendBulkTemplatedEmailRequest::SerializePayload() const
 
   if(m_defaultTagsHasBeenSet)
   {
-    unsigned defaultTagsCount = 1;
-    for(auto& item : m_defaultTags)
+    if (m_defaultTags.empty())
     {
-      item.OutputToStream(ss, "DefaultTags.member.", defaultTagsCount, "");
-      defaultTagsCount++;
+      ss << "DefaultTags=&";
+    }
+    else
+    {
+      unsigned defaultTagsCount = 1;
+      for(auto& item : m_defaultTags)
+      {
+        item.OutputToStream(ss, "DefaultTags.member.", defaultTagsCount, "");
+        defaultTagsCount++;
+      }
     }
   }
 
@@ -92,11 +106,18 @@ Aws::String SendBulkTemplatedEmailRequest::SerializePayload() const
 
   if(m_destinationsHasBeenSet)
   {
-    unsigned destinationsCount = 1;
-    for(auto& item : m_destinations)
+    if (m_destinations.empty())
     {
-      item.OutputToStream(ss, "Destinations.member.", destinationsCount, "");
-      destinationsCount++;
+      ss << "Destinations=&";
+    }
+    else
+    {
+      unsigned destinationsCount = 1;
+      for(auto& item : m_destinations)
+      {
+        item.OutputToStream(ss, "Destinations.member.", destinationsCount, "");
+        destinationsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-email/source/model/SendEmailRequest.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/model/SendEmailRequest.cpp
@@ -44,12 +44,19 @@ Aws::String SendEmailRequest::SerializePayload() const
 
   if(m_replyToAddressesHasBeenSet)
   {
-    unsigned replyToAddressesCount = 1;
-    for(auto& item : m_replyToAddresses)
+    if (m_replyToAddresses.empty())
     {
-      ss << "ReplyToAddresses.member." << replyToAddressesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      replyToAddressesCount++;
+      ss << "ReplyToAddresses=&";
+    }
+    else
+    {
+      unsigned replyToAddressesCount = 1;
+      for(auto& item : m_replyToAddresses)
+      {
+        ss << "ReplyToAddresses.member." << replyToAddressesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        replyToAddressesCount++;
+      }
     }
   }
 
@@ -70,11 +77,18 @@ Aws::String SendEmailRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-email/source/model/SendRawEmailRequest.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/model/SendRawEmailRequest.cpp
@@ -33,12 +33,19 @@ Aws::String SendRawEmailRequest::SerializePayload() const
 
   if(m_destinationsHasBeenSet)
   {
-    unsigned destinationsCount = 1;
-    for(auto& item : m_destinations)
+    if (m_destinations.empty())
     {
-      ss << "Destinations.member." << destinationsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      destinationsCount++;
+      ss << "Destinations=&";
+    }
+    else
+    {
+      unsigned destinationsCount = 1;
+      for(auto& item : m_destinations)
+      {
+        ss << "Destinations.member." << destinationsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        destinationsCount++;
+      }
     }
   }
 
@@ -64,11 +71,18 @@ Aws::String SendRawEmailRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-email/source/model/SendTemplatedEmailRequest.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/model/SendTemplatedEmailRequest.cpp
@@ -41,12 +41,19 @@ Aws::String SendTemplatedEmailRequest::SerializePayload() const
 
   if(m_replyToAddressesHasBeenSet)
   {
-    unsigned replyToAddressesCount = 1;
-    for(auto& item : m_replyToAddresses)
+    if (m_replyToAddresses.empty())
     {
-      ss << "ReplyToAddresses.member." << replyToAddressesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      replyToAddressesCount++;
+      ss << "ReplyToAddresses=&";
+    }
+    else
+    {
+      unsigned replyToAddressesCount = 1;
+      for(auto& item : m_replyToAddresses)
+      {
+        ss << "ReplyToAddresses.member." << replyToAddressesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        replyToAddressesCount++;
+      }
     }
   }
 
@@ -67,11 +74,18 @@ Aws::String SendTemplatedEmailRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/CreateInstanceProfileRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/CreateInstanceProfileRequest.cpp
@@ -33,11 +33,18 @@ Aws::String CreateInstanceProfileRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/CreateOpenIDConnectProviderRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/CreateOpenIDConnectProviderRequest.cpp
@@ -29,33 +29,54 @@ Aws::String CreateOpenIDConnectProviderRequest::SerializePayload() const
 
   if(m_clientIDListHasBeenSet)
   {
-    unsigned clientIDListCount = 1;
-    for(auto& item : m_clientIDList)
+    if (m_clientIDList.empty())
     {
-      ss << "ClientIDList.member." << clientIDListCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      clientIDListCount++;
+      ss << "ClientIDList=&";
+    }
+    else
+    {
+      unsigned clientIDListCount = 1;
+      for(auto& item : m_clientIDList)
+      {
+        ss << "ClientIDList.member." << clientIDListCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        clientIDListCount++;
+      }
     }
   }
 
   if(m_thumbprintListHasBeenSet)
   {
-    unsigned thumbprintListCount = 1;
-    for(auto& item : m_thumbprintList)
+    if (m_thumbprintList.empty())
     {
-      ss << "ThumbprintList.member." << thumbprintListCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      thumbprintListCount++;
+      ss << "ThumbprintList=&";
+    }
+    else
+    {
+      unsigned thumbprintListCount = 1;
+      for(auto& item : m_thumbprintList)
+      {
+        ss << "ThumbprintList.member." << thumbprintListCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        thumbprintListCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/CreatePolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/CreatePolicyRequest.cpp
@@ -45,11 +45,18 @@ Aws::String CreatePolicyRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/CreateRoleRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/CreateRoleRequest.cpp
@@ -58,11 +58,18 @@ Aws::String CreateRoleRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/CreateSAMLProviderRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/CreateSAMLProviderRequest.cpp
@@ -33,11 +33,18 @@ Aws::String CreateSAMLProviderRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/CreateUserRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/CreateUserRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CreateUserRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/CreateVirtualMFADeviceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/CreateVirtualMFADeviceRequest.cpp
@@ -33,11 +33,18 @@ Aws::String CreateVirtualMFADeviceRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/GetAccountAuthorizationDetailsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/GetAccountAuthorizationDetailsRequest.cpp
@@ -24,12 +24,19 @@ Aws::String GetAccountAuthorizationDetailsRequest::SerializePayload() const
   ss << "Action=GetAccountAuthorizationDetails&";
   if(m_filterHasBeenSet)
   {
-    unsigned filterCount = 1;
-    for(auto& item : m_filter)
+    if (m_filter.empty())
     {
-      ss << "Filter.member." << filterCount << "="
-          << StringUtils::URLEncode(EntityTypeMapper::GetNameForEntityType(item).c_str()) << "&";
-      filterCount++;
+      ss << "Filter=&";
+    }
+    else
+    {
+      unsigned filterCount = 1;
+      for(auto& item : m_filter)
+      {
+        ss << "Filter.member." << filterCount << "="
+            << StringUtils::URLEncode(EntityTypeMapper::GetNameForEntityType(item).c_str()) << "&";
+        filterCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/GetContextKeysForCustomPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/GetContextKeysForCustomPolicyRequest.cpp
@@ -21,12 +21,19 @@ Aws::String GetContextKeysForCustomPolicyRequest::SerializePayload() const
   ss << "Action=GetContextKeysForCustomPolicy&";
   if(m_policyInputListHasBeenSet)
   {
-    unsigned policyInputListCount = 1;
-    for(auto& item : m_policyInputList)
+    if (m_policyInputList.empty())
     {
-      ss << "PolicyInputList.member." << policyInputListCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      policyInputListCount++;
+      ss << "PolicyInputList=&";
+    }
+    else
+    {
+      unsigned policyInputListCount = 1;
+      for(auto& item : m_policyInputList)
+      {
+        ss << "PolicyInputList.member." << policyInputListCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        policyInputListCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/GetContextKeysForPrincipalPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/GetContextKeysForPrincipalPolicyRequest.cpp
@@ -27,12 +27,19 @@ Aws::String GetContextKeysForPrincipalPolicyRequest::SerializePayload() const
 
   if(m_policyInputListHasBeenSet)
   {
-    unsigned policyInputListCount = 1;
-    for(auto& item : m_policyInputList)
+    if (m_policyInputList.empty())
     {
-      ss << "PolicyInputList.member." << policyInputListCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      policyInputListCount++;
+      ss << "PolicyInputList=&";
+    }
+    else
+    {
+      unsigned policyInputListCount = 1;
+      for(auto& item : m_policyInputList)
+      {
+        ss << "PolicyInputList.member." << policyInputListCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        policyInputListCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/ListPoliciesGrantingServiceAccessRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/ListPoliciesGrantingServiceAccessRequest.cpp
@@ -33,12 +33,19 @@ Aws::String ListPoliciesGrantingServiceAccessRequest::SerializePayload() const
 
   if(m_serviceNamespacesHasBeenSet)
   {
-    unsigned serviceNamespacesCount = 1;
-    for(auto& item : m_serviceNamespaces)
+    if (m_serviceNamespaces.empty())
     {
-      ss << "ServiceNamespaces.member." << serviceNamespacesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      serviceNamespacesCount++;
+      ss << "ServiceNamespaces=&";
+    }
+    else
+    {
+      unsigned serviceNamespacesCount = 1;
+      for(auto& item : m_serviceNamespaces)
+      {
+        ss << "ServiceNamespaces.member." << serviceNamespacesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        serviceNamespacesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/SimulateCustomPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/SimulateCustomPolicyRequest.cpp
@@ -32,45 +32,73 @@ Aws::String SimulateCustomPolicyRequest::SerializePayload() const
   ss << "Action=SimulateCustomPolicy&";
   if(m_policyInputListHasBeenSet)
   {
-    unsigned policyInputListCount = 1;
-    for(auto& item : m_policyInputList)
+    if (m_policyInputList.empty())
     {
-      ss << "PolicyInputList.member." << policyInputListCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      policyInputListCount++;
+      ss << "PolicyInputList=&";
+    }
+    else
+    {
+      unsigned policyInputListCount = 1;
+      for(auto& item : m_policyInputList)
+      {
+        ss << "PolicyInputList.member." << policyInputListCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        policyInputListCount++;
+      }
     }
   }
 
   if(m_permissionsBoundaryPolicyInputListHasBeenSet)
   {
-    unsigned permissionsBoundaryPolicyInputListCount = 1;
-    for(auto& item : m_permissionsBoundaryPolicyInputList)
+    if (m_permissionsBoundaryPolicyInputList.empty())
     {
-      ss << "PermissionsBoundaryPolicyInputList.member." << permissionsBoundaryPolicyInputListCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      permissionsBoundaryPolicyInputListCount++;
+      ss << "PermissionsBoundaryPolicyInputList=&";
+    }
+    else
+    {
+      unsigned permissionsBoundaryPolicyInputListCount = 1;
+      for(auto& item : m_permissionsBoundaryPolicyInputList)
+      {
+        ss << "PermissionsBoundaryPolicyInputList.member." << permissionsBoundaryPolicyInputListCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        permissionsBoundaryPolicyInputListCount++;
+      }
     }
   }
 
   if(m_actionNamesHasBeenSet)
   {
-    unsigned actionNamesCount = 1;
-    for(auto& item : m_actionNames)
+    if (m_actionNames.empty())
     {
-      ss << "ActionNames.member." << actionNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      actionNamesCount++;
+      ss << "ActionNames=&";
+    }
+    else
+    {
+      unsigned actionNamesCount = 1;
+      for(auto& item : m_actionNames)
+      {
+        ss << "ActionNames.member." << actionNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        actionNamesCount++;
+      }
     }
   }
 
   if(m_resourceArnsHasBeenSet)
   {
-    unsigned resourceArnsCount = 1;
-    for(auto& item : m_resourceArns)
+    if (m_resourceArns.empty())
     {
-      ss << "ResourceArns.member." << resourceArnsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      resourceArnsCount++;
+      ss << "ResourceArns=&";
+    }
+    else
+    {
+      unsigned resourceArnsCount = 1;
+      for(auto& item : m_resourceArns)
+      {
+        ss << "ResourceArns.member." << resourceArnsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        resourceArnsCount++;
+      }
     }
   }
 
@@ -91,11 +119,18 @@ Aws::String SimulateCustomPolicyRequest::SerializePayload() const
 
   if(m_contextEntriesHasBeenSet)
   {
-    unsigned contextEntriesCount = 1;
-    for(auto& item : m_contextEntries)
+    if (m_contextEntries.empty())
     {
-      item.OutputToStream(ss, "ContextEntries.member.", contextEntriesCount, "");
-      contextEntriesCount++;
+      ss << "ContextEntries=&";
+    }
+    else
+    {
+      unsigned contextEntriesCount = 1;
+      for(auto& item : m_contextEntries)
+      {
+        item.OutputToStream(ss, "ContextEntries.member.", contextEntriesCount, "");
+        contextEntriesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/SimulatePrincipalPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/SimulatePrincipalPolicyRequest.cpp
@@ -38,45 +38,73 @@ Aws::String SimulatePrincipalPolicyRequest::SerializePayload() const
 
   if(m_policyInputListHasBeenSet)
   {
-    unsigned policyInputListCount = 1;
-    for(auto& item : m_policyInputList)
+    if (m_policyInputList.empty())
     {
-      ss << "PolicyInputList.member." << policyInputListCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      policyInputListCount++;
+      ss << "PolicyInputList=&";
+    }
+    else
+    {
+      unsigned policyInputListCount = 1;
+      for(auto& item : m_policyInputList)
+      {
+        ss << "PolicyInputList.member." << policyInputListCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        policyInputListCount++;
+      }
     }
   }
 
   if(m_permissionsBoundaryPolicyInputListHasBeenSet)
   {
-    unsigned permissionsBoundaryPolicyInputListCount = 1;
-    for(auto& item : m_permissionsBoundaryPolicyInputList)
+    if (m_permissionsBoundaryPolicyInputList.empty())
     {
-      ss << "PermissionsBoundaryPolicyInputList.member." << permissionsBoundaryPolicyInputListCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      permissionsBoundaryPolicyInputListCount++;
+      ss << "PermissionsBoundaryPolicyInputList=&";
+    }
+    else
+    {
+      unsigned permissionsBoundaryPolicyInputListCount = 1;
+      for(auto& item : m_permissionsBoundaryPolicyInputList)
+      {
+        ss << "PermissionsBoundaryPolicyInputList.member." << permissionsBoundaryPolicyInputListCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        permissionsBoundaryPolicyInputListCount++;
+      }
     }
   }
 
   if(m_actionNamesHasBeenSet)
   {
-    unsigned actionNamesCount = 1;
-    for(auto& item : m_actionNames)
+    if (m_actionNames.empty())
     {
-      ss << "ActionNames.member." << actionNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      actionNamesCount++;
+      ss << "ActionNames=&";
+    }
+    else
+    {
+      unsigned actionNamesCount = 1;
+      for(auto& item : m_actionNames)
+      {
+        ss << "ActionNames.member." << actionNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        actionNamesCount++;
+      }
     }
   }
 
   if(m_resourceArnsHasBeenSet)
   {
-    unsigned resourceArnsCount = 1;
-    for(auto& item : m_resourceArns)
+    if (m_resourceArns.empty())
     {
-      ss << "ResourceArns.member." << resourceArnsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      resourceArnsCount++;
+      ss << "ResourceArns=&";
+    }
+    else
+    {
+      unsigned resourceArnsCount = 1;
+      for(auto& item : m_resourceArns)
+      {
+        ss << "ResourceArns.member." << resourceArnsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        resourceArnsCount++;
+      }
     }
   }
 
@@ -97,11 +125,18 @@ Aws::String SimulatePrincipalPolicyRequest::SerializePayload() const
 
   if(m_contextEntriesHasBeenSet)
   {
-    unsigned contextEntriesCount = 1;
-    for(auto& item : m_contextEntries)
+    if (m_contextEntries.empty())
     {
-      item.OutputToStream(ss, "ContextEntries.member.", contextEntriesCount, "");
-      contextEntriesCount++;
+      ss << "ContextEntries=&";
+    }
+    else
+    {
+      unsigned contextEntriesCount = 1;
+      for(auto& item : m_contextEntries)
+      {
+        item.OutputToStream(ss, "ContextEntries.member.", contextEntriesCount, "");
+        contextEntriesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/TagInstanceProfileRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/TagInstanceProfileRequest.cpp
@@ -27,11 +27,18 @@ Aws::String TagInstanceProfileRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/TagMFADeviceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/TagMFADeviceRequest.cpp
@@ -27,11 +27,18 @@ Aws::String TagMFADeviceRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/TagOpenIDConnectProviderRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/TagOpenIDConnectProviderRequest.cpp
@@ -27,11 +27,18 @@ Aws::String TagOpenIDConnectProviderRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/TagPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/TagPolicyRequest.cpp
@@ -27,11 +27,18 @@ Aws::String TagPolicyRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/TagRoleRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/TagRoleRequest.cpp
@@ -27,11 +27,18 @@ Aws::String TagRoleRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/TagSAMLProviderRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/TagSAMLProviderRequest.cpp
@@ -27,11 +27,18 @@ Aws::String TagSAMLProviderRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/TagServerCertificateRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/TagServerCertificateRequest.cpp
@@ -27,11 +27,18 @@ Aws::String TagServerCertificateRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/TagUserRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/TagUserRequest.cpp
@@ -27,11 +27,18 @@ Aws::String TagUserRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/UntagInstanceProfileRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/UntagInstanceProfileRequest.cpp
@@ -27,12 +27,19 @@ Aws::String UntagInstanceProfileRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/UntagMFADeviceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/UntagMFADeviceRequest.cpp
@@ -27,12 +27,19 @@ Aws::String UntagMFADeviceRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/UntagOpenIDConnectProviderRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/UntagOpenIDConnectProviderRequest.cpp
@@ -27,12 +27,19 @@ Aws::String UntagOpenIDConnectProviderRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/UntagPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/UntagPolicyRequest.cpp
@@ -27,12 +27,19 @@ Aws::String UntagPolicyRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/UntagRoleRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/UntagRoleRequest.cpp
@@ -27,12 +27,19 @@ Aws::String UntagRoleRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/UntagSAMLProviderRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/UntagSAMLProviderRequest.cpp
@@ -27,12 +27,19 @@ Aws::String UntagSAMLProviderRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/UntagServerCertificateRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/UntagServerCertificateRequest.cpp
@@ -27,12 +27,19 @@ Aws::String UntagServerCertificateRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/UntagUserRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/UntagUserRequest.cpp
@@ -27,12 +27,19 @@ Aws::String UntagUserRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/UpdateOpenIDConnectProviderThumbprintRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/UpdateOpenIDConnectProviderThumbprintRequest.cpp
@@ -27,12 +27,19 @@ Aws::String UpdateOpenIDConnectProviderThumbprintRequest::SerializePayload() con
 
   if(m_thumbprintListHasBeenSet)
   {
-    unsigned thumbprintListCount = 1;
-    for(auto& item : m_thumbprintList)
+    if (m_thumbprintList.empty())
     {
-      ss << "ThumbprintList.member." << thumbprintListCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      thumbprintListCount++;
+      ss << "ThumbprintList=&";
+    }
+    else
+    {
+      unsigned thumbprintListCount = 1;
+      for(auto& item : m_thumbprintList)
+      {
+        ss << "ThumbprintList.member." << thumbprintListCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        thumbprintListCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-iam/source/model/UploadServerCertificateRequest.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/model/UploadServerCertificateRequest.cpp
@@ -51,11 +51,18 @@ Aws::String UploadServerCertificateRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-importexport/source/model/GetShippingLabelRequest.cpp
+++ b/generated/src/aws-cpp-sdk-importexport/source/model/GetShippingLabelRequest.cpp
@@ -32,12 +32,19 @@ Aws::String GetShippingLabelRequest::SerializePayload() const
   ss << "Action=GetShippingLabel&";
   if(m_jobIdsHasBeenSet)
   {
-    unsigned jobIdsCount = 1;
-    for(auto& item : m_jobIds)
+    if (m_jobIds.empty())
     {
-      ss << "jobIds.member." << jobIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      jobIdsCount++;
+      ss << "jobIds=&";
+    }
+    else
+    {
+      unsigned jobIdsCount = 1;
+      for(auto& item : m_jobIds)
+      {
+        ss << "jobIds.member." << jobIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        jobIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/DeleteAlarmsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/DeleteAlarmsRequest.cpp
@@ -21,12 +21,19 @@ Aws::String DeleteAlarmsRequest::SerializePayload() const
   ss << "Action=DeleteAlarms&";
   if(m_alarmNamesHasBeenSet)
   {
-    unsigned alarmNamesCount = 1;
-    for(auto& item : m_alarmNames)
+    if (m_alarmNames.empty())
     {
-      ss << "AlarmNames.member." << alarmNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      alarmNamesCount++;
+      ss << "AlarmNames=&";
+    }
+    else
+    {
+      unsigned alarmNamesCount = 1;
+      for(auto& item : m_alarmNames)
+      {
+        ss << "AlarmNames.member." << alarmNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        alarmNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/DeleteDashboardsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/DeleteDashboardsRequest.cpp
@@ -21,12 +21,19 @@ Aws::String DeleteDashboardsRequest::SerializePayload() const
   ss << "Action=DeleteDashboards&";
   if(m_dashboardNamesHasBeenSet)
   {
-    unsigned dashboardNamesCount = 1;
-    for(auto& item : m_dashboardNames)
+    if (m_dashboardNames.empty())
     {
-      ss << "DashboardNames.member." << dashboardNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      dashboardNamesCount++;
+      ss << "DashboardNames=&";
+    }
+    else
+    {
+      unsigned dashboardNamesCount = 1;
+      for(auto& item : m_dashboardNames)
+      {
+        ss << "DashboardNames.member." << dashboardNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        dashboardNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/DeleteInsightRulesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/DeleteInsightRulesRequest.cpp
@@ -21,12 +21,19 @@ Aws::String DeleteInsightRulesRequest::SerializePayload() const
   ss << "Action=DeleteInsightRules&";
   if(m_ruleNamesHasBeenSet)
   {
-    unsigned ruleNamesCount = 1;
-    for(auto& item : m_ruleNames)
+    if (m_ruleNames.empty())
     {
-      ss << "RuleNames.member." << ruleNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      ruleNamesCount++;
+      ss << "RuleNames=&";
+    }
+    else
+    {
+      unsigned ruleNamesCount = 1;
+      for(auto& item : m_ruleNames)
+      {
+        ss << "RuleNames.member." << ruleNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        ruleNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/DescribeAlarmHistoryRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/DescribeAlarmHistoryRequest.cpp
@@ -36,12 +36,19 @@ Aws::String DescribeAlarmHistoryRequest::SerializePayload() const
 
   if(m_alarmTypesHasBeenSet)
   {
-    unsigned alarmTypesCount = 1;
-    for(auto& item : m_alarmTypes)
+    if (m_alarmTypes.empty())
     {
-      ss << "AlarmTypes.member." << alarmTypesCount << "="
-          << StringUtils::URLEncode(AlarmTypeMapper::GetNameForAlarmType(item).c_str()) << "&";
-      alarmTypesCount++;
+      ss << "AlarmTypes=&";
+    }
+    else
+    {
+      unsigned alarmTypesCount = 1;
+      for(auto& item : m_alarmTypes)
+      {
+        ss << "AlarmTypes.member." << alarmTypesCount << "="
+            << StringUtils::URLEncode(AlarmTypeMapper::GetNameForAlarmType(item).c_str()) << "&";
+        alarmTypesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/DescribeAlarmsForMetricRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/DescribeAlarmsForMetricRequest.cpp
@@ -50,11 +50,18 @@ Aws::String DescribeAlarmsForMetricRequest::SerializePayload() const
 
   if(m_dimensionsHasBeenSet)
   {
-    unsigned dimensionsCount = 1;
-    for(auto& item : m_dimensions)
+    if (m_dimensions.empty())
     {
-      item.OutputToStream(ss, "Dimensions.member.", dimensionsCount, "");
-      dimensionsCount++;
+      ss << "Dimensions=&";
+    }
+    else
+    {
+      unsigned dimensionsCount = 1;
+      for(auto& item : m_dimensions)
+      {
+        item.OutputToStream(ss, "Dimensions.member.", dimensionsCount, "");
+        dimensionsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/DescribeAlarmsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/DescribeAlarmsRequest.cpp
@@ -31,12 +31,19 @@ Aws::String DescribeAlarmsRequest::SerializePayload() const
   ss << "Action=DescribeAlarms&";
   if(m_alarmNamesHasBeenSet)
   {
-    unsigned alarmNamesCount = 1;
-    for(auto& item : m_alarmNames)
+    if (m_alarmNames.empty())
     {
-      ss << "AlarmNames.member." << alarmNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      alarmNamesCount++;
+      ss << "AlarmNames=&";
+    }
+    else
+    {
+      unsigned alarmNamesCount = 1;
+      for(auto& item : m_alarmNames)
+      {
+        ss << "AlarmNames.member." << alarmNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        alarmNamesCount++;
+      }
     }
   }
 
@@ -47,12 +54,19 @@ Aws::String DescribeAlarmsRequest::SerializePayload() const
 
   if(m_alarmTypesHasBeenSet)
   {
-    unsigned alarmTypesCount = 1;
-    for(auto& item : m_alarmTypes)
+    if (m_alarmTypes.empty())
     {
-      ss << "AlarmTypes.member." << alarmTypesCount << "="
-          << StringUtils::URLEncode(AlarmTypeMapper::GetNameForAlarmType(item).c_str()) << "&";
-      alarmTypesCount++;
+      ss << "AlarmTypes=&";
+    }
+    else
+    {
+      unsigned alarmTypesCount = 1;
+      for(auto& item : m_alarmTypes)
+      {
+        ss << "AlarmTypes.member." << alarmTypesCount << "="
+            << StringUtils::URLEncode(AlarmTypeMapper::GetNameForAlarmType(item).c_str()) << "&";
+        alarmTypesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/DescribeAnomalyDetectorsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/DescribeAnomalyDetectorsRequest.cpp
@@ -47,22 +47,36 @@ Aws::String DescribeAnomalyDetectorsRequest::SerializePayload() const
 
   if(m_dimensionsHasBeenSet)
   {
-    unsigned dimensionsCount = 1;
-    for(auto& item : m_dimensions)
+    if (m_dimensions.empty())
     {
-      item.OutputToStream(ss, "Dimensions.member.", dimensionsCount, "");
-      dimensionsCount++;
+      ss << "Dimensions=&";
+    }
+    else
+    {
+      unsigned dimensionsCount = 1;
+      for(auto& item : m_dimensions)
+      {
+        item.OutputToStream(ss, "Dimensions.member.", dimensionsCount, "");
+        dimensionsCount++;
+      }
     }
   }
 
   if(m_anomalyDetectorTypesHasBeenSet)
   {
-    unsigned anomalyDetectorTypesCount = 1;
-    for(auto& item : m_anomalyDetectorTypes)
+    if (m_anomalyDetectorTypes.empty())
     {
-      ss << "AnomalyDetectorTypes.member." << anomalyDetectorTypesCount << "="
-          << StringUtils::URLEncode(AnomalyDetectorTypeMapper::GetNameForAnomalyDetectorType(item).c_str()) << "&";
-      anomalyDetectorTypesCount++;
+      ss << "AnomalyDetectorTypes=&";
+    }
+    else
+    {
+      unsigned anomalyDetectorTypesCount = 1;
+      for(auto& item : m_anomalyDetectorTypes)
+      {
+        ss << "AnomalyDetectorTypes.member." << anomalyDetectorTypesCount << "="
+            << StringUtils::URLEncode(AnomalyDetectorTypeMapper::GetNameForAnomalyDetectorType(item).c_str()) << "&";
+        anomalyDetectorTypesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/DisableAlarmActionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/DisableAlarmActionsRequest.cpp
@@ -21,12 +21,19 @@ Aws::String DisableAlarmActionsRequest::SerializePayload() const
   ss << "Action=DisableAlarmActions&";
   if(m_alarmNamesHasBeenSet)
   {
-    unsigned alarmNamesCount = 1;
-    for(auto& item : m_alarmNames)
+    if (m_alarmNames.empty())
     {
-      ss << "AlarmNames.member." << alarmNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      alarmNamesCount++;
+      ss << "AlarmNames=&";
+    }
+    else
+    {
+      unsigned alarmNamesCount = 1;
+      for(auto& item : m_alarmNames)
+      {
+        ss << "AlarmNames.member." << alarmNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        alarmNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/DisableInsightRulesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/DisableInsightRulesRequest.cpp
@@ -21,12 +21,19 @@ Aws::String DisableInsightRulesRequest::SerializePayload() const
   ss << "Action=DisableInsightRules&";
   if(m_ruleNamesHasBeenSet)
   {
-    unsigned ruleNamesCount = 1;
-    for(auto& item : m_ruleNames)
+    if (m_ruleNames.empty())
     {
-      ss << "RuleNames.member." << ruleNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      ruleNamesCount++;
+      ss << "RuleNames=&";
+    }
+    else
+    {
+      unsigned ruleNamesCount = 1;
+      for(auto& item : m_ruleNames)
+      {
+        ss << "RuleNames.member." << ruleNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        ruleNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/EnableAlarmActionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/EnableAlarmActionsRequest.cpp
@@ -21,12 +21,19 @@ Aws::String EnableAlarmActionsRequest::SerializePayload() const
   ss << "Action=EnableAlarmActions&";
   if(m_alarmNamesHasBeenSet)
   {
-    unsigned alarmNamesCount = 1;
-    for(auto& item : m_alarmNames)
+    if (m_alarmNames.empty())
     {
-      ss << "AlarmNames.member." << alarmNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      alarmNamesCount++;
+      ss << "AlarmNames=&";
+    }
+    else
+    {
+      unsigned alarmNamesCount = 1;
+      for(auto& item : m_alarmNames)
+      {
+        ss << "AlarmNames.member." << alarmNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        alarmNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/EnableInsightRulesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/EnableInsightRulesRequest.cpp
@@ -21,12 +21,19 @@ Aws::String EnableInsightRulesRequest::SerializePayload() const
   ss << "Action=EnableInsightRules&";
   if(m_ruleNamesHasBeenSet)
   {
-    unsigned ruleNamesCount = 1;
-    for(auto& item : m_ruleNames)
+    if (m_ruleNames.empty())
     {
-      ss << "RuleNames.member." << ruleNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      ruleNamesCount++;
+      ss << "RuleNames=&";
+    }
+    else
+    {
+      unsigned ruleNamesCount = 1;
+      for(auto& item : m_ruleNames)
+      {
+        ss << "RuleNames.member." << ruleNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        ruleNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/GetInsightRuleReportRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/GetInsightRuleReportRequest.cpp
@@ -54,12 +54,19 @@ Aws::String GetInsightRuleReportRequest::SerializePayload() const
 
   if(m_metricsHasBeenSet)
   {
-    unsigned metricsCount = 1;
-    for(auto& item : m_metrics)
+    if (m_metrics.empty())
     {
-      ss << "Metrics.member." << metricsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      metricsCount++;
+      ss << "Metrics=&";
+    }
+    else
+    {
+      unsigned metricsCount = 1;
+      for(auto& item : m_metrics)
+      {
+        ss << "Metrics.member." << metricsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        metricsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/GetMetricDataRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/GetMetricDataRequest.cpp
@@ -29,11 +29,18 @@ Aws::String GetMetricDataRequest::SerializePayload() const
   ss << "Action=GetMetricData&";
   if(m_metricDataQueriesHasBeenSet)
   {
-    unsigned metricDataQueriesCount = 1;
-    for(auto& item : m_metricDataQueries)
+    if (m_metricDataQueries.empty())
     {
-      item.OutputToStream(ss, "MetricDataQueries.member.", metricDataQueriesCount, "");
-      metricDataQueriesCount++;
+      ss << "MetricDataQueries=&";
+    }
+    else
+    {
+      unsigned metricDataQueriesCount = 1;
+      for(auto& item : m_metricDataQueries)
+      {
+        item.OutputToStream(ss, "MetricDataQueries.member.", metricDataQueriesCount, "");
+        metricDataQueriesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/GetMetricStatisticsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/GetMetricStatisticsRequest.cpp
@@ -41,11 +41,18 @@ Aws::String GetMetricStatisticsRequest::SerializePayload() const
 
   if(m_dimensionsHasBeenSet)
   {
-    unsigned dimensionsCount = 1;
-    for(auto& item : m_dimensions)
+    if (m_dimensions.empty())
     {
-      item.OutputToStream(ss, "Dimensions.member.", dimensionsCount, "");
-      dimensionsCount++;
+      ss << "Dimensions=&";
+    }
+    else
+    {
+      unsigned dimensionsCount = 1;
+      for(auto& item : m_dimensions)
+      {
+        item.OutputToStream(ss, "Dimensions.member.", dimensionsCount, "");
+        dimensionsCount++;
+      }
     }
   }
 
@@ -66,23 +73,37 @@ Aws::String GetMetricStatisticsRequest::SerializePayload() const
 
   if(m_statisticsHasBeenSet)
   {
-    unsigned statisticsCount = 1;
-    for(auto& item : m_statistics)
+    if (m_statistics.empty())
     {
-      ss << "Statistics.member." << statisticsCount << "="
-          << StringUtils::URLEncode(StatisticMapper::GetNameForStatistic(item).c_str()) << "&";
-      statisticsCount++;
+      ss << "Statistics=&";
+    }
+    else
+    {
+      unsigned statisticsCount = 1;
+      for(auto& item : m_statistics)
+      {
+        ss << "Statistics.member." << statisticsCount << "="
+            << StringUtils::URLEncode(StatisticMapper::GetNameForStatistic(item).c_str()) << "&";
+        statisticsCount++;
+      }
     }
   }
 
   if(m_extendedStatisticsHasBeenSet)
   {
-    unsigned extendedStatisticsCount = 1;
-    for(auto& item : m_extendedStatistics)
+    if (m_extendedStatistics.empty())
     {
-      ss << "ExtendedStatistics.member." << extendedStatisticsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      extendedStatisticsCount++;
+      ss << "ExtendedStatistics=&";
+    }
+    else
+    {
+      unsigned extendedStatisticsCount = 1;
+      for(auto& item : m_extendedStatistics)
+      {
+        ss << "ExtendedStatistics.member." << extendedStatisticsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        extendedStatisticsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/ListMetricsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/ListMetricsRequest.cpp
@@ -39,11 +39,18 @@ Aws::String ListMetricsRequest::SerializePayload() const
 
   if(m_dimensionsHasBeenSet)
   {
-    unsigned dimensionsCount = 1;
-    for(auto& item : m_dimensions)
+    if (m_dimensions.empty())
     {
-      item.OutputToStream(ss, "Dimensions.member.", dimensionsCount, "");
-      dimensionsCount++;
+      ss << "Dimensions=&";
+    }
+    else
+    {
+      unsigned dimensionsCount = 1;
+      for(auto& item : m_dimensions)
+      {
+        item.OutputToStream(ss, "Dimensions.member.", dimensionsCount, "");
+        dimensionsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/PutCompositeAlarmRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/PutCompositeAlarmRequest.cpp
@@ -39,12 +39,19 @@ Aws::String PutCompositeAlarmRequest::SerializePayload() const
 
   if(m_alarmActionsHasBeenSet)
   {
-    unsigned alarmActionsCount = 1;
-    for(auto& item : m_alarmActions)
+    if (m_alarmActions.empty())
     {
-      ss << "AlarmActions.member." << alarmActionsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      alarmActionsCount++;
+      ss << "AlarmActions=&";
+    }
+    else
+    {
+      unsigned alarmActionsCount = 1;
+      for(auto& item : m_alarmActions)
+      {
+        ss << "AlarmActions.member." << alarmActionsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        alarmActionsCount++;
+      }
     }
   }
 
@@ -65,33 +72,54 @@ Aws::String PutCompositeAlarmRequest::SerializePayload() const
 
   if(m_insufficientDataActionsHasBeenSet)
   {
-    unsigned insufficientDataActionsCount = 1;
-    for(auto& item : m_insufficientDataActions)
+    if (m_insufficientDataActions.empty())
     {
-      ss << "InsufficientDataActions.member." << insufficientDataActionsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      insufficientDataActionsCount++;
+      ss << "InsufficientDataActions=&";
+    }
+    else
+    {
+      unsigned insufficientDataActionsCount = 1;
+      for(auto& item : m_insufficientDataActions)
+      {
+        ss << "InsufficientDataActions.member." << insufficientDataActionsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        insufficientDataActionsCount++;
+      }
     }
   }
 
   if(m_oKActionsHasBeenSet)
   {
-    unsigned oKActionsCount = 1;
-    for(auto& item : m_oKActions)
+    if (m_oKActions.empty())
     {
-      ss << "OKActions.member." << oKActionsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      oKActionsCount++;
+      ss << "OKActions=&";
+    }
+    else
+    {
+      unsigned oKActionsCount = 1;
+      for(auto& item : m_oKActions)
+      {
+        ss << "OKActions.member." << oKActionsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        oKActionsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/PutInsightRuleRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/PutInsightRuleRequest.cpp
@@ -39,11 +39,18 @@ Aws::String PutInsightRuleRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/PutManagedInsightRulesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/PutManagedInsightRulesRequest.cpp
@@ -21,11 +21,18 @@ Aws::String PutManagedInsightRulesRequest::SerializePayload() const
   ss << "Action=PutManagedInsightRules&";
   if(m_managedRulesHasBeenSet)
   {
-    unsigned managedRulesCount = 1;
-    for(auto& item : m_managedRules)
+    if (m_managedRules.empty())
     {
-      item.OutputToStream(ss, "ManagedRules.member.", managedRulesCount, "");
-      managedRulesCount++;
+      ss << "ManagedRules=&";
+    }
+    else
+    {
+      unsigned managedRulesCount = 1;
+      for(auto& item : m_managedRules)
+      {
+        item.OutputToStream(ss, "ManagedRules.member.", managedRulesCount, "");
+        managedRulesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/PutMetricAlarmRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/PutMetricAlarmRequest.cpp
@@ -65,34 +65,55 @@ Aws::String PutMetricAlarmRequest::SerializePayload() const
 
   if(m_oKActionsHasBeenSet)
   {
-    unsigned oKActionsCount = 1;
-    for(auto& item : m_oKActions)
+    if (m_oKActions.empty())
     {
-      ss << "OKActions.member." << oKActionsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      oKActionsCount++;
+      ss << "OKActions=&";
+    }
+    else
+    {
+      unsigned oKActionsCount = 1;
+      for(auto& item : m_oKActions)
+      {
+        ss << "OKActions.member." << oKActionsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        oKActionsCount++;
+      }
     }
   }
 
   if(m_alarmActionsHasBeenSet)
   {
-    unsigned alarmActionsCount = 1;
-    for(auto& item : m_alarmActions)
+    if (m_alarmActions.empty())
     {
-      ss << "AlarmActions.member." << alarmActionsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      alarmActionsCount++;
+      ss << "AlarmActions=&";
+    }
+    else
+    {
+      unsigned alarmActionsCount = 1;
+      for(auto& item : m_alarmActions)
+      {
+        ss << "AlarmActions.member." << alarmActionsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        alarmActionsCount++;
+      }
     }
   }
 
   if(m_insufficientDataActionsHasBeenSet)
   {
-    unsigned insufficientDataActionsCount = 1;
-    for(auto& item : m_insufficientDataActions)
+    if (m_insufficientDataActions.empty())
     {
-      ss << "InsufficientDataActions.member." << insufficientDataActionsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      insufficientDataActionsCount++;
+      ss << "InsufficientDataActions=&";
+    }
+    else
+    {
+      unsigned insufficientDataActionsCount = 1;
+      for(auto& item : m_insufficientDataActions)
+      {
+        ss << "InsufficientDataActions.member." << insufficientDataActionsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        insufficientDataActionsCount++;
+      }
     }
   }
 
@@ -118,11 +139,18 @@ Aws::String PutMetricAlarmRequest::SerializePayload() const
 
   if(m_dimensionsHasBeenSet)
   {
-    unsigned dimensionsCount = 1;
-    for(auto& item : m_dimensions)
+    if (m_dimensions.empty())
     {
-      item.OutputToStream(ss, "Dimensions.member.", dimensionsCount, "");
-      dimensionsCount++;
+      ss << "Dimensions=&";
+    }
+    else
+    {
+      unsigned dimensionsCount = 1;
+      for(auto& item : m_dimensions)
+      {
+        item.OutputToStream(ss, "Dimensions.member.", dimensionsCount, "");
+        dimensionsCount++;
+      }
     }
   }
 
@@ -168,21 +196,35 @@ Aws::String PutMetricAlarmRequest::SerializePayload() const
 
   if(m_metricsHasBeenSet)
   {
-    unsigned metricsCount = 1;
-    for(auto& item : m_metrics)
+    if (m_metrics.empty())
     {
-      item.OutputToStream(ss, "Metrics.member.", metricsCount, "");
-      metricsCount++;
+      ss << "Metrics=&";
+    }
+    else
+    {
+      unsigned metricsCount = 1;
+      for(auto& item : m_metrics)
+      {
+        item.OutputToStream(ss, "Metrics.member.", metricsCount, "");
+        metricsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/PutMetricDataRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/PutMetricDataRequest.cpp
@@ -27,11 +27,18 @@ Aws::String PutMetricDataRequest::SerializePayload() const
 
   if(m_metricDataHasBeenSet)
   {
-    unsigned metricDataCount = 1;
-    for(auto& item : m_metricData)
+    if (m_metricData.empty())
     {
-      item.OutputToStream(ss, "MetricData.member.", metricDataCount, "");
-      metricDataCount++;
+      ss << "MetricData=&";
+    }
+    else
+    {
+      unsigned metricDataCount = 1;
+      for(auto& item : m_metricData)
+      {
+        item.OutputToStream(ss, "MetricData.member.", metricDataCount, "");
+        metricDataCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/PutMetricStreamRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/PutMetricStreamRequest.cpp
@@ -36,21 +36,35 @@ Aws::String PutMetricStreamRequest::SerializePayload() const
 
   if(m_includeFiltersHasBeenSet)
   {
-    unsigned includeFiltersCount = 1;
-    for(auto& item : m_includeFilters)
+    if (m_includeFilters.empty())
     {
-      item.OutputToStream(ss, "IncludeFilters.member.", includeFiltersCount, "");
-      includeFiltersCount++;
+      ss << "IncludeFilters=&";
+    }
+    else
+    {
+      unsigned includeFiltersCount = 1;
+      for(auto& item : m_includeFilters)
+      {
+        item.OutputToStream(ss, "IncludeFilters.member.", includeFiltersCount, "");
+        includeFiltersCount++;
+      }
     }
   }
 
   if(m_excludeFiltersHasBeenSet)
   {
-    unsigned excludeFiltersCount = 1;
-    for(auto& item : m_excludeFilters)
+    if (m_excludeFilters.empty())
     {
-      item.OutputToStream(ss, "ExcludeFilters.member.", excludeFiltersCount, "");
-      excludeFiltersCount++;
+      ss << "ExcludeFilters=&";
+    }
+    else
+    {
+      unsigned excludeFiltersCount = 1;
+      for(auto& item : m_excludeFilters)
+      {
+        item.OutputToStream(ss, "ExcludeFilters.member.", excludeFiltersCount, "");
+        excludeFiltersCount++;
+      }
     }
   }
 
@@ -71,21 +85,35 @@ Aws::String PutMetricStreamRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
   if(m_statisticsConfigurationsHasBeenSet)
   {
-    unsigned statisticsConfigurationsCount = 1;
-    for(auto& item : m_statisticsConfigurations)
+    if (m_statisticsConfigurations.empty())
     {
-      item.OutputToStream(ss, "StatisticsConfigurations.member.", statisticsConfigurationsCount, "");
-      statisticsConfigurationsCount++;
+      ss << "StatisticsConfigurations=&";
+    }
+    else
+    {
+      unsigned statisticsConfigurationsCount = 1;
+      for(auto& item : m_statisticsConfigurations)
+      {
+        item.OutputToStream(ss, "StatisticsConfigurations.member.", statisticsConfigurationsCount, "");
+        statisticsConfigurationsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/StartMetricStreamsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/StartMetricStreamsRequest.cpp
@@ -21,12 +21,19 @@ Aws::String StartMetricStreamsRequest::SerializePayload() const
   ss << "Action=StartMetricStreams&";
   if(m_namesHasBeenSet)
   {
-    unsigned namesCount = 1;
-    for(auto& item : m_names)
+    if (m_names.empty())
     {
-      ss << "Names.member." << namesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      namesCount++;
+      ss << "Names=&";
+    }
+    else
+    {
+      unsigned namesCount = 1;
+      for(auto& item : m_names)
+      {
+        ss << "Names.member." << namesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        namesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/StopMetricStreamsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/StopMetricStreamsRequest.cpp
@@ -21,12 +21,19 @@ Aws::String StopMetricStreamsRequest::SerializePayload() const
   ss << "Action=StopMetricStreams&";
   if(m_namesHasBeenSet)
   {
-    unsigned namesCount = 1;
-    for(auto& item : m_names)
+    if (m_names.empty())
     {
-      ss << "Names.member." << namesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      namesCount++;
+      ss << "Names=&";
+    }
+    else
+    {
+      unsigned namesCount = 1;
+      for(auto& item : m_names)
+      {
+        ss << "Names.member." << namesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        namesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/TagResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/TagResourceRequest.cpp
@@ -27,11 +27,18 @@ Aws::String TagResourceRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/model/UntagResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/model/UntagResourceRequest.cpp
@@ -27,12 +27,19 @@ Aws::String UntagResourceRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/AddTagsToResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/AddTagsToResourceRequest.cpp
@@ -27,11 +27,18 @@ Aws::String AddTagsToResourceRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/CopyDBClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/CopyDBClusterParameterGroupRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CopyDBClusterParameterGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/CopyDBClusterSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/CopyDBClusterSnapshotRequest.cpp
@@ -53,11 +53,18 @@ Aws::String CopyDBClusterSnapshotRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/CopyDBParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/CopyDBParameterGroupRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CopyDBParameterGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/CreateDBClusterEndpointRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/CreateDBClusterEndpointRequest.cpp
@@ -41,33 +41,54 @@ Aws::String CreateDBClusterEndpointRequest::SerializePayload() const
 
   if(m_staticMembersHasBeenSet)
   {
-    unsigned staticMembersCount = 1;
-    for(auto& item : m_staticMembers)
+    if (m_staticMembers.empty())
     {
-      ss << "StaticMembers.member." << staticMembersCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      staticMembersCount++;
+      ss << "StaticMembers=&";
+    }
+    else
+    {
+      unsigned staticMembersCount = 1;
+      for(auto& item : m_staticMembers)
+      {
+        ss << "StaticMembers.member." << staticMembersCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        staticMembersCount++;
+      }
     }
   }
 
   if(m_excludedMembersHasBeenSet)
   {
-    unsigned excludedMembersCount = 1;
-    for(auto& item : m_excludedMembers)
+    if (m_excludedMembers.empty())
     {
-      ss << "ExcludedMembers.member." << excludedMembersCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      excludedMembersCount++;
+      ss << "ExcludedMembers=&";
+    }
+    else
+    {
+      unsigned excludedMembersCount = 1;
+      for(auto& item : m_excludedMembers)
+      {
+        ss << "ExcludedMembers.member." << excludedMembersCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        excludedMembersCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/CreateDBClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/CreateDBClusterParameterGroupRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CreateDBClusterParameterGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/CreateDBClusterRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/CreateDBClusterRequest.cpp
@@ -55,12 +55,19 @@ Aws::String CreateDBClusterRequest::SerializePayload() const
   ss << "Action=CreateDBCluster&";
   if(m_availabilityZonesHasBeenSet)
   {
-    unsigned availabilityZonesCount = 1;
-    for(auto& item : m_availabilityZones)
+    if (m_availabilityZones.empty())
     {
-      ss << "AvailabilityZones.member." << availabilityZonesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      availabilityZonesCount++;
+      ss << "AvailabilityZones=&";
+    }
+    else
+    {
+      unsigned availabilityZonesCount = 1;
+      for(auto& item : m_availabilityZones)
+      {
+        ss << "AvailabilityZones.member." << availabilityZonesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        availabilityZonesCount++;
+      }
     }
   }
 
@@ -96,12 +103,19 @@ Aws::String CreateDBClusterRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -157,11 +171,18 @@ Aws::String CreateDBClusterRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -187,12 +208,19 @@ Aws::String CreateDBClusterRequest::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/CreateDBClusterSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/CreateDBClusterSnapshotRequest.cpp
@@ -33,11 +33,18 @@ Aws::String CreateDBClusterSnapshotRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/CreateDBInstanceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/CreateDBInstanceRequest.cpp
@@ -110,23 +110,37 @@ Aws::String CreateDBInstanceRequest::SerializePayload() const
 
   if(m_dBSecurityGroupsHasBeenSet)
   {
-    unsigned dBSecurityGroupsCount = 1;
-    for(auto& item : m_dBSecurityGroups)
+    if (m_dBSecurityGroups.empty())
     {
-      ss << "DBSecurityGroups.member." << dBSecurityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      dBSecurityGroupsCount++;
+      ss << "DBSecurityGroups=&";
+    }
+    else
+    {
+      unsigned dBSecurityGroupsCount = 1;
+      for(auto& item : m_dBSecurityGroups)
+      {
+        ss << "DBSecurityGroups.member." << dBSecurityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        dBSecurityGroupsCount++;
+      }
     }
   }
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -202,11 +216,18 @@ Aws::String CreateDBInstanceRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -292,12 +313,19 @@ Aws::String CreateDBInstanceRequest::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/CreateDBParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/CreateDBParameterGroupRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CreateDBParameterGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/CreateDBSubnetGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/CreateDBSubnetGroupRequest.cpp
@@ -34,22 +34,36 @@ Aws::String CreateDBSubnetGroupRequest::SerializePayload() const
 
   if(m_subnetIdsHasBeenSet)
   {
-    unsigned subnetIdsCount = 1;
-    for(auto& item : m_subnetIds)
+    if (m_subnetIds.empty())
     {
-      ss << "SubnetIds.member." << subnetIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetIdsCount++;
+      ss << "SubnetIds=&";
+    }
+    else
+    {
+      unsigned subnetIdsCount = 1;
+      for(auto& item : m_subnetIds)
+      {
+        ss << "SubnetIds.member." << subnetIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetIdsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/CreateEventSubscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/CreateEventSubscriptionRequest.cpp
@@ -43,23 +43,37 @@ Aws::String CreateEventSubscriptionRequest::SerializePayload() const
 
   if(m_eventCategoriesHasBeenSet)
   {
-    unsigned eventCategoriesCount = 1;
-    for(auto& item : m_eventCategories)
+    if (m_eventCategories.empty())
     {
-      ss << "EventCategories.member." << eventCategoriesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      eventCategoriesCount++;
+      ss << "EventCategories=&";
+    }
+    else
+    {
+      unsigned eventCategoriesCount = 1;
+      for(auto& item : m_eventCategories)
+      {
+        ss << "EventCategories.member." << eventCategoriesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        eventCategoriesCount++;
+      }
     }
   }
 
   if(m_sourceIdsHasBeenSet)
   {
-    unsigned sourceIdsCount = 1;
-    for(auto& item : m_sourceIds)
+    if (m_sourceIds.empty())
     {
-      ss << "SourceIds.member." << sourceIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      sourceIdsCount++;
+      ss << "SourceIds=&";
+    }
+    else
+    {
+      unsigned sourceIdsCount = 1;
+      for(auto& item : m_sourceIds)
+      {
+        ss << "SourceIds.member." << sourceIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        sourceIdsCount++;
+      }
     }
   }
 
@@ -70,11 +84,18 @@ Aws::String CreateEventSubscriptionRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBClusterEndpointsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBClusterEndpointsRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeDBClusterEndpointsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBClusterParameterGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBClusterParameterGroupsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBClusterParameterGroupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBClusterParametersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBClusterParametersRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeDBClusterParametersRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBClusterSnapshotsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBClusterSnapshotsRequest.cpp
@@ -46,11 +46,18 @@ Aws::String DescribeDBClusterSnapshotsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBClustersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBClustersRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBClustersRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBEngineVersionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBEngineVersionsRequest.cpp
@@ -48,11 +48,18 @@ Aws::String DescribeDBEngineVersionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBInstancesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBInstancesRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBInstancesRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBParameterGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBParameterGroupsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBParameterGroupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBParametersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBParametersRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeDBParametersRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBSubnetGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeDBSubnetGroupsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBSubnetGroupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeEngineDefaultClusterParametersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeEngineDefaultClusterParametersRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeEngineDefaultClusterParametersRequest::SerializePayload() co
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeEngineDefaultParametersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeEngineDefaultParametersRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeEngineDefaultParametersRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeEventCategoriesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeEventCategoriesRequest.cpp
@@ -27,11 +27,18 @@ Aws::String DescribeEventCategoriesRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeEventSubscriptionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeEventSubscriptionsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeEventSubscriptionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeEventsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeEventsRequest.cpp
@@ -57,22 +57,36 @@ Aws::String DescribeEventsRequest::SerializePayload() const
 
   if(m_eventCategoriesHasBeenSet)
   {
-    unsigned eventCategoriesCount = 1;
-    for(auto& item : m_eventCategories)
+    if (m_eventCategories.empty())
     {
-      ss << "EventCategories.member." << eventCategoriesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      eventCategoriesCount++;
+      ss << "EventCategories=&";
+    }
+    else
+    {
+      unsigned eventCategoriesCount = 1;
+      for(auto& item : m_eventCategories)
+      {
+        ss << "EventCategories.member." << eventCategoriesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        eventCategoriesCount++;
+      }
     }
   }
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribeOrderableDBInstanceOptionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribeOrderableDBInstanceOptionsRequest.cpp
@@ -55,11 +55,18 @@ Aws::String DescribeOrderableDBInstanceOptionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/DescribePendingMaintenanceActionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/DescribePendingMaintenanceActionsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribePendingMaintenanceActionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/ListTagsForResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/ListTagsForResourceRequest.cpp
@@ -27,11 +27,18 @@ Aws::String ListTagsForResourceRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/ModifyDBClusterEndpointRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/ModifyDBClusterEndpointRequest.cpp
@@ -34,23 +34,37 @@ Aws::String ModifyDBClusterEndpointRequest::SerializePayload() const
 
   if(m_staticMembersHasBeenSet)
   {
-    unsigned staticMembersCount = 1;
-    for(auto& item : m_staticMembers)
+    if (m_staticMembers.empty())
     {
-      ss << "StaticMembers.member." << staticMembersCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      staticMembersCount++;
+      ss << "StaticMembers=&";
+    }
+    else
+    {
+      unsigned staticMembersCount = 1;
+      for(auto& item : m_staticMembers)
+      {
+        ss << "StaticMembers.member." << staticMembersCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        staticMembersCount++;
+      }
     }
   }
 
   if(m_excludedMembersHasBeenSet)
   {
-    unsigned excludedMembersCount = 1;
-    for(auto& item : m_excludedMembers)
+    if (m_excludedMembers.empty())
     {
-      ss << "ExcludedMembers.member." << excludedMembersCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      excludedMembersCount++;
+      ss << "ExcludedMembers=&";
+    }
+    else
+    {
+      unsigned excludedMembersCount = 1;
+      for(auto& item : m_excludedMembers)
+      {
+        ss << "ExcludedMembers.member." << excludedMembersCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        excludedMembersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/ModifyDBClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/ModifyDBClusterParameterGroupRequest.cpp
@@ -27,11 +27,18 @@ Aws::String ModifyDBClusterParameterGroupRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/ModifyDBClusterRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/ModifyDBClusterRequest.cpp
@@ -72,12 +72,19 @@ Aws::String ModifyDBClusterRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/ModifyDBClusterSnapshotAttributeRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/ModifyDBClusterSnapshotAttributeRequest.cpp
@@ -34,23 +34,37 @@ Aws::String ModifyDBClusterSnapshotAttributeRequest::SerializePayload() const
 
   if(m_valuesToAddHasBeenSet)
   {
-    unsigned valuesToAddCount = 1;
-    for(auto& item : m_valuesToAdd)
+    if (m_valuesToAdd.empty())
     {
-      ss << "ValuesToAdd.member." << valuesToAddCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      valuesToAddCount++;
+      ss << "ValuesToAdd=&";
+    }
+    else
+    {
+      unsigned valuesToAddCount = 1;
+      for(auto& item : m_valuesToAdd)
+      {
+        ss << "ValuesToAdd.member." << valuesToAddCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        valuesToAddCount++;
+      }
     }
   }
 
   if(m_valuesToRemoveHasBeenSet)
   {
-    unsigned valuesToRemoveCount = 1;
-    for(auto& item : m_valuesToRemove)
+    if (m_valuesToRemove.empty())
     {
-      ss << "ValuesToRemove.member." << valuesToRemoveCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      valuesToRemoveCount++;
+      ss << "ValuesToRemove=&";
+    }
+    else
+    {
+      unsigned valuesToRemoveCount = 1;
+      for(auto& item : m_valuesToRemove)
+      {
+        ss << "ValuesToRemove.member." << valuesToRemoveCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        valuesToRemoveCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/ModifyDBInstanceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/ModifyDBInstanceRequest.cpp
@@ -90,23 +90,37 @@ Aws::String ModifyDBInstanceRequest::SerializePayload() const
 
   if(m_dBSecurityGroupsHasBeenSet)
   {
-    unsigned dBSecurityGroupsCount = 1;
-    for(auto& item : m_dBSecurityGroups)
+    if (m_dBSecurityGroups.empty())
     {
-      ss << "DBSecurityGroups.member." << dBSecurityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      dBSecurityGroupsCount++;
+      ss << "DBSecurityGroups=&";
+    }
+    else
+    {
+      unsigned dBSecurityGroupsCount = 1;
+      for(auto& item : m_dBSecurityGroups)
+      {
+        ss << "DBSecurityGroups.member." << dBSecurityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        dBSecurityGroupsCount++;
+      }
     }
   }
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/ModifyDBParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/ModifyDBParameterGroupRequest.cpp
@@ -27,11 +27,18 @@ Aws::String ModifyDBParameterGroupRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/ModifyDBSubnetGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/ModifyDBSubnetGroupRequest.cpp
@@ -33,12 +33,19 @@ Aws::String ModifyDBSubnetGroupRequest::SerializePayload() const
 
   if(m_subnetIdsHasBeenSet)
   {
-    unsigned subnetIdsCount = 1;
-    for(auto& item : m_subnetIds)
+    if (m_subnetIds.empty())
     {
-      ss << "SubnetIds.member." << subnetIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetIdsCount++;
+      ss << "SubnetIds=&";
+    }
+    else
+    {
+      unsigned subnetIdsCount = 1;
+      for(auto& item : m_subnetIds)
+      {
+        ss << "SubnetIds.member." << subnetIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/ModifyEventSubscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/ModifyEventSubscriptionRequest.cpp
@@ -41,12 +41,19 @@ Aws::String ModifyEventSubscriptionRequest::SerializePayload() const
 
   if(m_eventCategoriesHasBeenSet)
   {
-    unsigned eventCategoriesCount = 1;
-    for(auto& item : m_eventCategories)
+    if (m_eventCategories.empty())
     {
-      ss << "EventCategories.member." << eventCategoriesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      eventCategoriesCount++;
+      ss << "EventCategories=&";
+    }
+    else
+    {
+      unsigned eventCategoriesCount = 1;
+      for(auto& item : m_eventCategories)
+      {
+        ss << "EventCategories.member." << eventCategoriesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        eventCategoriesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/RemoveTagsFromResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/RemoveTagsFromResourceRequest.cpp
@@ -27,12 +27,19 @@ Aws::String RemoveTagsFromResourceRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/ResetDBClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/ResetDBClusterParameterGroupRequest.cpp
@@ -34,11 +34,18 @@ Aws::String ResetDBClusterParameterGroupRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/ResetDBParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/ResetDBParameterGroupRequest.cpp
@@ -34,11 +34,18 @@ Aws::String ResetDBParameterGroupRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/RestoreDBClusterFromSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/RestoreDBClusterFromSnapshotRequest.cpp
@@ -43,12 +43,19 @@ Aws::String RestoreDBClusterFromSnapshotRequest::SerializePayload() const
   ss << "Action=RestoreDBClusterFromSnapshot&";
   if(m_availabilityZonesHasBeenSet)
   {
-    unsigned availabilityZonesCount = 1;
-    for(auto& item : m_availabilityZones)
+    if (m_availabilityZones.empty())
     {
-      ss << "AvailabilityZones.member." << availabilityZonesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      availabilityZonesCount++;
+      ss << "AvailabilityZones=&";
+    }
+    else
+    {
+      unsigned availabilityZonesCount = 1;
+      for(auto& item : m_availabilityZones)
+      {
+        ss << "AvailabilityZones.member." << availabilityZonesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        availabilityZonesCount++;
+      }
     }
   }
 
@@ -94,22 +101,36 @@ Aws::String RestoreDBClusterFromSnapshotRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -125,12 +146,19 @@ Aws::String RestoreDBClusterFromSnapshotRequest::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/model/RestoreDBClusterToPointInTimeRequest.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/model/RestoreDBClusterToPointInTimeRequest.cpp
@@ -81,22 +81,36 @@ Aws::String RestoreDBClusterToPointInTimeRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -112,12 +126,19 @@ Aws::String RestoreDBClusterToPointInTimeRequest::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/AddTagsToResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/AddTagsToResourceRequest.cpp
@@ -27,11 +27,18 @@ Aws::String AddTagsToResourceRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CopyDBClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CopyDBClusterParameterGroupRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CopyDBClusterParameterGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CopyDBClusterSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CopyDBClusterSnapshotRequest.cpp
@@ -53,11 +53,18 @@ Aws::String CopyDBClusterSnapshotRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CopyDBParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CopyDBParameterGroupRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CopyDBParameterGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CopyDBSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CopyDBSnapshotRequest.cpp
@@ -47,11 +47,18 @@ Aws::String CopyDBSnapshotRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CopyOptionGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CopyOptionGroupRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CopyOptionGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateBlueGreenDeploymentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateBlueGreenDeploymentRequest.cpp
@@ -54,11 +54,18 @@ Aws::String CreateBlueGreenDeploymentRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateCustomDBEngineVersionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateCustomDBEngineVersionRequest.cpp
@@ -72,11 +72,18 @@ Aws::String CreateCustomDBEngineVersionRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateDBClusterEndpointRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateDBClusterEndpointRequest.cpp
@@ -41,33 +41,54 @@ Aws::String CreateDBClusterEndpointRequest::SerializePayload() const
 
   if(m_staticMembersHasBeenSet)
   {
-    unsigned staticMembersCount = 1;
-    for(auto& item : m_staticMembers)
+    if (m_staticMembers.empty())
     {
-      ss << "StaticMembers.member." << staticMembersCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      staticMembersCount++;
+      ss << "StaticMembers=&";
+    }
+    else
+    {
+      unsigned staticMembersCount = 1;
+      for(auto& item : m_staticMembers)
+      {
+        ss << "StaticMembers.member." << staticMembersCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        staticMembersCount++;
+      }
     }
   }
 
   if(m_excludedMembersHasBeenSet)
   {
-    unsigned excludedMembersCount = 1;
-    for(auto& item : m_excludedMembers)
+    if (m_excludedMembers.empty())
     {
-      ss << "ExcludedMembers.member." << excludedMembersCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      excludedMembersCount++;
+      ss << "ExcludedMembers=&";
+    }
+    else
+    {
+      unsigned excludedMembersCount = 1;
+      for(auto& item : m_excludedMembers)
+      {
+        ss << "ExcludedMembers.member." << excludedMembersCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        excludedMembersCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateDBClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateDBClusterParameterGroupRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CreateDBClusterParameterGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateDBClusterRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateDBClusterRequest.cpp
@@ -94,12 +94,19 @@ Aws::String CreateDBClusterRequest::SerializePayload() const
   ss << "Action=CreateDBCluster&";
   if(m_availabilityZonesHasBeenSet)
   {
-    unsigned availabilityZonesCount = 1;
-    for(auto& item : m_availabilityZones)
+    if (m_availabilityZones.empty())
     {
-      ss << "AvailabilityZones.member." << availabilityZonesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      availabilityZonesCount++;
+      ss << "AvailabilityZones=&";
+    }
+    else
+    {
+      unsigned availabilityZonesCount = 1;
+      for(auto& item : m_availabilityZones)
+      {
+        ss << "AvailabilityZones.member." << availabilityZonesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        availabilityZonesCount++;
+      }
     }
   }
 
@@ -130,12 +137,19 @@ Aws::String CreateDBClusterRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -191,11 +205,18 @@ Aws::String CreateDBClusterRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -226,12 +247,19 @@ Aws::String CreateDBClusterRequest::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateDBClusterSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateDBClusterSnapshotRequest.cpp
@@ -33,11 +33,18 @@ Aws::String CreateDBClusterSnapshotRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateDBInstanceReadReplicaRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateDBInstanceReadReplicaRequest.cpp
@@ -140,11 +140,18 @@ Aws::String CreateDBInstanceReadReplicaRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -155,12 +162,19 @@ Aws::String CreateDBInstanceReadReplicaRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -216,22 +230,36 @@ Aws::String CreateDBInstanceReadReplicaRequest::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 
   if(m_processorFeaturesHasBeenSet)
   {
-    unsigned processorFeaturesCount = 1;
-    for(auto& item : m_processorFeatures)
+    if (m_processorFeatures.empty())
     {
-      item.OutputToStream(ss, "ProcessorFeatures.member.", processorFeaturesCount, "");
-      processorFeaturesCount++;
+      ss << "ProcessorFeatures=&";
+    }
+    else
+    {
+      unsigned processorFeaturesCount = 1;
+      for(auto& item : m_processorFeatures)
+      {
+        item.OutputToStream(ss, "ProcessorFeatures.member.", processorFeaturesCount, "");
+        processorFeaturesCount++;
+      }
     }
   }
 
@@ -272,12 +300,19 @@ Aws::String CreateDBInstanceReadReplicaRequest::SerializePayload() const
 
   if(m_domainDnsIpsHasBeenSet)
   {
-    unsigned domainDnsIpsCount = 1;
-    for(auto& item : m_domainDnsIps)
+    if (m_domainDnsIps.empty())
     {
-      ss << "DomainDnsIps.member." << domainDnsIpsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      domainDnsIpsCount++;
+      ss << "DomainDnsIps=&";
+    }
+    else
+    {
+      unsigned domainDnsIpsCount = 1;
+      for(auto& item : m_domainDnsIps)
+      {
+        ss << "DomainDnsIps.member." << domainDnsIpsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        domainDnsIpsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateDBInstanceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateDBInstanceRequest.cpp
@@ -139,23 +139,37 @@ Aws::String CreateDBInstanceRequest::SerializePayload() const
 
   if(m_dBSecurityGroupsHasBeenSet)
   {
-    unsigned dBSecurityGroupsCount = 1;
-    for(auto& item : m_dBSecurityGroups)
+    if (m_dBSecurityGroups.empty())
     {
-      ss << "DBSecurityGroups.member." << dBSecurityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      dBSecurityGroupsCount++;
+      ss << "DBSecurityGroups=&";
+    }
+    else
+    {
+      unsigned dBSecurityGroupsCount = 1;
+      for(auto& item : m_dBSecurityGroups)
+      {
+        ss << "DBSecurityGroups.member." << dBSecurityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        dBSecurityGroupsCount++;
+      }
     }
   }
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -241,11 +255,18 @@ Aws::String CreateDBInstanceRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -301,12 +322,19 @@ Aws::String CreateDBInstanceRequest::SerializePayload() const
 
   if(m_domainDnsIpsHasBeenSet)
   {
-    unsigned domainDnsIpsCount = 1;
-    for(auto& item : m_domainDnsIps)
+    if (m_domainDnsIps.empty())
     {
-      ss << "DomainDnsIps.member." << domainDnsIpsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      domainDnsIpsCount++;
+      ss << "DomainDnsIps=&";
+    }
+    else
+    {
+      unsigned domainDnsIpsCount = 1;
+      for(auto& item : m_domainDnsIps)
+      {
+        ss << "DomainDnsIps.member." << domainDnsIpsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        domainDnsIpsCount++;
+      }
     }
   }
 
@@ -362,22 +390,36 @@ Aws::String CreateDBInstanceRequest::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 
   if(m_processorFeaturesHasBeenSet)
   {
-    unsigned processorFeaturesCount = 1;
-    for(auto& item : m_processorFeatures)
+    if (m_processorFeatures.empty())
     {
-      item.OutputToStream(ss, "ProcessorFeatures.member.", processorFeaturesCount, "");
-      processorFeaturesCount++;
+      ss << "ProcessorFeatures=&";
+    }
+    else
+    {
+      unsigned processorFeaturesCount = 1;
+      for(auto& item : m_processorFeatures)
+      {
+        item.OutputToStream(ss, "ProcessorFeatures.member.", processorFeaturesCount, "");
+        processorFeaturesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateDBParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateDBParameterGroupRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CreateDBParameterGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateDBProxyEndpointRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateDBProxyEndpointRequest.cpp
@@ -37,23 +37,37 @@ Aws::String CreateDBProxyEndpointRequest::SerializePayload() const
 
   if(m_vpcSubnetIdsHasBeenSet)
   {
-    unsigned vpcSubnetIdsCount = 1;
-    for(auto& item : m_vpcSubnetIds)
+    if (m_vpcSubnetIds.empty())
     {
-      ss << "VpcSubnetIds.member." << vpcSubnetIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSubnetIdsCount++;
+      ss << "VpcSubnetIds=&";
+    }
+    else
+    {
+      unsigned vpcSubnetIdsCount = 1;
+      for(auto& item : m_vpcSubnetIds)
+      {
+        ss << "VpcSubnetIds.member." << vpcSubnetIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSubnetIdsCount++;
+      }
     }
   }
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -64,11 +78,18 @@ Aws::String CreateDBProxyEndpointRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateDBProxyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateDBProxyRequest.cpp
@@ -44,11 +44,18 @@ Aws::String CreateDBProxyRequest::SerializePayload() const
 
   if(m_authHasBeenSet)
   {
-    unsigned authCount = 1;
-    for(auto& item : m_auth)
+    if (m_auth.empty())
     {
-      item.OutputToStream(ss, "Auth.member.", authCount, "");
-      authCount++;
+      ss << "Auth=&";
+    }
+    else
+    {
+      unsigned authCount = 1;
+      for(auto& item : m_auth)
+      {
+        item.OutputToStream(ss, "Auth.member.", authCount, "");
+        authCount++;
+      }
     }
   }
 
@@ -59,23 +66,37 @@ Aws::String CreateDBProxyRequest::SerializePayload() const
 
   if(m_vpcSubnetIdsHasBeenSet)
   {
-    unsigned vpcSubnetIdsCount = 1;
-    for(auto& item : m_vpcSubnetIds)
+    if (m_vpcSubnetIds.empty())
     {
-      ss << "VpcSubnetIds.member." << vpcSubnetIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSubnetIdsCount++;
+      ss << "VpcSubnetIds=&";
+    }
+    else
+    {
+      unsigned vpcSubnetIdsCount = 1;
+      for(auto& item : m_vpcSubnetIds)
+      {
+        ss << "VpcSubnetIds.member." << vpcSubnetIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSubnetIdsCount++;
+      }
     }
   }
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -96,11 +117,18 @@ Aws::String CreateDBProxyRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateDBSecurityGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateDBSecurityGroupRequest.cpp
@@ -33,11 +33,18 @@ Aws::String CreateDBSecurityGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateDBSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateDBSnapshotRequest.cpp
@@ -33,11 +33,18 @@ Aws::String CreateDBSnapshotRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateDBSubnetGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateDBSubnetGroupRequest.cpp
@@ -34,22 +34,36 @@ Aws::String CreateDBSubnetGroupRequest::SerializePayload() const
 
   if(m_subnetIdsHasBeenSet)
   {
-    unsigned subnetIdsCount = 1;
-    for(auto& item : m_subnetIds)
+    if (m_subnetIds.empty())
     {
-      ss << "SubnetIds.member." << subnetIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetIdsCount++;
+      ss << "SubnetIds=&";
+    }
+    else
+    {
+      unsigned subnetIdsCount = 1;
+      for(auto& item : m_subnetIds)
+      {
+        ss << "SubnetIds.member." << subnetIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetIdsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateEventSubscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateEventSubscriptionRequest.cpp
@@ -43,23 +43,37 @@ Aws::String CreateEventSubscriptionRequest::SerializePayload() const
 
   if(m_eventCategoriesHasBeenSet)
   {
-    unsigned eventCategoriesCount = 1;
-    for(auto& item : m_eventCategories)
+    if (m_eventCategories.empty())
     {
-      ss << "EventCategories.member." << eventCategoriesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      eventCategoriesCount++;
+      ss << "EventCategories=&";
+    }
+    else
+    {
+      unsigned eventCategoriesCount = 1;
+      for(auto& item : m_eventCategories)
+      {
+        ss << "EventCategories.member." << eventCategoriesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        eventCategoriesCount++;
+      }
     }
   }
 
   if(m_sourceIdsHasBeenSet)
   {
-    unsigned sourceIdsCount = 1;
-    for(auto& item : m_sourceIds)
+    if (m_sourceIds.empty())
     {
-      ss << "SourceIds.member." << sourceIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      sourceIdsCount++;
+      ss << "SourceIds=&";
+    }
+    else
+    {
+      unsigned sourceIdsCount = 1;
+      for(auto& item : m_sourceIds)
+      {
+        ss << "SourceIds.member." << sourceIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        sourceIdsCount++;
+      }
     }
   }
 
@@ -70,11 +84,18 @@ Aws::String CreateEventSubscriptionRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateIntegrationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateIntegrationRequest.cpp
@@ -61,11 +61,18 @@ Aws::String CreateIntegrationRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateOptionGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateOptionGroupRequest.cpp
@@ -45,11 +45,18 @@ Aws::String CreateOptionGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/CreateTenantDatabaseRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/CreateTenantDatabaseRequest.cpp
@@ -57,11 +57,18 @@ Aws::String CreateTenantDatabaseRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DeregisterDBProxyTargetsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DeregisterDBProxyTargetsRequest.cpp
@@ -34,23 +34,37 @@ Aws::String DeregisterDBProxyTargetsRequest::SerializePayload() const
 
   if(m_dBInstanceIdentifiersHasBeenSet)
   {
-    unsigned dBInstanceIdentifiersCount = 1;
-    for(auto& item : m_dBInstanceIdentifiers)
+    if (m_dBInstanceIdentifiers.empty())
     {
-      ss << "DBInstanceIdentifiers.member." << dBInstanceIdentifiersCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      dBInstanceIdentifiersCount++;
+      ss << "DBInstanceIdentifiers=&";
+    }
+    else
+    {
+      unsigned dBInstanceIdentifiersCount = 1;
+      for(auto& item : m_dBInstanceIdentifiers)
+      {
+        ss << "DBInstanceIdentifiers.member." << dBInstanceIdentifiersCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        dBInstanceIdentifiersCount++;
+      }
     }
   }
 
   if(m_dBClusterIdentifiersHasBeenSet)
   {
-    unsigned dBClusterIdentifiersCount = 1;
-    for(auto& item : m_dBClusterIdentifiers)
+    if (m_dBClusterIdentifiers.empty())
     {
-      ss << "DBClusterIdentifiers.member." << dBClusterIdentifiersCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      dBClusterIdentifiersCount++;
+      ss << "DBClusterIdentifiers=&";
+    }
+    else
+    {
+      unsigned dBClusterIdentifiersCount = 1;
+      for(auto& item : m_dBClusterIdentifiers)
+      {
+        ss << "DBClusterIdentifiers.member." << dBClusterIdentifiersCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        dBClusterIdentifiersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeBlueGreenDeploymentsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeBlueGreenDeploymentsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeBlueGreenDeploymentsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeCertificatesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeCertificatesRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeCertificatesRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBClusterAutomatedBackupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBClusterAutomatedBackupsRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeDBClusterAutomatedBackupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBClusterBacktracksRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBClusterBacktracksRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeDBClusterBacktracksRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBClusterEndpointsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBClusterEndpointsRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeDBClusterEndpointsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBClusterParameterGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBClusterParameterGroupsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBClusterParameterGroupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBClusterParametersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBClusterParametersRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeDBClusterParametersRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBClusterSnapshotsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBClusterSnapshotsRequest.cpp
@@ -47,11 +47,18 @@ Aws::String DescribeDBClusterSnapshotsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBClustersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBClustersRequest.cpp
@@ -32,11 +32,18 @@ Aws::String DescribeDBClustersRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBEngineVersionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBEngineVersionsRequest.cpp
@@ -50,11 +50,18 @@ Aws::String DescribeDBEngineVersionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBInstanceAutomatedBackupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBInstanceAutomatedBackupsRequest.cpp
@@ -37,11 +37,18 @@ Aws::String DescribeDBInstanceAutomatedBackupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBInstancesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBInstancesRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBInstancesRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBLogFilesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBLogFilesRequest.cpp
@@ -50,11 +50,18 @@ Aws::String DescribeDBLogFilesRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBParameterGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBParameterGroupsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBParameterGroupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBParametersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBParametersRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeDBParametersRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBProxiesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBProxiesRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBProxiesRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBProxyEndpointsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBProxyEndpointsRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeDBProxyEndpointsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBProxyTargetGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBProxyTargetGroupsRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeDBProxyTargetGroupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBProxyTargetsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBProxyTargetsRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeDBProxyTargetsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBRecommendationsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBRecommendationsRequest.cpp
@@ -42,11 +42,18 @@ Aws::String DescribeDBRecommendationsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBSecurityGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBSecurityGroupsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBSecurityGroupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBShardGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBShardGroupsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBShardGroupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBSnapshotTenantDatabasesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBSnapshotTenantDatabasesRequest.cpp
@@ -43,11 +43,18 @@ Aws::String DescribeDBSnapshotTenantDatabasesRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBSnapshotsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBSnapshotsRequest.cpp
@@ -47,11 +47,18 @@ Aws::String DescribeDBSnapshotsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBSubnetGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeDBSubnetGroupsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeDBSubnetGroupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeEngineDefaultClusterParametersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeEngineDefaultClusterParametersRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeEngineDefaultClusterParametersRequest::SerializePayload() co
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeEngineDefaultParametersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeEngineDefaultParametersRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeEngineDefaultParametersRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeEventCategoriesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeEventCategoriesRequest.cpp
@@ -27,11 +27,18 @@ Aws::String DescribeEventCategoriesRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeEventSubscriptionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeEventSubscriptionsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeEventSubscriptionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeEventsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeEventsRequest.cpp
@@ -57,22 +57,36 @@ Aws::String DescribeEventsRequest::SerializePayload() const
 
   if(m_eventCategoriesHasBeenSet)
   {
-    unsigned eventCategoriesCount = 1;
-    for(auto& item : m_eventCategories)
+    if (m_eventCategories.empty())
     {
-      ss << "EventCategories.member." << eventCategoriesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      eventCategoriesCount++;
+      ss << "EventCategories=&";
+    }
+    else
+    {
+      unsigned eventCategoriesCount = 1;
+      for(auto& item : m_eventCategories)
+      {
+        ss << "EventCategories.member." << eventCategoriesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        eventCategoriesCount++;
+      }
     }
   }
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeExportTasksRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeExportTasksRequest.cpp
@@ -38,11 +38,18 @@ Aws::String DescribeExportTasksRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeGlobalClustersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeGlobalClustersRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeGlobalClustersRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeIntegrationsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeIntegrationsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribeIntegrationsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeOptionGroupOptionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeOptionGroupOptionsRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeOptionGroupOptionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeOptionGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeOptionGroupsRequest.cpp
@@ -32,11 +32,18 @@ Aws::String DescribeOptionGroupsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeOrderableDBInstanceOptionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeOrderableDBInstanceOptionsRequest.cpp
@@ -61,11 +61,18 @@ Aws::String DescribeOrderableDBInstanceOptionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribePendingMaintenanceActionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribePendingMaintenanceActionsRequest.cpp
@@ -30,11 +30,18 @@ Aws::String DescribePendingMaintenanceActionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeReservedDBInstancesOfferingsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeReservedDBInstancesOfferingsRequest.cpp
@@ -61,11 +61,18 @@ Aws::String DescribeReservedDBInstancesOfferingsRequest::SerializePayload() cons
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeReservedDBInstancesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeReservedDBInstancesRequest.cpp
@@ -73,11 +73,18 @@ Aws::String DescribeReservedDBInstancesRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeSourceRegionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeSourceRegionsRequest.cpp
@@ -40,11 +40,18 @@ Aws::String DescribeSourceRegionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/DescribeTenantDatabasesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/DescribeTenantDatabasesRequest.cpp
@@ -36,11 +36,18 @@ Aws::String DescribeTenantDatabasesRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ListTagsForResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ListTagsForResourceRequest.cpp
@@ -27,11 +27,18 @@ Aws::String ListTagsForResourceRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBClusterEndpointRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBClusterEndpointRequest.cpp
@@ -34,23 +34,37 @@ Aws::String ModifyDBClusterEndpointRequest::SerializePayload() const
 
   if(m_staticMembersHasBeenSet)
   {
-    unsigned staticMembersCount = 1;
-    for(auto& item : m_staticMembers)
+    if (m_staticMembers.empty())
     {
-      ss << "StaticMembers.member." << staticMembersCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      staticMembersCount++;
+      ss << "StaticMembers=&";
+    }
+    else
+    {
+      unsigned staticMembersCount = 1;
+      for(auto& item : m_staticMembers)
+      {
+        ss << "StaticMembers.member." << staticMembersCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        staticMembersCount++;
+      }
     }
   }
 
   if(m_excludedMembersHasBeenSet)
   {
-    unsigned excludedMembersCount = 1;
-    for(auto& item : m_excludedMembers)
+    if (m_excludedMembers.empty())
     {
-      ss << "ExcludedMembers.member." << excludedMembersCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      excludedMembersCount++;
+      ss << "ExcludedMembers=&";
+    }
+    else
+    {
+      unsigned excludedMembersCount = 1;
+      for(auto& item : m_excludedMembers)
+      {
+        ss << "ExcludedMembers.member." << excludedMembersCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        excludedMembersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBClusterParameterGroupRequest.cpp
@@ -27,11 +27,18 @@ Aws::String ModifyDBClusterParameterGroupRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBClusterRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBClusterRequest.cpp
@@ -111,12 +111,19 @@ Aws::String ModifyDBClusterRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBClusterSnapshotAttributeRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBClusterSnapshotAttributeRequest.cpp
@@ -34,23 +34,37 @@ Aws::String ModifyDBClusterSnapshotAttributeRequest::SerializePayload() const
 
   if(m_valuesToAddHasBeenSet)
   {
-    unsigned valuesToAddCount = 1;
-    for(auto& item : m_valuesToAdd)
+    if (m_valuesToAdd.empty())
     {
-      ss << "ValuesToAdd.member." << valuesToAddCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      valuesToAddCount++;
+      ss << "ValuesToAdd=&";
+    }
+    else
+    {
+      unsigned valuesToAddCount = 1;
+      for(auto& item : m_valuesToAdd)
+      {
+        ss << "ValuesToAdd.member." << valuesToAddCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        valuesToAddCount++;
+      }
     }
   }
 
   if(m_valuesToRemoveHasBeenSet)
   {
-    unsigned valuesToRemoveCount = 1;
-    for(auto& item : m_valuesToRemove)
+    if (m_valuesToRemove.empty())
     {
-      ss << "ValuesToRemove.member." << valuesToRemoveCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      valuesToRemoveCount++;
+      ss << "ValuesToRemove=&";
+    }
+    else
+    {
+      unsigned valuesToRemoveCount = 1;
+      for(auto& item : m_valuesToRemove)
+      {
+        ss << "ValuesToRemove.member." << valuesToRemoveCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        valuesToRemoveCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBInstanceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBInstanceRequest.cpp
@@ -129,23 +129,37 @@ Aws::String ModifyDBInstanceRequest::SerializePayload() const
 
   if(m_dBSecurityGroupsHasBeenSet)
   {
-    unsigned dBSecurityGroupsCount = 1;
-    for(auto& item : m_dBSecurityGroups)
+    if (m_dBSecurityGroups.empty())
     {
-      ss << "DBSecurityGroups.member." << dBSecurityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      dBSecurityGroupsCount++;
+      ss << "DBSecurityGroups=&";
+    }
+    else
+    {
+      unsigned dBSecurityGroupsCount = 1;
+      for(auto& item : m_dBSecurityGroups)
+      {
+        ss << "DBSecurityGroups.member." << dBSecurityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        dBSecurityGroupsCount++;
+      }
     }
   }
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -261,12 +275,19 @@ Aws::String ModifyDBInstanceRequest::SerializePayload() const
 
   if(m_domainDnsIpsHasBeenSet)
   {
-    unsigned domainDnsIpsCount = 1;
-    for(auto& item : m_domainDnsIps)
+    if (m_domainDnsIps.empty())
     {
-      ss << "DomainDnsIps.member." << domainDnsIpsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      domainDnsIpsCount++;
+      ss << "DomainDnsIps=&";
+    }
+    else
+    {
+      unsigned domainDnsIpsCount = 1;
+      for(auto& item : m_domainDnsIps)
+      {
+        ss << "DomainDnsIps.member." << domainDnsIpsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        domainDnsIpsCount++;
+      }
     }
   }
 
@@ -337,11 +358,18 @@ Aws::String ModifyDBInstanceRequest::SerializePayload() const
 
   if(m_processorFeaturesHasBeenSet)
   {
-    unsigned processorFeaturesCount = 1;
-    for(auto& item : m_processorFeatures)
+    if (m_processorFeatures.empty())
     {
-      item.OutputToStream(ss, "ProcessorFeatures.member.", processorFeaturesCount, "");
-      processorFeaturesCount++;
+      ss << "ProcessorFeatures=&";
+    }
+    else
+    {
+      unsigned processorFeaturesCount = 1;
+      for(auto& item : m_processorFeatures)
+      {
+        item.OutputToStream(ss, "ProcessorFeatures.member.", processorFeaturesCount, "");
+        processorFeaturesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBParameterGroupRequest.cpp
@@ -27,11 +27,18 @@ Aws::String ModifyDBParameterGroupRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBProxyEndpointRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBProxyEndpointRequest.cpp
@@ -33,12 +33,19 @@ Aws::String ModifyDBProxyEndpointRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBProxyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBProxyRequest.cpp
@@ -41,11 +41,18 @@ Aws::String ModifyDBProxyRequest::SerializePayload() const
 
   if(m_authHasBeenSet)
   {
-    unsigned authCount = 1;
-    for(auto& item : m_auth)
+    if (m_auth.empty())
     {
-      item.OutputToStream(ss, "Auth.member.", authCount, "");
-      authCount++;
+      ss << "Auth=&";
+    }
+    else
+    {
+      unsigned authCount = 1;
+      for(auto& item : m_auth)
+      {
+        item.OutputToStream(ss, "Auth.member.", authCount, "");
+        authCount++;
+      }
     }
   }
 
@@ -71,12 +78,19 @@ Aws::String ModifyDBProxyRequest::SerializePayload() const
 
   if(m_securityGroupsHasBeenSet)
   {
-    unsigned securityGroupsCount = 1;
-    for(auto& item : m_securityGroups)
+    if (m_securityGroups.empty())
     {
-      ss << "SecurityGroups.member." << securityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      securityGroupsCount++;
+      ss << "SecurityGroups=&";
+    }
+    else
+    {
+      unsigned securityGroupsCount = 1;
+      for(auto& item : m_securityGroups)
+      {
+        ss << "SecurityGroups.member." << securityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        securityGroupsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBRecommendationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBRecommendationRequest.cpp
@@ -39,11 +39,18 @@ Aws::String ModifyDBRecommendationRequest::SerializePayload() const
 
   if(m_recommendedActionUpdatesHasBeenSet)
   {
-    unsigned recommendedActionUpdatesCount = 1;
-    for(auto& item : m_recommendedActionUpdates)
+    if (m_recommendedActionUpdates.empty())
     {
-      item.OutputToStream(ss, "RecommendedActionUpdates.member.", recommendedActionUpdatesCount, "");
-      recommendedActionUpdatesCount++;
+      ss << "RecommendedActionUpdates=&";
+    }
+    else
+    {
+      unsigned recommendedActionUpdatesCount = 1;
+      for(auto& item : m_recommendedActionUpdates)
+      {
+        item.OutputToStream(ss, "RecommendedActionUpdates.member.", recommendedActionUpdatesCount, "");
+        recommendedActionUpdatesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBSnapshotAttributeRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBSnapshotAttributeRequest.cpp
@@ -34,23 +34,37 @@ Aws::String ModifyDBSnapshotAttributeRequest::SerializePayload() const
 
   if(m_valuesToAddHasBeenSet)
   {
-    unsigned valuesToAddCount = 1;
-    for(auto& item : m_valuesToAdd)
+    if (m_valuesToAdd.empty())
     {
-      ss << "ValuesToAdd.member." << valuesToAddCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      valuesToAddCount++;
+      ss << "ValuesToAdd=&";
+    }
+    else
+    {
+      unsigned valuesToAddCount = 1;
+      for(auto& item : m_valuesToAdd)
+      {
+        ss << "ValuesToAdd.member." << valuesToAddCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        valuesToAddCount++;
+      }
     }
   }
 
   if(m_valuesToRemoveHasBeenSet)
   {
-    unsigned valuesToRemoveCount = 1;
-    for(auto& item : m_valuesToRemove)
+    if (m_valuesToRemove.empty())
     {
-      ss << "ValuesToRemove.member." << valuesToRemoveCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      valuesToRemoveCount++;
+      ss << "ValuesToRemove=&";
+    }
+    else
+    {
+      unsigned valuesToRemoveCount = 1;
+      for(auto& item : m_valuesToRemove)
+      {
+        ss << "ValuesToRemove.member." << valuesToRemoveCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        valuesToRemoveCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBSubnetGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ModifyDBSubnetGroupRequest.cpp
@@ -33,12 +33,19 @@ Aws::String ModifyDBSubnetGroupRequest::SerializePayload() const
 
   if(m_subnetIdsHasBeenSet)
   {
-    unsigned subnetIdsCount = 1;
-    for(auto& item : m_subnetIds)
+    if (m_subnetIds.empty())
     {
-      ss << "SubnetIds.member." << subnetIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetIdsCount++;
+      ss << "SubnetIds=&";
+    }
+    else
+    {
+      unsigned subnetIdsCount = 1;
+      for(auto& item : m_subnetIds)
+      {
+        ss << "SubnetIds.member." << subnetIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ModifyEventSubscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ModifyEventSubscriptionRequest.cpp
@@ -41,12 +41,19 @@ Aws::String ModifyEventSubscriptionRequest::SerializePayload() const
 
   if(m_eventCategoriesHasBeenSet)
   {
-    unsigned eventCategoriesCount = 1;
-    for(auto& item : m_eventCategories)
+    if (m_eventCategories.empty())
     {
-      ss << "EventCategories.member." << eventCategoriesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      eventCategoriesCount++;
+      ss << "EventCategories=&";
+    }
+    else
+    {
+      unsigned eventCategoriesCount = 1;
+      for(auto& item : m_eventCategories)
+      {
+        ss << "EventCategories.member." << eventCategoriesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        eventCategoriesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ModifyOptionGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ModifyOptionGroupRequest.cpp
@@ -30,22 +30,36 @@ Aws::String ModifyOptionGroupRequest::SerializePayload() const
 
   if(m_optionsToIncludeHasBeenSet)
   {
-    unsigned optionsToIncludeCount = 1;
-    for(auto& item : m_optionsToInclude)
+    if (m_optionsToInclude.empty())
     {
-      item.OutputToStream(ss, "OptionsToInclude.member.", optionsToIncludeCount, "");
-      optionsToIncludeCount++;
+      ss << "OptionsToInclude=&";
+    }
+    else
+    {
+      unsigned optionsToIncludeCount = 1;
+      for(auto& item : m_optionsToInclude)
+      {
+        item.OutputToStream(ss, "OptionsToInclude.member.", optionsToIncludeCount, "");
+        optionsToIncludeCount++;
+      }
     }
   }
 
   if(m_optionsToRemoveHasBeenSet)
   {
-    unsigned optionsToRemoveCount = 1;
-    for(auto& item : m_optionsToRemove)
+    if (m_optionsToRemove.empty())
     {
-      ss << "OptionsToRemove.member." << optionsToRemoveCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      optionsToRemoveCount++;
+      ss << "OptionsToRemove=&";
+    }
+    else
+    {
+      unsigned optionsToRemoveCount = 1;
+      for(auto& item : m_optionsToRemove)
+      {
+        ss << "OptionsToRemove.member." << optionsToRemoveCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        optionsToRemoveCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/PurchaseReservedDBInstancesOfferingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/PurchaseReservedDBInstancesOfferingRequest.cpp
@@ -40,11 +40,18 @@ Aws::String PurchaseReservedDBInstancesOfferingRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/RegisterDBProxyTargetsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/RegisterDBProxyTargetsRequest.cpp
@@ -34,23 +34,37 @@ Aws::String RegisterDBProxyTargetsRequest::SerializePayload() const
 
   if(m_dBInstanceIdentifiersHasBeenSet)
   {
-    unsigned dBInstanceIdentifiersCount = 1;
-    for(auto& item : m_dBInstanceIdentifiers)
+    if (m_dBInstanceIdentifiers.empty())
     {
-      ss << "DBInstanceIdentifiers.member." << dBInstanceIdentifiersCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      dBInstanceIdentifiersCount++;
+      ss << "DBInstanceIdentifiers=&";
+    }
+    else
+    {
+      unsigned dBInstanceIdentifiersCount = 1;
+      for(auto& item : m_dBInstanceIdentifiers)
+      {
+        ss << "DBInstanceIdentifiers.member." << dBInstanceIdentifiersCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        dBInstanceIdentifiersCount++;
+      }
     }
   }
 
   if(m_dBClusterIdentifiersHasBeenSet)
   {
-    unsigned dBClusterIdentifiersCount = 1;
-    for(auto& item : m_dBClusterIdentifiers)
+    if (m_dBClusterIdentifiers.empty())
     {
-      ss << "DBClusterIdentifiers.member." << dBClusterIdentifiersCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      dBClusterIdentifiersCount++;
+      ss << "DBClusterIdentifiers=&";
+    }
+    else
+    {
+      unsigned dBClusterIdentifiersCount = 1;
+      for(auto& item : m_dBClusterIdentifiers)
+      {
+        ss << "DBClusterIdentifiers.member." << dBClusterIdentifiersCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        dBClusterIdentifiersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/RemoveTagsFromResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/RemoveTagsFromResourceRequest.cpp
@@ -27,12 +27,19 @@ Aws::String RemoveTagsFromResourceRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ResetDBClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ResetDBClusterParameterGroupRequest.cpp
@@ -34,11 +34,18 @@ Aws::String ResetDBClusterParameterGroupRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/ResetDBParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/ResetDBParameterGroupRequest.cpp
@@ -34,11 +34,18 @@ Aws::String ResetDBParameterGroupRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/RestoreDBClusterFromS3Request.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/RestoreDBClusterFromS3Request.cpp
@@ -65,12 +65,19 @@ Aws::String RestoreDBClusterFromS3Request::SerializePayload() const
   ss << "Action=RestoreDBClusterFromS3&";
   if(m_availabilityZonesHasBeenSet)
   {
-    unsigned availabilityZonesCount = 1;
-    for(auto& item : m_availabilityZones)
+    if (m_availabilityZones.empty())
     {
-      ss << "AvailabilityZones.member." << availabilityZonesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      availabilityZonesCount++;
+      ss << "AvailabilityZones=&";
+    }
+    else
+    {
+      unsigned availabilityZonesCount = 1;
+      for(auto& item : m_availabilityZones)
+      {
+        ss << "AvailabilityZones.member." << availabilityZonesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        availabilityZonesCount++;
+      }
     }
   }
 
@@ -101,12 +108,19 @@ Aws::String RestoreDBClusterFromS3Request::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -157,11 +171,18 @@ Aws::String RestoreDBClusterFromS3Request::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -212,12 +233,19 @@ Aws::String RestoreDBClusterFromS3Request::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/RestoreDBClusterFromSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/RestoreDBClusterFromSnapshotRequest.cpp
@@ -57,12 +57,19 @@ Aws::String RestoreDBClusterFromSnapshotRequest::SerializePayload() const
   ss << "Action=RestoreDBClusterFromSnapshot&";
   if(m_availabilityZonesHasBeenSet)
   {
-    unsigned availabilityZonesCount = 1;
-    for(auto& item : m_availabilityZones)
+    if (m_availabilityZones.empty())
     {
-      ss << "AvailabilityZones.member." << availabilityZonesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      availabilityZonesCount++;
+      ss << "AvailabilityZones=&";
+    }
+    else
+    {
+      unsigned availabilityZonesCount = 1;
+      for(auto& item : m_availabilityZones)
+      {
+        ss << "AvailabilityZones.member." << availabilityZonesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        availabilityZonesCount++;
+      }
     }
   }
 
@@ -108,22 +115,36 @@ Aws::String RestoreDBClusterFromSnapshotRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -144,12 +165,19 @@ Aws::String RestoreDBClusterFromSnapshotRequest::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/RestoreDBClusterToPointInTimeRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/RestoreDBClusterToPointInTimeRequest.cpp
@@ -98,22 +98,36 @@ Aws::String RestoreDBClusterToPointInTimeRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -134,12 +148,19 @@ Aws::String RestoreDBClusterToPointInTimeRequest::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/RestoreDBInstanceFromDBSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/RestoreDBInstanceFromDBSnapshotRequest.cpp
@@ -145,11 +145,18 @@ Aws::String RestoreDBInstanceFromDBSnapshotRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -170,12 +177,19 @@ Aws::String RestoreDBInstanceFromDBSnapshotRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -201,12 +215,19 @@ Aws::String RestoreDBInstanceFromDBSnapshotRequest::SerializePayload() const
 
   if(m_domainDnsIpsHasBeenSet)
   {
-    unsigned domainDnsIpsCount = 1;
-    for(auto& item : m_domainDnsIps)
+    if (m_domainDnsIps.empty())
     {
-      ss << "DomainDnsIps.member." << domainDnsIpsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      domainDnsIpsCount++;
+      ss << "DomainDnsIps=&";
+    }
+    else
+    {
+      unsigned domainDnsIpsCount = 1;
+      for(auto& item : m_domainDnsIps)
+      {
+        ss << "DomainDnsIps.member." << domainDnsIpsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        domainDnsIpsCount++;
+      }
     }
   }
 
@@ -227,22 +248,36 @@ Aws::String RestoreDBInstanceFromDBSnapshotRequest::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 
   if(m_processorFeaturesHasBeenSet)
   {
-    unsigned processorFeaturesCount = 1;
-    for(auto& item : m_processorFeatures)
+    if (m_processorFeatures.empty())
     {
-      item.OutputToStream(ss, "ProcessorFeatures.member.", processorFeaturesCount, "");
-      processorFeaturesCount++;
+      ss << "ProcessorFeatures=&";
+    }
+    else
+    {
+      unsigned processorFeaturesCount = 1;
+      for(auto& item : m_processorFeatures)
+      {
+        item.OutputToStream(ss, "ProcessorFeatures.member.", processorFeaturesCount, "");
+        processorFeaturesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/RestoreDBInstanceFromS3Request.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/RestoreDBInstanceFromS3Request.cpp
@@ -125,23 +125,37 @@ Aws::String RestoreDBInstanceFromS3Request::SerializePayload() const
 
   if(m_dBSecurityGroupsHasBeenSet)
   {
-    unsigned dBSecurityGroupsCount = 1;
-    for(auto& item : m_dBSecurityGroups)
+    if (m_dBSecurityGroups.empty())
     {
-      ss << "DBSecurityGroups.member." << dBSecurityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      dBSecurityGroupsCount++;
+      ss << "DBSecurityGroups=&";
+    }
+    else
+    {
+      unsigned dBSecurityGroupsCount = 1;
+      for(auto& item : m_dBSecurityGroups)
+      {
+        ss << "DBSecurityGroups.member." << dBSecurityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        dBSecurityGroupsCount++;
+      }
     }
   }
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -217,11 +231,18 @@ Aws::String RestoreDBInstanceFromS3Request::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -302,22 +323,36 @@ Aws::String RestoreDBInstanceFromS3Request::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 
   if(m_processorFeaturesHasBeenSet)
   {
-    unsigned processorFeaturesCount = 1;
-    for(auto& item : m_processorFeatures)
+    if (m_processorFeatures.empty())
     {
-      item.OutputToStream(ss, "ProcessorFeatures.member.", processorFeaturesCount, "");
-      processorFeaturesCount++;
+      ss << "ProcessorFeatures=&";
+    }
+    else
+    {
+      unsigned processorFeaturesCount = 1;
+      for(auto& item : m_processorFeatures)
+      {
+        item.OutputToStream(ss, "ProcessorFeatures.member.", processorFeaturesCount, "");
+        processorFeaturesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/RestoreDBInstanceToPointInTimeRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/RestoreDBInstanceToPointInTimeRequest.cpp
@@ -166,11 +166,18 @@ Aws::String RestoreDBInstanceToPointInTimeRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -191,12 +198,19 @@ Aws::String RestoreDBInstanceToPointInTimeRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -227,12 +241,19 @@ Aws::String RestoreDBInstanceToPointInTimeRequest::SerializePayload() const
 
   if(m_domainDnsIpsHasBeenSet)
   {
-    unsigned domainDnsIpsCount = 1;
-    for(auto& item : m_domainDnsIps)
+    if (m_domainDnsIps.empty())
     {
-      ss << "DomainDnsIps.member." << domainDnsIpsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      domainDnsIpsCount++;
+      ss << "DomainDnsIps=&";
+    }
+    else
+    {
+      unsigned domainDnsIpsCount = 1;
+      for(auto& item : m_domainDnsIps)
+      {
+        ss << "DomainDnsIps.member." << domainDnsIpsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        domainDnsIpsCount++;
+      }
     }
   }
 
@@ -243,22 +264,36 @@ Aws::String RestoreDBInstanceToPointInTimeRequest::SerializePayload() const
 
   if(m_enableCloudwatchLogsExportsHasBeenSet)
   {
-    unsigned enableCloudwatchLogsExportsCount = 1;
-    for(auto& item : m_enableCloudwatchLogsExports)
+    if (m_enableCloudwatchLogsExports.empty())
     {
-      ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      enableCloudwatchLogsExportsCount++;
+      ss << "EnableCloudwatchLogsExports=&";
+    }
+    else
+    {
+      unsigned enableCloudwatchLogsExportsCount = 1;
+      for(auto& item : m_enableCloudwatchLogsExports)
+      {
+        ss << "EnableCloudwatchLogsExports.member." << enableCloudwatchLogsExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        enableCloudwatchLogsExportsCount++;
+      }
     }
   }
 
   if(m_processorFeaturesHasBeenSet)
   {
-    unsigned processorFeaturesCount = 1;
-    for(auto& item : m_processorFeatures)
+    if (m_processorFeatures.empty())
     {
-      item.OutputToStream(ss, "ProcessorFeatures.member.", processorFeaturesCount, "");
-      processorFeaturesCount++;
+      ss << "ProcessorFeatures=&";
+    }
+    else
+    {
+      unsigned processorFeaturesCount = 1;
+      for(auto& item : m_processorFeatures)
+      {
+        item.OutputToStream(ss, "ProcessorFeatures.member.", processorFeaturesCount, "");
+        processorFeaturesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-rds/source/model/StartExportTaskRequest.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/model/StartExportTaskRequest.cpp
@@ -57,12 +57,19 @@ Aws::String StartExportTaskRequest::SerializePayload() const
 
   if(m_exportOnlyHasBeenSet)
   {
-    unsigned exportOnlyCount = 1;
-    for(auto& item : m_exportOnly)
+    if (m_exportOnly.empty())
     {
-      ss << "ExportOnly.member." << exportOnlyCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      exportOnlyCount++;
+      ss << "ExportOnly=&";
+    }
+    else
+    {
+      unsigned exportOnlyCount = 1;
+      for(auto& item : m_exportOnly)
+      {
+        ss << "ExportOnly.member." << exportOnlyCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        exportOnlyCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/AuthorizeEndpointAccessRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/AuthorizeEndpointAccessRequest.cpp
@@ -33,12 +33,19 @@ Aws::String AuthorizeEndpointAccessRequest::SerializePayload() const
 
   if(m_vpcIdsHasBeenSet)
   {
-    unsigned vpcIdsCount = 1;
-    for(auto& item : m_vpcIds)
+    if (m_vpcIds.empty())
     {
-      ss << "VpcIds.member." << vpcIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcIdsCount++;
+      ss << "VpcIds=&";
+    }
+    else
+    {
+      unsigned vpcIdsCount = 1;
+      for(auto& item : m_vpcIds)
+      {
+        ss << "VpcIds.member." << vpcIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/BatchDeleteClusterSnapshotsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/BatchDeleteClusterSnapshotsRequest.cpp
@@ -21,11 +21,18 @@ Aws::String BatchDeleteClusterSnapshotsRequest::SerializePayload() const
   ss << "Action=BatchDeleteClusterSnapshots&";
   if(m_identifiersHasBeenSet)
   {
-    unsigned identifiersCount = 1;
-    for(auto& item : m_identifiers)
+    if (m_identifiers.empty())
     {
-      item.OutputToStream(ss, "Identifiers.member.", identifiersCount, "");
-      identifiersCount++;
+      ss << "Identifiers=&";
+    }
+    else
+    {
+      unsigned identifiersCount = 1;
+      for(auto& item : m_identifiers)
+      {
+        item.OutputToStream(ss, "Identifiers.member.", identifiersCount, "");
+        identifiersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/BatchModifyClusterSnapshotsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/BatchModifyClusterSnapshotsRequest.cpp
@@ -25,12 +25,19 @@ Aws::String BatchModifyClusterSnapshotsRequest::SerializePayload() const
   ss << "Action=BatchModifyClusterSnapshots&";
   if(m_snapshotIdentifierListHasBeenSet)
   {
-    unsigned snapshotIdentifierListCount = 1;
-    for(auto& item : m_snapshotIdentifierList)
+    if (m_snapshotIdentifierList.empty())
     {
-      ss << "SnapshotIdentifierList.member." << snapshotIdentifierListCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      snapshotIdentifierListCount++;
+      ss << "SnapshotIdentifierList=&";
+    }
+    else
+    {
+      unsigned snapshotIdentifierListCount = 1;
+      for(auto& item : m_snapshotIdentifierList)
+      {
+        ss << "SnapshotIdentifierList.member." << snapshotIdentifierListCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        snapshotIdentifierListCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/CreateClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/CreateClusterParameterGroupRequest.cpp
@@ -39,11 +39,18 @@ Aws::String CreateClusterParameterGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/CreateClusterRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/CreateClusterRequest.cpp
@@ -101,23 +101,37 @@ Aws::String CreateClusterRequest::SerializePayload() const
 
   if(m_clusterSecurityGroupsHasBeenSet)
   {
-    unsigned clusterSecurityGroupsCount = 1;
-    for(auto& item : m_clusterSecurityGroups)
+    if (m_clusterSecurityGroups.empty())
     {
-      ss << "ClusterSecurityGroups.member." << clusterSecurityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      clusterSecurityGroupsCount++;
+      ss << "ClusterSecurityGroups=&";
+    }
+    else
+    {
+      unsigned clusterSecurityGroupsCount = 1;
+      for(auto& item : m_clusterSecurityGroups)
+      {
+        ss << "ClusterSecurityGroups.member." << clusterSecurityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        clusterSecurityGroupsCount++;
+      }
     }
   }
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -198,11 +212,18 @@ Aws::String CreateClusterRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
@@ -223,12 +244,19 @@ Aws::String CreateClusterRequest::SerializePayload() const
 
   if(m_iamRolesHasBeenSet)
   {
-    unsigned iamRolesCount = 1;
-    for(auto& item : m_iamRoles)
+    if (m_iamRoles.empty())
     {
-      ss << "IamRoles.member." << iamRolesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      iamRolesCount++;
+      ss << "IamRoles=&";
+    }
+    else
+    {
+      unsigned iamRolesCount = 1;
+      for(auto& item : m_iamRoles)
+      {
+        ss << "IamRoles.member." << iamRolesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        iamRolesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/CreateClusterSecurityGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/CreateClusterSecurityGroupRequest.cpp
@@ -33,11 +33,18 @@ Aws::String CreateClusterSecurityGroupRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/CreateClusterSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/CreateClusterSnapshotRequest.cpp
@@ -40,11 +40,18 @@ Aws::String CreateClusterSnapshotRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/CreateClusterSubnetGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/CreateClusterSubnetGroupRequest.cpp
@@ -34,22 +34,36 @@ Aws::String CreateClusterSubnetGroupRequest::SerializePayload() const
 
   if(m_subnetIdsHasBeenSet)
   {
-    unsigned subnetIdsCount = 1;
-    for(auto& item : m_subnetIds)
+    if (m_subnetIds.empty())
     {
-      ss << "SubnetIds.member." << subnetIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetIdsCount++;
+      ss << "SubnetIds=&";
+    }
+    else
+    {
+      unsigned subnetIdsCount = 1;
+      for(auto& item : m_subnetIds)
+      {
+        ss << "SubnetIds.member." << subnetIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetIdsCount++;
+      }
     }
   }
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/CreateEndpointAccessRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/CreateEndpointAccessRequest.cpp
@@ -45,12 +45,19 @@ Aws::String CreateEndpointAccessRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/CreateEventSubscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/CreateEventSubscriptionRequest.cpp
@@ -44,23 +44,37 @@ Aws::String CreateEventSubscriptionRequest::SerializePayload() const
 
   if(m_sourceIdsHasBeenSet)
   {
-    unsigned sourceIdsCount = 1;
-    for(auto& item : m_sourceIds)
+    if (m_sourceIds.empty())
     {
-      ss << "SourceIds.member." << sourceIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      sourceIdsCount++;
+      ss << "SourceIds=&";
+    }
+    else
+    {
+      unsigned sourceIdsCount = 1;
+      for(auto& item : m_sourceIds)
+      {
+        ss << "SourceIds.member." << sourceIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        sourceIdsCount++;
+      }
     }
   }
 
   if(m_eventCategoriesHasBeenSet)
   {
-    unsigned eventCategoriesCount = 1;
-    for(auto& item : m_eventCategories)
+    if (m_eventCategories.empty())
     {
-      ss << "EventCategories.member." << eventCategoriesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      eventCategoriesCount++;
+      ss << "EventCategories=&";
+    }
+    else
+    {
+      unsigned eventCategoriesCount = 1;
+      for(auto& item : m_eventCategories)
+      {
+        ss << "EventCategories.member." << eventCategoriesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        eventCategoriesCount++;
+      }
     }
   }
 
@@ -76,11 +90,18 @@ Aws::String CreateEventSubscriptionRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/CreateHsmClientCertificateRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/CreateHsmClientCertificateRequest.cpp
@@ -27,11 +27,18 @@ Aws::String CreateHsmClientCertificateRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/CreateHsmConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/CreateHsmConfigurationRequest.cpp
@@ -57,11 +57,18 @@ Aws::String CreateHsmConfigurationRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/CreateRedshiftIdcApplicationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/CreateRedshiftIdcApplicationRequest.cpp
@@ -52,21 +52,35 @@ Aws::String CreateRedshiftIdcApplicationRequest::SerializePayload() const
 
   if(m_authorizedTokenIssuerListHasBeenSet)
   {
-    unsigned authorizedTokenIssuerListCount = 1;
-    for(auto& item : m_authorizedTokenIssuerList)
+    if (m_authorizedTokenIssuerList.empty())
     {
-      item.OutputToStream(ss, "AuthorizedTokenIssuerList.member.", authorizedTokenIssuerListCount, "");
-      authorizedTokenIssuerListCount++;
+      ss << "AuthorizedTokenIssuerList=&";
+    }
+    else
+    {
+      unsigned authorizedTokenIssuerListCount = 1;
+      for(auto& item : m_authorizedTokenIssuerList)
+      {
+        item.OutputToStream(ss, "AuthorizedTokenIssuerList.member.", authorizedTokenIssuerListCount, "");
+        authorizedTokenIssuerListCount++;
+      }
     }
   }
 
   if(m_serviceIntegrationsHasBeenSet)
   {
-    unsigned serviceIntegrationsCount = 1;
-    for(auto& item : m_serviceIntegrations)
+    if (m_serviceIntegrations.empty())
     {
-      item.OutputToStream(ss, "ServiceIntegrations.member.", serviceIntegrationsCount, "");
-      serviceIntegrationsCount++;
+      ss << "ServiceIntegrations=&";
+    }
+    else
+    {
+      unsigned serviceIntegrationsCount = 1;
+      for(auto& item : m_serviceIntegrations)
+      {
+        item.OutputToStream(ss, "ServiceIntegrations.member.", serviceIntegrationsCount, "");
+        serviceIntegrationsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/CreateSnapshotCopyGrantRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/CreateSnapshotCopyGrantRequest.cpp
@@ -33,11 +33,18 @@ Aws::String CreateSnapshotCopyGrantRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/CreateSnapshotScheduleRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/CreateSnapshotScheduleRequest.cpp
@@ -28,12 +28,19 @@ Aws::String CreateSnapshotScheduleRequest::SerializePayload() const
   ss << "Action=CreateSnapshotSchedule&";
   if(m_scheduleDefinitionsHasBeenSet)
   {
-    unsigned scheduleDefinitionsCount = 1;
-    for(auto& item : m_scheduleDefinitions)
+    if (m_scheduleDefinitions.empty())
     {
-      ss << "ScheduleDefinitions.member." << scheduleDefinitionsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      scheduleDefinitionsCount++;
+      ss << "ScheduleDefinitions=&";
+    }
+    else
+    {
+      unsigned scheduleDefinitionsCount = 1;
+      for(auto& item : m_scheduleDefinitions)
+      {
+        ss << "ScheduleDefinitions.member." << scheduleDefinitionsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        scheduleDefinitionsCount++;
+      }
     }
   }
 
@@ -49,11 +56,18 @@ Aws::String CreateSnapshotScheduleRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/CreateTagsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/CreateTagsRequest.cpp
@@ -27,11 +27,18 @@ Aws::String CreateTagsRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/CreateUsageLimitRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/CreateUsageLimitRequest.cpp
@@ -62,11 +62,18 @@ Aws::String CreateUsageLimitRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DeleteTagsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DeleteTagsRequest.cpp
@@ -27,12 +27,19 @@ Aws::String DeleteTagsRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeAccountAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeAccountAttributesRequest.cpp
@@ -21,12 +21,19 @@ Aws::String DescribeAccountAttributesRequest::SerializePayload() const
   ss << "Action=DescribeAccountAttributes&";
   if(m_attributeNamesHasBeenSet)
   {
-    unsigned attributeNamesCount = 1;
-    for(auto& item : m_attributeNames)
+    if (m_attributeNames.empty())
     {
-      ss << "AttributeNames.member." << attributeNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      attributeNamesCount++;
+      ss << "AttributeNames=&";
+    }
+    else
+    {
+      unsigned attributeNamesCount = 1;
+      for(auto& item : m_attributeNames)
+      {
+        ss << "AttributeNames.member." << attributeNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        attributeNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeClusterParameterGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeClusterParameterGroupsRequest.cpp
@@ -41,23 +41,37 @@ Aws::String DescribeClusterParameterGroupsRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 
   if(m_tagValuesHasBeenSet)
   {
-    unsigned tagValuesCount = 1;
-    for(auto& item : m_tagValues)
+    if (m_tagValues.empty())
     {
-      ss << "TagValues.member." << tagValuesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagValuesCount++;
+      ss << "TagValues=&";
+    }
+    else
+    {
+      unsigned tagValuesCount = 1;
+      for(auto& item : m_tagValues)
+      {
+        ss << "TagValues.member." << tagValuesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagValuesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeClusterSecurityGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeClusterSecurityGroupsRequest.cpp
@@ -41,23 +41,37 @@ Aws::String DescribeClusterSecurityGroupsRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 
   if(m_tagValuesHasBeenSet)
   {
-    unsigned tagValuesCount = 1;
-    for(auto& item : m_tagValues)
+    if (m_tagValues.empty())
     {
-      ss << "TagValues.member." << tagValuesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagValuesCount++;
+      ss << "TagValues=&";
+    }
+    else
+    {
+      unsigned tagValuesCount = 1;
+      for(auto& item : m_tagValues)
+      {
+        ss << "TagValues.member." << tagValuesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagValuesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeClusterSnapshotsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeClusterSnapshotsRequest.cpp
@@ -80,23 +80,37 @@ Aws::String DescribeClusterSnapshotsRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 
   if(m_tagValuesHasBeenSet)
   {
-    unsigned tagValuesCount = 1;
-    for(auto& item : m_tagValues)
+    if (m_tagValues.empty())
     {
-      ss << "TagValues.member." << tagValuesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagValuesCount++;
+      ss << "TagValues=&";
+    }
+    else
+    {
+      unsigned tagValuesCount = 1;
+      for(auto& item : m_tagValues)
+      {
+        ss << "TagValues.member." << tagValuesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagValuesCount++;
+      }
     }
   }
 
@@ -107,11 +121,18 @@ Aws::String DescribeClusterSnapshotsRequest::SerializePayload() const
 
   if(m_sortingEntitiesHasBeenSet)
   {
-    unsigned sortingEntitiesCount = 1;
-    for(auto& item : m_sortingEntities)
+    if (m_sortingEntities.empty())
     {
-      item.OutputToStream(ss, "SortingEntities.member.", sortingEntitiesCount, "");
-      sortingEntitiesCount++;
+      ss << "SortingEntities=&";
+    }
+    else
+    {
+      unsigned sortingEntitiesCount = 1;
+      for(auto& item : m_sortingEntities)
+      {
+        item.OutputToStream(ss, "SortingEntities.member.", sortingEntitiesCount, "");
+        sortingEntitiesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeClusterSubnetGroupsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeClusterSubnetGroupsRequest.cpp
@@ -41,23 +41,37 @@ Aws::String DescribeClusterSubnetGroupsRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 
   if(m_tagValuesHasBeenSet)
   {
-    unsigned tagValuesCount = 1;
-    for(auto& item : m_tagValues)
+    if (m_tagValues.empty())
     {
-      ss << "TagValues.member." << tagValuesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagValuesCount++;
+      ss << "TagValues=&";
+    }
+    else
+    {
+      unsigned tagValuesCount = 1;
+      for(auto& item : m_tagValues)
+      {
+        ss << "TagValues.member." << tagValuesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagValuesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeClustersRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeClustersRequest.cpp
@@ -41,23 +41,37 @@ Aws::String DescribeClustersRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 
   if(m_tagValuesHasBeenSet)
   {
-    unsigned tagValuesCount = 1;
-    for(auto& item : m_tagValues)
+    if (m_tagValues.empty())
     {
-      ss << "TagValues.member." << tagValuesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagValuesCount++;
+      ss << "TagValues=&";
+    }
+    else
+    {
+      unsigned tagValuesCount = 1;
+      for(auto& item : m_tagValues)
+      {
+        ss << "TagValues.member." << tagValuesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagValuesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeEventSubscriptionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeEventSubscriptionsRequest.cpp
@@ -41,23 +41,37 @@ Aws::String DescribeEventSubscriptionsRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 
   if(m_tagValuesHasBeenSet)
   {
-    unsigned tagValuesCount = 1;
-    for(auto& item : m_tagValues)
+    if (m_tagValues.empty())
     {
-      ss << "TagValues.member." << tagValuesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagValuesCount++;
+      ss << "TagValues=&";
+    }
+    else
+    {
+      unsigned tagValuesCount = 1;
+      for(auto& item : m_tagValues)
+      {
+        ss << "TagValues.member." << tagValuesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagValuesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeHsmClientCertificatesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeHsmClientCertificatesRequest.cpp
@@ -41,23 +41,37 @@ Aws::String DescribeHsmClientCertificatesRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 
   if(m_tagValuesHasBeenSet)
   {
-    unsigned tagValuesCount = 1;
-    for(auto& item : m_tagValues)
+    if (m_tagValues.empty())
     {
-      ss << "TagValues.member." << tagValuesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagValuesCount++;
+      ss << "TagValues=&";
+    }
+    else
+    {
+      unsigned tagValuesCount = 1;
+      for(auto& item : m_tagValues)
+      {
+        ss << "TagValues.member." << tagValuesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagValuesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeHsmConfigurationsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeHsmConfigurationsRequest.cpp
@@ -41,23 +41,37 @@ Aws::String DescribeHsmConfigurationsRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 
   if(m_tagValuesHasBeenSet)
   {
-    unsigned tagValuesCount = 1;
-    for(auto& item : m_tagValues)
+    if (m_tagValues.empty())
     {
-      ss << "TagValues.member." << tagValuesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagValuesCount++;
+      ss << "TagValues=&";
+    }
+    else
+    {
+      unsigned tagValuesCount = 1;
+      for(auto& item : m_tagValues)
+      {
+        ss << "TagValues.member." << tagValuesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagValuesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeNodeConfigurationOptionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeNodeConfigurationOptionsRequest.cpp
@@ -55,11 +55,18 @@ Aws::String DescribeNodeConfigurationOptionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filter.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filter.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeScheduledActionsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeScheduledActionsRequest.cpp
@@ -56,11 +56,18 @@ Aws::String DescribeScheduledActionsRequest::SerializePayload() const
 
   if(m_filtersHasBeenSet)
   {
-    unsigned filtersCount = 1;
-    for(auto& item : m_filters)
+    if (m_filters.empty())
     {
-      item.OutputToStream(ss, "Filters.member.", filtersCount, "");
-      filtersCount++;
+      ss << "Filters=&";
+    }
+    else
+    {
+      unsigned filtersCount = 1;
+      for(auto& item : m_filters)
+      {
+        item.OutputToStream(ss, "Filters.member.", filtersCount, "");
+        filtersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeSnapshotCopyGrantsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeSnapshotCopyGrantsRequest.cpp
@@ -41,23 +41,37 @@ Aws::String DescribeSnapshotCopyGrantsRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 
   if(m_tagValuesHasBeenSet)
   {
-    unsigned tagValuesCount = 1;
-    for(auto& item : m_tagValues)
+    if (m_tagValues.empty())
     {
-      ss << "TagValues.member." << tagValuesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagValuesCount++;
+      ss << "TagValues=&";
+    }
+    else
+    {
+      unsigned tagValuesCount = 1;
+      for(auto& item : m_tagValues)
+      {
+        ss << "TagValues.member." << tagValuesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagValuesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeSnapshotSchedulesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeSnapshotSchedulesRequest.cpp
@@ -37,23 +37,37 @@ Aws::String DescribeSnapshotSchedulesRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 
   if(m_tagValuesHasBeenSet)
   {
-    unsigned tagValuesCount = 1;
-    for(auto& item : m_tagValues)
+    if (m_tagValues.empty())
     {
-      ss << "TagValues.member." << tagValuesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagValuesCount++;
+      ss << "TagValues=&";
+    }
+    else
+    {
+      unsigned tagValuesCount = 1;
+      for(auto& item : m_tagValues)
+      {
+        ss << "TagValues.member." << tagValuesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagValuesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeTagsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeTagsRequest.cpp
@@ -47,23 +47,37 @@ Aws::String DescribeTagsRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 
   if(m_tagValuesHasBeenSet)
   {
-    unsigned tagValuesCount = 1;
-    for(auto& item : m_tagValues)
+    if (m_tagValues.empty())
     {
-      ss << "TagValues.member." << tagValuesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagValuesCount++;
+      ss << "TagValues=&";
+    }
+    else
+    {
+      unsigned tagValuesCount = 1;
+      for(auto& item : m_tagValues)
+      {
+        ss << "TagValues.member." << tagValuesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagValuesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/DescribeUsageLimitsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/DescribeUsageLimitsRequest.cpp
@@ -54,23 +54,37 @@ Aws::String DescribeUsageLimitsRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 
   if(m_tagValuesHasBeenSet)
   {
-    unsigned tagValuesCount = 1;
-    for(auto& item : m_tagValues)
+    if (m_tagValues.empty())
     {
-      ss << "TagValues.member." << tagValuesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagValuesCount++;
+      ss << "TagValues=&";
+    }
+    else
+    {
+      unsigned tagValuesCount = 1;
+      for(auto& item : m_tagValues)
+      {
+        ss << "TagValues.member." << tagValuesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagValuesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/EnableLoggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/EnableLoggingRequest.cpp
@@ -46,12 +46,19 @@ Aws::String EnableLoggingRequest::SerializePayload() const
 
   if(m_logExportsHasBeenSet)
   {
-    unsigned logExportsCount = 1;
-    for(auto& item : m_logExports)
+    if (m_logExports.empty())
     {
-      ss << "LogExports.member." << logExportsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      logExportsCount++;
+      ss << "LogExports=&";
+    }
+    else
+    {
+      unsigned logExportsCount = 1;
+      for(auto& item : m_logExports)
+      {
+        ss << "LogExports.member." << logExportsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        logExportsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/GetClusterCredentialsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/GetClusterCredentialsRequest.cpp
@@ -54,12 +54,19 @@ Aws::String GetClusterCredentialsRequest::SerializePayload() const
 
   if(m_dbGroupsHasBeenSet)
   {
-    unsigned dbGroupsCount = 1;
-    for(auto& item : m_dbGroups)
+    if (m_dbGroups.empty())
     {
-      ss << "DbGroups.member." << dbGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      dbGroupsCount++;
+      ss << "DbGroups=&";
+    }
+    else
+    {
+      unsigned dbGroupsCount = 1;
+      for(auto& item : m_dbGroups)
+      {
+        ss << "DbGroups.member." << dbGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        dbGroupsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/ModifyClusterIamRolesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/ModifyClusterIamRolesRequest.cpp
@@ -29,23 +29,37 @@ Aws::String ModifyClusterIamRolesRequest::SerializePayload() const
 
   if(m_addIamRolesHasBeenSet)
   {
-    unsigned addIamRolesCount = 1;
-    for(auto& item : m_addIamRoles)
+    if (m_addIamRoles.empty())
     {
-      ss << "AddIamRoles.member." << addIamRolesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      addIamRolesCount++;
+      ss << "AddIamRoles=&";
+    }
+    else
+    {
+      unsigned addIamRolesCount = 1;
+      for(auto& item : m_addIamRoles)
+      {
+        ss << "AddIamRoles.member." << addIamRolesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        addIamRolesCount++;
+      }
     }
   }
 
   if(m_removeIamRolesHasBeenSet)
   {
-    unsigned removeIamRolesCount = 1;
-    for(auto& item : m_removeIamRoles)
+    if (m_removeIamRoles.empty())
     {
-      ss << "RemoveIamRoles.member." << removeIamRolesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      removeIamRolesCount++;
+      ss << "RemoveIamRoles=&";
+    }
+    else
+    {
+      unsigned removeIamRolesCount = 1;
+      for(auto& item : m_removeIamRoles)
+      {
+        ss << "RemoveIamRoles.member." << removeIamRolesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        removeIamRolesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/ModifyClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/ModifyClusterParameterGroupRequest.cpp
@@ -27,11 +27,18 @@ Aws::String ModifyClusterParameterGroupRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/ModifyClusterRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/ModifyClusterRequest.cpp
@@ -80,23 +80,37 @@ Aws::String ModifyClusterRequest::SerializePayload() const
 
   if(m_clusterSecurityGroupsHasBeenSet)
   {
-    unsigned clusterSecurityGroupsCount = 1;
-    for(auto& item : m_clusterSecurityGroups)
+    if (m_clusterSecurityGroups.empty())
     {
-      ss << "ClusterSecurityGroups.member." << clusterSecurityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      clusterSecurityGroupsCount++;
+      ss << "ClusterSecurityGroups=&";
+    }
+    else
+    {
+      unsigned clusterSecurityGroupsCount = 1;
+      for(auto& item : m_clusterSecurityGroups)
+      {
+        ss << "ClusterSecurityGroups.member." << clusterSecurityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        clusterSecurityGroupsCount++;
+      }
     }
   }
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/ModifyClusterSubnetGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/ModifyClusterSubnetGroupRequest.cpp
@@ -33,12 +33,19 @@ Aws::String ModifyClusterSubnetGroupRequest::SerializePayload() const
 
   if(m_subnetIdsHasBeenSet)
   {
-    unsigned subnetIdsCount = 1;
-    for(auto& item : m_subnetIds)
+    if (m_subnetIds.empty())
     {
-      ss << "SubnetIds.member." << subnetIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      subnetIdsCount++;
+      ss << "SubnetIds=&";
+    }
+    else
+    {
+      unsigned subnetIdsCount = 1;
+      for(auto& item : m_subnetIds)
+      {
+        ss << "SubnetIds.member." << subnetIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        subnetIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/ModifyEndpointAccessRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/ModifyEndpointAccessRequest.cpp
@@ -27,12 +27,19 @@ Aws::String ModifyEndpointAccessRequest::SerializePayload() const
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/ModifyEventSubscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/ModifyEventSubscriptionRequest.cpp
@@ -43,23 +43,37 @@ Aws::String ModifyEventSubscriptionRequest::SerializePayload() const
 
   if(m_sourceIdsHasBeenSet)
   {
-    unsigned sourceIdsCount = 1;
-    for(auto& item : m_sourceIds)
+    if (m_sourceIds.empty())
     {
-      ss << "SourceIds.member." << sourceIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      sourceIdsCount++;
+      ss << "SourceIds=&";
+    }
+    else
+    {
+      unsigned sourceIdsCount = 1;
+      for(auto& item : m_sourceIds)
+      {
+        ss << "SourceIds.member." << sourceIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        sourceIdsCount++;
+      }
     }
   }
 
   if(m_eventCategoriesHasBeenSet)
   {
-    unsigned eventCategoriesCount = 1;
-    for(auto& item : m_eventCategories)
+    if (m_eventCategories.empty())
     {
-      ss << "EventCategories.member." << eventCategoriesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      eventCategoriesCount++;
+      ss << "EventCategories=&";
+    }
+    else
+    {
+      unsigned eventCategoriesCount = 1;
+      for(auto& item : m_eventCategories)
+      {
+        ss << "EventCategories.member." << eventCategoriesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        eventCategoriesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/ModifyRedshiftIdcApplicationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/ModifyRedshiftIdcApplicationRequest.cpp
@@ -46,21 +46,35 @@ Aws::String ModifyRedshiftIdcApplicationRequest::SerializePayload() const
 
   if(m_authorizedTokenIssuerListHasBeenSet)
   {
-    unsigned authorizedTokenIssuerListCount = 1;
-    for(auto& item : m_authorizedTokenIssuerList)
+    if (m_authorizedTokenIssuerList.empty())
     {
-      item.OutputToStream(ss, "AuthorizedTokenIssuerList.member.", authorizedTokenIssuerListCount, "");
-      authorizedTokenIssuerListCount++;
+      ss << "AuthorizedTokenIssuerList=&";
+    }
+    else
+    {
+      unsigned authorizedTokenIssuerListCount = 1;
+      for(auto& item : m_authorizedTokenIssuerList)
+      {
+        item.OutputToStream(ss, "AuthorizedTokenIssuerList.member.", authorizedTokenIssuerListCount, "");
+        authorizedTokenIssuerListCount++;
+      }
     }
   }
 
   if(m_serviceIntegrationsHasBeenSet)
   {
-    unsigned serviceIntegrationsCount = 1;
-    for(auto& item : m_serviceIntegrations)
+    if (m_serviceIntegrations.empty())
     {
-      item.OutputToStream(ss, "ServiceIntegrations.member.", serviceIntegrationsCount, "");
-      serviceIntegrationsCount++;
+      ss << "ServiceIntegrations=&";
+    }
+    else
+    {
+      unsigned serviceIntegrationsCount = 1;
+      for(auto& item : m_serviceIntegrations)
+      {
+        item.OutputToStream(ss, "ServiceIntegrations.member.", serviceIntegrationsCount, "");
+        serviceIntegrationsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/ModifySnapshotScheduleRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/ModifySnapshotScheduleRequest.cpp
@@ -27,12 +27,19 @@ Aws::String ModifySnapshotScheduleRequest::SerializePayload() const
 
   if(m_scheduleDefinitionsHasBeenSet)
   {
-    unsigned scheduleDefinitionsCount = 1;
-    for(auto& item : m_scheduleDefinitions)
+    if (m_scheduleDefinitions.empty())
     {
-      ss << "ScheduleDefinitions.member." << scheduleDefinitionsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      scheduleDefinitionsCount++;
+      ss << "ScheduleDefinitions=&";
+    }
+    else
+    {
+      unsigned scheduleDefinitionsCount = 1;
+      for(auto& item : m_scheduleDefinitions)
+      {
+        ss << "ScheduleDefinitions.member." << scheduleDefinitionsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        scheduleDefinitionsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/ResetClusterParameterGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/ResetClusterParameterGroupRequest.cpp
@@ -34,11 +34,18 @@ Aws::String ResetClusterParameterGroupRequest::SerializePayload() const
 
   if(m_parametersHasBeenSet)
   {
-    unsigned parametersCount = 1;
-    for(auto& item : m_parameters)
+    if (m_parameters.empty())
     {
-      item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
-      parametersCount++;
+      ss << "Parameters=&";
+    }
+    else
+    {
+      unsigned parametersCount = 1;
+      for(auto& item : m_parameters)
+      {
+        item.OutputToStream(ss, "Parameters.member.", parametersCount, "");
+        parametersCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/RestoreFromClusterSnapshotRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/RestoreFromClusterSnapshotRequest.cpp
@@ -139,23 +139,37 @@ Aws::String RestoreFromClusterSnapshotRequest::SerializePayload() const
 
   if(m_clusterSecurityGroupsHasBeenSet)
   {
-    unsigned clusterSecurityGroupsCount = 1;
-    for(auto& item : m_clusterSecurityGroups)
+    if (m_clusterSecurityGroups.empty())
     {
-      ss << "ClusterSecurityGroups.member." << clusterSecurityGroupsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      clusterSecurityGroupsCount++;
+      ss << "ClusterSecurityGroups=&";
+    }
+    else
+    {
+      unsigned clusterSecurityGroupsCount = 1;
+      for(auto& item : m_clusterSecurityGroups)
+      {
+        ss << "ClusterSecurityGroups.member." << clusterSecurityGroupsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        clusterSecurityGroupsCount++;
+      }
     }
   }
 
   if(m_vpcSecurityGroupIdsHasBeenSet)
   {
-    unsigned vpcSecurityGroupIdsCount = 1;
-    for(auto& item : m_vpcSecurityGroupIds)
+    if (m_vpcSecurityGroupIds.empty())
     {
-      ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcSecurityGroupIdsCount++;
+      ss << "VpcSecurityGroupIds=&";
+    }
+    else
+    {
+      unsigned vpcSecurityGroupIdsCount = 1;
+      for(auto& item : m_vpcSecurityGroupIds)
+      {
+        ss << "VpcSecurityGroupIds.member." << vpcSecurityGroupIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcSecurityGroupIdsCount++;
+      }
     }
   }
 
@@ -196,12 +210,19 @@ Aws::String RestoreFromClusterSnapshotRequest::SerializePayload() const
 
   if(m_iamRolesHasBeenSet)
   {
-    unsigned iamRolesCount = 1;
-    for(auto& item : m_iamRoles)
+    if (m_iamRoles.empty())
     {
-      ss << "IamRoles.member." << iamRolesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      iamRolesCount++;
+      ss << "IamRoles=&";
+    }
+    else
+    {
+      unsigned iamRolesCount = 1;
+      for(auto& item : m_iamRoles)
+      {
+        ss << "IamRoles.member." << iamRolesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        iamRolesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/model/RevokeEndpointAccessRequest.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/model/RevokeEndpointAccessRequest.cpp
@@ -35,12 +35,19 @@ Aws::String RevokeEndpointAccessRequest::SerializePayload() const
 
   if(m_vpcIdsHasBeenSet)
   {
-    unsigned vpcIdsCount = 1;
-    for(auto& item : m_vpcIds)
+    if (m_vpcIds.empty())
     {
-      ss << "VpcIds.member." << vpcIdsCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      vpcIdsCount++;
+      ss << "VpcIds=&";
+    }
+    else
+    {
+      unsigned vpcIdsCount = 1;
+      for(auto& item : m_vpcIds)
+      {
+        ss << "VpcIds.member." << vpcIdsCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        vpcIdsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sdb/source/model/BatchDeleteAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sdb/source/model/BatchDeleteAttributesRequest.cpp
@@ -27,11 +27,18 @@ Aws::String BatchDeleteAttributesRequest::SerializePayload() const
 
   if(m_itemsHasBeenSet)
   {
-    unsigned itemsCount = 1;
-    for(auto& item : m_items)
+    if (m_items.empty())
     {
-      item.OutputToStream(ss, "Item.", itemsCount, "");
-      itemsCount++;
+      ss << "Items=&";
+    }
+    else
+    {
+      unsigned itemsCount = 1;
+      for(auto& item : m_items)
+      {
+        item.OutputToStream(ss, "Item.", itemsCount, "");
+        itemsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sdb/source/model/BatchPutAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sdb/source/model/BatchPutAttributesRequest.cpp
@@ -27,11 +27,18 @@ Aws::String BatchPutAttributesRequest::SerializePayload() const
 
   if(m_itemsHasBeenSet)
   {
-    unsigned itemsCount = 1;
-    for(auto& item : m_items)
+    if (m_items.empty())
     {
-      item.OutputToStream(ss, "Item.", itemsCount, "");
-      itemsCount++;
+      ss << "Items=&";
+    }
+    else
+    {
+      unsigned itemsCount = 1;
+      for(auto& item : m_items)
+      {
+        item.OutputToStream(ss, "Item.", itemsCount, "");
+        itemsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sdb/source/model/DeleteAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sdb/source/model/DeleteAttributesRequest.cpp
@@ -34,11 +34,18 @@ Aws::String DeleteAttributesRequest::SerializePayload() const
 
   if(m_attributesHasBeenSet)
   {
-    unsigned attributesCount = 1;
-    for(auto& item : m_attributes)
+    if (m_attributes.empty())
     {
-      item.OutputToStream(ss, "Attribute.", attributesCount, "");
-      attributesCount++;
+      ss << "Attributes=&";
+    }
+    else
+    {
+      unsigned attributesCount = 1;
+      for(auto& item : m_attributes)
+      {
+        item.OutputToStream(ss, "Attribute.", attributesCount, "");
+        attributesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sdb/source/model/GetAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sdb/source/model/GetAttributesRequest.cpp
@@ -35,12 +35,19 @@ Aws::String GetAttributesRequest::SerializePayload() const
 
   if(m_attributeNamesHasBeenSet)
   {
-    unsigned attributeNamesCount = 1;
-    for(auto& item : m_attributeNames)
+    if (m_attributeNames.empty())
     {
-      ss << "AttributeName." << attributeNamesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      attributeNamesCount++;
+      ss << "AttributeNames=&";
+    }
+    else
+    {
+      unsigned attributeNamesCount = 1;
+      for(auto& item : m_attributeNames)
+      {
+        ss << "AttributeName." << attributeNamesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        attributeNamesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sdb/source/model/PutAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sdb/source/model/PutAttributesRequest.cpp
@@ -34,11 +34,18 @@ Aws::String PutAttributesRequest::SerializePayload() const
 
   if(m_attributesHasBeenSet)
   {
-    unsigned attributesCount = 1;
-    for(auto& item : m_attributes)
+    if (m_attributes.empty())
     {
-      item.OutputToStream(ss, "Attribute.", attributesCount, "");
-      attributesCount++;
+      ss << "Attributes=&";
+    }
+    else
+    {
+      unsigned attributesCount = 1;
+      for(auto& item : m_attributes)
+      {
+        item.OutputToStream(ss, "Attribute.", attributesCount, "");
+        attributesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sns/source/model/AddPermissionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sns/source/model/AddPermissionRequest.cpp
@@ -34,23 +34,37 @@ Aws::String AddPermissionRequest::SerializePayload() const
 
   if(m_aWSAccountIdHasBeenSet)
   {
-    unsigned aWSAccountIdCount = 1;
-    for(auto& item : m_aWSAccountId)
+    if (m_aWSAccountId.empty())
     {
-      ss << "AWSAccountId.member." << aWSAccountIdCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      aWSAccountIdCount++;
+      ss << "AWSAccountId=&";
+    }
+    else
+    {
+      unsigned aWSAccountIdCount = 1;
+      for(auto& item : m_aWSAccountId)
+      {
+        ss << "AWSAccountId.member." << aWSAccountIdCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        aWSAccountIdCount++;
+      }
     }
   }
 
   if(m_actionNameHasBeenSet)
   {
-    unsigned actionNameCount = 1;
-    for(auto& item : m_actionName)
+    if (m_actionName.empty())
     {
-      ss << "ActionName.member." << actionNameCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      actionNameCount++;
+      ss << "ActionName=&";
+    }
+    else
+    {
+      unsigned actionNameCount = 1;
+      for(auto& item : m_actionName)
+      {
+        ss << "ActionName.member." << actionNameCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        actionNameCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sns/source/model/CreateTopicRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sns/source/model/CreateTopicRequest.cpp
@@ -42,11 +42,18 @@ Aws::String CreateTopicRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sns/source/model/GetSMSAttributesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sns/source/model/GetSMSAttributesRequest.cpp
@@ -21,12 +21,19 @@ Aws::String GetSMSAttributesRequest::SerializePayload() const
   ss << "Action=GetSMSAttributes&";
   if(m_attributesHasBeenSet)
   {
-    unsigned attributesCount = 1;
-    for(auto& item : m_attributes)
+    if (m_attributes.empty())
     {
-      ss << "attributes.member." << attributesCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      attributesCount++;
+      ss << "attributes=&";
+    }
+    else
+    {
+      unsigned attributesCount = 1;
+      for(auto& item : m_attributes)
+      {
+        ss << "attributes.member." << attributesCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        attributesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sns/source/model/PublishBatchRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sns/source/model/PublishBatchRequest.cpp
@@ -27,11 +27,18 @@ Aws::String PublishBatchRequest::SerializePayload() const
 
   if(m_publishBatchRequestEntriesHasBeenSet)
   {
-    unsigned publishBatchRequestEntriesCount = 1;
-    for(auto& item : m_publishBatchRequestEntries)
+    if (m_publishBatchRequestEntries.empty())
     {
-      item.OutputToStream(ss, "PublishBatchRequestEntries.member.", publishBatchRequestEntriesCount, "");
-      publishBatchRequestEntriesCount++;
+      ss << "PublishBatchRequestEntries=&";
+    }
+    else
+    {
+      unsigned publishBatchRequestEntriesCount = 1;
+      for(auto& item : m_publishBatchRequestEntries)
+      {
+        item.OutputToStream(ss, "PublishBatchRequestEntries.member.", publishBatchRequestEntriesCount, "");
+        publishBatchRequestEntriesCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sns/source/model/TagResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sns/source/model/TagResourceRequest.cpp
@@ -27,11 +27,18 @@ Aws::String TagResourceRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sns/source/model/UntagResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sns/source/model/UntagResourceRequest.cpp
@@ -27,12 +27,19 @@ Aws::String UntagResourceRequest::SerializePayload() const
 
   if(m_tagKeysHasBeenSet)
   {
-    unsigned tagKeysCount = 1;
-    for(auto& item : m_tagKeys)
+    if (m_tagKeys.empty())
     {
-      ss << "TagKeys.member." << tagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      tagKeysCount++;
+      ss << "TagKeys=&";
+    }
+    else
+    {
+      unsigned tagKeysCount = 1;
+      for(auto& item : m_tagKeys)
+      {
+        ss << "TagKeys.member." << tagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        tagKeysCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sts/source/model/AssumeRoleRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sts/source/model/AssumeRoleRequest.cpp
@@ -43,11 +43,18 @@ Aws::String AssumeRoleRequest::SerializePayload() const
 
   if(m_policyArnsHasBeenSet)
   {
-    unsigned policyArnsCount = 1;
-    for(auto& item : m_policyArns)
+    if (m_policyArns.empty())
     {
-      item.OutputToStream(ss, "PolicyArns.member.", policyArnsCount, "");
-      policyArnsCount++;
+      ss << "PolicyArns=&";
+    }
+    else
+    {
+      unsigned policyArnsCount = 1;
+      for(auto& item : m_policyArns)
+      {
+        item.OutputToStream(ss, "PolicyArns.member.", policyArnsCount, "");
+        policyArnsCount++;
+      }
     }
   }
 
@@ -63,22 +70,36 @@ Aws::String AssumeRoleRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 
   if(m_transitiveTagKeysHasBeenSet)
   {
-    unsigned transitiveTagKeysCount = 1;
-    for(auto& item : m_transitiveTagKeys)
+    if (m_transitiveTagKeys.empty())
     {
-      ss << "TransitiveTagKeys.member." << transitiveTagKeysCount << "="
-          << StringUtils::URLEncode(item.c_str()) << "&";
-      transitiveTagKeysCount++;
+      ss << "TransitiveTagKeys=&";
+    }
+    else
+    {
+      unsigned transitiveTagKeysCount = 1;
+      for(auto& item : m_transitiveTagKeys)
+      {
+        ss << "TransitiveTagKeys.member." << transitiveTagKeysCount << "="
+            << StringUtils::URLEncode(item.c_str()) << "&";
+        transitiveTagKeysCount++;
+      }
     }
   }
 
@@ -104,11 +125,18 @@ Aws::String AssumeRoleRequest::SerializePayload() const
 
   if(m_providedContextsHasBeenSet)
   {
-    unsigned providedContextsCount = 1;
-    for(auto& item : m_providedContexts)
+    if (m_providedContexts.empty())
     {
-      item.OutputToStream(ss, "ProvidedContexts.member.", providedContextsCount, "");
-      providedContextsCount++;
+      ss << "ProvidedContexts=&";
+    }
+    else
+    {
+      unsigned providedContextsCount = 1;
+      for(auto& item : m_providedContexts)
+      {
+        item.OutputToStream(ss, "ProvidedContexts.member.", providedContextsCount, "");
+        providedContextsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sts/source/model/AssumeRoleWithSAMLRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sts/source/model/AssumeRoleWithSAMLRequest.cpp
@@ -42,11 +42,18 @@ Aws::String AssumeRoleWithSAMLRequest::SerializePayload() const
 
   if(m_policyArnsHasBeenSet)
   {
-    unsigned policyArnsCount = 1;
-    for(auto& item : m_policyArns)
+    if (m_policyArns.empty())
     {
-      item.OutputToStream(ss, "PolicyArns.member.", policyArnsCount, "");
-      policyArnsCount++;
+      ss << "PolicyArns=&";
+    }
+    else
+    {
+      unsigned policyArnsCount = 1;
+      for(auto& item : m_policyArns)
+      {
+        item.OutputToStream(ss, "PolicyArns.member.", policyArnsCount, "");
+        policyArnsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sts/source/model/AssumeRoleWithWebIdentityRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sts/source/model/AssumeRoleWithWebIdentityRequest.cpp
@@ -48,11 +48,18 @@ Aws::String AssumeRoleWithWebIdentityRequest::SerializePayload() const
 
   if(m_policyArnsHasBeenSet)
   {
-    unsigned policyArnsCount = 1;
-    for(auto& item : m_policyArns)
+    if (m_policyArns.empty())
     {
-      item.OutputToStream(ss, "PolicyArns.member.", policyArnsCount, "");
-      policyArnsCount++;
+      ss << "PolicyArns=&";
+    }
+    else
+    {
+      unsigned policyArnsCount = 1;
+      for(auto& item : m_policyArns)
+      {
+        item.OutputToStream(ss, "PolicyArns.member.", policyArnsCount, "");
+        policyArnsCount++;
+      }
     }
   }
 

--- a/generated/src/aws-cpp-sdk-sts/source/model/GetFederationTokenRequest.cpp
+++ b/generated/src/aws-cpp-sdk-sts/source/model/GetFederationTokenRequest.cpp
@@ -36,11 +36,18 @@ Aws::String GetFederationTokenRequest::SerializePayload() const
 
   if(m_policyArnsHasBeenSet)
   {
-    unsigned policyArnsCount = 1;
-    for(auto& item : m_policyArns)
+    if (m_policyArns.empty())
     {
-      item.OutputToStream(ss, "PolicyArns.member.", policyArnsCount, "");
-      policyArnsCount++;
+      ss << "PolicyArns=&";
+    }
+    else
+    {
+      unsigned policyArnsCount = 1;
+      for(auto& item : m_policyArns)
+      {
+        item.OutputToStream(ss, "PolicyArns.member.", policyArnsCount, "");
+        policyArnsCount++;
+      }
     }
   }
 
@@ -51,11 +58,18 @@ Aws::String GetFederationTokenRequest::SerializePayload() const
 
   if(m_tagsHasBeenSet)
   {
-    unsigned tagsCount = 1;
-    for(auto& item : m_tags)
+    if (m_tags.empty())
     {
-      item.OutputToStream(ss, "Tags.member.", tagsCount, "");
-      tagsCount++;
+      ss << "Tags=&";
+    }
+    else
+    {
+      unsigned tagsCount = 1;
+      for(auto& item : m_tags)
+      {
+        item.OutputToStream(ss, "Tags.member.", tagsCount, "");
+        tagsCount++;
+      }
     }
   }
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/queryxml/QueryRequestSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/queryxml/QueryRequestSource.vm
@@ -47,6 +47,15 @@ Aws::String ${typeInfo.className}::SerializePayload() const
 #set($spaces = "  ")
 #end
 #if($member.value.shape.list)
+#if($metadata.protocol != "ec2")
+#set($spaces = "    ")
+    if (${memberVarName}.empty())
+    {
+      ss << "${member.key}=&";
+    }
+    else
+    {
+#end
   ${spaces}unsigned ${varName}Count = 1;
   ${spaces}for(auto& item : $memberVarName)
   ${spaces}{
@@ -95,6 +104,9 @@ Aws::String ${typeInfo.className}::SerializePayload() const
 #end
   ${spaces}  ${varName}Count++;
   ${spaces}}
+#if($metadata.protocol != "ec2")
+${spaces}}
+#end
 #elseif($member.value.shape.map)##--#if($member.value.shape.list)
 #if($member.value.locationName)
 #set($mapLocationName = $member.value.locationName)


### PR DESCRIPTION
*Description of changes:*

Per the [smithy spec](https://smithy.io/2.0/aws/protocols/aws-query-protocol.html) on aws query protocol

> UTF-8 value of the string. Empty strings are serialized as empty values, meaning a Foo member set to an empty string would be serialized as "&Foo=".

currently the SDK does not do this. consider the following code

```cpp
#include <aws/core/Aws.h>
#include <aws/monitoring/CloudWatchClient.h>
#include <aws/monitoring/model/DescribeAlarmsRequest.h>

using namespace Aws;
using namespace Aws::Utils::Logging;
using namespace Aws::Monitoring;
using namespace Aws::CloudWatch::Model;

int main()
{
    SDKOptions options;
    options.loggingOptions.logLevel = LogLevel::Trace;
    InitAPI(options);
    {
        CloudWatch::CloudWatchClient client{};
        auto request = DescribeAlarmsRequest().WithAlarmTypes({});
        std::cout << request.SerializePayload() << "\n";
    }
    ShutdownAPI(options);
    return 0;
}
```

before this change the request would serialize as
`Action=DescribeAlarms&Version=2010-08-01`
after this change the request would serialize as
`Action=DescribeAlarms&AlarmTypes=&Version=2010-08-01`

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
