### PR TITLE
Fix old GCC error

### DIFF
--- a/src/aws-cpp-sdk-core/include/smithy/identity/auth/AuthSchemeOption.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/auth/AuthSchemeOption.h
@@ -23,8 +23,8 @@ namespace smithy {
 
         const char* schemeId = nullptr;
 
-        PropertyBag virtual identityProperties() const { return {}; };
-        PropertyBag virtual signerProperties() const { return {}; };
-        EndpointParameters virtual endpointParameters() const { return {}; };
+        PropertyBag virtual identityProperties() const { return PropertyBag{}; };
+        PropertyBag virtual signerProperties() const { return PropertyBag{}; };
+        EndpointParameters virtual endpointParameters() const { return EndpointParameters{}; };
     };
 }


### PR DESCRIPTION
*Description of changes:*

Fixes a compilation error on older GCC (specifically AL2012)

```
In file included from aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientBase.h:7:0,
                 from aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClient.h:7,
                 from aws-sdk-cpp/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp:6:
aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/identity/auth/AuthSchemeOption.h: In member function 'virtual smithy::AuthSchemeOption::PropertyBag smithy::AuthSchemeOption::identityProperties() const':
aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/identity/auth/AuthSchemeOption.h:26:66: error: converting to 'smithy::AuthSchemeOption::PropertyBag {aka std::unordered_map<std::basic_string<char>, Aws::Crt::Variant<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool>, std::hash<std::basic_string<char> >, std::equal_to<std::basic_string<char> >, std::allocator<std::pair<const std::basic_string<char>, Aws::Crt::Variant<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool> > > >}' from initializer list would use explicit constructor 'std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_map(std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::size_type, const hasher&, const key_equal&, const allocator_type&) [with _Key = std::basic_string<char>; _Tp = Aws::Crt::Variant<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool>; _Hash = std::hash<std::basic_string<char> >; _Pred = std::equal_to<std::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::basic_string<char>, Aws::Crt::Variant<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool> > >; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::size_type = long unsigned int; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::hasher = std::hash<std::basic_string<char> >; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::key_equal = std::equal_to<std::basic_string<char> >; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::allocator_type = std::allocator<std::pair<const std::basic_string<char>, Aws::Crt::Variant<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool> > >]'
         PropertyBag virtual identityProperties() const { return {}; };
                                                                  ^
aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/identity/auth/AuthSchemeOption.h: In member function 'virtual smithy::AuthSchemeOption::PropertyBag smithy::AuthSchemeOption::signerProperties() const':
aws-sdk-cpp/src/aws-cpp-sdk-core/include/smithy/identity/auth/AuthSchemeOption.h:27:64: error: converting to 'smithy::AuthSchemeOption::PropertyBag {aka std::unordered_map<std::basic_string<char>, Aws::Crt::Variant<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool>, std::hash<std::basic_string<char> >, std::equal_to<std::basic_string<char> >, std::allocator<std::pair<const std::basic_string<char>, Aws::Crt::Variant<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool> > > >}' from initializer list would use explicit constructor 'std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_map(std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::size_type, const hasher&, const key_equal&, const allocator_type&) [with _Key = std::basic_string<char>; _Tp = Aws::Crt::Variant<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool>; _Hash = std::hash<std::basic_string<char> >; _Pred = std::equal_to<std::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::basic_string<char>, Aws::Crt::Variant<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool> > >; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::size_type = long unsigned int; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::hasher = std::hash<std::basic_string<char> >; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::key_equal = std::equal_to<std::basic_string<char> >; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::allocator_type = std::allocator<std::pair<const std::basic_string<char>, Aws::Crt::Variant<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool> > >]'
         PropertyBag virtual signerProperties() const { return {}; };
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
