### PR TITLE
add no-op option to codegen from smithy client

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/main.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/main.java
@@ -41,6 +41,7 @@ public class main {
     static final String LICENSE_TEXT = "license-text";
     static final String STANDALONE_OPTION = "standalone";
     static final String ENABLE_VIRTUAL_OPERATIONS = "enable-virtual-operations";
+    static final String USE_SMITHY_CLIENT = "use-smithy-client";
 
     public static void main(String[] args) throws IOException {
 
@@ -99,6 +100,8 @@ public class main {
             if (argPairs.containsKey(OUTPUT_FILE_NAME) && !argPairs.get(OUTPUT_FILE_NAME).isEmpty()) {
                 outputFileName = argPairs.get(OUTPUT_FILE_NAME);
             }
+
+            boolean useSmithyClient = argPairs.containsKey(USE_SMITHY_CLIENT);
 
             if (arbitraryJson != null && arbitraryJson.length() > 0) {
                 try {

--- a/tools/scripts/run_code_generation.py
+++ b/tools/scripts/run_code_generation.py
@@ -368,6 +368,9 @@ def parse_arguments() -> dict:
                         help="Code generator raw argument to be passed through to "
                              "mark operation functions in service client as virtual functions. Always on by default",
                         action="store_true")
+    parser.add_argument("--use-smithy-client",
+                        help="generate clients using smithy base client if supported",
+                        action="store_true")
 
     args = vars(parser.parse_args())
     arg_map = {}
@@ -432,9 +435,12 @@ def parse_arguments() -> dict:
     arg_map["list_all"] = args["list_all"] or False
 
     raw_generator_arguments = dict()
-    for raw_argument in ["license-text", "namespace", "standalone"]:
+    for raw_argument in ["license-text", "namespace", "standalone", "use_smithy_client"]:
         if args.get(raw_argument):
             raw_generator_arguments[raw_argument] = args[raw_argument]
+    if raw_generator_arguments.get("use_smithy_client"):
+        del raw_generator_arguments["use_smithy_client"]
+        raw_generator_arguments["use-smithy-client"] = ""
     arg_map["raw_generator_arguments"] = raw_generator_arguments
 
     return arg_map


### PR DESCRIPTION
*Description of changes:*

Pre cursor to [pull/3091](https://github.com/aws/aws-sdk-cpp/pull/3091). This adds no-op arguments to the client generator to generate smithy vs aws client based classes. The argument is currently unused and will result in no code change.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
