### PR TITLE
fix name shadow warning as error in context param generation

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/CppEndpointsJmesPathVisitor.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/CppEndpointsJmesPathVisitor.java
@@ -95,7 +95,7 @@ class CppEndpointsJmesPathVisitor implements ExpressionVisitor<Pair<String, Shap
         }
 
         // at the start of each code block
-        String varName = expression.getName() + "Elem";
+        String varName = expression.getName() + "Elems";
         // if a new scope started, declare variable accessed
         if (context.isStartOfNewScope() || context.getVarName().isEmpty()) {
           context.addVariableInScope(varName);


### PR DESCRIPTION
*Description of changes:*

Fixes a name shadowing warning as error when generating context params that are arrays. [Since we create a variable that may be a list with the suffix](https://github.com/aws/aws-sdk-cpp/blob/main/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/CppEndpointsJmesPathVisitor.java#L98-L102) "Elem". when we create a for loop to loop over that variable it will shadow it because it [has the same suffix](https://github.com/aws/aws-sdk-cpp/blob/main/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/CppEndpointsJmesPathVisitor.java#L72-L73). this fixes the shadowing.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
