### PR TITLE
compilation fix access protected member of parent class for older GCC

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSErrorMarshaller.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSErrorMarshaller.h
@@ -94,6 +94,7 @@ namespace Aws
         };
 
         class AWS_CORE_API JsonErrorMarshallerQueryCompatible : public JsonErrorMarshaller {
+         using AWSErrorMarshaller::Marshall;
          public:
           /**
            * Converts an exceptionName and message into an Error object, if it

--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSErrorMarshaller.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSErrorMarshaller.h
@@ -94,7 +94,8 @@ namespace Aws
         };
 
         class AWS_CORE_API JsonErrorMarshallerQueryCompatible : public JsonErrorMarshaller {
-         using AWSErrorMarshaller::Marshall;
+          using AWSErrorMarshaller::Marshall;
+
          public:
           /**
            * Converts an exceptionName and message into an Error object, if it


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
