### PR TITLE
fix aws chunked encoding for a empty stream

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/stream/AwsChunkedStream.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/stream/AwsChunkedStream.h
@@ -77,7 +77,7 @@ class AwsChunkedStream {
       m_request->GetRequestHash().second->Update(reinterpret_cast<unsigned char *>(m_data.GetUnderlyingData()), bytesRead);
     }
 
-    if (m_chunkingStream != nullptr && !m_chunkingStream->bad()) {
+    if (bytesRead > 0 && m_chunkingStream != nullptr && !m_chunkingStream->bad()) {
       if (m_chunkingStream->eof()) {
         m_chunkingStream->clear();
       }

--- a/tests/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/tests/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp
@@ -1311,6 +1311,28 @@ namespace
         ASSERT_TRUE(isErrorEventReceived);
     }
 
+    TEST_F(BucketAndObjectOperationTest, TestNullBody)
+    {
+        const Aws::String fullBucketName = CalculateBucketName(BASE_PUT_OBJECTS_BUCKET_NAME.c_str());
+        SCOPED_TRACE(Aws::String("FullBucketName ") + fullBucketName);
+        CreateBucketRequest createBucketRequest;
+        createBucketRequest.SetBucket(fullBucketName);
+        createBucketRequest.SetACL(BucketCannedACL::private_);
+
+        CreateBucketOutcome createBucketOutcome = Client->CreateBucket(createBucketRequest);
+        AWS_ASSERT_SUCCESS(createBucketOutcome);
+        const CreateBucketResult& createBucketResult = createBucketOutcome.GetResult();
+        ASSERT_TRUE(!createBucketResult.GetLocation().empty());
+        ASSERT_TRUE(WaitForBucketToPropagate(fullBucketName));
+        TagTestBucket(fullBucketName, Client);
+
+        PutObjectRequest putObjectRequest;
+        putObjectRequest.SetBucket(fullBucketName);
+        putObjectRequest.SetKey("sbiscigl_was_here_null");
+        PutObjectOutcome putObjectOutcome = Client->PutObject(putObjectRequest);
+        AWS_ASSERT_SUCCESS(putObjectOutcome);
+    }
+
     TEST_F(BucketAndObjectOperationTest, TestEmptyBody)
     {
         const Aws::String fullBucketName = CalculateBucketName(BASE_PUT_OBJECTS_BUCKET_NAME.c_str());
@@ -1328,7 +1350,8 @@ namespace
 
         PutObjectRequest putObjectRequest;
         putObjectRequest.SetBucket(fullBucketName);
-        putObjectRequest.SetKey("sbiscigl_was_here");
+        putObjectRequest.SetKey("sbiscigl_was_here_empty");
+        putObjectRequest.SetBody(Aws::MakeShared<StringStream>(ALLOCATION_TAG, ""));
         PutObjectOutcome putObjectOutcome = Client->PutObject(putObjectRequest);
         AWS_ASSERT_SUCCESS(putObjectOutcome);
     }

--- a/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
@@ -2387,6 +2387,28 @@ namespace
         }
     }
 
+  TEST_F(BucketAndObjectOperationTest, TestNullBody) {
+        const Aws::String fullBucketName = CalculateBucketName(BASE_PUT_OBJECTS_BUCKET_NAME.c_str());
+        SCOPED_TRACE(Aws::String("FullBucketName ") + fullBucketName);
+
+        CreateBucketRequest createBucketRequest;
+        createBucketRequest.SetBucket(fullBucketName);
+        createBucketRequest.SetACL(BucketCannedACL::private_);
+
+        CreateBucketOutcome createBucketOutcome = CreateBucket(createBucketRequest);
+        AWS_ASSERT_SUCCESS(createBucketOutcome);
+        const CreateBucketResult& createBucketResult = createBucketOutcome.GetResult();
+        ASSERT_TRUE(!createBucketResult.GetLocation().empty());
+        ASSERT_TRUE(WaitForBucketToPropagate(fullBucketName, Client));
+        TagTestBucket(fullBucketName, Client);
+
+        PutObjectRequest putObjectRequest;
+        putObjectRequest.SetBucket(fullBucketName);
+        putObjectRequest.SetKey("sbiscigl_was_here_null");
+        PutObjectOutcome putObjectOutcome = Client->PutObject(putObjectRequest);
+        AWS_ASSERT_SUCCESS(putObjectOutcome);
+    }
+
     TEST_F(BucketAndObjectOperationTest, TestEmptyBody) {
         const Aws::String fullBucketName = CalculateBucketName(BASE_PUT_OBJECTS_BUCKET_NAME.c_str());
         SCOPED_TRACE(Aws::String("FullBucketName ") + fullBucketName);
@@ -2404,7 +2426,8 @@ namespace
 
         PutObjectRequest putObjectRequest;
         putObjectRequest.SetBucket(fullBucketName);
-        putObjectRequest.SetKey("sbiscigl_was_here");
+        putObjectRequest.SetKey("sbiscigl_was_here_empty");
+        putObjectRequest.SetBody(Aws::MakeShared<StringStream>(ALLOCATION_TAG, ""));
         PutObjectOutcome putObjectOutcome = Client->PutObject(putObjectRequest);
         AWS_ASSERT_SUCCESS(putObjectOutcome);
     }


### PR DESCRIPTION
*Issue #, if available:*

Incorrect chunked encoding with 0-length underlying stream #3259 

*Description of changes:*

Fixes a issue where if a empty stream was provided to a s3 operation it would write a empty chunk followed by another empty chunk before the trailer resulting in a aws-chunked stream that looked like

```
0\r\n\r\n0\r\nx-amz-checksum-crc32:AAAAAA==\r\n\r\n
```

where it should look like

```
0\r\nx-amz-checksum-crc32:AAAAAA==\r\n\r\n
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
