### PR TITLE
Fix SSO session token refresh

### DIFF
--- a/src/aws-cpp-sdk-core/source/auth/bearer-token-provider/SSOBearerTokenProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/bearer-token-provider/SSOBearerTokenProvider.cpp
@@ -77,14 +77,14 @@ void SSOBearerTokenProvider::Reload()
         AWS_LOGSTREAM_TRACE(SSO_BEARER_TOKEN_PROVIDER_LOG_TAG, "Access token for SSO not available");
         return;
     }
+    m_token.SetToken(cachedSsoToken.accessToken);
+    m_token.SetExpiration(cachedSsoToken.expiresAt);
+
     const Aws::Utils::DateTime now = Aws::Utils::DateTime::Now();
     if(cachedSsoToken.expiresAt < now) {
         AWS_LOGSTREAM_ERROR(SSO_BEARER_TOKEN_PROVIDER_LOG_TAG, "Cached Token is already expired at " << cachedSsoToken.expiresAt.ToGmtString(Aws::Utils::DateFormat::ISO_8601));
         return;
     }
-
-    m_token.SetToken(cachedSsoToken.accessToken);
-    m_token.SetExpiration(cachedSsoToken.expiresAt);
 }
 
 void SSOBearerTokenProvider::RefreshFromSso()


### PR DESCRIPTION
Description of changes: SSO session token refresh didn't work with the C++ SDK (but worked with the AWS CLI). This commit fixes the behaviour of `SSOBearerTokenProvider` in to enable successful SSO session token refresh.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
