### PR TITLE
Added CustomSSOCredentialsProvider to retain higher-level ClientConfiguration

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/auth/CustomSSOCredentialsProvider.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/CustomSSOCredentialsProvider.h
@@ -1,0 +1,34 @@
+/**
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+#include <aws/core/auth/SSOCredentialsProvider.h>
+#include <aws/core/client/ClientConfiguration.h>
+
+namespace Aws {
+    namespace Auth {
+        class AWS_CORE_API CustomSSOCredentialsProvider : public SSOCredentialsProvider {
+        public:
+            CustomSSOCredentialsProvider(const Aws::Client::ClientConfiguration& clientConfig)
+                : SSOCredentialsProvider(), m_clientConfig(clientConfig)
+            {
+            }
+
+            void Reload() override {
+                Aws::Client::ClientConfiguration config = m_clientConfig;
+                config.scheme = Aws::Http::Scheme::HTTPS;
+                config.region = m_ssoRegion;
+
+                m_client = Aws::MakeUnique<Aws::Internal::SSOCredentialsClient>(SSO_CREDENTIALS_PROVIDER_LOG_TAG, config);
+
+                SSOCredentialsProvider::Reload();
+            }
+
+        private:
+            Aws::Client::ClientConfiguration m_clientConfig;
+        };
+    } // namespace Auth
+} // namespace Aws

--- a/src/aws-cpp-sdk-core/include/aws/core/auth/SSOCredentialsProvider.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/SSOCredentialsProvider.h
@@ -21,6 +21,7 @@ namespace Aws {
         public:
             SSOCredentialsProvider();
             explicit SSOCredentialsProvider(const Aws::String& profile);
+            explicit SSOCredentialsProvider(const Aws::Client::ClientConfiguration& clientConfig);
             /**
              * Retrieves the credentials if found, otherwise returns empty credential set.
              */
@@ -42,6 +43,8 @@ namespace Aws {
             Aws::Utils::DateTime m_expiresAt;
             // The SSO Token Provider
             Aws::Auth::SSOBearerTokenProvider m_bearerTokenProvider;
+            // Custom ClientConfiguration used by the SSOCredentialsClient during Reload()
+            Aws::Client::ClientConfiguration m_clientConfig;
 
             void Reload() override;
             void RefreshIfExpired();

--- a/src/aws-cpp-sdk-core/source/auth/SSOCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/SSOCredentialsProvider.cpp
@@ -39,6 +39,13 @@ SSOCredentialsProvider::SSOCredentialsProvider(const Aws::String& profile) : m_p
     AWS_LOGSTREAM_INFO(SSO_CREDENTIALS_PROVIDER_LOG_TAG, "Setting sso credentials provider to read config from " <<  m_profileToUse);
 }
 
+SSOCredentialsProvider::SSOCredentialsProvider(const Aws::Client::ClientConfiguration& clientConfig)
+    : m_profileToUse(GetConfigProfileName()), m_clientConfig(clientConfig)
+{
+    AWS_LOGSTREAM_INFO(SSO_CREDENTIALS_PROVIDER_LOG_TAG, "Setting sso credentials provider to read config from " << m_profileToUse);
+}
+
+
 AWSCredentials SSOCredentialsProvider::GetAWSCredentials()
 {
     RefreshIfExpired();
@@ -80,7 +87,7 @@ void SSOCredentialsProvider::Reload()
     request.m_ssoRoleName = profile.GetSsoRoleName();
     request.m_accessToken = accessToken;
 
-    Aws::Client::ClientConfiguration config;
+    Aws::Client::ClientConfiguration config = m_clientConfig;
     config.scheme = Aws::Http::Scheme::HTTPS;
     config.region = m_ssoRegion;
     AWS_LOGSTREAM_DEBUG(SSO_CREDENTIALS_PROVIDER_LOG_TAG, "Passing config to client for region: " << m_ssoRegion);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The existing `SSOCredentialsProvider` class was overwriting the higher-level `ClientConfiguration` settings, which is leading to issue while authenticating through SSO.Added a new custom provider class called `CustomSSOCredentialsProvider` that inherits from `SSOCredentialsProvider` and allows the use of a custom `ClientConfiguration`.

 In the `Reload()` method of `CustomSSOCredentialsProvider`, a new `ClientConfiguration` object is created using the provided `m_clientConfig` member variable, and the `scheme` and `region` properties are set before passing it to the `SSOCredentialsClient` constructor.

This will ensure  that the higher-level `ClientConfiguration` is retained, and the `SSOCredentialsClient` is created with the correct configuration. 

*Check all that applies:*
- [x] Did a review by yourself.
- [] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [] Checked if this PR is a breaking (APIs have been changed) change.
- [] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
