### PR TITLE
[ProtocolTests] Add JSonize method to a Document type

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/Document.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/Document.h
@@ -207,6 +207,10 @@ namespace Aws
              */
             DocumentView View() const;
 
+            /**
+             * Convert this document to a JsonValue
+             */
+            Aws::Utils::Json::JsonValue Jsonize() const;
         private:
             void Destroy();
             Document(cJSON* value);

--- a/src/aws-cpp-sdk-core/source/utils/Document.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/Document.cpp
@@ -393,6 +393,10 @@ DocumentView Document::View() const
     return *this;
 }
 
+Json::JsonValue Document::Jsonize() const {
+  return Json::JsonValue(View());
+}
+
 DocumentView::DocumentView() : m_json(nullptr)
 {
 }


### PR DESCRIPTION
*Issue #, if available:*
Protocol test
Document type did not have "Jsonize" method added.
if used as an input, the codegen is generating the following code:
```
Aws::String DocumentTypeAsPayloadRequest::SerializePayload() const
{
  JsonValue payload;

  if(m_documentValueHasBeenSet)
  {
   payload = m_documentValue.Jsonize();
  }
```
*Description of changes:*
Add Jsonize method to a Document type.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
