### PR TITLE
update user agent to 2.1

### DIFF
--- a/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClient.cpp
@@ -109,6 +109,7 @@ DynamoDBClient::DynamoDBClient(const DynamoDB::DynamoDBClientConfiguration& clie
                            std::shared_ptr<DynamoDBEndpointProviderBase> endpointProvider) :
     AwsSmithyClientT(clientConfiguration,
         GetServiceName(),
+        "DynamoDB",
         Aws::Http::CreateHttpClient(clientConfiguration),
         Aws::MakeShared<DynamoDBErrorMarshaller>(ALLOCATION_TAG),
         endpointProvider ? endpointProvider : Aws::MakeShared<DynamoDBEndpointProvider>(ALLOCATION_TAG),
@@ -123,6 +124,7 @@ DynamoDBClient::DynamoDBClient(const AWSCredentials& credentials,
                            const DynamoDB::DynamoDBClientConfiguration& clientConfiguration) :
     AwsSmithyClientT(clientConfiguration,
         GetServiceName(),
+        "DynamoDB",
         Aws::Http::CreateHttpClient(clientConfiguration),
         Aws::MakeShared<DynamoDBErrorMarshaller>(ALLOCATION_TAG),
         endpointProvider ? endpointProvider : Aws::MakeShared<DynamoDBEndpointProvider>(ALLOCATION_TAG),
@@ -137,6 +139,7 @@ DynamoDBClient::DynamoDBClient(const std::shared_ptr<AWSCredentialsProvider>& cr
                            const DynamoDB::DynamoDBClientConfiguration& clientConfiguration) :
     AwsSmithyClientT(clientConfiguration,
         GetServiceName(),
+        "DynamoDB",
         Aws::Http::CreateHttpClient(clientConfiguration),
         Aws::MakeShared<DynamoDBErrorMarshaller>(ALLOCATION_TAG),
         endpointProvider ? endpointProvider : Aws::MakeShared<DynamoDBEndpointProvider>(ALLOCATION_TAG),
@@ -150,6 +153,7 @@ DynamoDBClient::DynamoDBClient(const std::shared_ptr<AWSCredentialsProvider>& cr
 DynamoDBClient::DynamoDBClient(const Client::ClientConfiguration& clientConfiguration) :
     AwsSmithyClientT(clientConfiguration,
       GetServiceName(),
+      "DynamoDB",
       Aws::Http::CreateHttpClient(clientConfiguration),
       Aws::MakeShared<DynamoDBErrorMarshaller>(ALLOCATION_TAG),
       Aws::MakeShared<DynamoDBEndpointProvider>(ALLOCATION_TAG),
@@ -163,6 +167,7 @@ DynamoDBClient::DynamoDBClient(const AWSCredentials& credentials,
                            const Client::ClientConfiguration& clientConfiguration) :
     AwsSmithyClientT(clientConfiguration,
         GetServiceName(),
+        "DynamoDB",
         Aws::Http::CreateHttpClient(clientConfiguration),
         Aws::MakeShared<DynamoDBErrorMarshaller>(ALLOCATION_TAG),
         Aws::MakeShared<DynamoDBEndpointProvider>(ALLOCATION_TAG),
@@ -176,6 +181,7 @@ DynamoDBClient::DynamoDBClient(const std::shared_ptr<AWSCredentialsProvider>& cr
                            const Client::ClientConfiguration& clientConfiguration) :
     AwsSmithyClientT(clientConfiguration,
         GetServiceName(),
+        "DynamoDB",
         Aws::Http::CreateHttpClient(clientConfiguration),
         Aws::MakeShared<DynamoDBErrorMarshaller>(ALLOCATION_TAG),
         Aws::MakeShared<DynamoDBEndpointProvider>(ALLOCATION_TAG),

--- a/src/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceRequest.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceRequest.h
@@ -8,6 +8,7 @@
 #include <aws/core/Core_EXPORTS.h>
 
 #include <aws/core/client/RequestCompression.h>
+#include <aws/core/client/UserAgent.h>
 #include <aws/core/auth/AWSAuthSigner.h>
 #include <aws/core/client/CoreErrors.h>
 #include <aws/core/endpoint/EndpointParameter.h>
@@ -203,6 +204,18 @@ namespace Aws
         virtual Aws::Client::CompressionAlgorithm
         GetSelectedCompressionAlgorithm(Aws::Client::RequestCompressionConfig) const { return Aws::Client::CompressionAlgorithm::NONE; }
 
+        /**
+         * Adds a used feature to the user agent string for the request.
+         * @param feature the feature to be added in the user agent string.
+         */
+        void AddUserAgentFeature(Aws::Client::UserAgentFeature feature) { m_userAgentFeatures.insert(feature); }
+
+        /**
+         * Gets all features that would be included in the requests user agent string.
+         * @return a set of features that will be included in the user agent associated with this request.
+         */
+        Aws::Set<Aws::Client::UserAgentFeature> GetUserAgentFeatures() const { return m_userAgentFeatures; }
+
     protected:
         /**
          * Default does nothing. Override this to convert what would otherwise be the payload of the
@@ -221,6 +234,7 @@ namespace Aws
         RequestSignedHandler m_onRequestSigned;
         RequestRetryHandler m_requestRetryHandler;
         mutable std::shared_ptr<Aws::Http::ServiceSpecificParameters> m_serviceSpecificParameters;
+        Aws::Set<Client::UserAgentFeature> m_userAgentFeatures;
     };
 
 } // namespace Aws

--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
@@ -16,6 +16,7 @@
 #include <aws/core/utils/crypto/Hash.h>
 #include <aws/core/auth/AWSAuthSignerProvider.h>
 #include <aws/core/endpoint/AWSEndpoint.h>
+#include <smithy/client/features/UserAgentInterceptor.h>
 #include <smithy/interceptor/Interceptor.h>
 #include <memory>
 #include <atomic>
@@ -341,7 +342,6 @@ namespace Aws
             void AddHeadersToRequest(const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest, const Http::HeaderValueCollection& headerValues) const;
             void AddContentBodyToRequest(const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest, const std::shared_ptr<Aws::IOStream>& body,
                                          bool needsContentMd5 = false, bool isChunked = false) const;
-            void AddCommonHeaders(Aws::Http::HttpRequest& httpRequest) const;
             void AppendHeaderValueToRequest(const std::shared_ptr<Http::HttpRequest> &request, String header, String value) const;
 
             std::shared_ptr<Aws::Http::HttpClient> m_httpClient;
@@ -349,12 +349,12 @@ namespace Aws
             std::shared_ptr<RetryStrategy> m_retryStrategy;
             std::shared_ptr<Aws::Utils::RateLimits::RateLimiterInterface> m_writeRateLimiter;
             std::shared_ptr<Aws::Utils::RateLimits::RateLimiterInterface> m_readRateLimiter;
-            Aws::String m_userAgent;
             std::shared_ptr<Aws::Utils::Crypto::Hash> m_hash;
             long m_requestTimeoutMs;
             bool m_enableClockSkewAdjustment;
             Aws::String m_serviceName = "AWSBaseClient";
             Aws::Client::RequestCompressionConfig m_requestCompressionConfig;
+            std::shared_ptr<smithy::client::UserAgentInterceptor> m_userAgentInterceptor;
             Aws::Vector<std::shared_ptr<smithy::interceptor::Interceptor>> m_interceptors;
         };
 

--- a/src/aws-cpp-sdk-core/include/aws/core/client/UserAgent.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/UserAgent.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/client/RetryStrategy.h>
+#include <aws/core/utils/memory/stl/AWSSet.h>
+
+namespace Aws {
+namespace Client {
+
+enum class UserAgentFeature {
+  RETRY_MODE_LEGACY,
+  RETRY_MODE_STANDARD,
+  RETRY_MODE_ADAPTIVE,
+  S3_TRANSFER,
+  S3_CRYPTO_V1N,
+  S3_CRYPTO_V2,
+};
+
+class AWS_CORE_API UserAgent {
+ public:
+  explicit UserAgent(const ClientConfiguration& clientConfiguration, const Aws::String& retryStrategyName, const Aws::String& apiName);
+  Aws::String SerializeWithFeatures(const Aws::Set<UserAgentFeature>& features) const;
+  void SetApiName(const Aws::String& apiName) { m_api = apiName; }
+  void AddLegacyFeature(const Aws::String& legacyFeature);
+
+ private:
+  const Aws::String m_sdkVersion;
+  const Aws::String m_userAgentVersion;
+  Aws::String m_api;
+  const Aws::String m_crtVersion;
+  const Aws::String m_osVersion;
+  const Aws::String m_archName;
+  const Aws::String m_cppVersion;
+  const Aws::String m_compilerMetadata;
+  const Aws::String m_retryStrategyName;
+  const Aws::String m_execEnv;
+  const Aws::String m_appId;
+  const Aws::String m_customizations;
+  Aws::Set<UserAgentFeature> m_features;
+};
+}  // namespace Client
+}  // namespace Aws

--- a/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClient.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClient.h
@@ -36,13 +36,19 @@ namespace client
     public:
         static_assert(std::is_base_of<Aws::Client::AWSErrorMarshaller, ErrorMarshallerT>::value, "MarshallerT must be derived from class Aws::Client::AWSErrorMarshaller");
 
-        explicit AwsSmithyClientT(const ServiceClientConfigurationT& clientConfig, const Aws::String& serviceName,
+        explicit AwsSmithyClientT(const ServiceClientConfigurationT& clientConfig,
+            const Aws::String& serviceName,
+            const Aws::String& serviceUserAgentName,
             const std::shared_ptr<Aws::Http::HttpClient>& httpClient,
             const std::shared_ptr<Aws::Client::AWSErrorMarshaller>& errorMarshaller,
             const std::shared_ptr<EndpointProviderT> endpointProvider,
             const std::shared_ptr<ServiceAuthSchemeResolverT>& authSchemeResolver,
             const Aws::UnorderedMap<Aws::String, AuthSchemesVariantT>& authSchemes)
-            : AwsSmithyClientBase(Aws::MakeUnique<ServiceClientConfigurationT>(ServiceNameT, clientConfig), serviceName, httpClient, errorMarshaller),
+            : AwsSmithyClientBase(Aws::MakeUnique<ServiceClientConfigurationT>(ServiceNameT, clientConfig),
+                serviceName,
+                serviceUserAgentName,
+                httpClient,
+                errorMarshaller),
               m_clientConfiguration(*static_cast<ServiceClientConfigurationT*>(AwsSmithyClientBase::m_clientConfig.get())),
               m_endpointProvider(endpointProvider),
               m_authSchemeResolver(authSchemeResolver),
@@ -57,6 +63,7 @@ namespace client
             AwsSmithyClientBase(other,
               Aws::MakeUnique<ServiceClientConfigurationT>(ServiceNameT, other.m_clientConfiguration),
               ServiceNameT,
+              other.m_serviceUserAgentName,
               Aws::Http::CreateHttpClient(other.m_clientConfiguration),
               Aws::MakeShared<ErrorMarshallerT>(ServiceNameT)),
             m_clientConfiguration{*static_cast<ServiceClientConfigurationT*>(m_clientConfig.get())},

--- a/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientBase.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientBase.h
@@ -9,6 +9,7 @@
 #include <smithy/tracing/TelemetryProvider.h>
 #include <smithy/interceptor/Interceptor.h>
 #include <smithy/client/features/ChecksumInterceptor.h>
+#include <smithy/client/features/UserAgentInterceptor.h>
 
 #include <aws/crt/Variant.h>
 #include <aws/core/client/ClientConfiguration.h>
@@ -85,11 +86,12 @@ namespace client
 
         AwsSmithyClientBase(Aws::UniquePtr<Aws::Client::ClientConfiguration>&& clientConfig,
                             Aws::String serviceName,
+                            Aws::String serviceUserAgentName,
                             std::shared_ptr<Aws::Http::HttpClient> httpClient,
                             std::shared_ptr<Aws::Client::AWSErrorMarshaller> errorMarshaller) :
           m_clientConfig(std::move(clientConfig)),
           m_serviceName(std::move(serviceName)),
-          m_userAgent(),
+          m_serviceUserAgentName(std::move(serviceUserAgentName)),
           m_httpClient(std::move(httpClient)),
           m_errorMarshaller(std::move(errorMarshaller)),
           m_interceptors{Aws::MakeShared<ChecksumInterceptor>("AwsSmithyClientBase")}
@@ -100,11 +102,12 @@ namespace client
         AwsSmithyClientBase(const AwsSmithyClientBase& other,
                             Aws::UniquePtr<Aws::Client::ClientConfiguration>&& clientConfig,
                             Aws::String serviceName,
+                            Aws::String serviceUserAgentName,
                             std::shared_ptr<Aws::Http::HttpClient> httpClient,
                             std::shared_ptr<Aws::Client::AWSErrorMarshaller> errorMarshaller) :
           m_clientConfig(std::move(clientConfig)),
           m_serviceName(std::move(serviceName)),
-          m_userAgent(),
+          m_serviceUserAgentName(std::move(serviceUserAgentName)),
           m_httpClient(std::move(httpClient)),
           m_errorMarshaller(std::move(errorMarshaller)),
           m_interceptors{Aws::MakeShared<ChecksumInterceptor>("AwsSmithyClientBase")}
@@ -181,7 +184,7 @@ namespace client
 
         std::shared_ptr<Aws::Client::ClientConfiguration> m_clientConfig;
         Aws::String m_serviceName;
-        Aws::String m_userAgent;
+        Aws::String m_serviceUserAgentName;
 
         std::shared_ptr<Aws::Http::HttpClient> m_httpClient;
         std::shared_ptr<Aws::Client::AWSErrorMarshaller> m_errorMarshaller;

--- a/src/aws-cpp-sdk-core/include/smithy/client/features/UserAgentInterceptor.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/features/UserAgentInterceptor.h
@@ -1,0 +1,46 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/client/RetryStrategy.h>
+#include <aws/core/client/UserAgent.h>
+#include <smithy/interceptor/Interceptor.h>
+
+#include <utility>
+
+namespace smithy {
+namespace client {
+class UserAgentInterceptor : public interceptor::Interceptor {
+ public:
+  explicit UserAgentInterceptor(const Aws::Client::ClientConfiguration& configuration,
+    const Aws::String& retryStrategyName,
+    const Aws::String& apiName)
+      : m_userAgent{configuration, retryStrategyName, apiName} {};
+  UserAgentInterceptor(const UserAgentInterceptor& other) = delete;
+  UserAgentInterceptor(UserAgentInterceptor&& other) noexcept = default;
+  UserAgentInterceptor& operator=(const UserAgentInterceptor& other) = delete;
+  UserAgentInterceptor& operator=(UserAgentInterceptor&& other) noexcept = delete;
+
+  ModifyRequestOutcome ModifyBeforeSigning(interceptor::InterceptorContext& context) override {
+    auto transmitRequest = context.GetTransmitRequest();
+    assert(transmitRequest);
+    transmitRequest->SetUserAgent(m_userAgent.SerializeWithFeatures(context.GetModeledRequest().GetUserAgentFeatures()));
+    return transmitRequest;
+  }
+
+  ModifyResponseOutcome ModifyBeforeDeserialization(interceptor::InterceptorContext& context) override {
+    return context.GetTransmitResponse();
+  }
+
+  void SetApiName(const Aws::String& apiName) { m_userAgent.SetApiName(apiName); }
+
+  void AddLegacyFeaturesToUserAgent(const Aws::String& valueToAppend) { m_userAgent.AddLegacyFeature(valueToAppend); }
+
+ private:
+  Aws::Client::UserAgent m_userAgent;
+};
+}  // namespace client
+}  // namespace smithy

--- a/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
@@ -131,6 +131,28 @@ Aws::String ComputeUserAgentString(ClientConfiguration const * const pConfig)
   return ss.str();
 }
 
+Aws::String calculateRegion() {
+  // Automatically determine the AWS region from environment variables, configuration file and EC2 metadata.
+  auto region = Aws::Environment::GetEnv("AWS_DEFAULT_REGION");
+  if (!region.empty())
+  {
+    return region;
+  }
+
+  region = Aws::Environment::GetEnv("AWS_REGION");
+  if (!region.empty())
+  {
+    return region;
+  }
+
+  region = Aws::Config::GetCachedConfigValue("region");
+  if (!region.empty())
+  {
+    return region;
+  }
+  return "";
+}
+
 void setLegacyClientConfigurationParameters(ClientConfiguration& clientConfig)
 {
     clientConfig.scheme = Aws::Http::Scheme::HTTPS;
@@ -192,24 +214,7 @@ void setLegacyClientConfigurationParameters(ClientConfiguration& clientConfig)
 
     AWS_LOGSTREAM_DEBUG(CLIENT_CONFIG_TAG, "ClientConfiguration will use SDK Auto Resolved profile: [" << clientConfig.profileName << "] if not specified by users.");
 
-    // Automatically determine the AWS region from environment variables, configuration file and EC2 metadata.
-    clientConfig.region = Aws::Environment::GetEnv("AWS_DEFAULT_REGION");
-    if (!clientConfig.region.empty())
-    {
-        return;
-    }
-
-    clientConfig.region = Aws::Environment::GetEnv("AWS_REGION");
-    if (!clientConfig.region.empty())
-    {
-        return;
-    }
-
-    clientConfig.region = Aws::Config::GetCachedConfigValue("region");
-    if (!clientConfig.region.empty())
-    {
-        return;
-    }
+    clientConfig.region = calculateRegion();
 
     // Set the endpoint to interact with EC2 instance's metadata service
     Aws::String ec2MetadataServiceEndpoint = Aws::Environment::GetEnv("AWS_EC2_METADATA_SERVICE_ENDPOINT");

--- a/src/aws-cpp-sdk-core/source/client/UserAgent.cpp
+++ b/src/aws-cpp-sdk-core/source/client/UserAgent.cpp
@@ -1,0 +1,188 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/core/Version.h>
+#include <aws/core/client/UserAgent.h>
+#include <aws/core/platform/Environment.h>
+#include <aws/core/platform/OSVersionInfo.h>
+#include <aws/core/utils/logging/LogMacros.h>
+#include <aws/core/utils/memory/stl/AWSStringStream.h>
+#include <aws/crt/Config.h>
+
+#include <numeric>
+#include <utility>
+
+using namespace Aws::Client;
+
+namespace {
+const char* LOG_TAG = "UserAgent";
+
+const std::pair<UserAgentFeature, const char*> BUSINESS_METRIC_MAPPING[] = {
+    {UserAgentFeature::RETRY_MODE_LEGACY, "D"},
+    {UserAgentFeature::RETRY_MODE_STANDARD, "E"},
+    {UserAgentFeature::RETRY_MODE_ADAPTIVE, "F"},
+    {UserAgentFeature::S3_TRANSFER, "G"},
+    {UserAgentFeature::S3_CRYPTO_V1N, "H"},
+    {UserAgentFeature::S3_CRYPTO_V2, "I"}
+};
+
+Aws::String BusinessMetricForFeature(UserAgentFeature feature) {
+  const auto* const metric =
+      std::find_if(std::begin(BUSINESS_METRIC_MAPPING), std::end(BUSINESS_METRIC_MAPPING),
+                   [feature](const std::pair<UserAgentFeature, const char*>& pair) -> bool { return pair.first == feature; });
+  if (metric == std::end(BUSINESS_METRIC_MAPPING)) {
+    AWS_LOGSTREAM_ERROR(LOG_TAG, "business metric mapping not found for feature");
+    return {};
+  }
+  return metric->second;
+}
+
+const std::pair<const char*, UserAgentFeature> RETRY_FEATURE_MAPPING[] = {
+    {"default", UserAgentFeature::RETRY_MODE_LEGACY},
+    {"standard", UserAgentFeature::RETRY_MODE_STANDARD},
+    {"adaptive", UserAgentFeature::RETRY_MODE_ADAPTIVE},
+};
+
+const char* EXEC_ENV_VAR = "AWS_EXECUTION_ENV";
+const char* METADATA = "md";
+const char* METADATA_DELIMINATOR = "/";
+const char* METADATA_VALUE_DELIMINATOR = "#";
+const char* RWS = " ";
+const char* SDK_VERSION = "aws-sdk-cpp";
+const char* USER_AGENT_VERSION = "2.1";
+const char* UA_VERSION = "ua";
+const char* API_NAME = "api";
+const char* CRT_VERSION = "aws-crt";
+const char* OS_VERSION = "os";
+const char* ARCH = "arch";
+const char* LANG = "lang";
+const char* CPP = "c++";
+const char* EXEC_ENV = "exec-env";
+const char* APP_ID = "app";
+const char* BUSINESS_METRICS = "m";
+}  // namespace
+
+UserAgent::UserAgent(const ClientConfiguration& clientConfiguration,
+  const Aws::String& retryStrategyName,
+  const Aws::String& apiName)
+    : m_sdkVersion{FilterUserAgentToken(Version::GetVersionString())},
+      m_userAgentVersion{USER_AGENT_VERSION},
+      m_api(apiName),
+      m_crtVersion{FilterUserAgentToken(AWS_CRT_CPP_VERSION)},
+      m_osVersion{FilterUserAgentToken(Aws::OSVersionInfo::ComputeOSVersionString().c_str())},
+      m_archName{FilterUserAgentToken(Aws::OSVersionInfo::ComputeOSVersionArch().c_str())},
+      m_cppVersion{FilterUserAgentToken(Version::GetCPPStandard())},
+      m_compilerMetadata{FilterUserAgentToken(Version::GetCompilerVersionString())},
+      m_retryStrategyName{retryStrategyName},
+      m_execEnv{FilterUserAgentToken(Aws::Environment::GetEnv(EXEC_ENV_VAR).c_str())},
+      m_appId{FilterUserAgentToken(clientConfiguration.appId.c_str())}
+#if defined(AWS_USER_AGENT_CUSTOMIZATION)
+#define XSTR(V) STR(V)
+#define STR(V) #V
+      , m_customizations{FilterUserAgentToken(XSTR(AWS_USER_AGENT_CUSTOMIZATION))}
+#undef STR
+#undef XSTR
+#endif
+{
+}
+
+Aws::String UserAgent::SerializeWithFeatures(const Aws::Set<UserAgentFeature>& features) const {
+  // Need to be in order
+  Aws::StringStream userAgentValue;
+
+  auto SerializeMetadata = [&](const Aws::String& metadataName, const Aws::String& metadataValue) -> void {
+    if (!metadataValue.empty()) {
+      userAgentValue << metadataName<< METADATA_DELIMINATOR << metadataValue << RWS;
+    }
+  };
+
+  auto SerializeMetadataWithVersion = [&](const Aws::String& metadataName, const Aws::String& metadataValue, const Aws::String& metadataVersion) -> void {
+    if (!metadataValue.empty() && !metadataVersion.empty()) {
+      userAgentValue << metadataName<< METADATA_DELIMINATOR << metadataValue << METADATA_VALUE_DELIMINATOR << metadataVersion << RWS;
+    }
+  };
+
+  SerializeMetadata(SDK_VERSION, m_sdkVersion);
+  if (!m_customizations.empty()) {
+    userAgentValue << m_customizations << RWS;
+  }
+  SerializeMetadata(UA_VERSION, m_userAgentVersion);
+  if (!m_api.empty()) {
+    SerializeMetadata(API_NAME, m_api);
+  }
+  SerializeMetadata(OS_VERSION, m_osVersion);
+  SerializeMetadataWithVersion(LANG, CPP, m_cppVersion);
+  SerializeMetadataWithVersion(METADATA, CRT_VERSION, m_crtVersion);
+  if (!m_execEnv.empty()) {
+    SerializeMetadata(EXEC_ENV, m_execEnv);
+  }
+
+  // Does not need to be in order
+  if (!m_archName.empty()) {
+    SerializeMetadataWithVersion(METADATA, ARCH, m_archName);
+  }
+  if (!m_appId.empty()) {
+    SerializeMetadata(APP_ID, m_appId);
+  }
+  if (!m_compilerMetadata.empty()) {
+    SerializeMetadata(METADATA, m_compilerMetadata);
+  }
+
+  // metrics
+  Aws::Vector<Aws::String> encodedMetrics{};
+
+  // add retry encoded value
+  if (!m_retryStrategyName.empty()) {
+    const auto* const retryFeature = std::find_if(
+        std::begin(RETRY_FEATURE_MAPPING), std::end(RETRY_FEATURE_MAPPING),
+        [this](const std::pair<const char*, UserAgentFeature>& pair) -> bool { return strcmp(pair.first, FilterUserAgentToken(m_retryStrategyName.c_str()).c_str()) == 0; });
+    if (retryFeature != std::end(RETRY_FEATURE_MAPPING)) {
+      encodedMetrics.emplace_back(BusinessMetricForFeature(retryFeature->second));
+    }
+  }
+
+  auto EncodeFeatures = [&encodedMetrics](const Aws::Set<UserAgentFeature>& features) -> void {
+    for (const auto& feature : features) {
+      auto encodedValue = BusinessMetricForFeature(feature);
+      if (!encodedValue.empty()) {
+        encodedMetrics.emplace_back(std::move(encodedValue));
+      }
+    }
+  };
+
+  // add all features attached to request.
+  EncodeFeatures(features);
+  EncodeFeatures(m_features);
+
+  // serialize the business metrics string.
+  if (!encodedMetrics.empty()) {
+    userAgentValue << BUSINESS_METRICS << METADATA_DELIMINATOR
+                   << std::accumulate(encodedMetrics.begin(), encodedMetrics.end(), Aws::String{},
+                                      [](const Aws::String& acc, const Aws::String& value) -> Aws::String {
+                                        return acc.empty() ? value : acc + "," + value;
+                                      });
+  }
+
+  return userAgentValue.str();
+}
+
+namespace {
+const std::pair<const char*, UserAgentFeature> LEGACY_FEATURE_MAPPING[] = {
+    {"ft/s3-transfer", UserAgentFeature::S3_TRANSFER},
+    {"ft/S3CryptoV1n", UserAgentFeature::S3_CRYPTO_V1N},
+    {"ft/S3CryptoV2", UserAgentFeature::S3_CRYPTO_V2},
+};
+}
+
+void UserAgent::AddLegacyFeature(const Aws::String& legacyFeature) {
+  const auto value = Aws::Client::FilterUserAgentToken(legacyFeature.c_str());
+  const auto* const feature = std::find_if(
+      std::begin(LEGACY_FEATURE_MAPPING), std::end(LEGACY_FEATURE_MAPPING),
+      [&value](const std::pair<const char*, UserAgentFeature>& pair) -> bool { return strcmp(pair.first, value.c_str()) == 0; });
+  if (feature != std::end(LEGACY_FEATURE_MAPPING)) {
+    m_features.insert(feature->second);
+  } else {
+    AWS_LOGSTREAM_ERROR(LOG_TAG, "Failed to add legacy feature " << legacyFeature);
+  }
+}

--- a/src/aws-cpp-sdk-core/source/platform/linux-shared/OSVersionInfo.cpp
+++ b/src/aws-cpp-sdk-core/source/platform/linux-shared/OSVersionInfo.cpp
@@ -48,7 +48,7 @@ Aws::String ComputeOSVersionString()
     if(success >= 0)
     {
         Aws::StringStream ss;
-        ss << name.sysname << "/" << name.release;
+        ss << name.sysname << "#" << name.release;
         return ss.str();
     }
 

--- a/src/aws-cpp-sdk-core/source/smithy/client/AwsSmithyClientBase.cpp
+++ b/src/aws-cpp-sdk-core/source/smithy/client/AwsSmithyClientBase.cpp
@@ -58,7 +58,12 @@ void AwsSmithyClientBase::baseInit() {
   createFromFactories(m_clientConfig->writeRateLimiter, m_clientConfig->configFactories.writeRateLimiterCreateFn);
   createFromFactories(m_clientConfig->readRateLimiter, m_clientConfig->configFactories.readRateLimiterCreateFn);
   createFromFactories(m_clientConfig->telemetryProvider, m_clientConfig->configFactories.telemetryProviderCreateFn);
-  m_userAgent = Aws::Client::ComputeUserAgentString(m_clientConfig.get());
+  if (m_clientConfig && m_clientConfig->retryStrategy) {
+    m_interceptors.emplace_back(Aws::MakeShared<UserAgentInterceptor>(AWS_SMITHY_CLIENT_LOG,
+                                                                      *m_clientConfig,
+                                                                      m_clientConfig->retryStrategy->GetStrategyName(),
+                                                                      m_serviceUserAgentName));
+  }
 }
 
 void AwsSmithyClientBase::baseCopyInit() {
@@ -67,7 +72,12 @@ void AwsSmithyClientBase::baseCopyInit() {
   createFromFactoriesIfPresent(m_clientConfig->writeRateLimiter, m_clientConfig->configFactories.writeRateLimiterCreateFn);
   createFromFactoriesIfPresent(m_clientConfig->readRateLimiter, m_clientConfig->configFactories.readRateLimiterCreateFn);
   createFromFactoriesIfPresent(m_clientConfig->telemetryProvider, m_clientConfig->configFactories.telemetryProviderCreateFn);
-  m_userAgent = Aws::Client::ComputeUserAgentString(m_clientConfig.get());
+  if (m_clientConfig && m_clientConfig->retryStrategy) {
+    m_interceptors.emplace_back(Aws::MakeShared<UserAgentInterceptor>(AWS_SMITHY_CLIENT_LOG,
+                                                                      *m_clientConfig,
+                                                                      m_clientConfig->retryStrategy->GetStrategyName(),
+                                                                      m_serviceUserAgentName));
+  }
 }
 
 std::shared_ptr<Aws::Http::HttpRequest>
@@ -90,7 +100,6 @@ AwsSmithyClientBase::BuildHttpRequest(const std::shared_ptr<AwsSmithyClientAsync
         return httpRequest;
     }
 
-    httpRequest->SetUserAgent(m_userAgent);
     httpRequest->SetHeaderValue(Aws::Http::SDK_INVOCATION_ID_HEADER, pRequestCtx->m_invocationId);
     httpRequest->SetHeaderValue(Aws::Http::SDK_REQUEST_HEADER, pRequestCtx->m_requestInfo.ToString());
     RecursionDetection::AppendRecursionDetectionHeader(pRequestCtx->m_httpRequest);

--- a/tests/aws-cpp-sdk-core-tests/aws/client/AWSClientTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/aws/client/AWSClientTest.cpp
@@ -571,21 +571,15 @@ TEST_F(AWSClientTestSuite, TestBuildHttpRequestWithHeadersOnly)
 
     ASSERT_TRUE(httpRequest->HasHeader("test1"));
     ASSERT_TRUE(httpRequest->HasHeader("test2"));
-    ASSERT_TRUE(httpRequest->HasHeader(Http::USER_AGENT_HEADER));
     ASSERT_TRUE(httpRequest->HasHeader(Http::HOST_HEADER));
     ASSERT_FALSE(httpRequest->HasHeader(Http::CONTENT_TYPE_HEADER));
     ASSERT_FALSE(httpRequest->HasHeader(Http::CONTENT_LENGTH_HEADER));
 
     HeaderValueCollection finalHeaders = httpRequest->GetHeaders();
-    ASSERT_EQ(4u, finalHeaders.size());
+    ASSERT_EQ(3u, finalHeaders.size());
     ASSERT_EQ("testValue1", finalHeaders["test1"]);
     ASSERT_EQ("testValue2", finalHeaders["test2"]);
     ASSERT_EQ("www.uri.com", finalHeaders[Http::HOST_HEADER]);
-    ASSERT_FALSE(finalHeaders[Http::USER_AGENT_HEADER].empty());
-    auto config = ClientConfiguration();
-    auto expUA = ComputeUserAgentString(&config);
-    auto actualUA = finalHeaders[Http::USER_AGENT_HEADER];
-    ASSERT_EQ(expUA, actualUA) << actualUA << " IS NOT " <<  expUA;
 
     headerValues[Http::CONTENT_LENGTH_HEADER] = "0";
     headerValues[Http::CONTENT_TYPE_HEADER] = "blah";
@@ -595,20 +589,15 @@ TEST_F(AWSClientTestSuite, TestBuildHttpRequestWithHeadersOnly)
 
     ASSERT_TRUE(httpRequest->HasHeader("test1"));
     ASSERT_TRUE(httpRequest->HasHeader("test2"));
-    ASSERT_TRUE(httpRequest->HasHeader(Http::USER_AGENT_HEADER));
     ASSERT_TRUE(httpRequest->HasHeader(Http::HOST_HEADER));
     ASSERT_FALSE(httpRequest->HasHeader(Http::CONTENT_TYPE_HEADER));
     ASSERT_FALSE(httpRequest->HasHeader(Http::CONTENT_LENGTH_HEADER));
 
     finalHeaders = httpRequest->GetHeaders();
-    ASSERT_EQ(4u, finalHeaders.size());
+    ASSERT_EQ(3u, finalHeaders.size());
     ASSERT_EQ("testValue1", finalHeaders["test1"]);
     ASSERT_EQ("testValue2", finalHeaders["test2"]);
     ASSERT_EQ("www.uri.com", finalHeaders[Http::HOST_HEADER]);
-    ASSERT_FALSE(finalHeaders[Http::USER_AGENT_HEADER].empty());
-    expUA = ComputeUserAgentString(&config);
-    actualUA = finalHeaders[Http::USER_AGENT_HEADER];
-    ASSERT_EQ(expUA, actualUA) << actualUA << " IS NOT " <<  expUA;
 }
 
 TEST_F(AWSClientTestSuite, TestBuildHttpRequestWithHeadersAndBody)
@@ -634,7 +623,6 @@ TEST_F(AWSClientTestSuite, TestBuildHttpRequestWithHeadersAndBody)
 
     ASSERT_TRUE(httpRequest->HasHeader("test1"));
     ASSERT_TRUE(httpRequest->HasHeader("test2"));
-    ASSERT_TRUE(httpRequest->HasHeader(Http::USER_AGENT_HEADER));
     ASSERT_TRUE(httpRequest->HasHeader(Http::HOST_HEADER));
     ASSERT_TRUE(httpRequest->HasHeader(Http::CONTENT_LENGTH_HEADER));
     ASSERT_TRUE(httpRequest->HasHeader(Http::CONTENT_MD5_HEADER));
@@ -642,16 +630,11 @@ TEST_F(AWSClientTestSuite, TestBuildHttpRequestWithHeadersAndBody)
     auto hashResult = Utils::HashingUtils::Base64Encode(Utils::HashingUtils::CalculateMD5(*ss));
 
     HeaderValueCollection finalHeaders = httpRequest->GetHeaders();
-    ASSERT_EQ(6u, finalHeaders.size());
+    ASSERT_EQ(5u, finalHeaders.size());
     ASSERT_EQ("testValue1", finalHeaders["test1"]);
     ASSERT_EQ("testValue2", finalHeaders["test2"]);
     ASSERT_EQ("www.uri.com", finalHeaders[Http::HOST_HEADER]);
     ASSERT_EQ(hashResult, finalHeaders[Http::CONTENT_MD5_HEADER]);
-    ASSERT_FALSE(finalHeaders[Http::USER_AGENT_HEADER].empty());
-    auto config = ClientConfiguration();
-    auto expUA = ComputeUserAgentString(&config);
-    auto actualUA = finalHeaders[Http::USER_AGENT_HEADER];
-    ASSERT_EQ(expUA, actualUA) << actualUA << " IS NOT " <<  expUA;
 
     Aws::StringStream contentLengthExpected;
     contentLengthExpected << ss->str().length();
@@ -686,7 +669,6 @@ TEST_F(AWSClientTestSuite, TestBuildHttpRequestWithAdditionalHeadersAndBody)
     ASSERT_TRUE(httpRequest->HasHeader("test2"));
     ASSERT_TRUE(httpRequest->HasHeader("test3"));
     ASSERT_TRUE(httpRequest->HasHeader("x-amz-request-payer"));
-    ASSERT_TRUE(httpRequest->HasHeader(Http::USER_AGENT_HEADER));
     ASSERT_TRUE(httpRequest->HasHeader(Http::HOST_HEADER));
     ASSERT_TRUE(httpRequest->HasHeader(Http::CONTENT_LENGTH_HEADER));
     ASSERT_TRUE(httpRequest->HasHeader(Http::CONTENT_MD5_HEADER));
@@ -694,18 +676,13 @@ TEST_F(AWSClientTestSuite, TestBuildHttpRequestWithAdditionalHeadersAndBody)
     auto hashResult = Utils::HashingUtils::Base64Encode(Utils::HashingUtils::CalculateMD5(*ss));
 
     HeaderValueCollection finalHeaders = httpRequest->GetHeaders();
-    ASSERT_EQ(8u, finalHeaders.size());
+    ASSERT_EQ(7u, finalHeaders.size());
     ASSERT_EQ("testValue1", finalHeaders["test1"]);
     ASSERT_EQ("testValue2", finalHeaders["test2"]);
     ASSERT_EQ("testValue3custom", finalHeaders["test3"]);
     ASSERT_EQ("requester", finalHeaders["x-amz-request-payer"]);
     ASSERT_EQ("www.uri.com", finalHeaders[Http::HOST_HEADER]);
     ASSERT_EQ(hashResult, finalHeaders[Http::CONTENT_MD5_HEADER]);
-    ASSERT_FALSE(finalHeaders[Http::USER_AGENT_HEADER].empty());
-    auto config = ClientConfiguration();
-    auto expUA = ComputeUserAgentString(&config);
-    auto actualUA = finalHeaders[Http::USER_AGENT_HEADER];
-    ASSERT_EQ(expUA, actualUA) << actualUA << " IS NOT " <<  expUA;
 
     Aws::StringStream contentLengthExpected;
     contentLengthExpected << ss->str().length();

--- a/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp
@@ -186,6 +186,7 @@ class TestClient : public MySmithyClient
             MySmithyClient(
                 clientConfig,
                 serviceName,
+                "ServiceUserAgentName",
                 httpClient,
                 errorMarshaller,
                 endpointProvider,
@@ -408,6 +409,7 @@ class SampleClient: public smithy::client::AwsSmithyClientT<SampleServiceName,
 public:
   SampleClient(): AwsSmithyClientT(SampleConfiguration{},
     SampleServiceName,
+    "SampleServiceUserAgentName",
     Aws::MakeShared<MockHttpClient>(SampleServiceName),
     Aws::MakeShared<Aws::Client::JsonErrorMarshaller>(SampleServiceName),
     Aws::MakeShared<SampleEndpointProvider>(SampleServiceName),

--- a/tests/aws-cpp-sdk-core-tests/smithy/client/feature/UserAgentInterceptorTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/smithy/client/feature/UserAgentInterceptorTest.cpp
@@ -1,0 +1,299 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/core/http/standard/StandardHttpRequest.h>
+#include <aws/core/platform/Environment.h>
+#include <aws/core/utils/FileSystemUtils.h>
+#include <aws/core/utils/StringUtils.h>
+#include <aws/testing/AwsCppSdkGTestSuite.h>
+#include <aws/testing/mocks/aws/client/MockAWSClient.h>
+#include <smithy/client/features/UserAgentInterceptor.h>
+
+#include <utility>
+
+using namespace smithy::interceptor;
+using namespace smithy::client;
+using namespace Aws;
+using namespace Aws::Http;
+using namespace Aws::Http::Standard;
+using namespace Aws::Testing;
+using namespace Aws::Utils;
+
+namespace {
+const char* LOG_TAG = "UserAgentInterceptorTest";
+const char* CONFIG_FILE_ENV_VAR = "AWS_CONFIG_FILE";
+const char* EXECUTION_ENV_VAR = "AWS_EXECUTION_ENV";
+const char* APP_ID_ENV_VAR = "AWS_SDK_UA_APP_ID";
+}  // namespace
+
+class UserAgentInterceptorTest : public AwsCppSdkGTestSuite {
+ public:
+  void SetUp() override {
+    m_envVars.emplace_back(CONFIG_FILE_ENV_VAR, Environment::GetEnv(CONFIG_FILE_ENV_VAR));
+    m_envVars.emplace_back(EXECUTION_ENV_VAR, Environment::GetEnv(EXECUTION_ENV_VAR));
+    m_envVars.emplace_back(APP_ID_ENV_VAR, Environment::GetEnv(APP_ID_ENV_VAR));
+    Environment::UnSetEnv(CONFIG_FILE_ENV_VAR);
+    Environment::UnSetEnv(EXECUTION_ENV_VAR);
+    Environment::UnSetEnv(APP_ID_ENV_VAR);
+  }
+
+  void TearDown() override {
+    for (auto& var : m_envVars) {
+      Environment::SetEnv(var.first.c_str(), var.second.c_str(), true);
+    }
+  }
+
+private:
+  Aws::Vector<std::pair<Aws::String, Aws::String>> m_envVars{};
+};
+
+TEST_F(UserAgentInterceptorTest, VerifyUserAgentFormat) {
+  // Create Interceptor
+  Environment::SetEnv(EXECUTION_ENV_VAR, "lambda", true);
+  Environment::SetEnv(APP_ID_ENV_VAR, "123456", true);
+  Client::ClientConfiguration configuration;
+  UserAgentInterceptor userAgentInterceptor{configuration, "standard", "TestService"};
+  userAgentInterceptor.AddLegacyFeaturesToUserAgent("ft/s3-transfer");
+
+  // Intercept Request
+  AmazonWebServiceRequestMock request{};
+  InterceptorContext context{request};
+  const auto wireRequest = Aws::MakeShared<StandardHttpRequest>(LOG_TAG, URI{"heismay.com/ninja"}, HttpMethod::HTTP_POST);
+  context.SetTransmitRequest(wireRequest);
+  userAgentInterceptor.ModifyBeforeSigning(context);
+
+  // Check for user agent header
+  EXPECT_TRUE(wireRequest->HasHeader("user-agent"));
+  const auto userAgentHeader = wireRequest->GetHeaderValue("user-agent");
+  const auto userAgentParsed = Utils::StringUtils::Split(userAgentHeader, ' ');
+  auto sdkMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("aws-sdk-cpp/") != Aws::String::npos; });
+  EXPECT_TRUE(sdkMetadata != userAgentParsed.end());
+  auto uaMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("ua/") != Aws::String::npos; });
+  EXPECT_TRUE(uaMetadata != userAgentParsed.end());
+  auto osMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("os/") != Aws::String::npos; });
+  EXPECT_TRUE(osMetadata != userAgentParsed.end());
+  auto langMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("lang/c++") != Aws::String::npos; });
+  EXPECT_TRUE(langMetadata != userAgentParsed.end());
+  auto crtMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("md/aws-crt") != Aws::String::npos; });
+  EXPECT_TRUE(crtMetadata != userAgentParsed.end());
+  auto execEnvMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("exec-env/lambda") != Aws::String::npos; });
+  EXPECT_TRUE(execEnvMetadata != userAgentParsed.end());
+  auto archMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("md/arch") != Aws::String::npos; });
+  EXPECT_TRUE(archMetadata != userAgentParsed.end());
+  auto appMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("app/123456") != Aws::String::npos; });
+  EXPECT_TRUE(appMetadata != userAgentParsed.end());
+  auto businessMetrics = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("m/") != Aws::String::npos; });
+  EXPECT_TRUE(businessMetrics != userAgentParsed.end());
+
+  // assert the order of the UA header
+  EXPECT_TRUE(sdkMetadata < uaMetadata);
+  EXPECT_TRUE(uaMetadata < osMetadata);
+  EXPECT_TRUE(osMetadata < langMetadata);
+  EXPECT_TRUE(langMetadata < crtMetadata);
+  EXPECT_TRUE(crtMetadata < execEnvMetadata);
+  EXPECT_TRUE(execEnvMetadata < archMetadata);
+  EXPECT_TRUE(archMetadata < appMetadata);
+  EXPECT_TRUE(appMetadata < businessMetrics);
+}
+
+TEST_F(UserAgentInterceptorTest, ValidAppIdAsEnviornmentVariable) {
+  // Create Interceptor
+  Environment::SetEnv(APP_ID_ENV_VAR, "123456", true);
+  Client::ClientConfiguration configuration;
+  UserAgentInterceptor userAgentInterceptor{configuration, "default", "TestService"};
+
+  // Intercept Request
+  AmazonWebServiceRequestMock request{};
+  InterceptorContext context{request};
+  const auto wireRequest = Aws::MakeShared<StandardHttpRequest>(LOG_TAG, URI{"eupha.com/summoner"}, HttpMethod::HTTP_POST);
+  context.SetTransmitRequest(wireRequest);
+  userAgentInterceptor.ModifyBeforeSigning(context);
+
+  // Check for user agent header
+  EXPECT_TRUE(wireRequest->HasHeader("user-agent"));
+  const auto userAgentHeader = wireRequest->GetHeaderValue("user-agent");
+  const auto userAgentParsed = Utils::StringUtils::Split(userAgentHeader, ' ');
+  auto sdkMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("aws-sdk-cpp/") != Aws::String::npos; });
+  EXPECT_TRUE(sdkMetadata != userAgentParsed.end());
+  auto uaMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("ua/") != Aws::String::npos; });
+  EXPECT_TRUE(uaMetadata != userAgentParsed.end());
+  auto osMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("os/") != Aws::String::npos; });
+  EXPECT_TRUE(osMetadata != userAgentParsed.end());
+  auto langMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("lang/c++") != Aws::String::npos; });
+  EXPECT_TRUE(langMetadata != userAgentParsed.end());
+  auto crtMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("md/aws-crt") != Aws::String::npos; });
+  EXPECT_TRUE(crtMetadata != userAgentParsed.end());
+  auto execEnvMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("exec-env/") != Aws::String::npos; });
+  EXPECT_TRUE(execEnvMetadata == userAgentParsed.end());
+  auto archMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("md/arch") != Aws::String::npos; });
+  EXPECT_TRUE(archMetadata != userAgentParsed.end());
+  auto appMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("app/123456") != Aws::String::npos; });
+  EXPECT_TRUE(appMetadata != userAgentParsed.end());
+  auto businessMetrics = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("m/") != Aws::String::npos; });
+  EXPECT_TRUE(businessMetrics != userAgentParsed.end());
+
+  // assert the order of the UA header
+  EXPECT_TRUE(sdkMetadata < uaMetadata);
+  EXPECT_TRUE(uaMetadata < osMetadata);
+  EXPECT_TRUE(osMetadata < langMetadata);
+  EXPECT_TRUE(langMetadata < crtMetadata);
+  EXPECT_TRUE(crtMetadata < appMetadata);
+  EXPECT_TRUE(appMetadata < businessMetrics);
+}
+
+TEST_F(UserAgentInterceptorTest, ValidAppIdAsAppIdSharedConfig) {
+  // Create Interceptor
+  TempFile configFile(std::ios_base::out | std::ios_base::trunc);
+  ASSERT_TRUE(configFile.good());
+  configFile << "[default]" <<std::endl;
+  configFile << "sdk_ua_app_id = will" <<std::endl;
+  configFile << "region = us-east-1" <<std::endl;
+  configFile << "output = json" <<std::endl;
+
+  Environment::SetEnv(CONFIG_FILE_ENV_VAR, configFile.GetFileName().c_str(), true);
+
+  Aws::Config::ReloadCachedConfigFile();
+
+  Client::ClientConfiguration configuration;
+  UserAgentInterceptor userAgentInterceptor{configuration, "default", "TestService"};
+
+  // Intercept Request
+  AmazonWebServiceRequestMock request{};
+  InterceptorContext context{request};
+  const auto wireRequest = Aws::MakeShared<StandardHttpRequest>(LOG_TAG, URI{"basilio.com/berserker"}, HttpMethod::HTTP_POST);
+  context.SetTransmitRequest(wireRequest);
+  userAgentInterceptor.ModifyBeforeSigning(context);
+
+  // Check for user agent header
+  EXPECT_TRUE(wireRequest->HasHeader("user-agent"));
+  const auto userAgentHeader = wireRequest->GetHeaderValue("user-agent");
+  const auto userAgentParsed = Utils::StringUtils::Split(userAgentHeader, ' ');
+  auto sdkMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("aws-sdk-cpp/") != Aws::String::npos; });
+  EXPECT_TRUE(sdkMetadata != userAgentParsed.end());
+  auto uaMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("ua/") != Aws::String::npos; });
+  EXPECT_TRUE(uaMetadata != userAgentParsed.end());
+  auto osMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("os/") != Aws::String::npos; });
+  EXPECT_TRUE(osMetadata != userAgentParsed.end());
+  auto langMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("lang/c++") != Aws::String::npos; });
+  EXPECT_TRUE(langMetadata != userAgentParsed.end());
+  auto crtMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("md/aws-crt") != Aws::String::npos; });
+  EXPECT_TRUE(crtMetadata != userAgentParsed.end());
+  auto execEnvMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("exec-env/") != Aws::String::npos; });
+  EXPECT_TRUE(execEnvMetadata == userAgentParsed.end());
+  auto archMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("md/arch") != Aws::String::npos; });
+  EXPECT_TRUE(archMetadata != userAgentParsed.end());
+  auto appMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("app/will") != Aws::String::npos; });
+  EXPECT_TRUE(appMetadata != userAgentParsed.end());
+  auto businessMetrics = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("m/") != Aws::String::npos; });
+  EXPECT_TRUE(businessMetrics != userAgentParsed.end());
+
+  // assert the order of the UA header
+  EXPECT_TRUE(sdkMetadata < uaMetadata);
+  EXPECT_TRUE(uaMetadata < osMetadata);
+  EXPECT_TRUE(osMetadata < langMetadata);
+  EXPECT_TRUE(langMetadata < crtMetadata);
+  EXPECT_TRUE(crtMetadata < appMetadata);
+  EXPECT_TRUE(appMetadata < businessMetrics);
+}
+
+TEST_F(UserAgentInterceptorTest, AppIdEnvVarHasPrescedencOverSharedConfig) {
+  // Create Interceptor
+  TempFile configFile(std::ios_base::out | std::ios_base::trunc);
+  ASSERT_TRUE(configFile.good());
+  configFile << "[default]" <<std::endl;
+  configFile << "sdk_ua_app_id = louis" <<std::endl;
+  configFile << "region = us-east-1" <<std::endl;
+  configFile << "output = json" <<std::endl;
+
+  Environment::SetEnv(APP_ID_ENV_VAR, "will", true);
+  Environment::SetEnv(CONFIG_FILE_ENV_VAR, configFile.GetFileName().c_str(), true);
+
+  Aws::Config::ReloadCachedConfigFile();
+
+  Client::ClientConfiguration configuration;
+  UserAgentInterceptor userAgentInterceptor{configuration, "default", "TestService"};
+
+  // Intercept Request
+  AmazonWebServiceRequestMock request{};
+  InterceptorContext context{request};
+  const auto wireRequest = Aws::MakeShared<StandardHttpRequest>(LOG_TAG, URI{"juna.com/maskeddancer"}, HttpMethod::HTTP_POST);
+  context.SetTransmitRequest(wireRequest);
+  userAgentInterceptor.ModifyBeforeSigning(context);
+
+  // Check for user agent header
+  EXPECT_TRUE(wireRequest->HasHeader("user-agent"));
+  const auto userAgentHeader = wireRequest->GetHeaderValue("user-agent");
+  const auto userAgentParsed = Utils::StringUtils::Split(userAgentHeader, ' ');
+  auto sdkMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("aws-sdk-cpp/") != Aws::String::npos; });
+  EXPECT_TRUE(sdkMetadata != userAgentParsed.end());
+  auto uaMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("ua/") != Aws::String::npos; });
+  EXPECT_TRUE(uaMetadata != userAgentParsed.end());
+  auto osMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("os/") != Aws::String::npos; });
+  EXPECT_TRUE(osMetadata != userAgentParsed.end());
+  auto langMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("lang/c++") != Aws::String::npos; });
+  EXPECT_TRUE(langMetadata != userAgentParsed.end());
+  auto crtMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("md/aws-crt") != Aws::String::npos; });
+  EXPECT_TRUE(crtMetadata != userAgentParsed.end());
+  auto execEnvMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("exec-env/") != Aws::String::npos; });
+  EXPECT_TRUE(execEnvMetadata == userAgentParsed.end());
+  auto archMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("md/arch") != Aws::String::npos; });
+  EXPECT_TRUE(archMetadata != userAgentParsed.end());
+  auto appMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("app/will") != Aws::String::npos; });
+  EXPECT_TRUE(appMetadata != userAgentParsed.end());
+  auto businessMetrics = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("m/") != Aws::String::npos; });
+  EXPECT_TRUE(businessMetrics != userAgentParsed.end());
+
+  // assert the order of the UA header
+  EXPECT_TRUE(sdkMetadata < uaMetadata);
+  EXPECT_TRUE(uaMetadata < osMetadata);
+  EXPECT_TRUE(osMetadata < langMetadata);
+  EXPECT_TRUE(langMetadata < crtMetadata);
+  EXPECT_TRUE(crtMetadata < appMetadata);
+  EXPECT_TRUE(appMetadata < businessMetrics);
+}
+
+TEST_F(UserAgentInterceptorTest, AppIdEnvVarHasInvalidCharacters) {
+  // Create Interceptor
+  Environment::SetEnv(APP_ID_ENV_VAR, "1234(", true);
+  Client::ClientConfiguration configuration;
+  UserAgentInterceptor userAgentInterceptor{configuration, "default", "TestService"};
+
+  // Intercept Request
+  AmazonWebServiceRequestMock request{};
+  InterceptorContext context{request};
+  const auto wireRequest = Aws::MakeShared<StandardHttpRequest>(LOG_TAG, URI{"juna.com/maskeddancer"}, HttpMethod::HTTP_POST);
+  context.SetTransmitRequest(wireRequest);
+  userAgentInterceptor.ModifyBeforeSigning(context);
+
+  // Check for user agent header
+  EXPECT_TRUE(wireRequest->HasHeader("user-agent"));
+  const auto userAgentHeader = wireRequest->GetHeaderValue("user-agent");
+  const auto userAgentParsed = Utils::StringUtils::Split(userAgentHeader, ' ');
+  auto sdkMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("aws-sdk-cpp/") != Aws::String::npos; });
+  EXPECT_TRUE(sdkMetadata != userAgentParsed.end());
+  auto uaMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("ua/") != Aws::String::npos; });
+  EXPECT_TRUE(uaMetadata != userAgentParsed.end());
+  auto osMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("os/") != Aws::String::npos; });
+  EXPECT_TRUE(osMetadata != userAgentParsed.end());
+  auto langMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("lang/c++") != Aws::String::npos; });
+  EXPECT_TRUE(langMetadata != userAgentParsed.end());
+  auto crtMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("md/aws-crt") != Aws::String::npos; });
+  EXPECT_TRUE(crtMetadata != userAgentParsed.end());
+  auto execEnvMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("exec-env/") != Aws::String::npos; });
+  EXPECT_TRUE(execEnvMetadata == userAgentParsed.end());
+  auto archMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("md/arch") != Aws::String::npos; });
+  EXPECT_TRUE(archMetadata != userAgentParsed.end());
+  auto appMetadata = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("app/1234-") != Aws::String::npos; });
+  EXPECT_TRUE(appMetadata != userAgentParsed.end());
+  auto businessMetrics = std::find_if(userAgentParsed.begin(), userAgentParsed.end(), [](const Aws::String & value) { return value.find("m/") != Aws::String::npos; });
+  EXPECT_TRUE(businessMetrics != userAgentParsed.end());
+
+  // assert the order of the UA header
+  EXPECT_TRUE(sdkMetadata < uaMetadata);
+  EXPECT_TRUE(uaMetadata < osMetadata);
+  EXPECT_TRUE(osMetadata < langMetadata);
+  EXPECT_TRUE(langMetadata < crtMetadata);
+  EXPECT_TRUE(crtMetadata < appMetadata);
+  EXPECT_TRUE(appMetadata < businessMetrics);
+}

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyClientSourceInit.vm
@@ -3,6 +3,7 @@ ${className}::${className}(const ${clientConfiguration}& clientConfiguration,
                            std::shared_ptr<${metadata.classNamePrefix}EndpointProviderBase> endpointProvider) :
     AwsSmithyClientT(clientConfiguration,
         GetServiceName(),
+        "${metadata.serviceId}",
         Aws::Http::CreateHttpClient(clientConfiguration),
         Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG),
         endpointProvider ? endpointProvider : Aws::MakeShared<${metadata.classNamePrefix}EndpointProvider>(ALLOCATION_TAG),
@@ -19,6 +20,7 @@ ${className}::${className}(const AWSCredentials& credentials,
                            const ${clientConfiguration}& clientConfiguration) :
     AwsSmithyClientT(clientConfiguration,
         GetServiceName(),
+        "${metadata.serviceId}",
         Aws::Http::CreateHttpClient(clientConfiguration),
         Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG),
         endpointProvider ? endpointProvider : Aws::MakeShared<${metadata.classNamePrefix}EndpointProvider>(ALLOCATION_TAG),
@@ -35,6 +37,7 @@ ${className}::${className}(const std::shared_ptr<AWSCredentialsProvider>& creden
                            const ${clientConfiguration}& clientConfiguration) :
     AwsSmithyClientT(clientConfiguration,
         GetServiceName(),
+        "${metadata.serviceId}",
         Aws::Http::CreateHttpClient(clientConfiguration),
         Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG),
         endpointProvider ? endpointProvider : Aws::MakeShared<${metadata.classNamePrefix}EndpointProvider>(ALLOCATION_TAG),
@@ -50,6 +53,7 @@ ${className}::${className}(const std::shared_ptr<AWSCredentialsProvider>& creden
 ${className}::${className}(const Client::ClientConfiguration& clientConfiguration) :
     AwsSmithyClientT(clientConfiguration,
       GetServiceName(),
+      "${metadata.serviceId}",
       Aws::Http::CreateHttpClient(clientConfiguration),
       Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG),
       Aws::MakeShared<${metadata.classNamePrefix}EndpointProvider>(ALLOCATION_TAG),
@@ -65,6 +69,7 @@ ${className}::${className}(const AWSCredentials& credentials,
                            const Client::ClientConfiguration& clientConfiguration) :
     AwsSmithyClientT(clientConfiguration,
         GetServiceName(),
+        "${metadata.serviceId}",
         Aws::Http::CreateHttpClient(clientConfiguration),
         Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG),
         Aws::MakeShared<${metadata.classNamePrefix}EndpointProvider>(ALLOCATION_TAG),
@@ -80,6 +85,7 @@ ${className}::${className}(const std::shared_ptr<AWSCredentialsProvider>& creden
                            const Client::ClientConfiguration& clientConfiguration) :
     AwsSmithyClientT(clientConfiguration,
         GetServiceName(),
+        "${metadata.serviceId}",
         Aws::Http::CreateHttpClient(clientConfiguration),
         Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG),
         Aws::MakeShared<${metadata.classNamePrefix}EndpointProvider>(ALLOCATION_TAG),


### PR DESCRIPTION
*Description of changes:*

Updates the user agent string to be compliant with the 2.1 revision. all  SDKs will eventually update to this version. For example go v2 already has in [this commit](https://github.com/aws/aws-sdk-go-v2/pull/2682/commits/dc6e9d915fd343555499e12aa40a4fed4e5b9031).

example before:
```
user-agent: 
  aws-sdk-cpp/1.11.479 
  ua/2.0 
  md/aws-crt#0.19.7 
  os/Darwin/23.6.0 
  md/arch#arm64 
  lang/c++#C++11 
  md/Clang#15.0.0 
  api/S3
```

example after:
```
user-agent: 
  aws-sdk-cpp/1.11.479 
  ua/2.1 
  api/S3 
  os/Darwin#23.6.0 
  lang/c++#C++11 
  md/aws-crt#0.19.7 
  md/arch#arm64 
  md/Clang#15.0.0 
  m/D
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
