### PR TITLE
fix copy and move constructors for client configuration with endpoint discovery

### DIFF
--- a/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBClientConfiguration.h
@@ -19,6 +19,34 @@ namespace Aws
             static const bool EndpointDiscoverySupported = true;
             static const bool EndpointDiscoveryRequired = false;
 
+            DynamoDBClientConfiguration(const DynamoDBClientConfiguration& other)
+                : Aws::Client::GenericClientConfiguration(other),
+                  enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery)
+            {
+            }
+
+            DynamoDBClientConfiguration(DynamoDBClientConfiguration&& other) noexcept
+                : Aws::Client::GenericClientConfiguration(std::move(other)),
+                  enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery)
+            {
+            }
+
+            DynamoDBClientConfiguration& operator=(const DynamoDBClientConfiguration& other)
+            {
+                if (this == &other)
+                    return *this;
+                Aws::Client::GenericClientConfiguration::operator =(other);
+                return *this;
+            }
+
+            DynamoDBClientConfiguration& operator=(DynamoDBClientConfiguration&& other) noexcept
+            {
+                if (this == &other)
+                    return *this;
+                Aws::Client::GenericClientConfiguration::operator =(std::move(other));
+                return *this;
+            }
+
             DynamoDBClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
 
             /**

--- a/generated/src/aws-cpp-sdk-timestream-query/include/aws/timestream-query/TimestreamQueryClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-timestream-query/include/aws/timestream-query/TimestreamQueryClientConfiguration.h
@@ -19,6 +19,34 @@ namespace Aws
             static const bool EndpointDiscoverySupported = true;
             static const bool EndpointDiscoveryRequired = true;
 
+            TimestreamQueryClientConfiguration(const TimestreamQueryClientConfiguration& other)
+                : Aws::Client::GenericClientConfiguration(other),
+                  enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery)
+            {
+            }
+
+            TimestreamQueryClientConfiguration(TimestreamQueryClientConfiguration&& other) noexcept
+                : Aws::Client::GenericClientConfiguration(std::move(other)),
+                  enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery)
+            {
+            }
+
+            TimestreamQueryClientConfiguration& operator=(const TimestreamQueryClientConfiguration& other)
+            {
+                if (this == &other)
+                    return *this;
+                Aws::Client::GenericClientConfiguration::operator =(other);
+                return *this;
+            }
+
+            TimestreamQueryClientConfiguration& operator=(TimestreamQueryClientConfiguration&& other) noexcept
+            {
+                if (this == &other)
+                    return *this;
+                Aws::Client::GenericClientConfiguration::operator =(std::move(other));
+                return *this;
+            }
+
             TimestreamQueryClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
 
             /**

--- a/generated/src/aws-cpp-sdk-timestream-write/include/aws/timestream-write/TimestreamWriteClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-timestream-write/include/aws/timestream-write/TimestreamWriteClientConfiguration.h
@@ -19,6 +19,34 @@ namespace Aws
             static const bool EndpointDiscoverySupported = true;
             static const bool EndpointDiscoveryRequired = true;
 
+            TimestreamWriteClientConfiguration(const TimestreamWriteClientConfiguration& other)
+                : Aws::Client::GenericClientConfiguration(other),
+                  enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery)
+            {
+            }
+
+            TimestreamWriteClientConfiguration(TimestreamWriteClientConfiguration&& other) noexcept
+                : Aws::Client::GenericClientConfiguration(std::move(other)),
+                  enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery)
+            {
+            }
+
+            TimestreamWriteClientConfiguration& operator=(const TimestreamWriteClientConfiguration& other)
+            {
+                if (this == &other)
+                    return *this;
+                Aws::Client::GenericClientConfiguration::operator =(other);
+                return *this;
+            }
+
+            TimestreamWriteClientConfiguration& operator=(TimestreamWriteClientConfiguration&& other) noexcept
+            {
+                if (this == &other)
+                    return *this;
+                Aws::Client::GenericClientConfiguration::operator =(std::move(other));
+                return *this;
+            }
+
             TimestreamWriteClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
 
             /**

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationHeader.vm
@@ -45,6 +45,36 @@ namespace ${rootNamespace}
 #end
 #end
 
+#if($metadata.hasEndpointDiscoveryTrait)
+            ${metadata.classNamePrefix}ClientConfiguration(const ${metadata.classNamePrefix}ClientConfiguration& other)
+                : Aws::Client::GenericClientConfiguration(other),
+                  enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery)
+            {
+            }
+
+            ${metadata.classNamePrefix}ClientConfiguration(${metadata.classNamePrefix}ClientConfiguration&& other) noexcept
+                : Aws::Client::GenericClientConfiguration(std::move(other)),
+                  enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery)
+            {
+            }
+
+            ${metadata.classNamePrefix}ClientConfiguration& operator=(const ${metadata.classNamePrefix}ClientConfiguration& other)
+            {
+                if (this == &other)
+                    return *this;
+                Aws::Client::GenericClientConfiguration::operator =(other);
+                return *this;
+            }
+
+            ${metadata.classNamePrefix}ClientConfiguration& operator=(${metadata.classNamePrefix}ClientConfiguration&& other) noexcept
+            {
+                if (this == &other)
+                    return *this;
+                Aws::Client::GenericClientConfiguration::operator =(std::move(other));
+                return *this;
+            }
+
+#end
             ${metadata.classNamePrefix}ClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
 
             /**


### PR DESCRIPTION
*Issue #, if available:*

[issues/3100](https://github.com/aws/aws-sdk-cpp/issues/3100)

*Description of changes:*

There was a issue where a implicit copy/move ctor would not point the ref of the service specific client configuration class to the correct parent instance creating a invalid access. This rule of 5 correctly assigns the service specific clients to the correct parent variable.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
