### PR TITLE
re-add commpression and sdkutils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,8 @@ if (LEGACY_BUILD)
     aws_use_package(aws-checksums)
     aws_use_package(aws-c-event-stream)
     aws_use_package(aws-c-s3)
+    aws_use_package(aws-c-compression)
+    aws_use_package(aws-c-sdkutils)
     set(AWS_COMMON_RUNTIME_LIBS ${DEP_AWS_LIBS})
 
     include(compiler_settings)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/discussions/3093

*Description of changes:*
re-add aws-c-commpression and aws-c-sdkutils that were removed when crypto dependency was moved from this sdk to crt. https://github.com/aws/aws-sdk-cpp/commit/b652aae94660c481400c385bf0b72f7adb8f7914

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
