### PR TITLE
Don't continue polling input stream in case it is closed

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -306,6 +306,11 @@ static size_t ReadBody(char* ptr, size_t size, size_t nmemb, void* userdata, boo
         size_t amountRead = 0;
         if (isStreaming)
         {
+            if (ioStream->bad())
+            {
+                AWS_LOGSTREAM_ERROR(CURL_HTTP_CLIENT_TAG, "Input stream has a bad bit set, can't continue");;
+                return CURL_READFUNC_ABORT;
+            }
             if (!ioStream->eof() && ioStream->peek() != EOF)
             {
                 amountRead = (size_t) ioStream->readsome(ptr, amountToRead);
@@ -433,7 +438,6 @@ int CurlHttpClient::CurlProgressCallback(void *userdata, double, double, double,
     const std::shared_ptr<Aws::IOStream>& ioStream = context->m_request->GetContentBody();
     if (ioStream->eof())
     {
-        curl_easy_pause(context->m_curlHandle, CURLPAUSE_CONT);
         return 0;
     }
 
@@ -453,7 +457,7 @@ int CurlHttpClient::CurlProgressCallback(void *userdata, double, double, double,
     else
     {
         char output[1];
-        if (ioStream->readsome(output, 1) > 0)
+        if (!ioStream->bad() && ioStream->readsome(output, 1) > 0)
         {
             ioStream->unget();
             if (!ioStream->good())


### PR DESCRIPTION
*Issue #, if available:*
n/a
*Description of changes:*
add checks for bad(), don't CURLPAUSE_CONT at the end of streaming.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
