### PR TITLE
Event stream event-name must use member name instead of a Shape name

### DIFF
--- a/generated/src/aws-cpp-sdk-qbusiness/include/aws/qbusiness/model/ChatInputStream.h
+++ b/generated/src/aws-cpp-sdk-qbusiness/include/aws/qbusiness/model/ChatInputStream.h
@@ -35,7 +35,7 @@ namespace Model
     {
        Aws::Utils::Event::Message msg;
        msg.InsertEventHeader(":message-type", Aws::String("event"));
-       msg.InsertEventHeader(":event-type", Aws::String("ConfigurationEvent"));
+       msg.InsertEventHeader(":event-type", Aws::String("configurationEvent"));
        msg.InsertEventHeader(":content-type", Aws::String("application/json"));
        msg.WriteEventPayload(value.Jsonize().View().WriteCompact());
        WriteEvent(msg);
@@ -45,7 +45,7 @@ namespace Model
     {
        Aws::Utils::Event::Message msg;
        msg.InsertEventHeader(":message-type", Aws::String("event"));
-       msg.InsertEventHeader(":event-type", Aws::String("TextInputEvent"));
+       msg.InsertEventHeader(":event-type", Aws::String("textEvent"));
        msg.InsertEventHeader(":content-type", Aws::String("text/plain"));
        msg.WriteEventPayload(value.GetUserMessage());
        WriteEvent(msg);
@@ -55,7 +55,7 @@ namespace Model
     {
        Aws::Utils::Event::Message msg;
        msg.InsertEventHeader(":message-type", Aws::String("event"));
-       msg.InsertEventHeader(":event-type", Aws::String("AttachmentInputEvent"));
+       msg.InsertEventHeader(":event-type", Aws::String("attachmentEvent"));
        msg.InsertEventHeader(":content-type", Aws::String("application/json"));
        msg.WriteEventPayload(value.Jsonize().View().WriteCompact());
        WriteEvent(msg);
@@ -65,7 +65,7 @@ namespace Model
     {
        Aws::Utils::Event::Message msg;
        msg.InsertEventHeader(":message-type", Aws::String("event"));
-       msg.InsertEventHeader(":event-type", Aws::String("ActionExecutionEvent"));
+       msg.InsertEventHeader(":event-type", Aws::String("actionExecutionEvent"));
        msg.InsertEventHeader(":content-type", Aws::String("application/json"));
        msg.WriteEventPayload(value.Jsonize().View().WriteCompact());
        WriteEvent(msg);
@@ -75,7 +75,7 @@ namespace Model
     {
        Aws::Utils::Event::Message msg;
        msg.InsertEventHeader(":message-type", Aws::String("event"));
-       msg.InsertEventHeader(":event-type", Aws::String("EndOfInputEvent"));
+       msg.InsertEventHeader(":event-type", Aws::String("endOfInputEvent"));
        AWS_UNREFERENCED_PARAM(value);
        WriteEvent(msg);
        return *this;
@@ -84,7 +84,7 @@ namespace Model
     {
        Aws::Utils::Event::Message msg;
        msg.InsertEventHeader(":message-type", Aws::String("event"));
-       msg.InsertEventHeader(":event-type", Aws::String("AuthChallengeResponseEvent"));
+       msg.InsertEventHeader(":event-type", Aws::String("authChallengeResponseEvent"));
        msg.InsertEventHeader(":content-type", Aws::String("application/json"));
        msg.WriteEventPayload(value.Jsonize().View().WriteCompact());
        WriteEvent(msg);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/EventStreamHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/EventStreamHeader.vm
@@ -50,7 +50,7 @@ namespace Model
        Aws::Utils::Event::Message msg;
 #if(!$entry.value.shape.eventPayloadType.equals("blob"))
        msg.InsertEventHeader(":message-type", Aws::String("event"));
-       msg.InsertEventHeader(":event-type", Aws::String("${entry.value.shape.name}"));
+       msg.InsertEventHeader(":event-type", Aws::String("${entry.key}"));
 #if($entry.value.shape.eventPayloadType.equals("string"))
        msg.InsertEventHeader(":content-type", Aws::String("text/plain"));
        msg.WriteEventPayload(value.Get$CppViewHelper.capitalizeFirstChar(${entry.value.shape.eventPayloadMemberName})());
@@ -64,7 +64,7 @@ namespace Model
        if(!value.Get$CppViewHelper.capitalizeFirstChar(${entry.value.shape.eventPayloadMemberName})().empty())
        {
            msg.InsertEventHeader(":message-type", Aws::String("event"));
-           msg.InsertEventHeader(":event-type", Aws::String("${entry.value.shape.name}"));
+           msg.InsertEventHeader(":event-type", Aws::String("${entry.key}"));
            msg.InsertEventHeader(":content-type", Aws::String("application/octet-stream"));
            msg.WriteEventPayload(value.Get$CppViewHelper.capitalizeFirstChar(${entry.value.shape.eventPayloadMemberName})());
        }


### PR DESCRIPTION
*Issue #, if available:*
qbusiness code generation
*Description of changes:*
Update code generator to match the (internal) spec.
Regenerated all and only qbusiness ChatInputStream was affected.

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
