### PR TITLE
fix for older gcc error

### DIFF
--- a/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp
@@ -414,7 +414,7 @@ public:
     Aws::MakeShared<Aws::Client::JsonErrorMarshaller>(SampleServiceName),
     Aws::MakeShared<SampleEndpointProvider>(SampleServiceName),
     Aws::MakeShared<smithy::SigV4AuthSchemeResolver<>>(SampleServiceName),
-    {})
+    Aws::UnorderedMap<std::string, Aws::Crt::Variant<smithy::SigV4aAuthScheme>>())
   {}
 };
 

--- a/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp
@@ -414,7 +414,7 @@ public:
     Aws::MakeShared<Aws::Client::JsonErrorMarshaller>(SampleServiceName),
     Aws::MakeShared<SampleEndpointProvider>(SampleServiceName),
     Aws::MakeShared<smithy::SigV4AuthSchemeResolver<>>(SampleServiceName),
-    Aws::UnorderedMap<std::string, Aws::Crt::Variant<smithy::SigV4aAuthScheme>>())
+    Aws::UnorderedMap<Aws::String, Aws::Crt::Variant<smithy::SigV4aAuthScheme>>())
   {}
 };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix for error in al2012

`/local/p4clients/pkgbuild-const/workspace/build/Aws-sdk-cpp-core/Aws-sdk-cpp-core-1.11.x_StdMemoryManagement.192499.0/AL2012/DEV.STD.PTHREAD/build/private/aws-sdk-cpp/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp: In constructor 'SampleClient::SampleClient()':
/local/p4clients/pkgbuild-const/workspace/build/Aws-sdk-cpp-core/Aws-sdk-cpp-core-1.11.x_StdMemoryManagement.192499.0/AL2012/DEV.STD.PTHREAD/build/private/aws-sdk-cpp/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp:417:7: error: converting to 'Aws::UnorderedMap<std::basic_string<char>, Aws::Crt::Variant<smithy::SigV4aAuthScheme> > {aka const std::unordered_map<std::basic_string<char>, Aws::Crt::Variant<smithy::SigV4aAuthScheme>, std::hash<std::basic_string<char> >, std::equal_to<std::basic_string<char> >, std::allocator<std::pair<const std::basic_string<char>, Aws::Crt::Variant<smithy::SigV4aAuthScheme> > > >}' from initializer list would use explicit constructor 'std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_map(std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::size_type, const hasher&, const key_equal&, const allocator_type&) [with _Key = std::basic_string<char>; _Tp = Aws::Crt::Variant<smithy::SigV4aAuthScheme>; _Hash = std::hash<std::basic_string<char> >; _Pred = std::equal_to<std::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::basic_string<char>, Aws::Crt::Variant<smithy::SigV4aAuthScheme> > >; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::size_type = long unsigned int; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::hasher = std::hash<std::basic_string<char> >; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::key_equal = std::equal_to<std::basic_string<char> >; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::allocator_type = std::allocator<std::pair<const std::basic_string<char>, Aws::Crt::Variant<smithy::SigV4aAuthScheme> > >]'
     {})`


*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
