### PR TITLE
dont sign transfer encoding header

### DIFF
--- a/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
@@ -62,7 +62,7 @@ AWSAuthV4Signer::AWSAuthV4Signer(const std::shared_ptr<Auth::AWSCredentialsProvi
       m_credentialsProvider(credentialsProvider),
       m_serviceName(serviceName),
       m_region(region),
-      m_unsignedHeaders({USER_AGENT, Aws::Auth::AWSAuthHelper::X_AMZN_TRACE_ID}),
+      m_unsignedHeaders({USER_AGENT, Aws::Auth::AWSAuthHelper::X_AMZN_TRACE_ID, TRANSFER_ENCODING_HEADER}),
       m_payloadSigningPolicy(signingPolicy),
       m_urlEscapePath(urlEscapePath) {
   // go ahead and warm up the signing cache.

--- a/tests/aws-cpp-sdk-core-tests/resources/aws4_testsuite/aws4_testsuite/post-vanilla/post-vanilla.req
+++ b/tests/aws-cpp-sdk-core-tests/resources/aws4_testsuite/aws4_testsuite/post-vanilla/post-vanilla.req
@@ -1,3 +1,4 @@
 POST / HTTP/1.1
 Host:example.amazonaws.com
 X-Amz-Date:20150830T123600Z
+Transfer-Encoding: chunked


### PR DESCRIPTION
*Description of changes:*

[Transfer Encoding is described as](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding):

> Transfer-Encoding is a [hop-by-hop header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers), that is applied to a message between two nodes, not to a resource itself. Each segment of a multi-node connection can use different Transfer-Encoding values. If you want to compress data over the whole connection, use the end-to-end [Content-Encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding) header instead.

which means that we cannot sign `Transfer-Encoding` as intermediate nodes are allowed to change it.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
