### PR TITLE
dont re-allocate sigv4a signer each request

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/auth/signer/AWSAuthV4Signer.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/signer/AWSAuthV4Signer.h
@@ -221,6 +221,7 @@ namespace Aws
             mutable Utils::Threading::ReaderWriterLock m_partialSignatureLock;
             PayloadSigningPolicy m_payloadSigningPolicy;
             bool m_urlEscapePath;
+            mutable Aws::Crt::Auth::Sigv4HttpRequestSigner m_crtSigner{};
         };
     } // namespace Client
 } // namespace Aws

--- a/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
@@ -146,10 +146,8 @@ bool AWSAuthV4Signer::SignRequestWithSigV4a(Aws::Http::HttpRequest& request, con
     awsSigningConfig.SetCredentials(crtCredentials);
 
     std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest = request.ToCrtHttpRequest();
-
-    auto sigv4HttpRequestSigner = Aws::MakeShared<Aws::Crt::Auth::Sigv4HttpRequestSigner>(v4AsymmetricLogTag);
     bool success = true;
-    sigv4HttpRequestSigner->SignRequest(crtHttpRequest, awsSigningConfig,
+    m_crtSigner.SignRequest(crtHttpRequest, awsSigningConfig,
         [&request, &success, signatureType](const std::shared_ptr<Aws::Crt::Http::HttpRequest>& signedCrtHttpRequest, int errorCode) {
             success = (errorCode == AWS_ERROR_SUCCESS);
             if (success)


### PR DESCRIPTION
*Description of changes:*

While looking through code I saw that we re-allocate the crt sigv4 signer each time we sign with sigv4. this moves the allocator to a member variable.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
