### PR TITLE
Remove build-time detection of supported WinINet/WinHTTP protocol versions.

### DIFF
--- a/src/aws-cpp-sdk-core/CMakeLists.txt
+++ b/src/aws-cpp-sdk-core/CMakeLists.txt
@@ -189,69 +189,6 @@ elseif(ENABLE_WINDOWS_CLIENT)
     else()
         file(GLOB HTTP_WINDOWS_CLIENT_HEADERS "include/aws/core/http/windows/Win*.h")
         file(GLOB HTTP_WINDOWS_CLIENT_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/http/windows/Win*.cpp")
-
-        # Starting with Windows 10, version 1507, WinINet supports HTTP2.
-        # https://docs.microsoft.com/en-us/windows/desktop/WinInet/option-flags#INTERNET_OPTION_ENABLE_HTTP_PROTOCOL
-        # Starting with Windows 10, version 1607, WinHttp supports HTTP2.
-        # https://docs.microsoft.com/en-us/windows/desktop/WinHttp/option-flags#WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL
-        set(CMAKE_REQUIRED_LIBRARIES "WinHttp.lib")
-        check_cxx_source_runs("
-        #include <Windows.h>
-        #include <winhttp.h>
-        int main() {
-
-        auto handle = WinHttpOpen(L\"aws-cpp-sdk\"/*user-agent*/,
-        WINHTTP_ACCESS_TYPE_NO_PROXY,
-        nullptr/*pszProxyW*/,
-        nullptr/*pszProxyBypassW*/,
-        0/*dwFlags*/);
-
-        DWORD http2 = WINHTTP_PROTOCOL_FLAG_HTTP2;
-        if (WinHttpSetOption(handle, WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL, &http2, sizeof(http2)))
-        {
-            return 0;
-        }
-        return 1;
-        }" WINHTTP_HAS_H2)
-
-        check_cxx_source_runs("
-        #include <Windows.h>
-        #include <winhttp.h>
-        int main() {
-
-        auto handle = WinHttpOpen(L\"aws-cpp-sdk\"/*user-agent*/,
-        WINHTTP_ACCESS_TYPE_NO_PROXY,
-        nullptr/*pszProxyW*/,
-        nullptr/*pszProxyBypassW*/,
-        0/*dwFlags*/);
-
-        DWORD http3 = WINHTTP_PROTOCOL_FLAG_HTTP3;
-        if (WinHttpSetOption(handle, WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL, &http3, sizeof(http3)))
-        {
-            return 0;
-        }
-        return 1;
-        }" WINHTTP_HAS_H3)
-
-        set(CMAKE_REQUIRED_LIBRARIES "Wininet.lib")
-        check_cxx_source_runs("
-        #include <Windows.h>
-        #include <WinInet.h>
-        int main() {
-        auto handle = InternetOpenA(\"aws-cpp-sdk\"/*lpszAgent*/,
-            INTERNET_OPEN_TYPE_DIRECT /*dwAccessType*/,
-            nullptr /*lpszProxy*/,
-            nullptr /*lpszProxyBypass*/,
-            0 /*dwFlags*/);
-        DWORD http2 = HTTP_PROTOCOL_FLAG_HTTP2;
-        if (InternetSetOptionA(handle, INTERNET_OPTION_ENABLE_HTTP_PROTOCOL, &http2, sizeof(http2)))
-        {
-            return 0;
-        }
-        return 1;
-        }" WININET_HAS_H2)
-        unset(CMAKE_REQUIRED_LIBRARIES)
-
     endif()
 elseif(USE_CRT_HTTP_CLIENT)
     file(GLOB CRT_HTTP_HEADERS "include/aws/core/http/crt/*.h")

--- a/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
@@ -68,7 +68,6 @@ const std::initializer_list<DWORD>& GetWinHttpVersionsToTry(const Aws::Http::Ver
     {
         return noPreference;
     }
-#ifdef WINHTTP_HAS_H2
     else if (version == Version::HTTP_VERSION_2_0 || version == Version::HTTP_VERSION_2TLS)
     {
         return http2;
@@ -78,8 +77,6 @@ const std::initializer_list<DWORD>& GetWinHttpVersionsToTry(const Aws::Http::Ver
         AWS_LOGSTREAM_WARN("WinHttpHttp2", "Unable to set HTTP/2 with Prior Knowledge on WinHTTP, enabling regular HTTP2");
         return http2;
     }
-#endif
-#ifdef WINHTTP_HAS_H3
     else if (version == Version::HTTP_VERSION_3)
     {
       return http2Or3;
@@ -89,7 +86,6 @@ const std::initializer_list<DWORD>& GetWinHttpVersionsToTry(const Aws::Http::Ver
       AWS_LOGSTREAM_WARN("WinHttpHttp2", "Unable to set HTTP3 only on WinHTTP");
       return http3;
     }
-#endif
     AWS_LOGSTREAM_WARN("WinHttpHttp2", "Unable to map requested HTTP Version: (raw enum value) "
                         << static_cast<std::underlying_type<Aws::Http::Version>::type>(version) << " defaulting to WINHTTP_PROTOCOL_FLAG_HTTP2");
     return http2;

--- a/src/aws-cpp-sdk-core/source/http/windows/WinINetSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinINetSyncHttpClient.cpp
@@ -27,9 +27,12 @@ using namespace Aws::Http::Standard;
 using namespace Aws::Utils;
 using namespace Aws::Utils::Logging;
 
+#ifndef HTTP_PROTOCOL_FLAG_HTTP2
+static const DWORD HTTP_PROTOCOL_FLAG_HTTP2 = 0x2;
+#endif
+
 static void WinINetEnableHttp2(void* handle)
 {
-#ifdef WININET_HAS_H2
     DWORD http2 = HTTP_PROTOCOL_FLAG_HTTP2;
     if (!InternetSetOptionA(handle, INTERNET_OPTION_ENABLE_HTTP_PROTOCOL, &http2, sizeof(http2)))
     {
@@ -39,9 +42,6 @@ static void WinINetEnableHttp2(void* handle)
     {
         AWS_LOGSTREAM_DEBUG("WinINetHttp2", "HTTP/2 enabled on WinInet handle: " << handle << ".");
     }
-#else
-    AWS_UNREFERENCED_PARAM(handle);
-#endif
 }
 
 WinINetSyncHttpClient::WinINetSyncHttpClient(const ClientConfiguration& config) :


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR removes build-time detection of WinHTTP and WinINet support for HTTP/2 and HTTP/3. In its place, we always attempt setting the HTTP version, ignoring errors (on WinHTTP in certin cases we try both enabling both HTTP/2 and 3, and then only 2).

The main reason for this is to make cross-compilation from x64 to ARM64 easier. Besides that, the built binaries will automatically take advantage of the capabilities of the system's HTTP stack even if they are built on an older machine.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [X] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
