### PR TITLE
Create interfaces for smithy interceptors

### DIFF
--- a/src/aws-cpp-sdk-core/CMakeLists.txt
+++ b/src/aws-cpp-sdk-core/CMakeLists.txt
@@ -90,6 +90,7 @@ file(GLOB SMITHY_IDENTITY_IDENTITY_IMPL_HEADERS "include/smithy/identity/identit
 file(GLOB SMITHY_IDENTITY_RESOLVER_IMPL_HEADERS "include/smithy/identity/resolver/impl/*.h")
 file(GLOB SMITHY_IDENTITY_SIGNER_HEADERS "include/smithy/identity/signer/*.h")
 file(GLOB SMITHY_IDENTITY_SIGNER_BUILTIN_HEADERS "include/smithy/identity/signer/built-in/*.h")
+file(GLOB SMITHY_INTERCEPTOR_HEADERS "include/smithy/interceptor/*.h")
 
 file(GLOB AWS_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp")
 file(GLOB AWS_TINYXML2_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/external/tinyxml2/*.cpp")
@@ -361,6 +362,7 @@ file(GLOB AWS_NATIVE_SDK_COMMON_HEADERS
   ${SMITHY_IDENTITY_RESOLVER_HEADERS}
   ${SMITHY_IDENTITY_RESOLVER_BUILTIN_HEADERS}
   ${OPTEL_HEADERS}
+  ${SMITHY_INTERCEPTOR_HEADERS}
 )
 
 # misc platform-specific, not related to features (encryption/http clients)
@@ -492,6 +494,7 @@ if(MSVC)
     source_group("Header Files\\smithy\\identity\\resolver\\impl" FILES ${SMITHY_IDENTITY_RESOLVER_IMPL_HEADERS})
     source_group("Header Files\\smithy\\identity\\signer" FILES ${SMITHY_IDENTITY_SIGNER_HEADERS})
     source_group("Header Files\\smithy\\identity\\signer\\built-in" FILES ${SMITHY_IDENTITY_SIGNER_BUILTIN_HEADERS})
+    source_group("Header Files\\smithy\\interceptor" FILES ${SMITHY_INTERCEPTOR_HEADERS})
 
     # http client conditional headers
     if(ENABLE_CURL_CLIENT)
@@ -770,6 +773,7 @@ install (FILES ${SMITHY_IDENTITY_IDENTITY_IMPL_HEADERS} DESTINATION ${INCLUDE_DI
 install (FILES ${SMITHY_IDENTITY_RESOLVER_IMPL_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/smithy/identity/resolver/impl)
 install (FILES ${SMITHY_IDENTITY_SIGNER_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/smithy/identity/signer)
 install (FILES ${SMITHY_IDENTITY_SIGNER_BUILTIN_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/smithy/identity/signer/built-in)
+install (FILES ${SMITHY_INTERCEPTOR_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/smithy/interceptor)
 
 # android logcat headers
 if(PLATFORM_ANDROID)

--- a/src/aws-cpp-sdk-core/include/smithy/interceptor/Interceptor.h
+++ b/src/aws-cpp-sdk-core/include/smithy/interceptor/Interceptor.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+#include <smithy/interceptor/InterceptorContext.h>
+
+namespace smithy
+{
+    namespace interceptor
+    {
+        class Interceptor
+        {
+        public:
+            virtual ~Interceptor() = default;
+
+            using ModifyRequestOutcome = Aws::Utils::Outcome<std::shared_ptr<Aws::Http::HttpRequest>, Aws::Client::AWSError<Aws::Client::CoreErrors>>;
+            virtual ModifyRequestOutcome ModifyRequest(InterceptorContext& context) = 0;
+
+            using ModifyResponseOutcome = Aws::Utils::Outcome<std::shared_ptr<Aws::Http::HttpResponse>, Aws::Client::AWSError<Aws::Client::CoreErrors>>;
+            virtual ModifyResponseOutcome ModifyResponse(InterceptorContext& context) = 0;
+        };
+    }
+}

--- a/src/aws-cpp-sdk-core/include/smithy/interceptor/InterceptorContext.h
+++ b/src/aws-cpp-sdk-core/include/smithy/interceptor/InterceptorContext.h
@@ -1,0 +1,94 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+#include <aws/core/utils/memory/stl/AWSString.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/core/http/HttpRequest.h>
+#include <aws/core/http/HttpResponse.h>
+#include <aws/core/client/AWSError.h>
+#include <aws/core/client/CoreErrors.h>
+
+namespace smithy
+{
+    namespace interceptor
+    {
+        class InterceptorContext
+        {
+        public:
+            InterceptorContext() = default;
+            virtual ~InterceptorContext() = default;
+            InterceptorContext(const InterceptorContext& other) = delete;
+            InterceptorContext(InterceptorContext&& other) noexcept = default;
+            InterceptorContext& operator=(const InterceptorContext& other) = delete;
+            InterceptorContext& operator=(InterceptorContext&& other) noexcept = default;
+
+            using GetRequestOutcome = Aws::Utils::Outcome<std::shared_ptr<Aws::Http::HttpRequest>, Aws::Client::AWSError<Aws::Client::CoreErrors>>;
+            GetRequestOutcome GetRequest() const
+            {
+                if (!m_request)
+                {
+                    return Aws::Client::AWSError<Aws::Client::CoreErrors>{
+                        Aws::Client::CoreErrors::RESOURCE_NOT_FOUND,
+                        "ResourceNotFoundException",
+                        "Request is NULL",
+                        false
+                    };
+                }
+                return m_request;
+            }
+
+            void SetRequest(const std::shared_ptr<Aws::Http::HttpRequest>& request)
+            {
+                this->m_request = request;
+            }
+
+            using GetResponseOutcome = Aws::Utils::Outcome<std::shared_ptr<Aws::Http::HttpResponse>, Aws::Client::AWSError<Aws::Client::CoreErrors>>;
+            GetResponseOutcome GetResponse() const
+            {
+                if (!m_response)
+                {
+                    return Aws::Client::AWSError<Aws::Client::CoreErrors>{
+                        Aws::Client::CoreErrors::RESOURCE_NOT_FOUND,
+                        "ResourceNotFoundException",
+                        "Response is NULL",
+                        false
+                    };
+                }
+                return m_response;
+            }
+
+            void SetResponse(const std::shared_ptr<Aws::Http::HttpResponse>& response)
+            {
+                this->m_response = response;
+            }
+
+            using GetAttributeOutcome = Aws::Utils::Outcome<Aws::String, Aws::Client::AWSError<Aws::Client::CoreErrors>>;
+            GetAttributeOutcome GetAttribute(const Aws::String& attribute)
+            {
+                const auto attribute_iter = m_attributes.find(attribute);
+                if (attribute_iter == m_attributes.end())
+                {
+                    return Aws::Client::AWSError<Aws::Client::CoreErrors>{
+                        Aws::Client::CoreErrors::RESOURCE_NOT_FOUND,
+                        "ResourceNotFoundException",
+                        "Attribute not found",
+                        false
+                    };
+                }
+                return attribute_iter->second;
+            }
+
+            void SetAttribute(const Aws::String& attribute, const Aws::String& value)
+            {
+                m_attributes.emplace(attribute, value);
+            }
+
+        private:
+            Aws::Map<Aws::String, Aws::String> m_attributes{};
+            std::shared_ptr<Aws::Http::HttpRequest> m_request{nullptr};
+            std::shared_ptr<Aws::Http::HttpResponse> m_response{nullptr};
+        };
+    }
+}

--- a/tests/aws-cpp-sdk-core-tests/CMakeLists.txt
+++ b/tests/aws-cpp-sdk-core-tests/CMakeLists.txt
@@ -27,6 +27,7 @@ file(GLOB SMITHY_TRACING_SRC "${CMAKE_CURRENT_SOURCE_DIR}/smithy/tracing/*.cpp")
 file(GLOB SMITHY_CLIENT_SRC "${CMAKE_CURRENT_SOURCE_DIR}/smithy/client/*.cpp")
 file(GLOB SMITHY_CLIENT_SERIALIZER_SRC "${CMAKE_CURRENT_SOURCE_DIR}/smithy/client/serializer/*.cpp")
 file(GLOB ENDPOINT_SRC "${CMAKE_CURRENT_SOURCE_DIR}/endpoint/*.cpp")
+file(GLOB SMITHY_INTERCEPTOR_SRC "${CMAKE_CURRENT_SOURCE_DIR}/smithy/interceptor/*.cpp")
 
 
 file(GLOB AWS_CPP_SDK_CORE_TESTS_SRC
@@ -54,6 +55,7 @@ file(GLOB AWS_CPP_SDK_CORE_TESTS_SRC
   ${SMITHY_CLIENT_SRC}
   ${SMITHY_CLIENT_SERIALIZER_SRC}
   ${ENDPOINT_SRC}
+  ${SMITHY_INTERCEPTOR_SRC}
 )
 
 if(PLATFORM_WINDOWS)
@@ -79,6 +81,7 @@ if(PLATFORM_WINDOWS)
     source_group("Source Files\\smithy\\tracing" FILES ${SMITHY_TRACING_SRC})
     source_group("Source Files\\smithy\\client" FILES ${SMITHY_CLIENT_SRC})
     source_group("Source Files\\smithy\\client" FILES ${SMITHY_CLIENT_SERIALIZER_SRC})
+    source_group("Source Files\\smithy\\client" FILES ${SMITHY_INTERCEPTOR_SRC})
   endif()
 endif()
 

--- a/tests/aws-cpp-sdk-core-tests/smithy/interceptor/InterceptorTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/smithy/interceptor/InterceptorTest.cpp
@@ -1,0 +1,177 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/testing/AwsCppSdkGTestSuite.h>
+#include <aws/core/http/standard/StandardHttpResponse.h>
+#include <smithy/interceptor/InterceptorContext.h>
+#include <smithy/interceptor/Interceptor.h>
+
+using namespace smithy::interceptor;
+using namespace Aws;
+using namespace Aws::Client;
+using namespace Aws::Http;
+using namespace Aws::Http::Standard;
+using namespace Aws::Utils;
+using namespace Aws::Utils::Stream;
+using namespace Aws::Testing;
+
+class SmithyInterceptorTest : public AwsCppSdkGTestSuite
+{
+};
+
+class  MockSuccessInterceptor : public Interceptor
+{
+public:
+    MockSuccessInterceptor() = default;
+    ~MockSuccessInterceptor() override = default;
+
+    ModifyRequestOutcome ModifyRequest(InterceptorContext& context) override
+    {
+        context.SetAttribute("MockInterceptorRequest", "Called");
+        return context.GetRequest();
+    }
+
+    ModifyResponseOutcome ModifyResponse(InterceptorContext& context) override
+    {
+        context.SetAttribute("MockInterceptorResponse", "Called");
+        return context.GetResponse();
+    }
+};
+
+class  MockRequestFailureInterceptor : public Interceptor
+{
+public:
+    MockRequestFailureInterceptor() = default;
+    ~MockRequestFailureInterceptor() override = default;
+
+    ModifyRequestOutcome ModifyRequest(InterceptorContext& context) override
+    {
+        context.SetAttribute("MockInterceptorRequest", "Called");
+        return Aws::Client::AWSError<CoreErrors>{
+            CoreErrors::VALIDATION,
+            "RequestInterceptorException",
+            "The request interceptor failed",
+            false
+        };;
+    }
+
+    ModifyResponseOutcome ModifyResponse(InterceptorContext& context) override
+    {
+        context.SetAttribute("MockInterceptorResponse", "Called");
+        return context.GetResponse();
+    }
+};
+
+class  MockResponseFailureInterceptor : public Interceptor
+{
+public:
+    MockResponseFailureInterceptor() = default;
+    ~MockResponseFailureInterceptor() override = default;
+
+    ModifyRequestOutcome ModifyRequest(InterceptorContext& context) override
+    {
+        context.SetAttribute("MockInterceptorRequest", "Called");
+        return context.GetRequest();
+    }
+
+    ModifyResponseOutcome ModifyResponse(InterceptorContext& context) override
+    {
+        context.SetAttribute("MockInterceptorResponse", "Called");
+        return Aws::Client::AWSError<CoreErrors>{
+            CoreErrors::VALIDATION,
+            "ResponseInterceptorException",
+            "The response interceptor failed",
+            false
+        };;
+    }
+};
+
+class MockClient
+{
+public:
+    MockClient() = delete;
+    MockClient(const MockClient& other) = delete;
+    MockClient(MockClient&& other) noexcept = default;
+    MockClient& operator=(const MockClient& other) = delete;
+    MockClient& operator=(MockClient&& other) noexcept = default;
+
+    static MockClient MakeClient(Aws::UniquePtr<Interceptor> interceptor)
+    {
+        Vector<UniquePtr<Interceptor>> interceptors;
+        interceptors.emplace_back(std::move(interceptor));
+        return MockClient{std::move(interceptors)};
+    }
+
+    using RequestOutcome = Outcome<std::shared_ptr<HttpResponse>, AWSError<CoreErrors>>;
+    RequestOutcome MakeRequest(const std::shared_ptr<HttpRequest>& request, InterceptorContext& context) const
+    {
+        context.SetRequest(request);
+        for (const auto& interceptor: m_interceptors)
+        {
+            const auto modifiedRequest = interceptor->ModifyRequest(context);
+            if (!modifiedRequest.IsSuccess())
+            {
+                return modifiedRequest.GetError();
+            }
+        }
+        auto response = Aws::MakeShared<StandardHttpResponse>("SmithyInterceptorTest", request);
+        context.SetResponse(response);
+        for (const auto& interceptor: m_interceptors)
+        {
+            const auto modifiedResponse = interceptor->ModifyResponse(context);
+            if (!modifiedResponse.IsSuccess())
+            {
+                return modifiedResponse.GetError();
+            }
+        }
+        return context.GetResponse();
+    }
+
+private:
+    explicit MockClient(Vector<UniquePtr<Interceptor>> interceptors)
+        : m_interceptors(std::move(interceptors))
+    {
+    }
+
+    Vector<UniquePtr<Interceptor>> m_interceptors{};
+};
+
+TEST_F(SmithyInterceptorTest, MockInterceptorShouldReturnSuccess)
+{
+    const auto uri = "https://www.villagepsychic.net/";
+    auto request = CreateHttpRequest(URI{uri}, HttpMethod::HTTP_GET, DefaultResponseStreamFactoryMethod);
+    auto interceptor = Aws::MakeUnique<MockSuccessInterceptor>("SmithyInterceptorTest");
+    const auto client = MockClient::MakeClient(std::move(interceptor));
+    InterceptorContext context{};
+    const auto response = client.MakeRequest(request, context);
+    EXPECT_TRUE(response.IsSuccess());
+    EXPECT_TRUE(context.GetAttribute("MockInterceptorRequest").IsSuccess());
+    EXPECT_TRUE(context.GetAttribute("MockInterceptorResponse").IsSuccess());
+}
+
+TEST_F(SmithyInterceptorTest, MockInterceptorShouldReturnFailureRequset)
+{
+    const auto uri = "https://www.villagepsychic.net/";
+    auto request = CreateHttpRequest(URI{uri}, HttpMethod::HTTP_GET, DefaultResponseStreamFactoryMethod);
+    auto interceptor = Aws::MakeUnique<MockRequestFailureInterceptor>("SmithyInterceptorTest");
+    const auto client = MockClient::MakeClient(std::move(interceptor));
+    InterceptorContext context{};
+    const auto response = client.MakeRequest(request, context);
+    EXPECT_FALSE(response.IsSuccess());
+    EXPECT_TRUE(context.GetAttribute("MockInterceptorRequest").IsSuccess());
+    EXPECT_FALSE(context.GetAttribute("MockInterceptorResponse").IsSuccess());
+}
+
+TEST_F(SmithyInterceptorTest, MockInterceptorShouldReturnFailureReseponse)
+{
+    const auto uri = "https://www.villagepsychic.net/";
+    auto request = CreateHttpRequest(URI{uri}, HttpMethod::HTTP_GET, DefaultResponseStreamFactoryMethod);
+    auto interceptor = Aws::MakeUnique<MockResponseFailureInterceptor>("SmithyInterceptorTest");
+    const auto client = MockClient::MakeClient(std::move(interceptor));
+    InterceptorContext context{};
+    const auto response = client.MakeRequest(request, context);
+    EXPECT_FALSE(response.IsSuccess());
+    EXPECT_TRUE(context.GetAttribute("MockInterceptorRequest").IsSuccess());
+    EXPECT_TRUE(context.GetAttribute("MockInterceptorResponse").IsSuccess());
+}


### PR DESCRIPTION
*Description of changes:*

Creates a paritial implementation of smithy interfaces for use in the SDK. The [Rust SDK uses interceptors](https://github.com/smithy-lang/smithy-rs/blob/3871e9aed7ed6fbecdc45a76c7a5b75f17a941b5/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs#L68) to compose discrete parts of their SDK. For example they apply checksums as part of [one of their interceptors](https://github.com/smithy-lang/smithy-rs/blob/3871e9aed7ed6fbecdc45a76c7a5b75f17a941b5/rust-runtime/inlineable/src/http_checksum_required.rs#L28) and we plan on moving our logic to one as well.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
