### PR TITLE
increase gradle jvm heap size

### DIFF
--- a/tools/code-generation/smithy/codegen/gradle.properties
+++ b/tools/code-generation/smithy/codegen/gradle.properties
@@ -1,1 +1,1 @@
-#org.gradle.jvmargs=-Xmx2g
+org.gradle.jvmargs=-Xmx6g


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Codegen uses Gradle . Gradle build uses a separate process called the Gradle Daemon, which is an instance of the JVM dedicated to executing Gradle builds. This daemon has its own heap settings. This is necessary to set increased heap memory so that cdk can run gradle build and generate code for all services

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
