### PR TITLE
require json for open telemetry build

### DIFF
--- a/cmake/external_dependencies.cmake
+++ b/cmake/external_dependencies.cmake
@@ -111,6 +111,7 @@ endif()
 
 # Open telemetry client
 if (BUILD_OPTEL)
+    find_package(nlohmann_json REQUIRED)
     find_package(opentelemetry-cpp CONFIG REQUIRED)
 endif ()
 if (BUILD_OPTEL_OTLP_BENCHMARKS)


### PR DESCRIPTION
*Issue #, if available:*

[issues/3213](https://github.com/aws/aws-sdk-cpp/issues/3213)

*Description of changes:*

Calls find_package on json if we are building with open telemetry client library as it is required.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
