### PR TITLE
Refactor and simplify logic in sdksCommon cmake script

### DIFF
--- a/cmake/sdks.cmake
+++ b/cmake/sdks.cmake
@@ -214,7 +214,6 @@ function(add_sdks)
         endif()
 
         add_subdirectory("${SDK_DIR}")
-        message(STATUS "exporting ${SDK_TARGET}")
         LIST(APPEND EXPORTS "${SDK_TARGET}")
         unset(SDK_TARGET)
     endforeach()


### PR DESCRIPTION
*Issue #, if available:*
cmake logic depends on c2j file list in `tools/code-generation/api-descriptions`
This does not make much sense anymore since
1. generated clients are all located under `generated/src` source tree
2. c2j file renaming logic is extracted and duplicated within the code generation script [run_code_generation.py](https://github.com/aws/aws-sdk-cpp/blob/main/tools/scripts/run_code_generation.py), so additional logic of datetime extraction, c2j filename renaming and etc is not actually required in the cmake script.

i.e. cmake can rely solely on the source tree

tested by building both full main and this branch and by comparing the cmake output and resulting build/install directories, i.e.
```
tree ~/sdk-install-main-clean/ > mainTree.log
tree ~/sdk-install-cmake-refactor/ > refactorTree.log
diff mainTree.log refactorTree.log
```

*Description of changes:*

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
