### PR TITLE
Allow cmake option to remove tests that depend on DNS lookup

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -57,7 +57,7 @@
     "MMSYSERR",
     "WAVEFORMATEX",
     "Unprepare",
-    "DDISABLE_IMDSV1",
+    "DDISABLE",
     "SENDREQUEST",
     "threadpool",
     "stdlib",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ if (LEGACY_BUILD)
     option(USE_TLS_V1_2 "Set http client to enforce TLS 1.2" ON)
     option(USE_TLS_V1_3 "Set http client to enforce TLS 1.3" OFF)
     option(ENABLE_SMOKE_TESTS "Enable smoke tests" OFF)
+    option(DISABLE_DNS_REQUIRED_TESTS "Disable unit tests that require DNS lookup to succeed, useful when using a http client that does not perform DNS lookup" OFF)
 
 
     set(AWS_USER_AGENT_CUSTOMIZATION "" CACHE STRING "User agent extension")
@@ -87,6 +88,10 @@ if (LEGACY_BUILD)
     endif ()
     if (USE_TLS_V1_3)
         add_definitions(-DENFORCE_TLS_V1_3)
+    endif ()
+
+    if (DISABLE_DNS_REQUIRED_TESTS)
+        add_definitions(-DDISABLE_DNS_REQUIRED_TESTS)
     endif ()
 
     #From https://stackoverflow.com/questions/18968979/how-to-get-colorized-output-with-cmake

--- a/tests/aws-cpp-sdk-core-tests/http/HttpClientTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/http/HttpClientTest.cpp
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
-
+#ifndef DISABLE_DNS_REQUIRED_TESTS
 #include <aws/testing/AwsCppSdkGTestSuite.h>
 #include <aws/core/http/HttpRequest.h>
 #include <aws/core/http/HttpResponse.h>
@@ -385,3 +385,4 @@ TEST_F(CURLHttpClientTest, TestHttpRequestWorksFine)
 #endif // ENABLE_CURL_CLIENT
 #endif // ENABLE_HTTP_CLIENT_TESTING
 #endif // NO_HTTP_CLIENT
+#endif  // DISABLE_DNS_REQUIRED_TESTS


### PR DESCRIPTION
*Description of changes:*

Creates a cmake option that allows the disabling of of tests that are dependent on DNS behavior. Some customers are using a custom HTTP client that does not perform DNS as expected that will result in the tests behavior not working as expected. This allows for customers to opt out of running these tests, but defaulting to keeping them on to find potential issues in HTTP clients.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
