### PR TITLE
TransferManager: Use same checksum algorithm for Single and MultiPart upload

### DIFF
--- a/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -550,7 +550,6 @@ namespace Aws
             putObjectRequest.SetChecksumAlgorithm(m_transferConfig.computeContentMD5
                                                   ? S3::Model::ChecksumAlgorithm::NOT_SET
                                                   : m_transferConfig.checksumAlgorithm);
-            putObjectRequest.SetChecksumAlgorithm(m_transferConfig.checksumAlgorithm);
             putObjectRequest.SetBucket(handle->GetBucketName());
             putObjectRequest.SetKey(handle->GetKey());
             putObjectRequest.SetContentLength(static_cast<long long>(handle->GetBytesTotalSize()));


### PR DESCRIPTION
TransferManager uses MD5 as checksum if it has to be computed for ContentMD5 anyway.

Remove an erroneous call in DoSinglePartUpload that overrides that intention.

*Issue #, if available:*

*Description of changes:*

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
The behavior is now the same as in DoMultiPartUpload and the removed line is obviously an error
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
