### PR TITLE
make smoke tests Java 8 compatible

### DIFF
--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/CppBlockWriter.java
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/CppBlockWriter.java
@@ -90,7 +90,7 @@ public class CppBlockWriter {
 
         public void addCode(String code, int indentLevel)
         {
-            String linePrefix = " ".repeat(indentLevel);
+            String linePrefix = new String(new char[indentLevel]).replace('\0', ' ');
             //split by line and add indent. make sure to skip escaped newlines
             String[] splitCode = code.split("(?<!\\\\)\\n");
             for (String line : splitCode) {

--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/CppImportContainer.java
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/CppImportContainer.java
@@ -7,12 +7,14 @@
 
  import software.amazon.smithy.codegen.core.ImportContainer;
  import software.amazon.smithy.codegen.core.Symbol;
+
  import java.util.Collections;
  import java.util.HashSet;
  import java.util.Set;
  import java.util.Map;
+ import java.util.HashMap;
 
- public final class CppImportContainer implements ImportContainer {
+public final class CppImportContainer implements ImportContainer {
 
      private final String c2jNamespace;
      private final Set<String> coreHeaders;
@@ -41,21 +43,19 @@
             "algorithm"
             );
 
-        this.unitTestHeaders = Set.of(
-            "aws/testing/AwsCppSdkGTestSuite.h",
-            "aws/testing/AwsTestHelpers.h"
-            );
+        this.unitTestHeaders = new HashSet<>();
+         this.unitTestHeaders.add("aws/testing/AwsCppSdkGTestSuite.h");
+         this.unitTestHeaders.add("aws/testing/AwsTestHelpers.h");
 
-        //this will be added to based upon datastructures found
-        containerHeaderMap = Map.ofEntries(
-            Map.entry("Aws::String", "aws/core/utils/memory/stl/AWSString.h"),
-            Map.entry("Aws::Map", "aws/core/utils/memory/stl/AWSMap.h"),
-            Map.entry("Aws::Utils::DateTime", "aws/core/utils/DateTime.h"),
-            Map.entry("Aws::Utils::Document","aws/core/utils/Document.h"),
-            Map.entry("Aws::Utils::ByteBuffer","aws/core/utils/Array.h")
-        );
-        
-        dynamicHeaders.add(String.format("aws/%s/%sClient.h", c2jNamespace, clientNamespace));
+         //this will be added to based upon datastructures found
+        containerHeaderMap = new HashMap<>();
+         containerHeaderMap.put("Aws::String", "aws/core/utils/memory/stl/AWSString.h");
+         containerHeaderMap.put("Aws::Map", "aws/core/utils/memory/stl/AWSMap.h");
+         containerHeaderMap.put("Aws::Utils::DateTime", "aws/core/utils/DateTime.h");
+         containerHeaderMap.put("Aws::Utils::Document", "aws/core/utils/Document.h");
+         containerHeaderMap.put("Aws::Utils::ByteBuffer", "aws/core/utils/Array.h");
+
+         dynamicHeaders.add(String.format("aws/%s/%sClient.h", c2jNamespace, clientNamespace));
         
     }
 

--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/CppImportContainer.java
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/CppImportContainer.java
@@ -5,6 +5,8 @@
 
  package com.amazonaws.util.awsclientsmithygenerator.generators;
 
+ import com.google.common.collect.ImmutableMap;
+ import com.google.common.collect.ImmutableSet;
  import software.amazon.smithy.codegen.core.ImportContainer;
  import software.amazon.smithy.codegen.core.Symbol;
 
@@ -12,7 +14,6 @@
  import java.util.HashSet;
  import java.util.Set;
  import java.util.Map;
- import java.util.HashMap;
 
 public final class CppImportContainer implements ImportContainer {
 
@@ -43,17 +44,15 @@ public final class CppImportContainer implements ImportContainer {
             "algorithm"
             );
 
-        this.unitTestHeaders = new HashSet<>();
-         this.unitTestHeaders.add("aws/testing/AwsCppSdkGTestSuite.h");
-         this.unitTestHeaders.add("aws/testing/AwsTestHelpers.h");
+        this.unitTestHeaders = ImmutableSet.of("aws/testing/AwsCppSdkGTestSuite.h", "aws/testing/AwsTestHelpers.h");
 
          //this will be added to based upon datastructures found
-        containerHeaderMap = new HashMap<>();
-         containerHeaderMap.put("Aws::String", "aws/core/utils/memory/stl/AWSString.h");
-         containerHeaderMap.put("Aws::Map", "aws/core/utils/memory/stl/AWSMap.h");
-         containerHeaderMap.put("Aws::Utils::DateTime", "aws/core/utils/DateTime.h");
-         containerHeaderMap.put("Aws::Utils::Document", "aws/core/utils/Document.h");
-         containerHeaderMap.put("Aws::Utils::ByteBuffer", "aws/core/utils/Array.h");
+        containerHeaderMap = ImmutableMap.of(
+                "Aws::String", "aws/core/utils/memory/stl/AWSString.h",
+                "Aws::Map", "aws/core/utils/memory/stl/AWSMap.h",
+                "Aws::Utils::DateTime", "aws/core/utils/DateTime.h",
+                "Aws::Utils::Document", "aws/core/utils/Document.h",
+                "Aws::Utils::ByteBuffer", "aws/core/utils/Array.h");
 
          dynamicHeaders.add(String.format("aws/%s/%sClient.h", c2jNamespace, clientNamespace));
         

--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/CppSymbolVisitor.java
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/CppSymbolVisitor.java
@@ -5,6 +5,7 @@
 
  package com.amazonaws.util.awsclientsmithygenerator.generators;
 
+ import lombok.val;
  import software.amazon.smithy.codegen.core.Symbol;
  import software.amazon.smithy.codegen.core.SymbolProvider;
  import software.amazon.smithy.codegen.core.CodegenException;
@@ -84,8 +85,8 @@
  
      @Override
      public Symbol listShape(ListShape listShape) {
-         var targetShape = model.expectShape(listShape.getMember().getTarget());
-         var targetSymbol = targetShape.accept(this);
+         val targetShape = model.expectShape(listShape.getMember().getTarget());
+         val targetSymbol = targetShape.accept(this);
          return createSymbolBuilder(listShape, "Aws::Vector<" + targetSymbol + ">")
                  .addReference(targetSymbol)
                  .build();
@@ -96,10 +97,10 @@
       */
      @Override
      public Symbol mapShape(MapShape mapShape) {
-         var keyShape = model.expectShape(mapShape.getKey().getTarget());
-         var keyType = keyShape.accept(this);
-         var valueShape = model.expectShape(mapShape.getValue().getTarget());
-         var valueType = valueShape.accept(this);
+         val keyShape = model.expectShape(mapShape.getKey().getTarget());
+         val keyType = keyShape.accept(this);
+         val valueShape = model.expectShape(mapShape.getValue().getTarget());
+         val valueType = valueShape.accept(this);
          return createSymbolBuilder(mapShape, "Aws::Map<"+keyType +"," + valueType + ">")
                  .addReference(valueType)
                  .build();

--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/CppSymbolVisitor.java
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/CppSymbolVisitor.java
@@ -5,7 +5,6 @@
 
  package com.amazonaws.util.awsclientsmithygenerator.generators;
 
- import lombok.val;
  import software.amazon.smithy.codegen.core.Symbol;
  import software.amazon.smithy.codegen.core.SymbolProvider;
  import software.amazon.smithy.codegen.core.CodegenException;
@@ -85,8 +84,8 @@
  
      @Override
      public Symbol listShape(ListShape listShape) {
-         val targetShape = model.expectShape(listShape.getMember().getTarget());
-         val targetSymbol = targetShape.accept(this);
+         Shape targetShape = model.expectShape(listShape.getMember().getTarget());
+         Symbol targetSymbol = targetShape.accept(this);
          return createSymbolBuilder(listShape, "Aws::Vector<" + targetSymbol + ">")
                  .addReference(targetSymbol)
                  .build();
@@ -97,10 +96,10 @@
       */
      @Override
      public Symbol mapShape(MapShape mapShape) {
-         val keyShape = model.expectShape(mapShape.getKey().getTarget());
-         val keyType = keyShape.accept(this);
-         val valueShape = model.expectShape(mapShape.getValue().getTarget());
-         val valueType = valueShape.accept(this);
+         Shape keyShape = model.expectShape(mapShape.getKey().getTarget());
+         Symbol keyType = keyShape.accept(this);
+         Shape valueShape = model.expectShape(mapShape.getValue().getTarget());
+         Symbol valueType = valueShape.accept(this);
          return createSymbolBuilder(mapShape, "Aws::Map<"+keyType +"," + valueType + ">")
                  .addReference(valueType)
                  .build();

--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmithyC2JNamespaceMap.java
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmithyC2JNamespaceMap.java
@@ -6,7 +6,7 @@ package com.amazonaws.util.awsclientsmithygenerator.generators;
 
 import java.lang.reflect.Type;
 import java.util.Map;
-
+import java.util.HashMap;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
@@ -17,9 +17,16 @@ public class SmithyC2JNamespaceMap {
 
     private SmithyC2JNamespaceMap(String jsonString){
 
-        Type mapType = new TypeToken<Map<String, String>>(){}.getType();
-        Gson gson = new Gson();
-        this.SMITHY_C2J_SERVICE_NAME_MAP = gson.fromJson(jsonString, mapType);
+        if(jsonString.isEmpty())
+        {
+            this.SMITHY_C2J_SERVICE_NAME_MAP = new HashMap<>();
+        }
+        else {
+            Type mapType = new TypeToken<Map<String, String>>() {
+            }.getType();
+            Gson gson = new Gson();
+            this.SMITHY_C2J_SERVICE_NAME_MAP = gson.fromJson(jsonString, mapType);
+        }
     }
 
     //This method must be called once to construct an internal mapping of smithy to c2j namespace

--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmokeTestsCMakeWriter.java
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmokeTestsCMakeWriter.java
@@ -19,58 +19,55 @@ public final class SmokeTestsCMakeWriter extends SymbolWriter<SmokeTestsCMakeWri
         String projectNameCaps = folderNamespace.toUpperCase();
         String awsTestSrc = "AWS_" + projectNameCaps + "_GENERATED_SMOKE_TEST_SRC" ;
 
-        write(""" 
-            add_project($L-smoke-tests
-            \"Tests for the AWS $L C++ SDK\" 
-             testing-resources
-             aws-cpp-sdk-$L
-             aws-cpp-sdk-core
-            )
-            """,folderNamespace, projectNameCaps,folderNamespace
+        write(
+        "add_project(" +
+                folderNamespace + "-smoke-tests\n" +
+                "\"Tests for the AWS " + projectNameCaps + " C++ SDK\"\n" +
+                "testing-resources\n" +
+                "aws-cpp-sdk-" + folderNamespace + "\n" +
+                "aws-cpp-sdk-core\n" +
+                ")"
         );
 
-        write(""" 
-            file(GLOB AWS_$L_GENERATED_SMOKE_TEST_SRC
-                \"$${CMAKE_CURRENT_SOURCE_DIR}/../RunTests.cpp\"
-                \"$${CMAKE_CURRENT_SOURCE_DIR}/*.cpp\"
-            )
-            if(MSVC AND BUILD_SHARED_LIBS)
-                add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
-            endif()
-
-            if (CMAKE_CROSSCOMPILING)
-                set(AUTORUN_UNIT_TESTS OFF)
-            endif()
-
-            if (AUTORUN_UNIT_TESTS)
-                enable_testing()
-            endif()
-            """,projectNameCaps
+        write(
+        "file(GLOB AWS_$L_GENERATED_SMOKE_TEST_SRC\n" +
+                "\"$${CMAKE_CURRENT_SOURCE_DIR}/../RunTests.cpp\"\n" +
+                "\"$${CMAKE_CURRENT_SOURCE_DIR}/*.cpp\"\n" +
+                ")\n" +
+                "if(MSVC AND BUILD_SHARED_LIBS)\n" +
+                "    add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)\n" +
+                "endif()\n" +
+                "\n" +
+                "if (CMAKE_CROSSCOMPILING)\n" +
+                "    set(AUTORUN_UNIT_TESTS OFF)\n" +
+                "endif()\n" +
+                "\n" +
+                "if (AUTORUN_UNIT_TESTS)\n" +
+                "    enable_testing()\n" +
+                "endif()\n",
+                projectNameCaps
         );
 
+        write(
+        "if(PLATFORM_ANDROID AND BUILD_SHARED_LIBS)\n" +
+                "    add_library($${PROJECT_NAME} \"$${$L}\")\n" +
+                "else()\n" +
+                "    add_executable($${PROJECT_NAME} \"$${$L}\")\n" +
+                "endif()\n\n" +
+                "set_compiler_flags($${PROJECT_NAME})\n" +
+                "set_compiler_warnings($${PROJECT_NAME})\n\n" +
+                "target_include_directories($${PROJECT_NAME} PUBLIC\n" +
+                "    $${CMAKE_CURRENT_SOURCE_DIR}/../../src/aws-cpp-sdk-$L/include)\n\n" +
+                "target_link_libraries($${PROJECT_NAME}\n" +
+                "    $${PROJECT_LIBS})\n",
+                awsTestSrc, awsTestSrc, folderNamespace
+        );
 
-        write(""" 
-            if(PLATFORM_ANDROID AND BUILD_SHARED_LIBS)
-                add_library($${PROJECT_NAME} "$${$L}")
-            else()
-                add_executable($${PROJECT_NAME} "$${$L}")
-            endif()
-
-            set_compiler_flags($${PROJECT_NAME})
-            set_compiler_warnings($${PROJECT_NAME})
-
-            target_include_directories($${PROJECT_NAME} PUBLIC
-                $${CMAKE_CURRENT_SOURCE_DIR}/../../src/aws-cpp-sdk-$L/include)
-
-            target_link_libraries($${PROJECT_NAME}
-                $${PROJECT_LIBS})
-            """, awsTestSrc, awsTestSrc,folderNamespace);
-
-        write(""" 
-            if(NOT CMAKE_CROSSCOMPILING)
-                SET_TARGET_PROPERTIES($${PROJECT_NAME} PROPERTIES OUTPUT_NAME $${PROJECT_NAME})
-            endif()
-            """);
+        write(
+        "if(NOT CMAKE_CROSSCOMPILING)\n" +
+                "    SET_TARGET_PROPERTIES($${PROJECT_NAME} PROPERTIES OUTPUT_NAME $${PROJECT_NAME})\n" +
+                "endif()\n"
+        );
         return toString();
     }
 

--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmokeTestsParser.java
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmokeTestsParser.java
@@ -114,7 +114,7 @@ public class SmokeTestsParser implements Runnable{
 
     private String getServiceName(ServiceShape serviceShape)
     {   
-        if(serviceShape.getTrait(ServiceTrait.class).isEmpty())
+        if(!serviceShape.getTrait(ServiceTrait.class).isPresent())
         {
             throw new RuntimeException(String.format("No service trait detected in service shape with name=%s",serviceShape.getId().getName()));
         }

--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmokeTestsSourceWriter.java
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmokeTestsSourceWriter.java
@@ -46,8 +46,9 @@ public final class SmokeTestsSourceWriter extends SymbolWriter<SmokeTestsSourceW
         //declare test fixture
         write("TEST_F($LSmokeTestSuite, $L )",clientNamespace, test.getTestcaseName()).write("{").indent().
         write("Aws::$L::$LClientConfiguration clientConfiguration;", clientNamespace,clientNamespace);
-        if(test.getConfig().getParams() instanceof AwsVendorParams configParams)
+        if(test.getConfig().getParams() instanceof AwsVendorParams)
         {
+            AwsVendorParams configParams = (AwsVendorParams) test.getConfig().getParams();
             if(!configParams.getRegion().isEmpty())
             {
                 write("clientConfiguration.region = \"$L\";",configParams.getRegion());

--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests/build.gradle.kts
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests/build.gradle.kts
@@ -69,8 +69,8 @@ tasks.register("generate-smithy-build") {
             val services = model.shapes(ServiceShape::class.java).sorted().toList();
 
             if (services.size != 1) {
-                println("Unexpected number of service shapes detected: ${services.size} while processing file: ${file.name}. ")
-                return@eachFile
+                throw Exception("There must be exactly one service in each aws model file, but found " +
+                        "${services.size} in ${file.name}");
             }
 
             val service = services[0]

--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests/build.gradle.kts
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests/build.gradle.kts
@@ -2,7 +2,11 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.aws.traits.ServiceTrait
-import software.amazon.smithy.model.shapes.OperationShape
+import org.gradle.api.logging.Logging
+import kotlin.streams.toList
+
+val logger = Logging.getLogger("MyLogger")
+
 plugins {
     id("java-library")
     id("software.amazon.smithy.gradle.smithy-base").version("1.0.0")
@@ -30,8 +34,6 @@ dependencies {
     implementation(codegen.waiters)
     implementation(codegen.aws.smoke.test.model)
     implementation(codegen.aws.endpoints)
-
-
 }
 
 tasks.jar {
@@ -56,44 +58,49 @@ tasks.register("generate-smithy-build") {
         val c2jMapStr: String = project.findProperty("c2jMap")?.toString() ?: ""
 
         fileTree(models).filter { it.isFile }.files.forEach eachFile@{ file ->
+
             val model = Model.assembler()
                     .addImport(file.absolutePath)
                     // Grab the result directly rather than worrying about checking for errors via unwrap.
                     // All we care about here is the service shape, any unchecked errors will be exposed
                     // as part of the actual build task done by the smithy gradle plugin.
                     .assemble().result.get();
-            val services = model.shapes(ServiceShape::class.javaObjectType).sorted().toList();
+
+            val services = model.shapes(ServiceShape::class.java).sorted().toList();
+
             if (services.size != 1) {
-                throw Exception("There must be exactly one service in each aws model file, but found " +
-                        "${services.size} in ${file.name}: ${services.map { it.id }}");
-            }
-            val service = services[0]
- 
-            val serviceTrait = service.getTrait(ServiceTrait::class.javaObjectType).get();
- 
-            val sdkId = serviceTrait.sdkId
-                        .replace(" ", "-")   
-                        .replace("_", "-")   
-                        .lowercase()
-                    
-            //service names must be match
-            if (filteredServiceList.isNotEmpty()) 
-            {
-                if(sdkId.toString() !in filteredServiceList)
-                {
-                    return@eachFile
-                }
+                println("Unexpected number of service shapes detected: ${services.size} while processing file: ${file.name}. ")
+                return@eachFile
             }
 
+            val service = services[0]
+            val serviceTrait = service.getTrait(ServiceTrait::class.java).get()
+
+            // Clean up sdkId
+            val sdkId = serviceTrait.sdkId
+                .replace(" ", "-")
+                .replace("_", "-")
+                .lowercase()
+
+            // Filter by service id if necessary
+            if (filteredServiceList.isNotEmpty() && sdkId !in filteredServiceList) {
+                return@eachFile  // Skip this file if the sdkId doesn't match
+            }
+            println("Processing file: ${file.name}")
+
+            // Create projection contents
             val projectionContents = Node.objectNodeBuilder()
-                    .withMember("imports", Node.fromStrings("${models.absolutePath}${File.separator}${file.name}"))
-                    .withMember("plugins", Node.objectNode()
-                            .withMember("cpp-codegen-smoke-tests-plugin", Node.objectNodeBuilder()
-                                    .withMember("serviceFilter", Node.arrayNode())
-                                    .withMember("c2jMap", Node.from(c2jMapStr))
-                                    .build()))
-                    .build()
-            projectionsBuilder.withMember(sdkId + "." + service.version.lowercase(), projectionContents)
+                .withMember("imports", Node.fromStrings("${models.absolutePath}${File.separator}${file.name}"))
+                .withMember("plugins", Node.objectNode()
+                    .withMember("cpp-codegen-smoke-tests-plugin", Node.objectNodeBuilder()
+                        .withMember("serviceFilter", Node.arrayNode())
+                        .withMember("c2jMap", Node.from(c2jMapStr))
+                        .build()))
+                .build()
+
+            // Add the projection contents to the projections builder
+            projectionsBuilder.withMember("$sdkId.${service.version.lowercase()}", projectionContents)
+          
         }
         val outputDirectoryArg = project.findProperty("outputDirectory")?.toString() ?: "output"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:
Previous iteration of changes are based on Java 16 which is not compatible with cdk. Hence, this change is necessary.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
