### PR TITLE
avoid double read from steam from curl when stream is small

### DIFF
--- a/tests/aws-cpp-sdk-core-tests/utils/stream/AwsChunkedStreamTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/stream/AwsChunkedStreamTest.cpp
@@ -39,3 +39,46 @@ TEST_F(AwsChunkedStreamTest, ChunkedStreamShouldWork) {
   auto expectedStreamWithChecksum = "A\r\n1234567890\r\nA\r\n1234567890\r\n5\r\n12345\r\n0\r\nx-amz-checksum-crc32:78DeVw==\r\n\r\n";
   EXPECT_EQ(expectedStreamWithChecksum, encodedStr);
 }
+
+TEST_F(AwsChunkedStreamTest, ShouldNotRequireTwoReadsOnSmallChunk) {
+  StandardHttpRequest request{"www.clemar.com/strohl", Http::HttpMethod::HTTP_GET};
+  auto requestHash = Aws::MakeShared<CRC32>(TEST_LOG_TAG);
+  request.SetRequestHash("crc32", requestHash);
+  std::shared_ptr<IOStream> inputStream = Aws::MakeShared<StringStream>(TEST_LOG_TAG, "12345");
+  AwsChunkedStream<100> chunkedStream{&request, inputStream};
+  Aws::Utils::Array<char> outputBuffer{100};
+  Aws::StringStream output;
+  const auto bufferOffset = chunkedStream.BufferedRead(outputBuffer.GetUnderlyingData(), 100);
+  std::copy(outputBuffer.GetUnderlyingData(), outputBuffer.GetUnderlyingData() + bufferOffset, std::ostream_iterator<char>(output));
+  EXPECT_EQ(46ul, bufferOffset);
+  const auto encodedStr = output.str();
+  auto expectedStreamWithChecksum = "5\r\n12345\r\n0\r\nx-amz-checksum-crc32:y/U6HA==\r\n\r\n";
+  EXPECT_EQ(expectedStreamWithChecksum, encodedStr);
+}
+
+TEST_F(AwsChunkedStreamTest, ShouldWorkOnSmallBuffer) {
+  StandardHttpRequest request{"www.eugief.com/hesimay", Http::HttpMethod::HTTP_GET};
+  auto requestHash = Aws::MakeShared<CRC32>(TEST_LOG_TAG);
+  request.SetRequestHash("crc32", requestHash);
+  std::shared_ptr<IOStream> inputStream = Aws::MakeShared<StringStream>(TEST_LOG_TAG, "1234567890");
+  AwsChunkedStream<5> chunkedStream{&request, inputStream};
+  Aws::Utils::Array<char> outputBuffer{100};
+  // Read first 5 bytes, we get back ten bytes chunk encoded since it is "5\r\n12345\r\n"
+  Aws::StringStream firstRead;
+  auto amountRead = chunkedStream.BufferedRead(outputBuffer.GetUnderlyingData(), 100);
+  std::copy(outputBuffer.GetUnderlyingData(), outputBuffer.GetUnderlyingData() + amountRead, std::ostream_iterator<char>(firstRead));
+  EXPECT_EQ(10ul, amountRead);
+  auto encodedStr = firstRead.str();
+  EXPECT_EQ("5\r\n12345\r\n", encodedStr);
+  // Read second 5 bytes, we get back 46 bytes because we exhaust the underlying buffer
+  // abd write the trailer "5\r\n67890\r\n0\r\nx-amz-checksum-crc32:Jh2u5Q==\r\n\r\n"
+  Aws::StringStream secondRead;
+  amountRead = chunkedStream.BufferedRead(outputBuffer.GetUnderlyingData(), 100);
+  std::copy(outputBuffer.GetUnderlyingData(), outputBuffer.GetUnderlyingData() + amountRead, std::ostream_iterator<char>(secondRead));
+  EXPECT_EQ(46ul, amountRead);
+  encodedStr = secondRead.str();
+  EXPECT_EQ("5\r\n67890\r\n0\r\nx-amz-checksum-crc32:Jh2u5Q==\r\n\r\n", encodedStr);
+  // Any subsequent reads will return 0 because all streams are exhausted
+  amountRead = chunkedStream.BufferedRead(outputBuffer.GetUnderlyingData(), 100);
+  EXPECT_EQ(0ul, amountRead);
+}


### PR DESCRIPTION
*Description of changes:*

Fixes a corner case in [aws chunked streaming](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming-trailers.html) that lead to performance problems. we recently fixed a bug in aws chunked streaming that fixed it in curl. There was however a performance oversight. on a chunk less that the default chunk size, it would require two stream reads from curl instead of one. requiring two stream reads increased latency very slightly for smaller objects.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
