### PR TITLE
add missing http verbs in http spec

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/http/HttpTypes.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/HttpTypes.h
@@ -20,43 +20,37 @@ namespace Aws
         /**
          * Models Http methods.
          */
-        enum class HttpMethod
-        {
-            HTTP_GET,
-            HTTP_POST,
-            HTTP_DELETE,
-            HTTP_PUT,
-            HTTP_HEAD,
-            HTTP_PATCH
-        };
+    enum class HttpMethod {
+      HTTP_GET,
+      HTTP_POST,
+      HTTP_DELETE,
+      HTTP_PUT,
+      HTTP_HEAD,
+      HTTP_PATCH,
+      HTTP_CONNECT,
+      HTTP_OPTIONS,
+      HTTP_TRACE,
+    };
 
-        /**
-         * Possible default http factory vended http client implementations.
-         */
-        enum class TransferLibType
-        {
-            DEFAULT_CLIENT = 0,
-            CURL_CLIENT,
-            WIN_INET_CLIENT,
-            WIN_HTTP_CLIENT
-        };
+    /**
+     * Possible default http factory vended http client implementations.
+     */
+    enum class TransferLibType { DEFAULT_CLIENT = 0, CURL_CLIENT, WIN_INET_CLIENT, WIN_HTTP_CLIENT };
 
-        /**
-         * Configuration for a HTTP client, currently used only by libCurl
-         */
-        enum class TransferLibPerformanceMode
-        {
-            LOW_LATENCY = 0, // run http client for a lower latency, at the expense of CPU
-            REGULAR
-        };
+    /**
+     * Configuration for a HTTP client, currently used only by libCurl
+     */
+    enum class TransferLibPerformanceMode {
+      LOW_LATENCY = 0,  // run http client for a lower latency, at the expense of CPU
+      REGULAR
+    };
 
-        namespace HttpMethodMapper
-        {
-            /**
-             * Gets the string value of an httpMethod.
-             */
-            AWS_CORE_API const char* GetNameForHttpMethod(HttpMethod httpMethod);
-        } // namespace HttpMethodMapper
+    namespace HttpMethodMapper {
+    /**
+     * Gets the string value of an httpMethod.
+     */
+    AWS_CORE_API const char* GetNameForHttpMethod(HttpMethod httpMethod);
+    }  // namespace HttpMethodMapper
 
         typedef std::pair<Aws::String, Aws::String> HeaderValuePair;
         typedef Aws::Map<Aws::String, Aws::String> HeaderValueCollection;

--- a/src/aws-cpp-sdk-core/source/http/HttpTypes.cpp
+++ b/src/aws-cpp-sdk-core/source/http/HttpTypes.cpp
@@ -31,9 +31,15 @@ const char* GetNameForHttpMethod(HttpMethod httpMethod)
             return "HEAD";
         case HttpMethod::HTTP_PATCH:
             return "PATCH";
+        case HttpMethod::HTTP_CONNECT:
+          return "CONNECT";
+        case HttpMethod::HTTP_OPTIONS:
+          return "OPTIONS";
+        case HttpMethod::HTTP_TRACE:
+          return "TRACE";
         default:
-            assert(0);
-            return "GET";
+          assert(0);
+          return "GET";
     }
 }
 


### PR DESCRIPTION
*Description of changes:*

Adds missing verbs from the [http spec](https://datatracker.ietf.org/doc/html/rfc9110.html#section-9.3) specifically `CONNECT`, `OPTIONS`, and `TRACE`

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
