### PR TITLE
Fix DefaultExecutor destruction deadlock if worker thread owns the Executor

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -361,7 +361,7 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config,
   m_crtCredProvider = Aws::Crt::Auth::CredentialsProvider::CreateCredentialsProviderDelegate({
      std::bind([](const std::shared_ptr<AWSCredentialsProvider>& provider) {
          if (provider == nullptr) {
-             AWS_LOGSTREAM_FATAL(ALLOCATION_TAG, "No provider provided, using anonymous provider")
+             AWS_LOGSTREAM_FATAL(ALLOCATION_TAG, "No provider provided, using anonymous provider");
              return Aws::MakeShared<Aws::Crt::Auth::Credentials>(ALLOCATION_TAG);
          }
          AWSCredentials credentials = provider->GetAWSCredentials();

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/logging/LogMacros.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/logging/LogMacros.h
@@ -77,8 +77,10 @@
         }
 
     #define AWS_LOGSTREAM_FATAL(tag, streamExpression) \
+    do { \
       AWS_LOGSTREAM(Aws::Utils::Logging::LogLevel::Fatal, tag, streamExpression) \
-      AWS_LOG_FLUSH()
+      AWS_LOG_FLUSH() \
+    } while(0)
     #define AWS_LOGSTREAM_ERROR(tag, streamExpression)  AWS_LOGSTREAM(Aws::Utils::Logging::LogLevel::Error, tag, streamExpression)
     #define AWS_LOGSTREAM_WARN(tag,  streamExpression)  AWS_LOGSTREAM(Aws::Utils::Logging::LogLevel::Warn,  tag, streamExpression)
     #define AWS_LOGSTREAM_INFO(tag,  streamExpression)  AWS_LOGSTREAM(Aws::Utils::Logging::LogLevel::Info,  tag, streamExpression)

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/logging/LogMacros.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/logging/LogMacros.h
@@ -76,7 +76,9 @@
             } \
         }
 
-    #define AWS_LOGSTREAM_FATAL(tag, streamExpression)  AWS_LOGSTREAM(Aws::Utils::Logging::LogLevel::Fatal, tag, streamExpression)
+    #define AWS_LOGSTREAM_FATAL(tag, streamExpression) \
+      AWS_LOGSTREAM(Aws::Utils::Logging::LogLevel::Fatal, tag, streamExpression) \
+      AWS_LOG_FLUSH()
     #define AWS_LOGSTREAM_ERROR(tag, streamExpression)  AWS_LOGSTREAM(Aws::Utils::Logging::LogLevel::Error, tag, streamExpression)
     #define AWS_LOGSTREAM_WARN(tag,  streamExpression)  AWS_LOGSTREAM(Aws::Utils::Logging::LogLevel::Warn,  tag, streamExpression)
     #define AWS_LOGSTREAM_INFO(tag,  streamExpression)  AWS_LOGSTREAM(Aws::Utils::Logging::LogLevel::Info,  tag, streamExpression)

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/threading/DefaultExecutor.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/threading/DefaultExecutor.h
@@ -31,6 +31,28 @@ namespace Aws
 
                 void WaitUntilStopped() override;
             protected:
+                class DefaultExecutorTask {
+                public:
+                  DefaultExecutorTask(std::function<void()>&& task, DefaultExecutor* executor);
+                  DefaultExecutorTask(const DefaultExecutorTask&) = delete;
+                  DefaultExecutorTask& operator=(const DefaultExecutorTask&) = delete;
+                  DefaultExecutorTask(DefaultExecutorTask&&) = default;
+
+                  /**
+                   * Detaches the task from the executor
+                   */
+                  void DoNotDetach();
+                  /**
+                   * Starts task execution on a new thread
+                   */
+                  static std::pair<std::thread, DefaultExecutorTask*> Launch(DefaultExecutorTask* task);
+                private:
+                  void Execute();
+
+                  std::function<void()> m_task;
+                  DefaultExecutor* m_executor = nullptr;
+                };
+
                 enum class State
                 {
                     Free, Locked, Shutdown
@@ -38,7 +60,9 @@ namespace Aws
                 bool SubmitToThread(std::function<void()>&&) override;
                 void Detach(std::thread::id id);
                 std::atomic<State> m_state;
-                Aws::UnorderedMap<std::thread::id, std::thread> m_threads;
+
+                using DefaultExecutorTaskPair = std::pair<std::thread, DefaultExecutorTask*>;
+                Aws::UnorderedMap<std::thread::id, DefaultExecutorTaskPair> m_tasks;
             };
         } // namespace Threading
     } // namespace Utils

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/threading/ThreadTask.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/threading/ThreadTask.h
@@ -33,15 +33,18 @@ namespace Aws
                 ThreadTask(ThreadTask&&) = delete;
                 ThreadTask& operator =(ThreadTask&&) = delete;
 
-                void StopProcessingWork();                
+                void StopProcessingWork();
 
+                std::thread::id GetThreadId() const;
+                void DetachFromExecutor();
             protected:
                 void MainTaskRunner();
 
-            private:                
+            private:
                 std::atomic<bool> m_continue;
                 PooledThreadExecutor& m_executor;
                 std::thread m_thread;
+                bool m_detached = false;
             };
         }
     }

--- a/src/aws-cpp-sdk-core/source/config/EC2InstanceProfileConfigLoader.cpp
+++ b/src/aws-cpp-sdk-core/source/config/EC2InstanceProfileConfigLoader.cpp
@@ -49,7 +49,7 @@ namespace Aws
             this->credentialsValidUntilMillis = DateTime::Now().Millis();
 
             if (!m_ec2metadataClient) {
-                AWS_LOGSTREAM_FATAL(EC2_INSTANCE_PROFILE_LOG_TAG, "EC2MetadataClient is a nullptr!")
+                AWS_LOGSTREAM_FATAL(EC2_INSTANCE_PROFILE_LOG_TAG, "EC2MetadataClient is a nullptr!");
                 return false;
             }
             auto credentialsStr = m_ec2metadataClient->GetDefaultCredentialsSecurely();

--- a/src/aws-cpp-sdk-core/source/utils/logging/DefaultCRTLogSystem.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/logging/DefaultCRTLogSystem.cpp
@@ -5,13 +5,10 @@
 
 #include <aws/core/utils/logging/DefaultCRTLogSystem.h>
 #include <aws/core/utils/logging/AWSLogging.h>
+#include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/logging/LogSystemInterface.h>
-#include <aws/core/utils/Array.h>
 #include <aws/common/common.h>
 #include <cstdarg>
-#include <chrono>
-#include <thread>
-#include <mutex>
 
 using namespace Aws::Utils;
 using namespace Aws::Utils::Logging;
@@ -48,6 +45,10 @@ namespace Aws
                 if (pLogSystem)
                 {
                      pLogSystem->vaLog(logLevel, subjectName, formatStr, args);
+                     if (LogLevel::Fatal == logLevel)
+                     {
+                          AWS_LOG_FLUSH();
+                     }
                 }
             }
         }

--- a/src/aws-cpp-sdk-core/source/utils/threading/DefaultExecutor.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/threading/DefaultExecutor.cpp
@@ -9,119 +9,181 @@
 
 #include <cassert>
 
-using namespace Aws::Utils::Threading;
+namespace Aws {
+namespace Utils {
+namespace Threading {
 
 static const char DEFAULT_EXECUTOR_LOG_TAG[] = "DefaultExecutor";
 
+class DefaultExecutorTask;
+using DefaultExecutorTaskPair = std::pair<std::thread, DefaultExecutorTask*>;
 
-DefaultExecutor::DefaultExecutorTask::DefaultExecutorTask(std::function<void()>&& task, DefaultExecutor* executor)
-    : m_task(std::move(task)), m_executor(executor) {
-  assert(m_task);
-}
+struct DefaultExecutor::impl {
+  impl() = default;
+  impl(const impl&) = delete;
+  impl(impl&&) = delete;
+  impl& operator=(const impl&) = delete;
+  impl& operator=(impl&&) = delete;
 
-void DefaultExecutor::DefaultExecutorTask::Execute() {
-  assert(m_task);
-  m_task();
-  if (m_executor) {
-    m_executor->Detach(std::this_thread::get_id());
+  enum class State { Free, Locked, Shutdown };
+
+  ~impl();
+
+  bool SubmitToThread(const std::shared_ptr<impl>& spThis, std::function<void()>&& fx);
+  void WaitUntilStopped();
+  void Detach(std::thread::id id);
+
+ private:
+  std::atomic<State> m_state{State::Free};
+  Aws::UnorderedMap<std::thread::id, DefaultExecutorTaskPair> m_tasks;
+};
+
+class DefaultExecutorTask {
+ public:
+  DefaultExecutorTask(std::function<void()>&& task, const std::shared_ptr<DefaultExecutor::impl>& pExecutor)
+      : m_task(std::move(task)), m_executor(pExecutor) {
+    assert(m_task);
   }
-  Aws::Delete(this);
-}
+  DefaultExecutorTask(const DefaultExecutorTask&) = delete;
+  DefaultExecutorTask& operator=(const DefaultExecutorTask&) = delete;
+  DefaultExecutorTask(DefaultExecutorTask&&) = default;
 
-void DefaultExecutor::DefaultExecutorTask::DoNotDetach() {
-  m_executor = nullptr;
-}
-
-std::pair<std::thread, DefaultExecutor::DefaultExecutorTask*> DefaultExecutor::DefaultExecutorTask::Launch(DefaultExecutorTask* task) {
-  if(!task) {
-    assert(task);
-    AWS_LOGSTREAM_FATAL(DEFAULT_EXECUTOR_LOG_TAG, "Attempted to launch a nullptr task");
-    return {};
+  /**
+   * Detaches the task from the executor
+   */
+  void DoNotDetach() { m_executor.reset(); }
+  /**
+   * Starts task execution on a new thread
+   */
+  static DefaultExecutorTaskPair Launch(DefaultExecutorTask* task) {
+    if (!task) {
+      AWS_LOGSTREAM_FATAL(DEFAULT_EXECUTOR_LOG_TAG, "Attempted to launch an empty task");
+      return {};
+    }
+    return {std::thread(&DefaultExecutorTask::Execute, task), task};
   }
-  return {std::thread(&DefaultExecutorTask::Execute, task), task};
-}
 
-bool DefaultExecutor::SubmitToThread(std::function<void()>&& fx)
-{
-    if(State::Shutdown == m_state.load()) {
-      AWS_LOGSTREAM_ERROR(DEFAULT_EXECUTOR_LOG_TAG, "Unable to submit async task: the executor is shut down!");
-      return false;
+ private:
+  void Execute() {
+    assert(m_task);
+    m_task();
+    if (const auto spExecutor = m_executor.lock()) {
+      spExecutor->Detach(std::this_thread::get_id());
     }
+    Aws::Delete(this);
+  }
 
-    auto* task = Aws::New<DefaultExecutorTask>(DEFAULT_EXECUTOR_LOG_TAG, std::move(fx), this);
-    if(!task) {
-      AWS_LOGSTREAM_ERROR(DEFAULT_EXECUTOR_LOG_TAG, "Unable to allocate async task!");
-      return false;
-    }
+  std::function<void()> m_task;
+  std::weak_ptr<DefaultExecutor::impl> m_executor;
+};
 
-    State expected;
-    do
-    {
-        expected = State::Free;
-        if(m_state.compare_exchange_strong(expected, State::Locked))
-        {
-            DefaultExecutorTaskPair taskPair = DefaultExecutorTask::Launch(task);
-            const auto id = taskPair.first.get_id();
-            m_tasks.emplace(id, std::move(taskPair));
-            m_state = State::Free;
-            return true;
-        }
-    }
-    while(expected != State::Shutdown);
+bool DefaultExecutor::SubmitToThread(std::function<void()>&& fx) {
+  if (!pImpl) {
+    AWS_LOGSTREAM_ERROR(DEFAULT_EXECUTOR_LOG_TAG, "Unable to submit async task: the executor is shut down!");
     return false;
+  }
+  return pImpl->SubmitToThread(pImpl, std::move(fx));
 }
 
-void DefaultExecutor::Detach(std::thread::id id)
-{
-    State expected;
-    do
-    {
-        expected = State::Free;
-        if(m_state.compare_exchange_strong(expected, State::Locked))
-        {
-            auto it = m_tasks.find(id);
-            assert(it != m_tasks.end());
-            it->second.first.detach();
-            m_tasks.erase(it);
-            m_state = State::Free;
-            return;
-        }
-    } 
-    while(expected != State::Shutdown);
+void DefaultExecutor::WaitUntilStopped() {
+  if (pImpl) {
+    pImpl->WaitUntilStopped();
+  }
 }
 
-void DefaultExecutor::WaitUntilStopped()
-{
-    auto expected = State::Free;
-    while(!m_state.compare_exchange_strong(expected, State::Shutdown))
-    {
-        //spin while currently detaching threads finish
-        assert(expected == State::Locked);
-        expected = State::Free;
+bool DefaultExecutor::impl::SubmitToThread(const std::shared_ptr<impl>& spThis, std::function<void()>&& fx) {
+  if (State::Shutdown == m_state.load()) {
+    AWS_LOGSTREAM_ERROR(DEFAULT_EXECUTOR_LOG_TAG, "Unable to submit async task: the executor is shut down!");
+    return false;
+  }
+
+  auto* task = Aws::New<DefaultExecutorTask>(DEFAULT_EXECUTOR_LOG_TAG, std::move(fx), spThis);
+  if (!task) {
+    AWS_LOGSTREAM_ERROR(DEFAULT_EXECUTOR_LOG_TAG, "Unable to allocate async task!");
+    return false;
+  }
+
+  State expected;
+  do {
+    expected = State::Free;
+    if (m_state.compare_exchange_strong(expected, State::Locked)) {
+      DefaultExecutorTaskPair taskPair = DefaultExecutorTask::Launch(task);
+      const auto id = taskPair.first.get_id();
+      m_tasks.emplace(id, std::move(taskPair));
+      m_state = State::Free;
+      return true;
     }
+  } while (expected != State::Shutdown);
+  return false;
 }
 
-DefaultExecutor::~DefaultExecutor()
-{
-    DefaultExecutor::WaitUntilStopped(); // virtual call is resolved at compile time
-    const auto thisThreadId = std::this_thread::get_id();
-    bool workerOwnsThis = false;
-
-    for(auto& taskItem : m_tasks) {
-      if (thisThreadId != taskItem.first) {
-        taskItem.second.first.join();
-      } else {
-        workerOwnsThis = true;
-        taskItem.second.second->DoNotDetach();  // prevent task from self-detaching from Executor
-      }
+void DefaultExecutor::impl::Detach(std::thread::id id) {
+  State expected;
+  do {
+    expected = State::Free;
+    if (m_state.compare_exchange_strong(expected, State::Locked)) {
+      auto it = m_tasks.find(id);
+      assert(it != m_tasks.end());
+      it->second.first.detach();
+      m_tasks.erase(it);
+      m_state = State::Free;
+      return;
     }
-
-    if(workerOwnsThis) {
-      std::thread toDetach = std::move(m_tasks[thisThreadId].first);
-      AWS_LOGSTREAM_WARN(DEFAULT_EXECUTOR_LOG_TAG, "DefaultExecutor is getting destructed from one of it's worker threads!");
-      AWS_LOGSTREAM_FLUSH(); // we are in UB zone and may crash soon.
-
-      m_tasks.clear();
-      toDetach.detach();
-    }
+  } while (expected != State::Shutdown);
 }
+
+void DefaultExecutor::impl::WaitUntilStopped() {
+  auto expected = State::Free;
+  while (!m_state.compare_exchange_strong(expected, State::Shutdown)) {
+    // spin while currently detaching threads finish
+    assert(expected == State::Locked);
+    expected = State::Free;
+  }
+}
+
+DefaultExecutor::DefaultExecutor() { pImpl = MakeShared<DefaultExecutor::impl>(DEFAULT_EXECUTOR_LOG_TAG); }
+
+DefaultExecutor::DefaultExecutor(const DefaultExecutor& other) {
+  AWS_UNREFERENCED_PARAM(other);
+  pImpl = MakeShared<DefaultExecutor::impl>(DEFAULT_EXECUTOR_LOG_TAG);
+}
+
+DefaultExecutor& DefaultExecutor::operator=(const DefaultExecutor& other) {
+  if (this != &other) {
+    WaitUntilStopped();
+    pImpl.reset();
+  }
+  return *this;
+}
+
+DefaultExecutor::~DefaultExecutor() {
+  DefaultExecutor::WaitUntilStopped();  // virtual call is resolved at compile time
+  pImpl.reset();
+}
+
+DefaultExecutor::impl::~impl() {
+  const auto thisThreadId = std::this_thread::get_id();
+  bool workerOwnsThis = false;
+
+  for (auto& taskItem : m_tasks) {
+    if (thisThreadId != taskItem.first) {
+      taskItem.second.first.join();
+    } else {
+      workerOwnsThis = true;
+      taskItem.second.second->DoNotDetach();  // prevent task from self-detaching from Executor
+    }
+  }
+
+  if (workerOwnsThis) {
+    std::thread toDetach = std::move(m_tasks[thisThreadId].first);
+    AWS_LOGSTREAM_WARN(DEFAULT_EXECUTOR_LOG_TAG, "DefaultExecutor is getting destructed from one of it's worker threads!");
+    AWS_LOGSTREAM_FLUSH();  // we are in UB zone and may crash soon.
+
+    m_tasks.clear();
+    toDetach.detach();
+  }
+}
+
+}  // namespace Threading
+}  // namespace Utils
+}  // namespace Aws

--- a/tests/aws-cpp-sdk-core-tests/utils/threading/PooledThreadExecutorTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/threading/PooledThreadExecutorTest.cpp
@@ -4,49 +4,19 @@
  */
 
 #include <aws/testing/AwsCppSdkGTestSuite.h>
-#include <aws/core/utils/threading/DefaultExecutor.h>
-#include <aws/core/utils/threading/Semaphore.h>
-#include <atomic>
+#include <aws/core/utils/threading/PooledThreadExecutor.h>
 #include <chrono>
 
 using namespace Aws::Utils::Threading;
 
-class DefaultExecutorTest : public Aws::Testing::AwsCppSdkGTestSuite
+class PooledThreadExecutorTest : public Aws::Testing::AwsCppSdkGTestSuite
 {
 };
 
-TEST_F(DefaultExecutorTest, ThreadsJoinOnDestructionTest)
-{
-    std::atomic<int> i(1);
-    {
-        DefaultExecutor exec;
-        static Semaphore ev(0, 2);
-        auto first = [&] { ev.WaitOne(); i++; };
-        auto second = [&] { ev.WaitOne(); i++; };
-        exec.Submit(first);
-        exec.Submit(second);
-        ev.ReleaseAll();
-    }
-    i = i * 10;
-    ASSERT_EQ(30, i.load());
-}
-
-TEST_F(DefaultExecutorTest, ThreadsDetachIfNotShuttingDown)
-{
-    using namespace std::chrono;
-    std::atomic<int> i(1);
-    static Semaphore ev(0, 1);
-    DefaultExecutor exec;
-    exec.Submit([&] { i++; ev.Release(); });
-    ev.WaitOne();
-    i = i * 10;
-    ASSERT_EQ(20, i.load());
-}
-
-TEST_F(DefaultExecutorTest, WorkerThreadTheOnlyOwner)
+TEST_F(PooledThreadExecutorTest, WorkerThreadTheOnlyOwner)
 {
   // If somehow the shared_ptr of the Executor gets owned by a worker thread of that Executor - Executor shutdown must not deadlock
-  auto pExec = Aws::MakeShared<DefaultExecutor>("WorkerThreadTheOnlyOwner");
+  auto pExec = Aws::MakeShared<PooledThreadExecutor>("WorkerThreadTheOnlyOwner", 4);
 
   std::mutex mtx;
   std::condition_variable cv;

--- a/tests/aws-cpp-sdk-core-tests/utils/threading/PooledThreadExecutorTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/threading/PooledThreadExecutorTest.cpp
@@ -3,18 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-#include <aws/testing/AwsCppSdkGTestSuite.h>
 #include <aws/core/utils/threading/PooledThreadExecutor.h>
+#include <aws/testing/AwsCppSdkGTestSuite.h>
+
 #include <chrono>
 
 using namespace Aws::Utils::Threading;
 
-class PooledThreadExecutorTest : public Aws::Testing::AwsCppSdkGTestSuite
-{
-};
+class PooledThreadExecutorTest : public Aws::Testing::AwsCppSdkGTestSuite {};
 
-TEST_F(PooledThreadExecutorTest, WorkerThreadTheOnlyOwner)
-{
+TEST_F(PooledThreadExecutorTest, WorkerThreadTheOnlyOwner) {
   // If somehow the shared_ptr of the Executor gets owned by a worker thread of that Executor - Executor shutdown must not deadlock
   auto pExec = Aws::MakeShared<PooledThreadExecutor>("WorkerThreadTheOnlyOwner", 4);
 
@@ -24,60 +22,37 @@ TEST_F(PooledThreadExecutorTest, WorkerThreadTheOnlyOwner)
   bool taskCanContinue = false;
   bool taskFinished = false;
 
-  pExec->Submit([pExec, &mtx, &cv, &taskStarted, &taskCanContinue, &taskFinished]() mutable {
-    {
-      std::unique_lock<std::mutex> lock(mtx);
-      taskStarted = true;
-      cv.notify_one();
-    }
+  auto sendSignal = [&mtx, &cv](bool& boolSignal) {
+    std::unique_lock<std::mutex> lock(mtx);
+    boolSignal = true;
+    cv.notify_one();
+  };
 
-    if (!taskCanContinue) {
+  auto waitForSignal = [&mtx, &cv](bool& boolSignal, const Aws::String& msg) {
+    if (!boolSignal) {
       std::unique_lock<std::mutex> lock(mtx);
-      cv.wait_for(lock, std::chrono::seconds(60), [&taskCanContinue]() { return taskCanContinue; });
+      cv.wait_for(lock, std::chrono::seconds(60), [&boolSignal]() { return boolSignal; });
     }
+    ASSERT_TRUE(boolSignal) << msg;
+  };
 
-    ASSERT_TRUE(taskCanContinue) << "Async task has not been allowed to continue withing 60 seconds!";
+  pExec->Submit([pExec, &sendSignal, &waitForSignal, &taskStarted, &taskCanContinue, &taskFinished]() mutable {
+    sendSignal(taskStarted);
+    waitForSignal(taskCanContinue, "Async task has not been allowed to continue within 60 seconds!");
     ASSERT_TRUE(pExec);
     ASSERT_EQ(1, pExec.use_count());
-
     pExec.reset();  // focal point of the test
     ASSERT_FALSE(pExec);
-
-    {
-      std::unique_lock<std::mutex> lock(mtx);
-      taskFinished = true;
-      cv.notify_one();
-    }
+    sendSignal(taskFinished);
   });
 
-  if (!taskStarted) {
-    std::unique_lock<std::mutex> lock(mtx);
-    cv.wait_for(lock, std::chrono::seconds(60), [&taskStarted]() { return taskStarted; });
-  }
-  ASSERT_TRUE(taskStarted) << "Async task has not started within 60 seconds!";
-  if (!taskStarted) {
-    std::terminate();  // avoid hanging tests
-  }
-
+  waitForSignal(taskStarted, "Async task has not started within 60 seconds!");
   ASSERT_EQ(2, pExec.use_count());
   pExec.reset();
   ASSERT_FALSE(pExec);
   // Now async task is the only owner of the Executor
+  sendSignal(taskCanContinue);
 
-  {
-    std::unique_lock<std::mutex> lock(mtx);
-    taskCanContinue = true;
-    cv.notify_one();
-  }
-
-  if (!taskFinished) {
-    std::unique_lock<std::mutex> lock(mtx);
-    cv.wait_for(lock, std::chrono::seconds(60), [&taskFinished]() { return taskFinished; });
-  }
-  ASSERT_TRUE(taskFinished) << "Async task has not finished within 60 seconds!";
-  if (!taskFinished) {
-    std::terminate();  // avoid hanging tests
-  }
-
+  waitForSignal(taskFinished, "Async task has not finished within 60 seconds!");
   ASSERT_FALSE(pExec);  // (just in case) executor pointer cannot magically resurrect.
 }

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -385,7 +385,7 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
   m_crtCredProvider = Aws::Crt::Auth::CredentialsProvider::CreateCredentialsProviderDelegate({
      std::bind([](const std::shared_ptr<AWSCredentialsProvider>& provider) {
          if (provider == nullptr) {
-             AWS_LOGSTREAM_FATAL(ALLOCATION_TAG, "No provider provided, using anonymous provider")
+             AWS_LOGSTREAM_FATAL(ALLOCATION_TAG, "No provider provided, using anonymous provider");
              return Aws::MakeShared<Aws::Crt::Auth::Credentials>(ALLOCATION_TAG);
          }
          AWSCredentials credentials = provider->GetAWSCredentials();


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/issues/3282
*Description of changes:*
Built-in SDK thread executors to handle the case when one of their workers/tasks is the only/final owner of the executor class.
Avoids the deadlock on the cyclic destruction.

Also, additionally, force log flush after FATAL log event has been logged to avoid logs buffering.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
