### PR TITLE
Fix GetServiceClientName for smithy based client

### DIFF
--- a/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBClient.h
+++ b/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBClient.h
@@ -48,6 +48,7 @@ namespace DynamoDB
     public:
       static const char* GetServiceName();
       static const char* GetAllocationTag();
+      inline const char* GetServiceClientName() const override { return "DynamoDB"; }
 
       typedef DynamoDBClientConfiguration ClientConfigurationType;
       typedef DynamoDBEndpointProvider EndpointProviderType;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyClientHeader.vm
@@ -48,6 +48,7 @@ namespace ${serviceNamespace}
     public:
       static const char* GetServiceName();
       static const char* GetAllocationTag();
+      inline const char* GetServiceClientName() const override { return "${metadata.serviceId}"; }
 
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConfigTypeDeclarations.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderConstructors.vm")


### PR DESCRIPTION
*Description of changes:*

Customers saw a issue when using a recent version of the DynamoDB client where `GetServiceClientName` started returning a lowercase string value instead of a camel case value, messing up their metrics. This updates the dynamo client to override `GetServiceClientName`. we should consider marking `GetServiceClientName` as pure virtual in the base class in the future.

```cpp
#include <aws/core/Aws.h>
#include <aws/dynamodb/DynamoDBClient.h>

using namespace Aws;
using namespace Aws::DynamoDB;

auto main() -> int {
  SDKOptions options;
  InitAPI(options);
  {
    DynamoDBClient client{};
    std::cout << client.GetServiceClientName() << "\n";
  }
  ShutdownAPI(options);
  return 0;
}
```
before it would print out "dynamodb"
now it correctly goes back to printing "DynamoDB"


*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
