### PR TITLE
Support passing `ClientConfiguration` to `GeneralHTTPCredentialsProvider`.

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/auth/GeneralHTTPCredentialsProvider.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/GeneralHTTPCredentialsProvider.h
@@ -34,6 +34,24 @@ namespace Aws
              * @param refreshRateMs The number of milliseconds after which the credentials will be fetched again.
              * @param ShouldCreateFunc
              */
+            GeneralHTTPCredentialsProvider(const Aws::Client::ClientConfiguration& clientConfig,
+                const Aws::String& relativeUri,
+                const Aws::String& absoluteUri,
+                const Aws::String& authTokenFilePath = "",
+                const Aws::String& authToken = "",
+                long refreshRateMs = REFRESH_THRESHOLD,
+                ShouldCreateFunc shouldCreateFunc = ShouldCreateGeneralHTTPProvider);
+
+            /**
+             * Initializes the provider to retrieve credentials from a general http provided endpoint every 5 minutes or before it
+             * expires.
+             * @param relativeUri A path appended to the metadata service endpoint. OR
+             * @param absoluteUri The full URI to resolve to get credentials.
+             * @param authTokenFilePath A path to a file with optional authorization token passed to the URI via the 'Authorization' HTTP header.
+             * @param authToken An optional authorization token passed to the URI via the 'Authorization' HTTP header.
+             * @param refreshRateMs The number of milliseconds after which the credentials will be fetched again.
+             * @param ShouldCreateFunc
+             */
             GeneralHTTPCredentialsProvider(const Aws::String& relativeUri,
                                            const Aws::String& absoluteUri,
                                            const Aws::String& authTokenFilePath = "",

--- a/src/aws-cpp-sdk-core/source/auth/GeneralHTTPCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/GeneralHTTPCredentialsProvider.cpp
@@ -147,6 +147,28 @@ bool GeneralHTTPCredentialsProvider::ShouldCreateGeneralHTTPProvider(const Aws::
     return false;
 }
 
+GeneralHTTPCredentialsProvider::GeneralHTTPCredentialsProvider(const Aws::Client::ClientConfiguration& clientConfig,
+                                                               const Aws::String& relativeUri,
+                                                               const Aws::String& absoluteUri,
+                                                               const Aws::String& authToken,
+                                                               const Aws::String& authTokenFilePath,
+                                                               long refreshRateMs,
+                                                               ShouldCreateFunc shouldCreateFunc) :
+    m_authTokenFilePath(authTokenFilePath),
+    m_loadFrequencyMs(refreshRateMs)
+{
+    if (shouldCreateFunc(relativeUri, absoluteUri, authToken))
+    {
+        AWS_LOGSTREAM_INFO(GEN_HTTP_LOG_TAG, "Creating GeneralHTTPCredentialsProvider with refresh rate " << refreshRateMs);
+        if (!relativeUri.empty()) {
+            m_ecsCredentialsClient = Aws::MakeShared<Aws::Internal::ECSCredentialsClient>(GEN_HTTP_LOG_TAG, clientConfig, relativeUri.c_str(), AWS_ECS_CONTAINER_HOST, authToken.c_str());
+        }
+        else if (!absoluteUri.empty()) {
+            m_ecsCredentialsClient = Aws::MakeShared<Aws::Internal::ECSCredentialsClient>(GEN_HTTP_LOG_TAG, clientConfig, "", absoluteUri.c_str(), authToken.c_str());
+        }
+    }
+}
+
 GeneralHTTPCredentialsProvider::GeneralHTTPCredentialsProvider(const Aws::String& relativeUri,
                                                                const Aws::String& absoluteUri,
                                                                const Aws::String& authToken,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds a constructor to `GeneralHTTPCredentialsProvider` that accepts a `ClientConfiguration`.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [X] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
