### PR TITLE
add configuration for MPU threshold for CRT

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
@@ -143,6 +143,16 @@ namespace Aws
                     uint32_t maxBackoffSecs = 20;
                 } config;
             } crtRetryStrategyConfig;
+
+            /**
+             * Optional.
+             * The size threshold in bytes for when to use multipart uploads.
+             * Uploads larger than this will use the multipart upload strategy.
+             * Uploads smaller or equal to this will use a single HTTP request.
+             * If set, this should be at least `partSize`.
+             * If not set, the max of `partSize` and 5 MiB will be used.
+             */
+            size_t multipartUploadThreshold{0};
             /* End of S3 CRT specifics */
         private:
             void LoadS3CrtSpecificConfig(const Aws::String& profileName);

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -381,6 +381,7 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config,
 
   static const size_t DEFAULT_PART_SIZE = 8 * 1024 * 1024; // 8MB
   s3CrtConfig.part_size = config.partSize < DEFAULT_PART_SIZE ? DEFAULT_PART_SIZE : config.partSize;
+  s3CrtConfig.multipart_upload_threshold = config.multipartUploadThreshold;
 
   Aws::Crt::Io::TlsConnectionOptions *rawPTlsConnectionOptions = nullptr;
   if (config.tlsConnectionOptions)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtClientConfigHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtClientConfigHeader.vm
@@ -76,4 +76,14 @@
                     uint32_t maxBackoffSecs = 20;
                 } config;
             } crtRetryStrategyConfig;
+
+            /**
+             * Optional.
+             * The size threshold in bytes for when to use multipart uploads.
+             * Uploads larger than this will use the multipart upload strategy.
+             * Uploads smaller or equal to this will use a single HTTP request.
+             * If set, this should be at least `partSize`.
+             * If not set, the max of `partSize` and 5 MiB will be used.
+             */
+            size_t multipartUploadThreshold{0};
             /* End of S3 CRT specifics */

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -408,6 +408,7 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
 
   static const size_t DEFAULT_PART_SIZE = 8 * 1024 * 1024; // 8MB
   s3CrtConfig.part_size = config.partSize < DEFAULT_PART_SIZE ? DEFAULT_PART_SIZE : config.partSize;
+  s3CrtConfig.multipart_upload_threshold = config.multipartUploadThreshold;
 
   Aws::Crt::Io::TlsConnectionOptions *rawPTlsConnectionOptions = nullptr;
   if (config.tlsConnectionOptions)


### PR DESCRIPTION
*Issue #, if available:*

[issues/3125](https://github.com/aws/aws-sdk-cpp/issues/3125)

*Description of changes:*

Introduces a configuration option `multipartUploadThreshold` to match the [crt's configuration option](https://github.com/awslabs/aws-c-s3/blob/main/include/aws/s3/s3_client.h#L432-L443).

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
