### PR TITLE
Fix the format of .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,9 +5,9 @@ HeaderFilterRegex: ''
 FormatStyle: 'none'
 CheckOptions:
   - key:             modernize-pass-by-value.ValuesOnly
-    value:           '1',
+    value:           '1'
   - key:             readability-implicit-bool-conversion.AllowPointerConditions
-    value:           '1',
+    value:           '1'
   - key:             readability-implicit-bool-conversion.AllowIntegerConditions
     value:           '1'
 


### PR DESCRIPTION
*Issue #, if available:*

The file format of .clang-tidy is not correct
```
contrib/aws/.clang-tidy:8:25: error: Unexpected token. Expected Key or Block End
    value:           '1',
                        ^
Error parsing contrib/aws/.clang-tidy: Invalid argument
```

According to https://clang.llvm.org/docs/ClangFormatStyleOptions.html
```
The .clang-format file uses YAML format:

key1: value1
key2: value2
# A comment.
...
```

*Description of changes:*

Remove the incorrect comma at the end

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
