### PR TITLE
codegen aws regions enums based on partitions.json

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -11,7 +11,8 @@
         "Bodyless", "HTTPGET", "ratelimiter", "Ratelimiter", "STDMETHODCALLTYPE", "CANTSAVE", "OLECHAR", "DISPID",
         "UNKNOWNNAME", "DISPPARAMS", "XMLHTTP", "comptr", "Metadataservice", "Streamfn", "HWAVEOUT", "matdesc",
         "Presigner", "xindex", "errortype", "waveout", "WAVEOUTCAPSA", "ALLOWSYNC", "WAVEHDR", "MMSYSERR",
-        "WAVEFORMATEX", "Unprepare", "DDISABLE_IMDSV1", "SENDREQUEST", "threadpool", "stdlib", "ALLOC",
+        "WAVEFORMATEX", "Unprepare", "DDISABLE_IMDSV1", "SENDREQUEST", "threadpool", "stdlib", "ALLOC", "ISOE",
+        "isoe",
         // AWS general
         "Arns", "AMZN", "amzn", "Paulo", "Ningxia", "ISOB", "isob", "AWSXML", "IMDSV", "AWSSTL",
         // AWS Signature

--- a/src/aws-cpp-sdk-core/include/aws/core/Region.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/Region.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <aws/core/Core_EXPORTS.h>
-
 #include <aws/core/utils/memory/stl/AWSString.h>
 
 namespace Aws
@@ -16,44 +15,48 @@ namespace Aws
      */
     namespace Region
     {
-        // AWS_GLOBAL is a pseudo region that can be used to tell SDK to use the service global endpoint if there is any.
-        // You can specify this region to corresponding environment variable, config file item and in your code.
-        // For services without global region, the request will be directed to us-east-1
-        static const char AWS_GLOBAL[] = "aws-global";
-        static const char US_EAST_1[] = "us-east-1"; // US East (N. Virginia)
-        static const char US_EAST_2[] = "us-east-2"; // US East (Ohio)
-        static const char US_WEST_1[] = "us-west-1"; // US West (N. California)
-        static const char US_WEST_2[] = "us-west-2"; // US West (Oregon)
-        static const char EU_WEST_1[] = "eu-west-1"; // EU (Ireland)
-        static const char EU_WEST_2[] = "eu-west-2"; // EU (London)
-        static const char EU_WEST_3[] = "eu-west-3"; // EU (Paris)
-        static const char EU_CENTRAL_1[] = "eu-central-1"; // EU (Frankfurt)
-        static const char EU_CENTRAL_2[] = "eu-central-2"; // EU (Zurich)
-        static const char EU_NORTH_1[] = "eu-north-1"; // EU (Stockholm)
-        static const char EU_SOUTH_1[] = "eu-south-1"; // EU (Milan)
-        static const char EU_SOUTH_2[] = "eu-south-2"; // EU (Spain)
+        static const char AF_SOUTH_1[] = "af-south-1"; // Africa (Cape Town)
         static const char AP_EAST_1[] = "ap-east-1"; // Asia Pacific (Hong Kong)
+        static const char AP_NORTHEAST_1[] = "ap-northeast-1"; // Asia Pacific (Tokyo)
+        static const char AP_NORTHEAST_2[] = "ap-northeast-2"; // Asia Pacific (Seoul)
+        static const char AP_NORTHEAST_3[] = "ap-northeast-3"; // Asia Pacific (Osaka)
         static const char AP_SOUTH_1[] = "ap-south-1"; // Asia Pacific (Mumbai)
         static const char AP_SOUTH_2[] = "ap-south-2"; // Asia Pacific (Hyderabad)
         static const char AP_SOUTHEAST_1[] = "ap-southeast-1"; // Asia Pacific (Singapore)
         static const char AP_SOUTHEAST_2[] = "ap-southeast-2"; // Asia Pacific (Sydney)
         static const char AP_SOUTHEAST_3[] = "ap-southeast-3"; // Asia Pacific (Jakarta)
-        static const char AP_NORTHEAST_1[] = "ap-northeast-1"; // Asia Pacific (Tokyo)
-        static const char AP_NORTHEAST_2[] = "ap-northeast-2"; // Asia Pacific (Seoul)
-        static const char AP_NORTHEAST_3[] = "ap-northeast-3"; // Asia Pacific (Osaka)
-        static const char AP_NORTHEAST_4[] = "ap-northeast-4"; // Asia Pacific (Melbourne)
-        static const char SA_EAST_1[] = "sa-east-1"; // South America (Sao Paulo)
+        static const char AP_SOUTHEAST_4[] = "ap-southeast-4"; // Asia Pacific (Melbourne)
+        static const char AWS_CN_GLOBAL[] = "aws-cn-global"; // AWS China global region
+        static const char AWS_GLOBAL[] = "aws-global"; // AWS Standard global region
+        static const char AWS_ISO_B_GLOBAL[] = "aws-iso-b-global"; // AWS ISOB (US) global region
+        static const char AWS_ISO_GLOBAL[] = "aws-iso-global"; // AWS ISO (US) global region
+        static const char AWS_US_GOV_GLOBAL[] = "aws-us-gov-global"; // AWS GovCloud (US) global region
+        static const char CA_CENTRAL_1[] = "ca-central-1"; // Canada (Central)
+        static const char CA_WEST_1[] = "ca-west-1"; // Canada West (Calgary)
         static const char CN_NORTH_1[] = "cn-north-1"; // China (Beijing)
         static const char CN_NORTHWEST_1[] = "cn-northwest-1"; // China (Ningxia)
-        static const char CA_CENTRAL_1[] = "ca-central-1"; // Canada (Central)
-        static const char ME_SOUTH_1[] = "me-south-1"; // Middle East (Bahrain)
+        static const char EU_CENTRAL_1[] = "eu-central-1"; // Europe (Frankfurt)
+        static const char EU_CENTRAL_2[] = "eu-central-2"; // Europe (Zurich)
+        static const char EU_ISOE_WEST_1[] = "eu-isoe-west-1"; // EU ISOE West
+        static const char EU_NORTH_1[] = "eu-north-1"; // Europe (Stockholm)
+        static const char EU_SOUTH_1[] = "eu-south-1"; // Europe (Milan)
+        static const char EU_SOUTH_2[] = "eu-south-2"; // Europe (Spain)
+        static const char EU_WEST_1[] = "eu-west-1"; // Europe (Ireland)
+        static const char EU_WEST_2[] = "eu-west-2"; // Europe (London)
+        static const char EU_WEST_3[] = "eu-west-3"; // Europe (Paris)
+        static const char IL_CENTRAL_1[] = "il-central-1"; // Israel (Tel Aviv)
         static const char ME_CENTRAL_1[] = "me-central-1"; // Middle East (UAE)
-        static const char AF_SOUTH_1[] = "af-south-1"; // Africa (Cape Town)
-        static const char US_GOV_WEST_1[] = "us-gov-west-1"; // AWS GovCloud (US-West)
+        static const char ME_SOUTH_1[] = "me-south-1"; // Middle East (Bahrain)
+        static const char SA_EAST_1[] = "sa-east-1"; // South America (Sao Paulo)
+        static const char US_EAST_1[] = "us-east-1"; // US East (N. Virginia)
+        static const char US_EAST_2[] = "us-east-2"; // US East (Ohio)
         static const char US_GOV_EAST_1[] = "us-gov-east-1"; // AWS GovCloud (US-East)
-        static const char US_ISO_EAST_1[] = "us-iso-east-1";  // US ISO East
+        static const char US_GOV_WEST_1[] = "us-gov-west-1"; // AWS GovCloud (US-West)
+        static const char US_ISO_EAST_1[] = "us-iso-east-1"; // US ISO East
+        static const char US_ISO_WEST_1[] = "us-iso-west-1"; // US ISO WEST
         static const char US_ISOB_EAST_1[] = "us-isob-east-1"; // US ISOB East (Ohio)
-        static const char US_ISO_WEST_1[] = "us-iso-west-1"; // US ISO West
+        static const char US_WEST_1[] = "us-west-1"; // US West (N. California)
+        static const char US_WEST_2[] = "us-west-2"; // US West (Oregon)
 
         // If a pseudo region, for example, aws-global or us-east-1-fips is provided, it should be converted to the region name used for signing.
         Aws::String AWS_CORE_API ComputeSignerRegion(const Aws::String& region);

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/PartitionsModel.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/PartitionsModel.java
@@ -7,7 +7,21 @@ package com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration;
 
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class PartitionsModel {
-    String partitionsBlob;
+    @Data
+    public static class Partition {
+        private String id;
+        private Map<String, RegionDescription> regions;
+
+        @Data
+        public static class RegionDescription {
+            private String description;
+        }
+    }
+    private List<Partition> partitions;
+    private String partitionsBlob;
 }

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
@@ -147,6 +147,10 @@ public class CppViewHelper {
         return CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_CAMEL, lowerCamel);
     }
 
+    public static String convertToUpperSnake(final String string) {
+        return CaseFormat.LOWER_HYPHEN.to(CaseFormat.UPPER_UNDERSCORE, string);
+    }
+
     public static String computeVariableHasBeenSetName(String memberName) {
         return String.format("%sHasBeenSet", computeMemberVariableName(memberName));
     }

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/DirectFromC2jGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/DirectFromC2jGenerator.java
@@ -21,9 +21,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.OutputStream;
-
 
 public class DirectFromC2jGenerator {
 
@@ -69,7 +66,7 @@ public class DirectFromC2jGenerator {
     public ByteArrayOutputStream generatePartitionsSourceFromJson(String rawJson, String languageBinding, String serviceName,
                                                                  String namespace, String licenseText,
                                                                  boolean generateStandalonePackage, boolean enableVirtualOperations) throws Exception {
-        PartitionsModel partitionsBom = new PartitionsModel();
+        PartitionsModel partitionsBom = parsePartitions(rawJson);
         partitionsBom.setPartitionsBlob(rawJson);
 
         return mainClientGenerator.generatePartitionsSourceFromStrBlob(partitionsBom, languageBinding, namespace, licenseText);
@@ -117,6 +114,17 @@ public class DirectFromC2jGenerator {
          */
         DefaultClientConfigs clientConfigBom = gson.fromJson(rawJson, DefaultClientConfigs.class);
         return clientConfigBom;
+    }
+
+    /**
+     * Parse rawJson into a structured Partitions object
+     *
+     * @param rawJson the raw json representation of the partitions object.
+     * @return a parsed object of partitions.
+     */
+    public PartitionsModel parsePartitions(final String rawJson) {
+        Gson gson = new Gson();
+        return gson.fromJson(rawJson, PartitionsModel.class);
     }
 
     /**

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/endpoint/region/AWSRegionHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/endpoint/region/AWSRegionHeader.vm
@@ -1,0 +1,27 @@
+#parse("com/amazonaws/util/awsclientgenerator/velocity/cfamily/Attribution.vm")
+
+#pragma once
+
+\#include <aws/core/Core_EXPORTS.h>
+\#include <aws/core/utils/memory/stl/AWSString.h>
+
+namespace Aws
+{
+    /**
+     * AWS Regions
+     */
+    namespace Region
+    {
+#foreach($region in $regions)
+        static const char ${CppViewHelper.convertToUpperSnake($region.getKey())}[] = "${region.getKey()}"; // ${region.getValue().getDescription()}
+#end
+
+        // If a pseudo region, for example, aws-global or us-east-1-fips is provided, it should be converted to the region name used for signing.
+        Aws::String AWS_CORE_API ComputeSignerRegion(const Aws::String& region);
+
+        // A FIPs region starts with "fips-" or ends with "-fips".
+        bool AWS_CORE_API IsFipsRegion(const Aws::String& region);
+    }
+
+} // namespace Aws
+


### PR DESCRIPTION
*Issue #, if available:*

[issues/3057](https://github.com/aws/aws-sdk-cpp/issues/3057)

*Description of changes:*

codegen `Region.h` enum from partitions.json instead of hand editing to prevent potential errors from hand editing adding new regions.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
