### PR TITLE
change order of parameters in header to match .cpp

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/auth/GeneralHTTPCredentialsProvider.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/GeneralHTTPCredentialsProvider.h
@@ -29,15 +29,15 @@ namespace Aws
              * expires.
              * @param relativeUri A path appended to the metadata service endpoint. OR
              * @param absoluteUri The full URI to resolve to get credentials.
-             * @param authTokenFilePath A path to a file with optional authorization token passed to the URI via the 'Authorization' HTTP header.
              * @param authToken An optional authorization token passed to the URI via the 'Authorization' HTTP header.
+             * @param authTokenFilePath A path to a file with optional authorization token passed to the URI via the 'Authorization' HTTP header.
              * @param refreshRateMs The number of milliseconds after which the credentials will be fetched again.
              * @param ShouldCreateFunc
              */
             GeneralHTTPCredentialsProvider(const Aws::String& relativeUri,
                                            const Aws::String& absoluteUri,
-                                           const Aws::String& authTokenFilePath = "",
                                            const Aws::String& authToken = "",
+                                           const Aws::String& authTokenFilePath = "",
                                            long refreshRateMs = REFRESH_THRESHOLD,
                                            ShouldCreateFunc shouldCreateFunc = ShouldCreateGeneralHTTPProvider);
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/issues/3143

*Description of changes:*
fix parameter order for GeneralHTTPCredentialsProvider

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
