### PR TITLE
hack around to fix init error when building for c++11

### DIFF
--- a/src/aws-cpp-sdk-core/include/smithy/identity/auth/AuthSchemeOption.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/auth/AuthSchemeOption.h
@@ -18,7 +18,7 @@ namespace smithy {
         using EndpointParameters = Aws::Vector<Aws::Endpoint::EndpointParameter>;
         /* note: AuthSchemeOption is not connected with AuthScheme by type system, only by the String of schemeId, this is in accordance with SRA */
     public:
-        AuthSchemeOption(const char* id = nullptr, PropertyBag identityProps = {}, PropertyBag signerProps = {}, EndpointParameters epParams = {})
+        AuthSchemeOption(const char* id = nullptr, PropertyBag identityProps = {{}}, PropertyBag signerProps = {{}}, EndpointParameters epParams = {{}})
             : schemeId(id), identityProperties(identityProps), signerProperties(signerProps), endpointParameters(epParams)
         {
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
