### PR TITLE
fixes S3 200 issue with correct error returned

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtErrorMarshaller.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtErrorMarshaller.cpp
@@ -127,6 +127,7 @@ AWSError<Aws::Client::CoreErrors> S3CrtErrorMarshaller::Marshall(const Aws::Http
   XmlDocument doc = XmlDocument::CreateFromXmlStream(body);
   body.seekg(readPointer);
   Aws::String bodyError;
+  Aws::String requestId;
 
   if (doc.WasParseSuccessful() &&
       !doc.GetRootElement().IsNull() && 
@@ -134,20 +135,27 @@ AWSError<Aws::Client::CoreErrors> S3CrtErrorMarshaller::Marshall(const Aws::Http
   {        
       //check if the first node fetched has no children
       auto messageNode = doc.GetRootElement().FirstChild("Message") ;
-      if(!messageNode.IsNull() && !messageNode.HasChildren())
+      if(!messageNode.IsNull())
       {
           message = messageNode.GetText();
       }
       auto codeNode = doc.GetRootElement().FirstChild("Code") ;
-      if(!codeNode.IsNull() && !codeNode.HasChildren())
+      if(!codeNode.IsNull())
       {
           bodyError = codeNode.GetText();
+      }
+
+      auto requestIdNode = doc.GetRootElement().FirstChild("RequestId") ;
+      if(!requestIdNode.IsNull())
+      {
+        requestId = requestIdNode.GetText();
       }
   }
 
   auto error = FindErrorByName(bodyError.c_str());
 
   error.SetMessage(message);
+  error.SetRequestId(requestId);
 
   return error;
 

--- a/generated/src/aws-cpp-sdk-s3/source/S3ErrorMarshaller.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3ErrorMarshaller.cpp
@@ -127,6 +127,7 @@ AWSError<Aws::Client::CoreErrors> S3ErrorMarshaller::Marshall(const Aws::Http::H
   XmlDocument doc = XmlDocument::CreateFromXmlStream(body);
   body.seekg(readPointer);
   Aws::String bodyError;
+  Aws::String requestId;
 
   if (doc.WasParseSuccessful() &&
       !doc.GetRootElement().IsNull() && 
@@ -134,20 +135,27 @@ AWSError<Aws::Client::CoreErrors> S3ErrorMarshaller::Marshall(const Aws::Http::H
   {        
       //check if the first node fetched has no children
       auto messageNode = doc.GetRootElement().FirstChild("Message") ;
-      if(!messageNode.IsNull() && !messageNode.HasChildren())
+      if(!messageNode.IsNull())
       {
           message = messageNode.GetText();
       }
       auto codeNode = doc.GetRootElement().FirstChild("Code") ;
-      if(!codeNode.IsNull() && !codeNode.HasChildren())
+      if(!codeNode.IsNull())
       {
           bodyError = codeNode.GetText();
+      }
+
+      auto requestIdNode = doc.GetRootElement().FirstChild("RequestId") ;
+      if(!requestIdNode.IsNull())
+      {
+        requestId = requestIdNode.GetText();
       }
   }
 
   auto error = FindErrorByName(bodyError.c_str());
 
   error.SetMessage(message);
+  error.SetRequestId(requestId);
 
   return error;
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ErrorMarshallerSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ErrorMarshallerSource.vm
@@ -127,6 +127,7 @@ AWSError<Aws::Client::CoreErrors> ${metadata.classNamePrefix}ErrorMarshaller::Ma
   XmlDocument doc = XmlDocument::CreateFromXmlStream(body);
   body.seekg(readPointer);
   Aws::String bodyError;
+  Aws::String requestId;
 
   if (doc.WasParseSuccessful() &&
       !doc.GetRootElement().IsNull() && 
@@ -134,20 +135,27 @@ AWSError<Aws::Client::CoreErrors> ${metadata.classNamePrefix}ErrorMarshaller::Ma
   {        
       //check if the first node fetched has no children
       auto messageNode = doc.GetRootElement().FirstChild("Message") ;
-      if(!messageNode.IsNull() && !messageNode.HasChildren())
+      if(!messageNode.IsNull())
       {
           message = messageNode.GetText();
       }
       auto codeNode = doc.GetRootElement().FirstChild("Code") ;
-      if(!codeNode.IsNull() && !codeNode.HasChildren())
+      if(!codeNode.IsNull())
       {
           bodyError = codeNode.GetText();
+      }
+
+      auto requestIdNode = doc.GetRootElement().FirstChild("RequestId") ;
+      if(!requestIdNode.IsNull())
+      {
+        requestId = requestIdNode.GetText();
       }
   }
 
   auto error = FindErrorByName(bodyError.c_str());
 
   error.SetMessage(message);
+  error.SetRequestId(requestId);
 
   return error;
 


### PR DESCRIPTION
*Description of changes:*

There is a rather peculiar behaviour in S3 where S3 can return a [200 OK with a error in the body](https://repost.aws/knowledge-center/s3-resolve-200-internalerror). We made a change to address this operation on [many APIs in july](https://github.com/aws/aws-sdk-cpp/pull/3024/files#diff-afd33f1c79a2c69ace5b2cfb4fdf9047dfdf8a2b854dec9bd8099a546bc1a769). There was a issue where while a error would be returned it wouldn't be actually translated to a error type instead being unknown

```
Aws::Client::AWSError<Aws::S3::S3Errors> = {Aws::Client::AWSError<Aws::S3::S3Errors>} 
 m_errorType = {Aws::S3::S3Errors} UNKNOWN
 m_exceptionName = {Aws::String} ""
 m_message = {Aws::String} "Error in body of the response"
 m_remoteHostIpAddress = {Aws::String} ""
 m_requestId = {Aws::String} ""
 m_responseHeaders = {Aws::Http::HeaderValueCollection} size=0
 m_responseCode = {Aws::Http::HttpResponseCode} REQUEST_NOT_MADE
 m_errorPayloadType = {Aws::Client::ErrorPayloadType} NOT_SET
 m_xmlPayload = {Aws::Utils::Xml::XmlDocument} 
 m_jsonPayload = {Aws::Utils::Json::JsonValue} 
 m_retryableType = {Aws::Client::RetryableType} NOT_RETRYABLE
```

this change correct a error where `!codeNode.HasChildren()` was used in the logic to create the error when it was not needed. This correctly produces the error object, and more importantly marks it as retryable

```
Aws::Client::AWSError<Aws::S3::S3Errors> = {Aws::Client::AWSError<Aws::S3::S3Errors>} 
 m_errorType = {Aws::S3::S3Errors} INTERNAL_FAILURE
 m_exceptionName = {Aws::String} ""
 m_message = {Aws::String} "We encountered an internal error. Please try again."
 m_remoteHostIpAddress = {Aws::String} ""
 m_requestId = {Aws::String} ""
 m_responseHeaders = {Aws::Http::HeaderValueCollection} size=0
 m_responseCode = {Aws::Http::HttpResponseCode} REQUEST_NOT_MADE
 m_errorPayloadType = {Aws::Client::ErrorPayloadType} NOT_SET
 m_xmlPayload = {Aws::Utils::Xml::XmlDocument} 
 m_jsonPayload = {Aws::Utils::Json::JsonValue} 
 m_retryableType = {Aws::Client::RetryableType} RETRYABLE
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
