### PR TITLE
Fix smithy signer ctors for older gcc

### DIFF
--- a/src/aws-cpp-sdk-core/include/smithy/identity/auth/built-in/SigV4AuthScheme.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/auth/built-in/SigV4AuthScheme.h
@@ -26,19 +26,22 @@ namespace smithy {
 
         //This allows to override the identity resolver
         explicit SigV4AuthScheme(std::shared_ptr<AwsCredentialIdentityResolverT> identityResolver, 
-                                 const SigV4AuthSchemeParameters& parameters)
+                                 const Aws::String& serviceName,
+                                 const Aws::String& region)
             : AuthScheme(SIGV4), 
             m_identityResolver{identityResolver}, 
-            m_signer{Aws::MakeShared<AwsSigV4Signer>("SigV4AuthScheme", parameters)}
+            m_signer{Aws::MakeShared<AwsSigV4Signer>("SigV4AuthScheme", serviceName, region)}
         {
             assert(m_identityResolver);
             assert(m_signer);
         }
 
         //delegate constructor
-        explicit SigV4AuthScheme(const SigV4AuthSchemeParameters& parameters)
+        explicit SigV4AuthScheme(const Aws::String& serviceName,
+                                 const Aws::String& region)
             : SigV4AuthScheme(Aws::MakeShared<DefaultAwsCredentialIdentityResolver>("SigV4AuthScheme"),  
-                              parameters)
+                              serviceName,
+                              region)
         {
         }
 

--- a/src/aws-cpp-sdk-core/include/smithy/identity/auth/built-in/SigV4aAuthScheme.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/auth/built-in/SigV4aAuthScheme.h
@@ -26,17 +26,19 @@ namespace smithy {
 
         //This allows to override the identity resolver
         explicit SigV4aAuthScheme(std::shared_ptr<AwsCredentialIdentityResolverT> identityResolver, 
-                                 const SigV4aAuthSchemeParameters& parameters)
+                                  const Aws::String& serviceName,
+                                  const Aws::String& region)
             : AuthScheme(SIGV4A), 
             m_identityResolver{identityResolver}, 
-            m_signer{Aws::MakeShared<AwsSigV4aSigner>("SigV4aAuthScheme", parameters)}
+            m_signer{Aws::MakeShared<AwsSigV4aSigner>("SigV4aAuthScheme", serviceName, region)}
         {
             assert(m_identityResolver);
             assert(m_signer);
         }
 
-        explicit SigV4aAuthScheme(const SigV4aAuthSchemeParameters& parameters)
-            : SigV4aAuthScheme(Aws::MakeShared<DefaultAwsCredentialIdentityResolver>("SigV4aAuthScheme"),parameters )
+        explicit SigV4aAuthScheme(const Aws::String& serviceName,
+                                  const Aws::String& region)
+            : SigV4aAuthScheme(Aws::MakeShared<DefaultAwsCredentialIdentityResolver>("SigV4aAuthScheme"), serviceName, region)
         {
             assert(m_identityResolver);
 

--- a/src/aws-cpp-sdk-core/include/smithy/identity/signer/built-in/SigV4aSigner.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/signer/built-in/SigV4aSigner.h
@@ -32,8 +32,8 @@ namespace smithy {
         
     public:
         using SigV4aAuthSchemeParameters = smithy::DefaultAuthSchemeResolverParameters;
-        explicit AwsSigV4aSigner(const SigV4aAuthSchemeParameters& parameters)
-            :  m_parameters{parameters}
+        explicit AwsSigV4aSigner(const Aws::String& serviceName, const Aws::String& region)
+            :  m_serviceName(serviceName), m_region(region)
         {
         }
 
@@ -136,8 +136,8 @@ namespace smithy {
         {
             awsSigningConfig.SetSigningAlgorithm(static_cast<Aws::Crt::Auth::SigningAlgorithm>(Aws::Auth::AWSSigningAlgorithm::ASYMMETRIC_SIGV4));
             awsSigningConfig.SetSignatureType(m_signatureType);
-            awsSigningConfig.SetRegion((*m_parameters.region).c_str());
-            awsSigningConfig.SetService((m_parameters.serviceName).c_str());
+            awsSigningConfig.SetRegion(m_region.c_str());
+            awsSigningConfig.SetService(m_region.c_str());
             awsSigningConfig.SetSigningTimepoint(GetSigningTimestamp().UnderlyingTimestamp());
             awsSigningConfig.SetUseDoubleUriEncode(m_urlEscape);
             awsSigningConfig.SetShouldNormalizeUriPath(true);
@@ -174,7 +174,7 @@ namespace smithy {
             }
             else if (m_signatureType == Aws::Crt::Auth::SignatureType::HttpRequestViaQueryParams)
             {
-                if (ServiceRequireUnsignedPayload(m_parameters.serviceName))
+                if (ServiceRequireUnsignedPayload(m_serviceName))
                 {
                     awsSigningConfig.SetSignedBodyValue(UNSIGNED_PAYLOAD);
                 }
@@ -205,7 +205,8 @@ namespace smithy {
             return "s3" == serviceName || "s3-object-lambda" == serviceName;
         }
 
-        SigV4aAuthSchemeParameters m_parameters;
+        Aws::String m_serviceName;
+        Aws::String m_region;
         //params that can be exposed later
         long long m_expirationTimeInSeconds{0};
         const bool m_includeSha256HashHeader{true};

--- a/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp
@@ -130,11 +130,6 @@ TEST_F(SmithyClientTest, testSigV4) {
 
     Aws::UnorderedMap<Aws::String, SigVariant> authSchemesMap;
 
-    smithy::SigV4AuthScheme::SigV4AuthSchemeParameters params;
-    params.serviceName = "MyService";
-    params.region = "us-west2";
-    params.operation = "TestOperation";
-
     Aws::String key{"aws.auth#sigv4"};  
 
     //add mock credentials provider for the test to the credentials provider chain
@@ -143,7 +138,7 @@ TEST_F(SmithyClientTest, testSigV4) {
     //create resolver with the credentials provider chain
     auto credentialsResolver = Aws::MakeShared<smithy::DefaultAwsCredentialIdentityResolver>(ALLOCATION_TAG, credsProviderChain);
 
-    SigVariant val{smithy::SigV4AuthScheme( credentialsResolver, params)};
+    SigVariant val{smithy::SigV4AuthScheme( credentialsResolver, "MyService", "us-west-2")};
     
     authSchemesMap.emplace(key, val);
 
@@ -196,7 +191,7 @@ TEST_F(SmithyClientTest, testSigV4a) {
     Aws::String key{"aws.auth#sigv4a"};
     auto credentialsResolver = Aws::MakeShared<smithy::DefaultAwsCredentialIdentityResolver>(ALLOCATION_TAG, credsProviderChain);
 
-    SigVariant val{smithy::SigV4aAuthScheme(credentialsResolver, params)};
+    SigVariant val{smithy::SigV4aAuthScheme(credentialsResolver, "MyService", "us-west-2")};
     
     authSchemesMap.emplace(key, val);
 


### PR DESCRIPTION
*Description of changes:*

On older GCC core builds with the error

```
In file included from aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/identity/auth/built-in/SigV4AuthScheme.h:13:0,
                 from aws-sdk-cpp/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp:8:
aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/identity/signer/built-in/SigV4Signer.h: In constructor 'smithy::AwsSigV4Signer::AwsSigV4Signer(const SigV4AuthSchemeParameters&)':
aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/identity/signer/built-in/SigV4Signer.h:24:113: error: could not convert 'parameters' from 'const SigV4AuthSchemeParameters {aka const smithy::DefaultAuthSchemeResolverParameters}' to 'Aws::String {aka std::basic_string<char>}'
             :  m_parameters{parameters},legacySigner{nullptr, parameters.serviceName.c_str(), *parameters.region}
                                                                                                                 ^
In file included from aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/identity/auth/built-in/SigV4aAuthScheme.h:13:0,
                 from aws-sdk-cpp/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp:12:
aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/identity/signer/built-in/SigV4aSigner.h: In constructor 'smithy::AwsSigV4aSigner::AwsSigV4aSigner(const SigV4aAuthSchemeParameters&)':
aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/identity/signer/built-in/SigV4aSigner.h:36:39: error: could not convert 'parameters' from 'const SigV4aAuthSchemeParameters {aka const smithy::DefaultAuthSchemeResolverParameters}' to 'Aws::String {aka std::basic_string<char>}'
             :  m_parameters{parameters}
```

Passing `DefaultAuthSchemeResolverParameters` to singers in the ctors was out of convenience beforehand, so this moves the ctors to use service name and region as that is what is required in the signers

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
