### PR TITLE
Revert "compilation fix access protected member of parent class for o…

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSErrorMarshaller.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSErrorMarshaller.h
@@ -94,8 +94,6 @@ namespace Aws
         };
 
         class AWS_CORE_API JsonErrorMarshallerQueryCompatible : public JsonErrorMarshaller {
-          using AWSErrorMarshaller::Marshall;
-
          public:
           /**
            * Converts an exceptionName and message into an Error object, if it


### PR DESCRIPTION
…lder GCC (#3216)"

This reverts commit 55372a21de51490ab435c38088b3476d405033ab.

*Issue #, if available:*
the build of HEAD main is broken
reported by
https://github.com/aws/aws-sdk-cpp/commit/55372a21de51490ab435c38088b3476d405033ab#commitcomment-150189831

also the same issue is present internally:
```
error: '\\''Aws::Client::AWSError<Aws::Client::CoreErrors> Aws::Client::AWSErrorMarshaller::Marshall(const String&, const String&) const'\\'' is private within this context\n
```

Also the CRT submodule was accidentally reverted to an older hash of 0.29.3.
*Description of changes:*
Revert the merged PR.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
