### PR TITLE
add workaround for gcc protected bug

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3ExpressIdentityProvider.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3ExpressIdentityProvider.h
@@ -30,11 +30,12 @@ namespace Aws {
 
             ResolveIdentityFutureOutcome
             getIdentity(const IdentityProperties& identityProperties, const AdditionalParameters& additionalParameters) override;
+            S3ExpressIdentity
+            getIdentity(const Aws::String &bucketName);
 
             virtual ~S3ExpressIdentityProvider() {}
 
         protected:
-            S3ExpressIdentity getIdentity(const Aws::String &bucketName);
             std::shared_ptr<std::mutex> GetMutexForBucketName(const Aws::String& bucketName);
 
         private:

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ExpressIdentityProvider.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ExpressIdentityProvider.h
@@ -30,11 +30,12 @@ namespace Aws {
 
             ResolveIdentityFutureOutcome
             getIdentity(const IdentityProperties& identityProperties, const AdditionalParameters& additionalParameters) override;
+            S3ExpressIdentity
+            getIdentity(const Aws::String &bucketName);
 
             virtual ~S3ExpressIdentityProvider() {}
 
         protected:
-            S3ExpressIdentity getIdentity(const Aws::String &bucketName);
             std::shared_ptr<std::mutex> GetMutexForBucketName(const Aws::String& bucketName);
 
         private:

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressIdentityProviderHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressIdentityProviderHeader.vm
@@ -30,11 +30,12 @@ namespace ${rootNamespace} {
 
             ResolveIdentityFutureOutcome
             getIdentity(const IdentityProperties& identityProperties, const AdditionalParameters& additionalParameters) override;
+            S3ExpressIdentity
+            getIdentity(const Aws::String &bucketName);
 
             virtual ~S3ExpressIdentityProvider() {}
 
         protected:
-            S3ExpressIdentity getIdentity(const Aws::String &bucketName);
             std::shared_ptr<std::mutex> GetMutexForBucketName(const Aws::String& bucketName);
 
         private:


### PR DESCRIPTION
*Description of changes:*

There is a [bug in GCC](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66957) with a incorrect "is protected within this context" error, which is present in older gcc versions that is causing the SDK to fail with build on older gcc versions

```
101.5 FAILED: generated/src/aws-cpp-sdk-s3/CMakeFiles/aws-cpp-sdk-s3.dir/ub_S3.cpp.o
101.5 In file included from generated/src/aws-cpp-sdk-s3/ub_S3.cpp:7:0:
101.5 /aws-sdk-cpp/generated/src/aws-cpp-sdk-s3/source/S3ExpressIdentityProvider.cpp: In lambda function:
101.5 /aws-sdk-cpp/generated/src/aws-cpp-sdk-s3/source/S3ExpressIdentityProvider.cpp:50:19: error: 'Aws::S3::S3ExpressIdentity Aws::S3::S3ExpressIdentityProvider::getIdentity(const String&)' is protected
101.5  S3ExpressIdentity S3ExpressIdentityProvider::getIdentity(const Aws::String &bucketName) {
101.5                    ^
101.5 In file included from generated/src/aws-cpp-sdk-s3/ub_S3.cpp:7:0:
101.5 /aws-sdk-cpp/generated/src/aws-cpp-sdk-s3/source/S3ExpressIdentityProvider.cpp:162:91: error: within this context
101.5              auto updatedIdentity = this->S3ExpressIdentityProvider::getIdentity(bucketName);
```

this moves the overloaded `getIdentity` to being a public function to support this older gcc version.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
