### PR TITLE
fix size_t to long conversion warning as error

### DIFF
--- a/src/aws-cpp-sdk-core/source/smithy/client/AwsSmithyClientBase.cpp
+++ b/src/aws-cpp-sdk-core/source/smithy/client/AwsSmithyClientBase.cpp
@@ -386,7 +386,7 @@ void AwsSmithyClientBase::HandleAsyncReply(std::shared_ptr<AwsSmithyClientAsyncR
 
         long sleepMillis = TracingUtils::MakeCallWithTiming<long>(
             [&]() -> long {
-                return m_clientConfig.retryStrategy->CalculateDelayBeforeNextRetry(outcome.GetError(), pRequestCtx->m_retryCount);
+                return m_clientConfig.retryStrategy->CalculateDelayBeforeNextRetry(outcome.GetError(), static_cast<long>(pRequestCtx->m_retryCount));
             },
             TracingUtils::SMITHY_CLIENT_SERVICE_BACKOFF_DELAY_METRIC,
             *m_clientConfig.telemetryProvider->getMeter(this->GetServiceClientName(), {}),
@@ -400,7 +400,7 @@ void AwsSmithyClientBase::HandleAsyncReply(std::shared_ptr<AwsSmithyClientAsyncR
             shouldSleep |= !this->AdjustClockSkew(outcome, pRequestCtx->m_authSchemeOption);
         }
 
-        if (!retryWithCorrectRegion && !m_clientConfig.retryStrategy->ShouldRetry(outcome.GetError(), pRequestCtx->m_retryCount))
+        if (!retryWithCorrectRegion && !m_clientConfig.retryStrategy->ShouldRetry(outcome.GetError(), static_cast<long>(pRequestCtx->m_retryCount)))
         {
             break;
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`pRequestCtx->m_retryCount` is size_t but `CalculateDelayBeforeNextRetry` expects a long. I ran into this when building on windows.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
