### PR TITLE
Add mapping for S3 CRT num_network_interface_names config

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
@@ -153,6 +153,13 @@ namespace Aws
              * If not set, the max of `partSize` and 5 MiB will be used.
              */
             size_t multipartUploadThreshold{0};
+
+            /**
+             * Optional.
+             * THIS IS AN EXPERIMENTAL AND UNSTABLE API
+             * This setting maps to CRT's network_interface_names_array config.
+             */
+            Aws::Vector<Aws::String> networkInterfaceNames;
             /* End of S3 CRT specifics */
         private:
             void LoadS3CrtSpecificConfig(const Aws::String& profileName);

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -488,6 +488,18 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config,
   s3CrtConfig.factory_user_data = static_cast<void *>(&m_identityProviderUserData);
   s3CrtConfig.s3express_provider_override_factory = S3CrtIdentityProviderAdapter::ProviderFactory;
 
+  UniqueArrayPtr<aws_byte_cursor> interfacesNameCRTArr;
+  if (!config.networkInterfaceNames.empty())
+  {
+    interfacesNameCRTArr = Aws::MakeUniqueArray<aws_byte_cursor>(config.networkInterfaceNames.size(), ALLOCATION_TAG);
+    for(size_t i = 0; i < config.networkInterfaceNames.size(); ++i)
+    {
+      interfacesNameCRTArr.get()[i] = Crt::ByteCursorFromCString(config.networkInterfaceNames[i].c_str());
+    }
+    s3CrtConfig.network_interface_names_array = interfacesNameCRTArr.get();
+    s3CrtConfig.num_network_interface_names = config.networkInterfaceNames.size();
+  }
+
   m_s3CrtClient = aws_s3_client_new(Aws::get_aws_allocator(), &s3CrtConfig);
   if (!m_s3CrtClient)
   {

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtClientConfigHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtClientConfigHeader.vm
@@ -86,4 +86,11 @@
              * If not set, the max of `partSize` and 5 MiB will be used.
              */
             size_t multipartUploadThreshold{0};
+
+            /**
+             * Optional.
+             * THIS IS AN EXPERIMENTAL AND UNSTABLE API
+             * This setting maps to CRT's network_interface_names_array config.
+             */
+            Aws::Vector<Aws::String> networkInterfaceNames;
             /* End of S3 CRT specifics */

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -429,6 +429,18 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
   s3CrtConfig.factory_user_data = static_cast<void *>(&m_identityProviderUserData);
   s3CrtConfig.s3express_provider_override_factory = S3CrtIdentityProviderAdapter::ProviderFactory;
 
+  UniqueArrayPtr<aws_byte_cursor> interfacesNameCRTArr;
+  if (!config.networkInterfaceNames.empty())
+  {
+    interfacesNameCRTArr = Aws::MakeUniqueArray<aws_byte_cursor>(config.networkInterfaceNames.size(), ALLOCATION_TAG);
+    for(size_t i = 0; i < config.networkInterfaceNames.size(); ++i)
+    {
+      interfacesNameCRTArr.get()[i] = Crt::ByteCursorFromCString(config.networkInterfaceNames[i].c_str());
+    }
+    s3CrtConfig.network_interface_names_array = interfacesNameCRTArr.get();
+    s3CrtConfig.num_network_interface_names = config.networkInterfaceNames.size();
+  }
+
   m_s3CrtClient = aws_s3_client_new(Aws::get_aws_allocator(), &s3CrtConfig);
   if (!m_s3CrtClient)
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
[CRT usage example](https://github.com/awslabs/aws-crt-s3-benchmarks/blob/trn1-multinic-experiment/runners/s3-benchrunner-c/CRunner.cpp#L201-L208)
```
    struct aws_byte_cursor *interface_names_array = (struct aws_byte_cursor *) aws_mem_calloc(alloc, 4, sizeof(struct aws_byte_cursor));
    interface_names_array[0] = aws_byte_cursor_from_c_str("ens32");
    interface_names_array[1] = aws_byte_cursor_from_c_str("ens33");
    interface_names_array[2] = aws_byte_cursor_from_c_str("ens64");
    interface_names_array[3] = aws_byte_cursor_from_c_str("ens65");

    s3ClientConfig.network_interface_names_array = interface_names_array;
    s3ClientConfig.num_network_interface_names = 4;

    s3Client = aws_s3_client_new(alloc, &s3ClientConfig);
    aws_mem_release(alloc, interface_names_array);
```

tested by setting
```
s3ClientConfig.networkInterfaceNames = {"eth0"};
// or
s3ClientConfig.networkInterfaceNames = {"eth0", "docker0"};
```
in [our CRT integ tests](https://github.com/aws/aws-sdk-cpp/blob/main/tests/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp#L181)

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
