### PR TITLE
fix unixtimestamp serialization on query xml clients

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
@@ -268,6 +268,21 @@ public class CppViewHelper {
         return C2J_TIMESTAMP_FORMAT_TO_CPP_DATE_TIME_FORMAT.get("iso8601");
     }
 
+    public static String computeTimeStampAccessInQueryString(final Shape shape) {
+        if (shape.getTimestampFormat() != null) {
+            if (C2J_TIMESTAMP_FORMAT_TO_CPP_DATE_TIME_FORMAT.containsKey(shape.getTimestampFormat().toLowerCase())) {
+                return String.format("ToGmtString(Aws::Utils::DateFormat::%s)",
+                        C2J_TIMESTAMP_FORMAT_TO_CPP_DATE_TIME_FORMAT.get(shape.getTimestampFormat().toLowerCase()));
+            } else if (shape.getTimestampFormat().equalsIgnoreCase("unixtimestamp")) {
+                return "SecondsWithMSPrecision()";
+            } else {
+                throw new RuntimeException("Illegal timestamp format: " + shape.getTimestampFormat());
+            }
+        }
+        return String.format("ToGmtString(Aws::Utils::DateFormat::%s)",
+                C2J_TIMESTAMP_FORMAT_TO_CPP_DATE_TIME_FORMAT.get("iso8601"));
+    }
+
     public static String computeTimestampFormatInXml(Shape shape) {
         if (shape.getTimestampFormat() != null) {
             return C2J_TIMESTAMP_FORMAT_TO_CPP_DATE_TIME_FORMAT.get(shape.getTimestampFormat().toLowerCase());

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/request/AddRequestQueryParameter.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/request/AddRequestQueryParameter.vm
@@ -3,7 +3,7 @@
 #if($shapeMember.shape.enum)
 ${shapeMember.shape.name}Mapper::GetNameFor${shapeMember.shape.name}(${memberVarName});
 #elseif($shapeMember.shape.timeStamp)
-${memberVarName}.ToGmtString(Aws::Utils::DateFormat::$CppViewHelper.computeTimestampFormatInQueryString($shapeMember.shape));
+${memberVarName}.$CppViewHelper.computeTimeStampAccessInQueryString($shapeMember.shape);
 #else
 $memberVarName;
 #end


### PR DESCRIPTION
*Description of changes:*

Fixes a issue for QueryXML models where if a time stamp used unix epoch as a timestamp it would serialize incorrectly i.e.

```
ss << m_timestamp.ToGmtString(Aws::Utils::DateFormat::$CppViewHelper.computeTimestampFormatInQueryString($shapeMember.shape));
```

where it will now correctly serialize to

```
ss << m_timestamp.SecondsWithMSPrecision();
```

[same as it does json client](https://github.com/aws/aws-sdk-cpp/blob/main/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java#L169-L181).

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
