### PR TITLE
fix noisy log when MD5 checksum is specified

### DIFF
--- a/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -866,9 +866,9 @@ void AWSClient::AddChecksumToRequest(const std::shared_ptr<Aws::Http::HttpReques
         {
             httpRequest->SetHeaderValue(Http::CONTENT_MD5_HEADER, HashingUtils::Base64Encode(HashingUtils::CalculateMD5(*(GetBodyStream(request)))));
         }
-        else
+        else if (headers.find(CONTENT_MD5_HEADER) == headers.end())
         {
-            AWS_LOGSTREAM_WARN(AWS_CLIENT_LOG_TAG, "Checksum algorithm: " << checksumAlgorithmName << "is not supported by SDK.");
+            AWS_LOGSTREAM_WARN(AWS_CLIENT_LOG_TAG, "Checksum algorithm: " << checksumAlgorithmName << " is not supported by SDK.");
         }
     }
 


### PR DESCRIPTION
*Description of changes:*

Fixes a problem where the following code would emit the log

> Checksum algorithm: md5is not supported by SDK.

even though the checksum was set and is supported. The log is incorrect and should not be logged in this case as MD5 was set and not calculated.

```
#include <aws/core/Aws.h>
#include <aws/s3/S3Client.h>
#include <aws/core/utils/HashingUtils.h>
#include <aws/s3/model/PutObjectRequest.h>

using namespace Aws;
using namespace Aws::S3;
using namespace Aws::S3::Model;
using namespace Aws::Utils;

const char * ALLOCATION_TAG = "test";

int main()
{
    SDKOptions options;
    options.loggingOptions.logLevel = Utils::Logging::LogLevel::Info;
    InitAPI(options);
    {
        S3Client client{};
        auto request = PutObjectRequest().WithBucket("bucket_name").WithKey("key");
        const String body{"a test string"};
        std::shared_ptr<Aws::IOStream> inputData = Aws::MakeShared<Aws::StringStream>(ALLOCATION_TAG,
          body,
          std::ios_base::in | std::ios_base::binary);
        request.SetBody(inputData);
        request.SetContentMD5(HashingUtils::Base64Encode(HashingUtils::CalculateMD5(body)));
        assert(client.PutObject(request).IsSuccess());
    }
    ShutdownAPI(options);
    return 0;
}
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
