### PR TITLE
fail a curl seek operation for aws chunked bodies

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -367,6 +367,14 @@ static size_t SeekBody(void* userdata, curl_off_t offset, int origin)
         return CURL_SEEKFUNC_FAIL;
     }
 
+    // fail seek for aws-chunk encoded body as the length and offset is unknown
+    if (context->m_request &&
+        context->m_request->HasHeader(Aws::Http::CONTENT_ENCODING_HEADER) &&
+        context->m_request->GetHeaderValue(Aws::Http::CONTENT_ENCODING_HEADER).find(Aws::Http::AWS_CHUNKED_VALUE) != Aws::String::npos)
+    {
+        return CURL_SEEKFUNC_FAIL;
+    }
+
     HttpRequest* request = context->m_request;
     const std::shared_ptr<Aws::IOStream>& ioStream = request->GetContentBody();
 


### PR DESCRIPTION
*Description of changes:*

Right now in the curl client we define a [CURLOPT_SEEKFUNCTION](https://curl.se/libcurl/c/CURLOPT_SEEKFUNCTION.html) call back that will seek a stream to a specific offset. This function is called when you pause/resume a connection. i.e. from their docs.

> This function gets called by libcurl to seek to a certain position in the input stream and can be used to fast forward a file in a resumed upload (instead of reading all uploaded bytes with the normal read function/callback). It is also called to rewind a stream when data has already been sent to the server and needs to be sent again. This may happen when doing an HTTP PUT or POST with a multi-pass authentication method, or when an existing HTTP connection is reused too late and the server closes the connection. The function shall work like fseek(3) or lseek(3) and it gets SEEK_SET, SEEK_CUR or SEEK_END as argument for origin, although libcurl currently only passes SEEK_SET.

This function is not currently invoked for aws-chunked uploads but if it were, it would result in bad behavior because we need to completely rewind the stream to read again. This will safe guard against this invariant from happening.

This is very hard to test because it required that curl issue a seek function callback, which we cannot force unless we run against a mock server. so that is why there is no associated tests that we can add. mock server tests are however a good idea that we should implement in the future.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
