### PR TITLE
Disable endpoint discovery on the dynamodb by default

### DIFF
--- a/generated/src/aws-cpp-sdk-cognito-idp/include/aws/cognito-idp/CognitoIdentityProviderEndpointProvider.h
+++ b/generated/src/aws-cpp-sdk-cognito-idp/include/aws/cognito-idp/CognitoIdentityProviderEndpointProvider.h
@@ -26,7 +26,7 @@ using Aws::Endpoint::DefaultEndpointProvider;
 
 using CognitoIdentityProviderClientContextParameters = Aws::Endpoint::ClientContextParameters;
 
-using CognitoIdentityProviderClientConfiguration = Aws::Client::GenericClientConfiguration<false>;
+using CognitoIdentityProviderClientConfiguration = Aws::Client::GenericClientConfiguration;
 using CognitoIdentityProviderBuiltInParameters = Aws::Endpoint::BuiltInParameters;
 
 /**

--- a/generated/src/aws-cpp-sdk-cognito-idp/include/aws/cognito-idp/CognitoIdentityProviderServiceClientModel.h
+++ b/generated/src/aws-cpp-sdk-cognito-idp/include/aws/cognito-idp/CognitoIdentityProviderServiceClientModel.h
@@ -145,7 +145,7 @@ namespace Aws
 
   namespace CognitoIdentityProvider
   {
-    using CognitoIdentityProviderClientConfiguration = Aws::Client::GenericClientConfiguration<false>;
+    using CognitoIdentityProviderClientConfiguration = Aws::Client::GenericClientConfiguration;
     using CognitoIdentityProviderEndpointProviderBase = Aws::CognitoIdentityProvider::Endpoint::CognitoIdentityProviderEndpointProviderBase;
     using CognitoIdentityProviderEndpointProvider = Aws::CognitoIdentityProvider::Endpoint::CognitoIdentityProviderEndpointProvider;
 

--- a/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBClientConfiguration.h
@@ -1,0 +1,61 @@
+﻿/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+#include <aws/dynamodb/DynamoDB_EXPORTS.h>
+#include <aws/core/client/GenericClientConfiguration.h>
+
+
+namespace Aws
+{
+    namespace DynamoDB
+    {
+        struct AWS_DYNAMODB_API DynamoDBClientConfiguration : public Aws::Client::GenericClientConfiguration
+        {
+            using BaseClientConfigClass = Aws::Client::GenericClientConfiguration;
+            static const bool EndpointDiscoverySupported = true;
+            static const bool EndpointDiscoveryRequired = false;
+
+            DynamoDBClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
+
+            /**
+            * Create a configuration based on settings in the aws configuration file for the given profile name.
+            * The configuration file location can be set via the environment variable AWS_CONFIG_FILE
+            * @param profileName the aws profile name.
+            * @param shouldDisableIMDS whether or not to disable IMDS calls.
+            */
+            DynamoDBClientConfiguration(const char* profileName, bool shouldDisableIMDS = false);
+
+            /**
+            * Create a configuration with a predefined smart defaults
+            * @param useSmartDefaults, required to differentiate c-tors
+            * @param defaultMode, default mode to use
+            * @param shouldDisableIMDS whether or not to disable IMDS calls.
+            */
+            DynamoDBClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool shouldDisableIMDS = false);
+
+            /**
+            * Converting constructors for compatibility with a legacy code
+            */
+            DynamoDBClientConfiguration(const Client::ClientConfiguration& config);
+
+            /**
+             * Enable endpoint discovery
+             * For some services to dynamically set up their endpoints for different requests.
+             * By default, service clients will decide if endpoint discovery is enabled or not.
+             * If disabled, regional or overridden endpoint will be used instead.
+             * If a request requires endpoint discovery, but it was disabled then the request will never succeed.
+             * A boolean value is either true of false, use Optional here to have an instance does not contain a value,
+             * such that SDK will decide the default behavior as stated before, if no value specified.
+             * DynamoDB service client does not require endpoint discovery. The default value for this setting is Disabled.
+             */
+            Aws::Crt::Optional<bool>& enableEndpointDiscovery;
+
+        private:
+            void LoadDynamoDBSpecificConfig(const Aws::String& profileName);
+        };
+    }
+}

--- a/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBEndpointProvider.h
+++ b/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBEndpointProvider.h
@@ -26,7 +26,7 @@ using Aws::Endpoint::DefaultEndpointProvider;
 
 using DynamoDBClientContextParameters = Aws::Endpoint::ClientContextParameters;
 
-using DynamoDBClientConfiguration = Aws::Client::GenericClientConfiguration<true>;
+using DynamoDBClientConfiguration = Aws::Client::GenericClientConfiguration;
 using DynamoDBBuiltInParameters = Aws::Endpoint::BuiltInParameters;
 
 /**

--- a/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBServiceClientModel.h
+++ b/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBServiceClientModel.h
@@ -7,7 +7,7 @@
 
 /* Generic header includes */
 #include <aws/dynamodb/DynamoDBErrors.h>
-#include <aws/core/client/GenericClientConfiguration.h>
+#include <aws/dynamodb/DynamoDBClientConfiguration.h>
 #include <aws/core/client/AWSError.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/client/AsyncCallerContext.h>
@@ -116,7 +116,6 @@ namespace Aws
 
   namespace DynamoDB
   {
-    using DynamoDBClientConfiguration = Aws::Client::GenericClientConfiguration<true>;
     using DynamoDBEndpointProviderBase = Aws::DynamoDB::Endpoint::DynamoDBEndpointProviderBase;
     using DynamoDBEndpointProvider = Aws::DynamoDB::Endpoint::DynamoDBEndpointProvider;
 

--- a/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClientConfiguration.cpp
@@ -1,0 +1,74 @@
+﻿/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/dynamodb/DynamoDBClientConfiguration.h>
+
+namespace Aws
+{
+namespace DynamoDB
+{
+
+
+bool IsEndpointDiscoveryEnabled(const Aws::String& endpointOverride, const Aws::String &profileName)
+{
+  bool enabled = false;
+
+  if (!endpointOverride.empty())
+  {
+    enabled = false;
+  }
+  else
+  {
+    static const char* AWS_ENABLE_ENDPOINT_DISCOVERY_ENV_KEY = "AWS_ENABLE_ENDPOINT_DISCOVERY";
+    static const char* AWS_ENABLE_ENDPOINT_DISCOVERY_PROFILE_KEY = "endpoint_discovery_enabled";
+    static const char* AWS_EP_DISCOVERY_ENABLED = "true";
+    static const char* AWS_EP_DISCOVERY_DISABLED = "false";
+    static const char* DEFAULT_VALUE_FOR_DYNAMODB = AWS_EP_DISCOVERY_DISABLED;
+
+    Aws::String configVal = Client::ClientConfiguration::LoadConfigFromEnvOrProfile(
+        AWS_ENABLE_ENDPOINT_DISCOVERY_ENV_KEY, profileName, AWS_ENABLE_ENDPOINT_DISCOVERY_PROFILE_KEY,
+        {AWS_EP_DISCOVERY_ENABLED, AWS_EP_DISCOVERY_DISABLED}, DEFAULT_VALUE_FOR_DYNAMODB);
+
+    if (AWS_EP_DISCOVERY_ENABLED == configVal) {
+      enabled = true;
+    } else if (AWS_EP_DISCOVERY_DISABLED == configVal) {
+      enabled = false;
+    }
+  }
+  return enabled;
+}
+
+void DynamoDBClientConfiguration::LoadDynamoDBSpecificConfig(const Aws::String& inputProfileName)
+{
+  if(!enableEndpointDiscovery) {
+    enableEndpointDiscovery = IsEndpointDiscoveryEnabled(this->endpointOverride, inputProfileName);
+  }
+}
+
+DynamoDBClientConfiguration::DynamoDBClientConfiguration(const Client::ClientConfigurationInitValues &configuration)
+: BaseClientConfigClass(configuration), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
+{
+  LoadDynamoDBSpecificConfig(this->profileName);
+}
+
+DynamoDBClientConfiguration::DynamoDBClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS)
+: BaseClientConfigClass(inputProfileName, shouldDisableIMDS), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
+{
+  LoadDynamoDBSpecificConfig(Aws::String(inputProfileName));
+}
+
+DynamoDBClientConfiguration::DynamoDBClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool shouldDisableIMDS)
+: BaseClientConfigClass(useSmartDefaults, defaultMode, shouldDisableIMDS), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
+{
+  LoadDynamoDBSpecificConfig(this->profileName);
+}
+
+DynamoDBClientConfiguration::DynamoDBClientConfiguration(const Client::ClientConfiguration& config)  : BaseClientConfigClass(config), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery){
+  LoadDynamoDBSpecificConfig(this->profileName);
+}
+
+
+} // namespace DynamoDB
+} // namespace Aws

--- a/generated/src/aws-cpp-sdk-logs/include/aws/logs/CloudWatchLogsEndpointProvider.h
+++ b/generated/src/aws-cpp-sdk-logs/include/aws/logs/CloudWatchLogsEndpointProvider.h
@@ -26,7 +26,7 @@ using Aws::Endpoint::DefaultEndpointProvider;
 
 using CloudWatchLogsClientContextParameters = Aws::Endpoint::ClientContextParameters;
 
-using CloudWatchLogsClientConfiguration = Aws::Client::GenericClientConfiguration<false>;
+using CloudWatchLogsClientConfiguration = Aws::Client::GenericClientConfiguration;
 using CloudWatchLogsBuiltInParameters = Aws::Endpoint::BuiltInParameters;
 
 /**

--- a/generated/src/aws-cpp-sdk-logs/include/aws/logs/CloudWatchLogsServiceClientModel.h
+++ b/generated/src/aws-cpp-sdk-logs/include/aws/logs/CloudWatchLogsServiceClientModel.h
@@ -113,7 +113,7 @@ namespace Aws
 
   namespace CloudWatchLogs
   {
-    using CloudWatchLogsClientConfiguration = Aws::Client::GenericClientConfiguration<false>;
+    using CloudWatchLogsClientConfiguration = Aws::Client::GenericClientConfiguration;
     using CloudWatchLogsEndpointProviderBase = Aws::CloudWatchLogs::Endpoint::CloudWatchLogsEndpointProviderBase;
     using CloudWatchLogsEndpointProvider = Aws::CloudWatchLogs::Endpoint::CloudWatchLogsEndpointProvider;
 

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
@@ -22,9 +22,9 @@ namespace Aws
             REGIONAL //stands for using regional endpoint for us-east-1
         };
 
-        struct AWS_S3CRT_API S3CrtClientConfiguration : public Aws::Client::GenericClientConfiguration</*EndpointDiscoverySupported*/true>
+        struct AWS_S3CRT_API S3CrtClientConfiguration : public Aws::Client::GenericClientConfiguration
         {
-            using BaseClientConfigClass = Aws::Client::GenericClientConfiguration</*EndpointDiscoverySupported*/true>;
+            using BaseClientConfigClass = Aws::Client::GenericClientConfiguration;
 
             S3CrtClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
 

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ClientConfiguration.h
@@ -22,9 +22,9 @@ namespace Aws
             REGIONAL //stands for using regional endpoint for us-east-1
         };
 
-        struct AWS_S3_API S3ClientConfiguration : public Aws::Client::GenericClientConfiguration</*EndpointDiscoverySupported*/true>
+        struct AWS_S3_API S3ClientConfiguration : public Aws::Client::GenericClientConfiguration
         {
-            using BaseClientConfigClass = Aws::Client::GenericClientConfiguration</*EndpointDiscoverySupported*/true>;
+            using BaseClientConfigClass = Aws::Client::GenericClientConfiguration;
 
             S3ClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
 

--- a/generated/src/aws-cpp-sdk-timestream-influxdb/include/aws/timestream-influxdb/TimestreamInfluxDBEndpointProvider.h
+++ b/generated/src/aws-cpp-sdk-timestream-influxdb/include/aws/timestream-influxdb/TimestreamInfluxDBEndpointProvider.h
@@ -26,7 +26,7 @@ using Aws::Endpoint::DefaultEndpointProvider;
 
 using TimestreamInfluxDBClientContextParameters = Aws::Endpoint::ClientContextParameters;
 
-using TimestreamInfluxDBClientConfiguration = Aws::Client::GenericClientConfiguration<false>;
+using TimestreamInfluxDBClientConfiguration = Aws::Client::GenericClientConfiguration;
 using TimestreamInfluxDBBuiltInParameters = Aws::Endpoint::BuiltInParameters;
 
 /**

--- a/generated/src/aws-cpp-sdk-timestream-influxdb/include/aws/timestream-influxdb/TimestreamInfluxDBServiceClientModel.h
+++ b/generated/src/aws-cpp-sdk-timestream-influxdb/include/aws/timestream-influxdb/TimestreamInfluxDBServiceClientModel.h
@@ -63,7 +63,7 @@ namespace Aws
 
   namespace TimestreamInfluxDB
   {
-    using TimestreamInfluxDBClientConfiguration = Aws::Client::GenericClientConfiguration<false>;
+    using TimestreamInfluxDBClientConfiguration = Aws::Client::GenericClientConfiguration;
     using TimestreamInfluxDBEndpointProviderBase = Aws::TimestreamInfluxDB::Endpoint::TimestreamInfluxDBEndpointProviderBase;
     using TimestreamInfluxDBEndpointProvider = Aws::TimestreamInfluxDB::Endpoint::TimestreamInfluxDBEndpointProvider;
 

--- a/generated/src/aws-cpp-sdk-timestream-query/include/aws/timestream-query/TimestreamQueryClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-timestream-query/include/aws/timestream-query/TimestreamQueryClientConfiguration.h
@@ -1,0 +1,61 @@
+﻿/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+#include <aws/timestream-query/TimestreamQuery_EXPORTS.h>
+#include <aws/core/client/GenericClientConfiguration.h>
+
+
+namespace Aws
+{
+    namespace TimestreamQuery
+    {
+        struct AWS_TIMESTREAMQUERY_API TimestreamQueryClientConfiguration : public Aws::Client::GenericClientConfiguration
+        {
+            using BaseClientConfigClass = Aws::Client::GenericClientConfiguration;
+            static const bool EndpointDiscoverySupported = true;
+            static const bool EndpointDiscoveryRequired = true;
+
+            TimestreamQueryClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
+
+            /**
+            * Create a configuration based on settings in the aws configuration file for the given profile name.
+            * The configuration file location can be set via the environment variable AWS_CONFIG_FILE
+            * @param profileName the aws profile name.
+            * @param shouldDisableIMDS whether or not to disable IMDS calls.
+            */
+            TimestreamQueryClientConfiguration(const char* profileName, bool shouldDisableIMDS = false);
+
+            /**
+            * Create a configuration with a predefined smart defaults
+            * @param useSmartDefaults, required to differentiate c-tors
+            * @param defaultMode, default mode to use
+            * @param shouldDisableIMDS whether or not to disable IMDS calls.
+            */
+            TimestreamQueryClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool shouldDisableIMDS = false);
+
+            /**
+            * Converting constructors for compatibility with a legacy code
+            */
+            TimestreamQueryClientConfiguration(const Client::ClientConfiguration& config);
+
+            /**
+             * Enable endpoint discovery
+             * For some services to dynamically set up their endpoints for different requests.
+             * By default, service clients will decide if endpoint discovery is enabled or not.
+             * If disabled, regional or overridden endpoint will be used instead.
+             * If a request requires endpoint discovery, but it was disabled then the request will never succeed.
+             * A boolean value is either true of false, use Optional here to have an instance does not contain a value,
+             * such that SDK will decide the default behavior as stated before, if no value specified.
+             * Timestream Query service client requires endpoint discovery. The default value for this setting is Enabled.
+             */
+            Aws::Crt::Optional<bool>& enableEndpointDiscovery;
+
+        private:
+            void LoadTimestreamQuerySpecificConfig(const Aws::String& profileName);
+        };
+    }
+}

--- a/generated/src/aws-cpp-sdk-timestream-query/include/aws/timestream-query/TimestreamQueryEndpointProvider.h
+++ b/generated/src/aws-cpp-sdk-timestream-query/include/aws/timestream-query/TimestreamQueryEndpointProvider.h
@@ -26,7 +26,7 @@ using Aws::Endpoint::DefaultEndpointProvider;
 
 using TimestreamQueryClientContextParameters = Aws::Endpoint::ClientContextParameters;
 
-using TimestreamQueryClientConfiguration = Aws::Client::GenericClientConfiguration<true>;
+using TimestreamQueryClientConfiguration = Aws::Client::GenericClientConfiguration;
 using TimestreamQueryBuiltInParameters = Aws::Endpoint::BuiltInParameters;
 
 /**

--- a/generated/src/aws-cpp-sdk-timestream-query/include/aws/timestream-query/TimestreamQueryServiceClientModel.h
+++ b/generated/src/aws-cpp-sdk-timestream-query/include/aws/timestream-query/TimestreamQueryServiceClientModel.h
@@ -7,7 +7,7 @@
 
 /* Generic header includes */
 #include <aws/timestream-query/TimestreamQueryErrors.h>
-#include <aws/core/client/GenericClientConfiguration.h>
+#include <aws/timestream-query/TimestreamQueryClientConfiguration.h>
 #include <aws/core/client/AWSError.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/client/AsyncCallerContext.h>
@@ -69,7 +69,6 @@ namespace Aws
 
   namespace TimestreamQuery
   {
-    using TimestreamQueryClientConfiguration = Aws::Client::GenericClientConfiguration<true>;
     using TimestreamQueryEndpointProviderBase = Aws::TimestreamQuery::Endpoint::TimestreamQueryEndpointProviderBase;
     using TimestreamQueryEndpointProvider = Aws::TimestreamQuery::Endpoint::TimestreamQueryEndpointProvider;
 

--- a/generated/src/aws-cpp-sdk-timestream-query/source/TimestreamQueryClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-timestream-query/source/TimestreamQueryClientConfiguration.cpp
@@ -1,0 +1,74 @@
+﻿/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/timestream-query/TimestreamQueryClientConfiguration.h>
+
+namespace Aws
+{
+namespace TimestreamQuery
+{
+
+
+bool IsEndpointDiscoveryEnabled(const Aws::String& endpointOverride, const Aws::String &profileName)
+{
+  bool enabled = true;
+
+  if (!endpointOverride.empty())
+  {
+    enabled = false;
+  }
+  else
+  {
+    static const char* AWS_ENABLE_ENDPOINT_DISCOVERY_ENV_KEY = "AWS_ENABLE_ENDPOINT_DISCOVERY";
+    static const char* AWS_ENABLE_ENDPOINT_DISCOVERY_PROFILE_KEY = "endpoint_discovery_enabled";
+    static const char* AWS_EP_DISCOVERY_ENABLED = "true";
+    static const char* AWS_EP_DISCOVERY_DISABLED = "false";
+    static const char* DEFAULT_VALUE_FOR_TIMESTREAM_QUERY = AWS_EP_DISCOVERY_ENABLED;
+
+    Aws::String configVal = Client::ClientConfiguration::LoadConfigFromEnvOrProfile(
+        AWS_ENABLE_ENDPOINT_DISCOVERY_ENV_KEY, profileName, AWS_ENABLE_ENDPOINT_DISCOVERY_PROFILE_KEY,
+        {AWS_EP_DISCOVERY_ENABLED, AWS_EP_DISCOVERY_DISABLED}, DEFAULT_VALUE_FOR_TIMESTREAM_QUERY);
+
+    if (AWS_EP_DISCOVERY_ENABLED == configVal) {
+      enabled = true;
+    } else if (AWS_EP_DISCOVERY_DISABLED == configVal) {
+      enabled = false;
+    }
+  }
+  return enabled;
+}
+
+void TimestreamQueryClientConfiguration::LoadTimestreamQuerySpecificConfig(const Aws::String& inputProfileName)
+{
+  if(!enableEndpointDiscovery) {
+    enableEndpointDiscovery = IsEndpointDiscoveryEnabled(this->endpointOverride, inputProfileName);
+  }
+}
+
+TimestreamQueryClientConfiguration::TimestreamQueryClientConfiguration(const Client::ClientConfigurationInitValues &configuration)
+: BaseClientConfigClass(configuration), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
+{
+  LoadTimestreamQuerySpecificConfig(this->profileName);
+}
+
+TimestreamQueryClientConfiguration::TimestreamQueryClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS)
+: BaseClientConfigClass(inputProfileName, shouldDisableIMDS), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
+{
+  LoadTimestreamQuerySpecificConfig(Aws::String(inputProfileName));
+}
+
+TimestreamQueryClientConfiguration::TimestreamQueryClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool shouldDisableIMDS)
+: BaseClientConfigClass(useSmartDefaults, defaultMode, shouldDisableIMDS), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
+{
+  LoadTimestreamQuerySpecificConfig(this->profileName);
+}
+
+TimestreamQueryClientConfiguration::TimestreamQueryClientConfiguration(const Client::ClientConfiguration& config)  : BaseClientConfigClass(config), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery){
+  LoadTimestreamQuerySpecificConfig(this->profileName);
+}
+
+
+} // namespace TimestreamQuery
+} // namespace Aws

--- a/generated/src/aws-cpp-sdk-timestream-write/include/aws/timestream-write/TimestreamWriteClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-timestream-write/include/aws/timestream-write/TimestreamWriteClientConfiguration.h
@@ -1,0 +1,61 @@
+﻿/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+#include <aws/timestream-write/TimestreamWrite_EXPORTS.h>
+#include <aws/core/client/GenericClientConfiguration.h>
+
+
+namespace Aws
+{
+    namespace TimestreamWrite
+    {
+        struct AWS_TIMESTREAMWRITE_API TimestreamWriteClientConfiguration : public Aws::Client::GenericClientConfiguration
+        {
+            using BaseClientConfigClass = Aws::Client::GenericClientConfiguration;
+            static const bool EndpointDiscoverySupported = true;
+            static const bool EndpointDiscoveryRequired = true;
+
+            TimestreamWriteClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
+
+            /**
+            * Create a configuration based on settings in the aws configuration file for the given profile name.
+            * The configuration file location can be set via the environment variable AWS_CONFIG_FILE
+            * @param profileName the aws profile name.
+            * @param shouldDisableIMDS whether or not to disable IMDS calls.
+            */
+            TimestreamWriteClientConfiguration(const char* profileName, bool shouldDisableIMDS = false);
+
+            /**
+            * Create a configuration with a predefined smart defaults
+            * @param useSmartDefaults, required to differentiate c-tors
+            * @param defaultMode, default mode to use
+            * @param shouldDisableIMDS whether or not to disable IMDS calls.
+            */
+            TimestreamWriteClientConfiguration(bool useSmartDefaults, const char* defaultMode = "legacy", bool shouldDisableIMDS = false);
+
+            /**
+            * Converting constructors for compatibility with a legacy code
+            */
+            TimestreamWriteClientConfiguration(const Client::ClientConfiguration& config);
+
+            /**
+             * Enable endpoint discovery
+             * For some services to dynamically set up their endpoints for different requests.
+             * By default, service clients will decide if endpoint discovery is enabled or not.
+             * If disabled, regional or overridden endpoint will be used instead.
+             * If a request requires endpoint discovery, but it was disabled then the request will never succeed.
+             * A boolean value is either true of false, use Optional here to have an instance does not contain a value,
+             * such that SDK will decide the default behavior as stated before, if no value specified.
+             * Timestream Write service client requires endpoint discovery. The default value for this setting is Enabled.
+             */
+            Aws::Crt::Optional<bool>& enableEndpointDiscovery;
+
+        private:
+            void LoadTimestreamWriteSpecificConfig(const Aws::String& profileName);
+        };
+    }
+}

--- a/generated/src/aws-cpp-sdk-timestream-write/include/aws/timestream-write/TimestreamWriteEndpointProvider.h
+++ b/generated/src/aws-cpp-sdk-timestream-write/include/aws/timestream-write/TimestreamWriteEndpointProvider.h
@@ -26,7 +26,7 @@ using Aws::Endpoint::DefaultEndpointProvider;
 
 using TimestreamWriteClientContextParameters = Aws::Endpoint::ClientContextParameters;
 
-using TimestreamWriteClientConfiguration = Aws::Client::GenericClientConfiguration<true>;
+using TimestreamWriteClientConfiguration = Aws::Client::GenericClientConfiguration;
 using TimestreamWriteBuiltInParameters = Aws::Endpoint::BuiltInParameters;
 
 /**

--- a/generated/src/aws-cpp-sdk-timestream-write/include/aws/timestream-write/TimestreamWriteServiceClientModel.h
+++ b/generated/src/aws-cpp-sdk-timestream-write/include/aws/timestream-write/TimestreamWriteServiceClientModel.h
@@ -7,7 +7,7 @@
 
 /* Generic header includes */
 #include <aws/timestream-write/TimestreamWriteErrors.h>
-#include <aws/core/client/GenericClientConfiguration.h>
+#include <aws/timestream-write/TimestreamWriteClientConfiguration.h>
 #include <aws/core/client/AWSError.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/client/AsyncCallerContext.h>
@@ -74,7 +74,6 @@ namespace Aws
 
   namespace TimestreamWrite
   {
-    using TimestreamWriteClientConfiguration = Aws::Client::GenericClientConfiguration<true>;
     using TimestreamWriteEndpointProviderBase = Aws::TimestreamWrite::Endpoint::TimestreamWriteEndpointProviderBase;
     using TimestreamWriteEndpointProvider = Aws::TimestreamWrite::Endpoint::TimestreamWriteEndpointProvider;
 

--- a/generated/src/aws-cpp-sdk-timestream-write/source/TimestreamWriteClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-timestream-write/source/TimestreamWriteClientConfiguration.cpp
@@ -1,0 +1,74 @@
+﻿/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/timestream-write/TimestreamWriteClientConfiguration.h>
+
+namespace Aws
+{
+namespace TimestreamWrite
+{
+
+
+bool IsEndpointDiscoveryEnabled(const Aws::String& endpointOverride, const Aws::String &profileName)
+{
+  bool enabled = true;
+
+  if (!endpointOverride.empty())
+  {
+    enabled = false;
+  }
+  else
+  {
+    static const char* AWS_ENABLE_ENDPOINT_DISCOVERY_ENV_KEY = "AWS_ENABLE_ENDPOINT_DISCOVERY";
+    static const char* AWS_ENABLE_ENDPOINT_DISCOVERY_PROFILE_KEY = "endpoint_discovery_enabled";
+    static const char* AWS_EP_DISCOVERY_ENABLED = "true";
+    static const char* AWS_EP_DISCOVERY_DISABLED = "false";
+    static const char* DEFAULT_VALUE_FOR_TIMESTREAM_WRITE = AWS_EP_DISCOVERY_ENABLED;
+
+    Aws::String configVal = Client::ClientConfiguration::LoadConfigFromEnvOrProfile(
+        AWS_ENABLE_ENDPOINT_DISCOVERY_ENV_KEY, profileName, AWS_ENABLE_ENDPOINT_DISCOVERY_PROFILE_KEY,
+        {AWS_EP_DISCOVERY_ENABLED, AWS_EP_DISCOVERY_DISABLED}, DEFAULT_VALUE_FOR_TIMESTREAM_WRITE);
+
+    if (AWS_EP_DISCOVERY_ENABLED == configVal) {
+      enabled = true;
+    } else if (AWS_EP_DISCOVERY_DISABLED == configVal) {
+      enabled = false;
+    }
+  }
+  return enabled;
+}
+
+void TimestreamWriteClientConfiguration::LoadTimestreamWriteSpecificConfig(const Aws::String& inputProfileName)
+{
+  if(!enableEndpointDiscovery) {
+    enableEndpointDiscovery = IsEndpointDiscoveryEnabled(this->endpointOverride, inputProfileName);
+  }
+}
+
+TimestreamWriteClientConfiguration::TimestreamWriteClientConfiguration(const Client::ClientConfigurationInitValues &configuration)
+: BaseClientConfigClass(configuration), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
+{
+  LoadTimestreamWriteSpecificConfig(this->profileName);
+}
+
+TimestreamWriteClientConfiguration::TimestreamWriteClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS)
+: BaseClientConfigClass(inputProfileName, shouldDisableIMDS), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
+{
+  LoadTimestreamWriteSpecificConfig(Aws::String(inputProfileName));
+}
+
+TimestreamWriteClientConfiguration::TimestreamWriteClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool shouldDisableIMDS)
+: BaseClientConfigClass(useSmartDefaults, defaultMode, shouldDisableIMDS), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
+{
+  LoadTimestreamWriteSpecificConfig(this->profileName);
+}
+
+TimestreamWriteClientConfiguration::TimestreamWriteClientConfiguration(const Client::ClientConfiguration& config)  : BaseClientConfigClass(config), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery){
+  LoadTimestreamWriteSpecificConfig(this->profileName);
+}
+
+
+} // namespace TimestreamWrite
+} // namespace Aws

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/TranscribeStreamingServiceEndpointProvider.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/TranscribeStreamingServiceEndpointProvider.h
@@ -26,7 +26,7 @@ using Aws::Endpoint::DefaultEndpointProvider;
 
 using TranscribeStreamingServiceClientContextParameters = Aws::Endpoint::ClientContextParameters;
 
-using TranscribeStreamingServiceClientConfiguration = Aws::Client::GenericClientConfiguration<false>;
+using TranscribeStreamingServiceClientConfiguration = Aws::Client::GenericClientConfiguration;
 using TranscribeStreamingServiceBuiltInParameters = Aws::Endpoint::BuiltInParameters;
 
 /**

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/TranscribeStreamingServiceServiceClientModel.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/TranscribeStreamingServiceServiceClientModel.h
@@ -57,7 +57,7 @@ namespace Aws
 
   namespace TranscribeStreamingService
   {
-    using TranscribeStreamingServiceClientConfiguration = Aws::Client::GenericClientConfiguration<false>;
+    using TranscribeStreamingServiceClientConfiguration = Aws::Client::GenericClientConfiguration;
     using TranscribeStreamingServiceEndpointProviderBase = Aws::TranscribeStreamingService::Endpoint::TranscribeStreamingServiceEndpointProviderBase;
     using TranscribeStreamingServiceEndpointProvider = Aws::TranscribeStreamingService::Endpoint::TranscribeStreamingServiceEndpointProvider;
 

--- a/src/aws-cpp-sdk-core/include/aws/core/client/GenericClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/GenericClientConfiguration.h
@@ -15,11 +15,8 @@ namespace Aws
         /**
          * This mutable structure is used to configure a regular AWS client.
          */
-        template<bool HasEndpointDiscovery = false>
         struct AWS_CORE_API GenericClientConfiguration : public ClientConfiguration
         {
-            static const bool EndpointDiscoverySupported = HasEndpointDiscovery;
-
             GenericClientConfiguration(const ClientConfigurationInitValues &configuration = {})
               : ClientConfiguration(configuration)
             {}
@@ -49,12 +46,15 @@ namespace Aws
             {}
         };
 
+#if 0
         /**
          * This mutable structure is used to configure a regular AWS client that supports endpoint discovery.
          */
-        template <> struct AWS_CORE_API GenericClientConfiguration<true> : public ClientConfiguration
+        template <bool EndpointDiscoveryDefaultValT = false>
+        struct AWS_CORE_API GenericClientConfiguration<EndpointDiscoveryDefaultValT, true> : public ClientConfiguration
         {
             static const bool EndpointDiscoverySupported = true;
+            static const bool EndpointDiscoveryDefaultValue = EndpointDiscoveryDefaultValT;
 
             GenericClientConfiguration(const ClientConfigurationInitValues &configuration = {});
             GenericClientConfiguration(const char* profileName, bool shouldDisableIMDS = false);
@@ -82,5 +82,6 @@ namespace Aws
              */
             Aws::Crt::Optional<bool>& enableEndpointDiscovery;
         };
+#endif
     } // namespace Client
 } // namespace Aws

--- a/src/aws-cpp-sdk-core/include/aws/core/endpoint/BuiltInParameters.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/endpoint/BuiltInParameters.h
@@ -22,11 +22,10 @@ namespace Aws
 
             BuiltInParameters() = default;
             BuiltInParameters(const BuiltInParameters&) = delete; // avoid accidental copy
-            virtual ~BuiltInParameters(){};
+            virtual ~BuiltInParameters() = default;
 
             virtual void SetFromClientConfiguration(const Client::ClientConfiguration& config);
-            virtual void SetFromClientConfiguration(const Client::GenericClientConfiguration<false>& config);
-            virtual void SetFromClientConfiguration(const Client::GenericClientConfiguration<true>& config);
+            virtual void SetFromClientConfiguration(const Client::GenericClientConfiguration& config);
 
             virtual void OverrideEndpoint(const Aws::String& endpoint, const Aws::Http::Scheme& scheme = Aws::Http::Scheme::HTTPS);
 

--- a/src/aws-cpp-sdk-core/include/aws/core/endpoint/DefaultEndpointProvider.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/endpoint/DefaultEndpointProvider.h
@@ -43,7 +43,7 @@ namespace Aws
         /**
          * Default endpoint provider template used in this SDK.
          */
-        template<typename ClientConfigurationT = Aws::Client::GenericClientConfiguration<false>,
+        template<typename ClientConfigurationT = Aws::Client::GenericClientConfiguration,
                  typename BuiltInParametersT = Aws::Endpoint::BuiltInParameters,
                  typename ClientContextParametersT = Aws::Endpoint::ClientContextParameters>
         class AWS_CORE_API DefaultEndpointProvider : public EndpointProviderBase<ClientConfigurationT, BuiltInParametersT, ClientContextParametersT>
@@ -113,10 +113,8 @@ namespace Aws
         /**
          * Export endpoint provider symbols for Windows DLL, otherwise declare as extern
          */
-        AWS_CORE_EXTERN template class AWS_CORE_API DefaultEndpointProvider<Aws::Client::GenericClientConfiguration<false>,
+        AWS_CORE_EXTERN template class AWS_CORE_API DefaultEndpointProvider<Aws::Client::GenericClientConfiguration,
             Aws::Endpoint::BuiltInParameters,
             Aws::Endpoint::ClientContextParameters>;
-        
-        AWS_CORE_EXTERN template class AWS_CORE_API DefaultEndpointProvider<Aws::Client::GenericClientConfiguration<true>>;
     } // namespace Endpoint
 } // namespace Aws

--- a/src/aws-cpp-sdk-core/include/aws/core/endpoint/EndpointProviderBase.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/endpoint/EndpointProviderBase.h
@@ -33,7 +33,7 @@ namespace Aws
           *   EndpointParameters to either an Endpoint or an error.
           * This Base class represents a min interface required to be implemented to override an endpoint provider.
           */
-        template<typename ClientConfigurationT = Aws::Client::GenericClientConfiguration<false>,
+        template<typename ClientConfigurationT = Aws::Client::GenericClientConfiguration,
                  typename BuiltInParametersT = Aws::Endpoint::BuiltInParameters,
                  typename ClientContextParametersT = Aws::Endpoint::ClientContextParameters>
         class AWS_CORE_API EndpointProviderBase
@@ -69,10 +69,5 @@ namespace Aws
              */
             virtual ResolveEndpointOutcome ResolveEndpoint(const EndpointParameters& endpointParameters) const = 0;
         };
-
-        /**
-         * Export endpoint provider symbols for Windows DLL, otherwise declare as extern
-         */
-        AWS_CORE_EXTERN template class AWS_CORE_API EndpointProviderBase<Aws::Client::GenericClientConfiguration<true>>;
     } // namespace Endpoint
 } // namespace Aws

--- a/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClient.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClient.h
@@ -31,7 +31,7 @@ namespace client
     class AwsSmithyClientT : public AwsSmithyClientBase
     {
     public:
-        AwsSmithyClientT(Aws::Client::ClientConfiguration& clientConfig, const Aws::String& serviceName,
+        AwsSmithyClientT(const ServiceClientConfigurationT& clientConfig, const Aws::String& serviceName,
             const std::shared_ptr<Aws::Http::HttpClient>& httpClient,
             const std::shared_ptr<Aws::Client::AWSErrorMarshaller>& errorMarshaller,
             const ServiceClientConfigurationT& m_client_config,

--- a/src/aws-cpp-sdk-core/source/client/GenericClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/GenericClientConfiguration.cpp
@@ -13,11 +13,11 @@ namespace Aws
 {
 namespace Client
 {
-template struct AWS_CORE_API GenericClientConfiguration<false>;
+struct AWS_CORE_API GenericClientConfiguration;
 
-bool IsEndpointDiscoveryEnabled(const Aws::String& endpointOverride, const Aws::String &profileName)
+bool IsEndpointDiscoveryEnabled(const Aws::String& endpointOverride, const Aws::String &profileName, const bool defaultValue)
 {
-  bool enabled = true;  // default value for AWS Services with enabled discovery trait
+  bool enabled = defaultValue;  // default value for AWS Services with enabled discovery trait
   if (!endpointOverride.empty())
   {
     enabled = false;
@@ -44,12 +44,13 @@ bool IsEndpointDiscoveryEnabled(const Aws::String& endpointOverride, const Aws::
   return enabled;
 }
 
+#if 0
 GenericClientConfiguration<true>::GenericClientConfiguration(const ClientConfigurationInitValues &configuration)
     : ClientConfiguration(configuration),
       enableHostPrefixInjection(ClientConfiguration::enableHostPrefixInjection),
       enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)
 {
-    enableEndpointDiscovery = IsEndpointDiscoveryEnabled(this->endpointOverride, this->profileName);
+    enableEndpointDiscovery = IsEndpointDiscoveryEnabled(this->endpointOverride, this->profileName, EndpointDiscoveryDefaultValue);
     enableHostPrefixInjection = false; // disabled by default in the SDK
 }
 
@@ -98,6 +99,7 @@ GenericClientConfiguration<true>& GenericClientConfiguration<true>::operator=(co
   }
   return *this;
 }
+#endif
 
 } // namespace Client
 } // namespace Aws

--- a/src/aws-cpp-sdk-core/source/endpoint/BuiltInParameters.cpp
+++ b/src/aws-cpp-sdk-core/source/endpoint/BuiltInParameters.cpp
@@ -73,14 +73,9 @@ namespace Endpoint
         }
     }
 
-    void BuiltInParameters::SetFromClientConfiguration(const Client::GenericClientConfiguration<false>& config)
+    void BuiltInParameters::SetFromClientConfiguration(const Client::GenericClientConfiguration& config)
     {
         return SetFromClientConfiguration(static_cast<const Client::ClientConfiguration&>(config));
-    }
-
-    void BuiltInParameters::SetFromClientConfiguration(const Client::GenericClientConfiguration<true>& config)
-    {
-        SetFromClientConfiguration(static_cast<const Client::ClientConfiguration&>(config));
     }
 
     const BuiltInParameters::EndpointParameter& BuiltInParameters::GetParameter(const Aws::String& name) const

--- a/src/aws-cpp-sdk-core/source/endpoint/DefaultEndpointProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/endpoint/DefaultEndpointProvider.cpp
@@ -16,11 +16,9 @@ namespace Endpoint
 /**
  * Instantiate endpoint providers
  */
-template class DefaultEndpointProvider<Aws::Client::GenericClientConfiguration<false>,
+template class DefaultEndpointProvider<Aws::Client::GenericClientConfiguration,
             Aws::Endpoint::BuiltInParameters,
             Aws::Endpoint::ClientContextParameters>;
-
-template class DefaultEndpointProvider<Aws::Client::GenericClientConfiguration<true>>;
 #endif
 
 char CharToDec(const char c)

--- a/src/aws-cpp-sdk-core/source/endpoint/EndpointProviderBase.cpp
+++ b/src/aws-cpp-sdk-core/source/endpoint/EndpointProviderBase.cpp
@@ -13,11 +13,9 @@ namespace Endpoint
 /**
  * Instantiate endpoint providers
  */
-template class EndpointProviderBase<Aws::Client::GenericClientConfiguration<false>,
+template class EndpointProviderBase<Aws::Client::GenericClientConfiguration,
             Aws::Endpoint::BuiltInParameters,
             Aws::Endpoint::ClientContextParameters>;
-
-template class EndpointProviderBase<Aws::Client::GenericClientConfiguration<true>>;
 #endif
 } // namespace Endpoint
 } // namespace Aws

--- a/tests/aws-cpp-sdk-dynamodb-integration-tests/TableOperationTest.cpp
+++ b/tests/aws-cpp-sdk-dynamodb-integration-tests/TableOperationTest.cpp
@@ -1509,6 +1509,16 @@ TEST_F(TableOperationTest, TestEndpointOverride)
         Aws::DynamoDB::Model::ListTablesOutcome outcome = client.ListTables(request);
         AWS_ASSERT_SUCCESS(outcome);
     }
+
+    config.endpointOverride.clear();
+    for (const auto val : {true, false})
+    {
+        config.enableEndpointDiscovery = val;
+        DynamoDBClient client(config);
+        Aws::DynamoDB::Model::ListTablesRequest request;
+        Aws::DynamoDB::Model::ListTablesOutcome outcome = client.ListTables(request);
+        AWS_ASSERT_SUCCESS(outcome);
+    }
 }
 
 } // anonymous namespace

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/CppClientGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/CppClientGenerator.java
@@ -115,7 +115,8 @@ public abstract class CppClientGenerator implements ClientGenerator {
 
             if (serviceModel.getMetadata().getServiceId().equalsIgnoreCase("S3") ||
                   serviceModel.getMetadata().getServiceId().equalsIgnoreCase("S3-CRT") ||
-                  serviceModel.getMetadata().getServiceId().equalsIgnoreCase("S3 Control")) {
+                  serviceModel.getMetadata().getServiceId().equalsIgnoreCase("S3 Control") ||
+                  serviceModel.getMetadata().isHasEndpointDiscoveryTrait()) {
                 fileList.add(generateServiceClientConfigurationHeaderFile(serviceModel));
                 fileList.add(generateServiceClientConfigurationSourceFile(serviceModel));
             }

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationHeader.vm
@@ -3,7 +3,7 @@
 #set($metadata = $serviceModel.metadata)
 #set($rootNamespace = $serviceModel.namespace)
 #set($serviceNamespace = $metadata.namespace)
-#if($metadata.hasEndpointDiscoveryTrait || $metadata.hasEndpointTrait)
+#if($metadata.hasEndpointDiscoveryTrait)
 #set($EndpointDiscoveryTraitSupported = "/*EndpointDiscoverySupported*/true")
 #else
 #set($EndpointDiscoveryTraitSupported = "/*EndpointDiscoverySupported*/false")
@@ -33,9 +33,17 @@ namespace ${rootNamespace}
         };
 
 #end
-        struct ${exportValue} ${metadata.classNamePrefix}ClientConfiguration : public Aws::Client::GenericClientConfiguration<${EndpointDiscoveryTraitSupported}>
+        struct ${exportValue} ${metadata.classNamePrefix}ClientConfiguration : public Aws::Client::GenericClientConfiguration
         {
-            using BaseClientConfigClass = Aws::Client::GenericClientConfiguration<${EndpointDiscoveryTraitSupported}>;
+            using BaseClientConfigClass = Aws::Client::GenericClientConfiguration;
+#if($metadata.hasEndpointDiscoveryTrait)
+            static const bool EndpointDiscoverySupported = true;
+#if($metadata.requireEndpointDiscovery)
+            static const bool EndpointDiscoveryRequired = true;
+#else
+            static const bool EndpointDiscoveryRequired = false;
+#end
+#end
 
             ${metadata.classNamePrefix}ClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
 
@@ -88,6 +96,25 @@ namespace ${rootNamespace}
             IdentityProviderSupplier identityProviderSupplier = [](const ${metadata.classNamePrefix}Client &client) -> std::shared_ptr<S3ExpressIdentityProvider> {
                 return Aws::MakeShared<DefaultS3ExpressIdentityProvider>("${metadata.classNamePrefix}ClientConfiguration", client);
             };
+#end
+#if($metadata.hasEndpointDiscoveryTrait)
+
+            /**
+             * Enable endpoint discovery
+             * For some services to dynamically set up their endpoints for different requests.
+             * By default, service clients will decide if endpoint discovery is enabled or not.
+             * If disabled, regional or overridden endpoint will be used instead.
+             * If a request requires endpoint discovery, but it was disabled then the request will never succeed.
+             * A boolean value is either true of false, use Optional here to have an instance does not contain a value,
+             * such that SDK will decide the default behavior as stated before, if no value specified.
+#if($metadata.requireEndpointDiscovery)
+             * $serviceModel.metadata.serviceId service client requires endpoint discovery. The default value for this setting is Enabled.
+#else
+             * $serviceModel.metadata.serviceId service client does not require endpoint discovery. The default value for this setting is Disabled.
+#end
+             */
+            Aws::Crt::Optional<bool>& enableEndpointDiscovery;
+
 #end
         private:
             void Load${serviceNamespace}SpecificConfig(const Aws::String& profileName);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationSource.vm
@@ -4,6 +4,7 @@
 #set($rootNamespace = $serviceModel.namespace)
 #set($serviceNamespace = $metadata.namespace)
 #set($endpointPrefix = $metadata.endpointPrefix)
+#set($serviceNameCaps = $metadata.serviceId.replaceAll("[^a-zA-Z\d]+", "_").toUpperCase())
 \#include <aws/${metadata.projectName}/${metadata.classNamePrefix}ClientConfiguration.h>
 
 namespace ${rootNamespace}
@@ -24,6 +25,45 @@ static const char S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE[] = "AWS_S3_USE_ARN_REG
 static const char S3_USE_ARN_REGION_CONFIG_FILE_OPTION[] = "s3_use_arn_region";
 #end
 
+#if($metadata.hasEndpointDiscoveryTrait)
+bool IsEndpointDiscoveryEnabled(const Aws::String& endpointOverride, const Aws::String &profileName)
+{
+#if($metadata.requireEndpointDiscovery)
+  bool enabled = true;
+#else
+  bool enabled = false;
+#end
+
+  if (!endpointOverride.empty())
+  {
+    enabled = false;
+  }
+  else
+  {
+    static const char* AWS_ENABLE_ENDPOINT_DISCOVERY_ENV_KEY = "AWS_ENABLE_ENDPOINT_DISCOVERY";
+    static const char* AWS_ENABLE_ENDPOINT_DISCOVERY_PROFILE_KEY = "endpoint_discovery_enabled";
+    static const char* AWS_EP_DISCOVERY_ENABLED = "true";
+    static const char* AWS_EP_DISCOVERY_DISABLED = "false";
+#if($metadata.requireEndpointDiscovery)
+    static const char* DEFAULT_VALUE_FOR_${serviceNameCaps} = AWS_EP_DISCOVERY_ENABLED;
+#else
+    static const char* DEFAULT_VALUE_FOR_${serviceNameCaps} = AWS_EP_DISCOVERY_DISABLED;
+#end
+
+    Aws::String configVal = Client::ClientConfiguration::LoadConfigFromEnvOrProfile(
+        AWS_ENABLE_ENDPOINT_DISCOVERY_ENV_KEY, profileName, AWS_ENABLE_ENDPOINT_DISCOVERY_PROFILE_KEY,
+        {AWS_EP_DISCOVERY_ENABLED, AWS_EP_DISCOVERY_DISABLED}, DEFAULT_VALUE_FOR_${serviceNameCaps});
+
+    if (AWS_EP_DISCOVERY_ENABLED == configVal) {
+      enabled = true;
+    } else if (AWS_EP_DISCOVERY_DISABLED == configVal) {
+      enabled = false;
+    }
+  }
+  return enabled;
+}
+
+#end
 void ${metadata.classNamePrefix}ClientConfiguration::Load${serviceNamespace}SpecificConfig(const Aws::String& inputProfileName)
 {
 #if($serviceModel.metadata.serviceId == "S3")
@@ -74,23 +114,25 @@ void ${metadata.classNamePrefix}ClientConfiguration::Load${serviceNamespace}Spec
     useArnRegion = true;
   }
 #end
+#if($metadata.hasEndpointDiscoveryTrait)
+  if(!enableEndpointDiscovery) {
+    enableEndpointDiscovery = IsEndpointDiscoveryEnabled(this->endpointOverride, inputProfileName);
+  }
+#end
 }
 
 ${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(const Client::ClientConfigurationInitValues &configuration)
-: BaseClientConfigClass(configuration)
-{
+: BaseClientConfigClass(configuration)#if($metadata.hasEndpointDiscoveryTrait), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)#end${nl}{
   Load${serviceNamespace}SpecificConfig(this->profileName);
 }
 
 ${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(const char* inputProfileName, bool shouldDisableIMDS)
-: BaseClientConfigClass(inputProfileName, shouldDisableIMDS)
-{
+: BaseClientConfigClass(inputProfileName, shouldDisableIMDS)#if($metadata.hasEndpointDiscoveryTrait), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)#end${nl}{
   Load${serviceNamespace}SpecificConfig(Aws::String(inputProfileName));
 }
 
 ${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(bool useSmartDefaults, const char* defaultMode, bool shouldDisableIMDS)
-: BaseClientConfigClass(useSmartDefaults, defaultMode, shouldDisableIMDS)
-{
+: BaseClientConfigClass(useSmartDefaults, defaultMode, shouldDisableIMDS)#if($metadata.hasEndpointDiscoveryTrait), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)#end${nl}{
   Load${serviceNamespace}SpecificConfig(this->profileName);
 }
 
@@ -104,7 +146,7 @@ ${clsPrefixWSpace}                     ${clsPrefixWSpace}Client::AWSAuthV4Signer
 ${clsPrefixWSpace}                     ${clsPrefixWSpace}bool iUseVirtualAddressing,
 ${clsPrefixWSpace}                     ${clsPrefixWSpace}US_EAST_1_REGIONAL_ENDPOINT_OPTION iUseUSEast1RegionalEndPointOption)
 #end
-  : BaseClientConfigClass(config)#if($serviceModel.metadata.serviceId == "S3"),
+  : BaseClientConfigClass(config)#if($metadata.hasEndpointDiscoveryTrait), enableEndpointDiscovery(ClientConfiguration::enableEndpointDiscovery)#end#if($serviceModel.metadata.serviceId == "S3"),
 #else
 #end
 #if($serviceModel.metadata.serviceId == "S3")

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/model/ServiceClientModelHeaderInclude.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/model/ServiceClientModelHeaderInclude.vm
@@ -8,7 +8,7 @@
 
 /* Generic header includes */
 \#include <aws/${metadata.projectName}/${metadata.classNamePrefix}Errors.h>
-#if($serviceModel.endpointRules && $serviceModel.metadata.serviceId == "S3")
+#if($serviceModel.metadata.serviceId == "S3" || $serviceModel.metadata.hasEndpointDiscoveryTrait)
 \#include <aws/${metadata.projectName}/${metadata.classNamePrefix}ClientConfiguration.h>
 #else
 \#include <aws/core/client/GenericClientConfiguration.h>
@@ -83,12 +83,8 @@ namespace ${rootNamespace}
 
   namespace ${metadata.namespace}
   {
-#if($serviceModel.metadata.serviceId != "S3" && $serviceModel.metadata.serviceId != "S3 Control")
-#if(!$metadata.hasEndpointDiscoveryTrait)
-    using ${metadata.classNamePrefix}ClientConfiguration = Aws::Client::GenericClientConfiguration<false>;
-#else
-    using ${metadata.classNamePrefix}ClientConfiguration = Aws::Client::GenericClientConfiguration<true>;
-#end
+#if($serviceModel.metadata.serviceId != "S3" && $serviceModel.metadata.serviceId != "S3 Control" && !$serviceModel.metadata.hasEndpointDiscoveryTrait)
+    using ${metadata.classNamePrefix}ClientConfiguration = Aws::Client::GenericClientConfiguration;
 #end
     using ${metadata.classNamePrefix}EndpointProviderBase = Aws::${metadata.namespace}::Endpoint::${metadata.classNamePrefix}EndpointProviderBase;
     using ${metadata.classNamePrefix}EndpointProvider = Aws::${metadata.namespace}::Endpoint::${metadata.classNamePrefix}EndpointProvider;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/endpoint/EndpointProviderHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/endpoint/EndpointProviderHeader.vm
@@ -66,11 +66,7 @@ using ${epContextClassName} = Aws::Endpoint::ClientContextParameters;
 #end
 
 #if($serviceModel.metadata.serviceId != "S3" && $serviceModel.metadata.serviceId != "S3 Control")
-#if(!$metadata.hasEndpointDiscoveryTrait)
-using ${metadata.classNamePrefix}ClientConfiguration = Aws::Client::GenericClientConfiguration<false>;
-#else
-using ${metadata.classNamePrefix}ClientConfiguration = Aws::Client::GenericClientConfiguration<true>;
-#end
+using ${metadata.classNamePrefix}ClientConfiguration = Aws::Client::GenericClientConfiguration;
 #end
 #if($serviceModel.metadata.serviceId == "S3" || $serviceModel.metadata.serviceId == "S3 Control")
 class ${exportMacro} ${epBuiltInClassName} : public Aws::Endpoint::BuiltInParameters


### PR DESCRIPTION
*Issue #, if available:*
Disable endpoint discovery on the dynamodb by default as it causes a lot of pain.
It is a feature on a deprecation path and the service team suggests to not use it.
It is there purely for backward compatibility.

Still, 2 clients of Timestream would require endpoint discovery enabled by default (because it is required, otherwise the API call would fail)
*Description of changes:*
Get rid of intermediate template GenericClientConfiguration, there are only 3 service clients using the endpoint discovery, so they will generate their service-specific ClientConfiguration classes.

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
