### PR TITLE
add account id to supproted identity providers

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3ExpressIdentity.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3ExpressIdentity.h
@@ -60,6 +60,11 @@ namespace Aws {
                 return getExpiration();
             }
 
+            Aws::Crt::Optional<Aws::String> accountId() const override
+            {
+                return Aws::Crt::Optional<Aws::String>{};
+            }
+
 
         private:
             Aws::String m_accessKeyId;

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ExpressIdentity.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/S3ExpressIdentity.h
@@ -60,6 +60,11 @@ namespace Aws {
                 return getExpiration();
             }
 
+            Aws::Crt::Optional<Aws::String> accountId() const override
+            {
+                return Aws::Crt::Optional<Aws::String>{};
+            }
+
 
         private:
             Aws::String m_accessKeyId;

--- a/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentials.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentials.h
@@ -54,12 +54,28 @@ namespace Aws
             {
             }
 
+            /**
+             * Initializes object with accessKeyId, secretKey, sessionToken, expiration date and account Id.
+             */
+            AWSCredentials(const Aws::String& accessKeyId,
+                           const Aws::String& secretKey,
+                           const Aws::String& sessionToken,
+                           Aws::Utils::DateTime expiration,
+                           const Aws::String& accountId)
+                : m_accessKeyId(accessKeyId),
+                  m_secretKey(secretKey),
+                  m_sessionToken(sessionToken),
+                  m_expiration(expiration),
+                  m_accountId(accountId) {}
+
             bool operator == (const AWSCredentials& other) const
             {
                 return m_accessKeyId  == other.m_accessKeyId
                     && m_secretKey    == other.m_secretKey
                     && m_sessionToken == other.m_sessionToken
-                    && m_expiration   == other.m_expiration;
+                    && m_expiration   == other.m_expiration
+                    && m_accountId    == other.m_accountId;
+
             }
 
             bool operator != (const AWSCredentials& other) const
@@ -110,6 +126,14 @@ namespace Aws
             }
 
             /**
+             * Gets the underlying account id
+             */
+            inline const Aws::String& GetAccountId() const
+            {
+              return m_accountId;
+            }
+
+            /**
              * Sets the underlying access key credential. Copies from parameter accessKeyId.
              */
             inline void SetAWSAccessKeyId(const Aws::String& accessKeyId)
@@ -131,6 +155,14 @@ namespace Aws
             inline void SetSessionToken(const Aws::String& sessionToken)
             {
                 m_sessionToken = sessionToken;
+            }
+
+            /**
+             * Sets the underlying account id. Copies from parameter accountId
+             */
+            inline void SetAccountId(const Aws::String& accountId)
+            {
+                m_accountId = accountId;
             }
 
 
@@ -159,6 +191,14 @@ namespace Aws
             }
 
             /**
+             * Sets the underlying account id. Copies from parameter accountId
+             */
+            inline void SetAccountId(const char* accountId)
+            {
+                m_accountId = accountId;
+            }
+
+            /**
              * Sets the expiration date of the credential
              */
             inline void SetExpiration(Aws::Utils::DateTime expiration)
@@ -171,6 +211,7 @@ namespace Aws
             Aws::String m_secretKey;
             Aws::String m_sessionToken;
             Aws::Utils::DateTime m_expiration;
+            Aws::String m_accountId;
         };
     }
 }

--- a/src/aws-cpp-sdk-core/include/smithy/identity/identity/AwsCredentialIdentity.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/identity/AwsCredentialIdentity.h
@@ -12,20 +12,26 @@ namespace smithy {
         AwsCredentialIdentity(const Aws::String& accessKeyId,
                               const Aws::String& secretAccessKey,
                               const Aws::Crt::Optional<Aws::String>& sessionToken,
-                              const Aws::Crt::Optional<AwsIdentity::DateTime>& expiration)
-            : m_accessKeyId(accessKeyId), m_secretAccessKey(secretAccessKey),
-              m_sessionToken(sessionToken), m_expiration(expiration) {}
+                              const Aws::Crt::Optional<AwsIdentity::DateTime>& expiration,
+                              const Aws::Crt::Optional<Aws::String>& accountId)
+            : m_accessKeyId(accessKeyId),
+              m_secretAccessKey(secretAccessKey),
+              m_sessionToken(sessionToken),
+              m_expiration(expiration),
+              m_accountId(accountId) {}
 
         Aws::String accessKeyId() const override;
         Aws::String secretAccessKey() const override;
         Aws::Crt::Optional<Aws::String> sessionToken() const override;
         Aws::Crt::Optional<AwsIdentity::DateTime> expiration() const override;
+        Aws::Crt::Optional<Aws::String> accountId() const override;
 
     protected:
         Aws::String m_accessKeyId;
         Aws::String m_secretAccessKey;
         Aws::Crt::Optional<Aws::String> m_sessionToken;
         Aws::Crt::Optional<AwsIdentity::DateTime> m_expiration;
+        Aws::Crt::Optional<Aws::String> m_accountId;
     };
 }
 

--- a/src/aws-cpp-sdk-core/include/smithy/identity/identity/AwsCredentialIdentityBase.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/identity/AwsCredentialIdentityBase.h
@@ -12,6 +12,7 @@ namespace smithy {
         virtual Aws::String accessKeyId() const = 0;
         virtual Aws::String secretAccessKey() const = 0;
         virtual Aws::Crt::Optional<Aws::String> sessionToken() const = 0;
-        virtual Aws::Crt::Optional<AwsIdentity::DateTime> expiration() const override = 0 ;
+        virtual Aws::Crt::Optional<AwsIdentity::DateTime> expiration() const override = 0;
+        virtual Aws::Crt::Optional<Aws::String> accountId() const override = 0;
     };
 }

--- a/src/aws-cpp-sdk-core/include/smithy/identity/identity/AwsIdentity.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/identity/AwsIdentity.h
@@ -17,5 +17,9 @@ namespace smithy {
         virtual Aws::Crt::Optional<DateTime> expiration() const {
             return Aws::Crt::Optional<DateTime>();
         };
+
+        virtual Aws::Crt::Optional<Aws::String> accountId() const {
+            return Aws::Crt::Optional<Aws::String>{};
+        }
     };
 }

--- a/src/aws-cpp-sdk-core/include/smithy/identity/identity/impl/AwsCredentialIdentityImpl.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/identity/impl/AwsCredentialIdentityImpl.h
@@ -23,4 +23,8 @@ namespace smithy {
     inline Aws::Crt::Optional<AwsIdentity::DateTime> AwsCredentialIdentity::expiration() const {
         return m_expiration;
     }
+
+    inline Aws::Crt::Optional<Aws::String> AwsCredentialIdentity::accountId() const {
+        return m_sessionToken;
+    }
 }

--- a/src/aws-cpp-sdk-core/include/smithy/identity/resolver/built-in/AwsCredentialsProviderIdentityResolver.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/resolver/built-in/AwsCredentialsProviderIdentityResolver.h
@@ -35,9 +35,12 @@ namespace smithy
 
             const auto fetchedCreds = m_credentialsProvider->GetAWSCredentials();
 
-            auto smithyCreds = Aws::MakeUnique<AwsCredentialIdentity>("DefaultAwsCredentialIdentityResolver",
-                                                                     fetchedCreds.GetAWSAccessKeyId(), fetchedCreds.GetAWSSecretKey(),
-                                                                     fetchedCreds.GetSessionToken(), fetchedCreds.GetExpiration());
+            auto smithyCreds = Aws::MakeUnique<AwsCredentialIdentity>("AwsCredentialsProviderIdentityResolver",
+              fetchedCreds.GetAWSAccessKeyId(),
+              fetchedCreds.GetAWSSecretKey(),
+              fetchedCreds.GetSessionToken(),
+              fetchedCreds.GetExpiration(),
+              fetchedCreds.GetAccountId());
 
             return {std::move(smithyCreds)};
         }

--- a/src/aws-cpp-sdk-core/include/smithy/identity/resolver/built-in/DefaultAwsCredentialIdentityResolver.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/resolver/built-in/DefaultAwsCredentialIdentityResolver.h
@@ -49,7 +49,8 @@ namespace smithy {
                                                                      legacyCreds.GetAWSAccessKeyId(), 
                                                                      legacyCreds.GetAWSSecretKey(),
                                                                      legacyCreds.GetSessionToken().empty()? Aws::Crt::Optional<Aws::String>() : legacyCreds.GetSessionToken(),
-                                                                     legacyCreds.GetExpiration());
+                                                                     legacyCreds.GetExpiration(),
+                                                                     legacyCreds.GetAccountId().empty()? Aws::Crt::Optional<Aws::String>() : legacyCreds.GetSessionToken());
 
             return ResolveIdentityFutureOutcome(std::move(smithyCreds));
         }

--- a/src/aws-cpp-sdk-core/include/smithy/identity/resolver/built-in/SimpleAwsCredentialIdentityResolver.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/resolver/built-in/SimpleAwsCredentialIdentityResolver.h
@@ -33,9 +33,12 @@ namespace smithy
             AWS_UNREFERENCED_PARAM(identityProperties);
             AWS_UNREFERENCED_PARAM(additionalParameters);
 
-            auto smithyCreds = Aws::MakeUnique<AwsCredentialIdentity>("DefaultAwsCredentialIdentityResolver",
-                                                                     m_credentials.GetAWSAccessKeyId(), m_credentials.GetAWSSecretKey(),
-                                                                     m_credentials.GetSessionToken(), m_credentials.GetExpiration());
+            auto smithyCreds = Aws::MakeUnique<AwsCredentialIdentity>("SimpleAwsCredentialIdentityResolver",
+                                                                     m_credentials.GetAWSAccessKeyId(),
+                                                                     m_credentials.GetAWSSecretKey(),
+                                                                     m_credentials.GetSessionToken().empty()? Aws::Crt::Optional<Aws::String>() : m_credentials.GetSessionToken(),
+                                                                     m_credentials.GetExpiration(),
+                                                                     m_credentials.GetAccountId().empty()? Aws::Crt::Optional<Aws::String>() : m_credentials.GetAccountId());
 
             return {std::move(smithyCreds)};
         }

--- a/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
@@ -36,6 +36,7 @@ using Aws::Utils::Threading::WriterLockGuard;
 static const char ACCESS_KEY_ENV_VAR[] = "AWS_ACCESS_KEY_ID";
 static const char SECRET_KEY_ENV_VAR[] = "AWS_SECRET_ACCESS_KEY";
 static const char SESSION_TOKEN_ENV_VAR[] = "AWS_SESSION_TOKEN";
+static const char ACCOUNT_ID_ENV_VAR[] = "AWS_ACCOUNT_ID";
 static const char DEFAULT_PROFILE[] = "default";
 static const char AWS_PROFILE_ENV_VAR[] = "AWS_PROFILE";
 static const char AWS_PROFILE_DEFAULT_ENV_VAR[] = "AWS_DEFAULT_PROFILE";
@@ -90,6 +91,14 @@ AWSCredentials EnvironmentAWSCredentialsProvider::GetAWSCredentials()
         {
             credentials.SetSessionToken(sessionToken);
             AWS_LOGSTREAM_DEBUG(ENVIRONMENT_LOG_TAG, "Found sessionToken");
+        }
+
+        const auto accountId = Aws::Environment::GetEnv(ACCOUNT_ID_ENV_VAR);
+
+        if (!accountId.empty())
+        {
+            credentials.SetAccountId(accountId);
+            AWS_LOGSTREAM_DEBUG(ENVIRONMENT_LOG_TAG, "Found accountId");
         }
     }
 
@@ -407,6 +416,11 @@ AWSCredentials Aws::Auth::GetCredentialsFromProcess(const Aws::String& process)
     else
     {
         credentials.SetExpiration((std::chrono::time_point<std::chrono::system_clock>::max)());
+    }
+
+    if (credentialsView.KeyExists("AccountId"))
+    {
+      credentials.SetAccountId(credentialsView.GetString("AccountId"));
     }
 
     AWS_LOGSTREAM_DEBUG(PROFILE_LOG_TAG, "Successfully pulled credentials from process credential with AccessKey: " << accessKey << ", Expiration:" << credentialsView.GetString("Expiration"));

--- a/src/aws-cpp-sdk-core/source/auth/GeneralHTTPCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/GeneralHTTPCredentialsProvider.cpp
@@ -232,17 +232,19 @@ void GeneralHTTPCredentialsProvider::Reload()
         return;
     }
 
-    Aws::String accessKey, secretKey, token;
+    Aws::String accessKey, secretKey, token, accountId;
     Utils::Json::JsonView credentialsView(credentialsDoc);
     accessKey = credentialsView.GetString("AccessKeyId");
     secretKey = credentialsView.GetString("SecretAccessKey");
     token = credentialsView.GetString("Token");
+    accountId = credentialsView.GetString("AccountId");
     AWS_LOGSTREAM_DEBUG(GEN_HTTP_LOG_TAG, "Successfully pulled credentials from metadata service with access key " << accessKey);
 
     m_credentials.SetAWSAccessKeyId(accessKey);
     m_credentials.SetAWSSecretKey(secretKey);
     m_credentials.SetSessionToken(token);
     m_credentials.SetExpiration(Aws::Utils::DateTime(credentialsView.GetString("Expiration"), Aws::Utils::DateFormat::ISO_8601));
+    m_credentials.SetAccountId(accountId);
     AWSCredentialsProvider::Reload();
 }
 

--- a/src/aws-cpp-sdk-core/source/config/AWSConfigFileProfileConfigLoader.cpp
+++ b/src/aws-cpp-sdk-core/source/config/AWSConfigFileProfileConfigLoader.cpp
@@ -21,6 +21,7 @@ namespace Aws
         static const char ACCESS_KEY_ID_KEY[]                = "aws_access_key_id";
         static const char SECRET_KEY_KEY[]                   = "aws_secret_access_key";
         static const char SESSION_TOKEN_KEY[]                = "aws_session_token";
+        static const char ACCOUNT_ID_KEY[]                   = "aws_account_id";
         static const char SSO_START_URL_KEY[]                = "sso_start_url";
         static const char SSO_REGION_KEY[]                   = "sso_region";
         static const char SSO_ACCOUNT_ID_KEY[]               = "sso_account_id";
@@ -445,7 +446,7 @@ namespace Aws
                     }
 
                     auto accessKeyIdIter = currentKeyValues.find(ACCESS_KEY_ID_KEY);
-                    Aws::String accessKey, secretKey, sessionToken;
+                    Aws::String accessKey, secretKey, sessionToken, accountId;
                     if (accessKeyIdIter != currentKeyValues.end())
                     {
                         accessKey = accessKeyIdIter->second;
@@ -467,7 +468,18 @@ namespace Aws
                             sessionToken = sessionTokenIter->second;
                         }
 
-                        profile.SetCredentials(Aws::Auth::AWSCredentials(accessKey, secretKey, sessionToken));
+                        const auto accountIdIter = currentKeyValues.find(ACCOUNT_ID_KEY);
+
+                        if (accountIdIter != currentKeyValues.end())
+                        {
+                            accountId = accountIdIter->second;
+                        }
+
+                        profile.SetCredentials(Aws::Auth::AWSCredentials(accessKey,
+                          secretKey,
+                          sessionToken,
+                          DateTime{(std::chrono::time_point<std::chrono::system_clock>::max)()},
+                          accountId));
                     }
 
                     if (!profile.GetSsoStartUrl().empty() || !profile.GetSsoRegion().empty()

--- a/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
+++ b/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
@@ -9,6 +9,7 @@
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/http/HttpResponse.h>
 #include <aws/core/utils/logging/LogMacros.h>
+#include <aws/core/utils/ARN.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/HashingUtils.h>
 #include <aws/core/platform/Environment.h>
@@ -588,6 +589,15 @@ namespace Aws
                     {
                         result.creds.SetExpiration(DateTime(StringUtils::Trim(expirationNode.GetText().c_str()).c_str(), DateFormat::ISO_8601));
                     }
+                    XmlNode assumeRoleUser = credentialsNode.FirstChild("AssumedRoleUser");
+                    if (!assumeRoleUser.IsNull())
+                    {
+                      XmlNode roleArn = assumeRoleUser.FirstChild("Arn");
+                      if (!roleArn.IsNull())
+                      {
+                        result.creds.SetAccountId(ARN{roleArn.GetText()}.GetAccountId());
+                      }
+                    }
                 }
             }
             return result;
@@ -670,6 +680,7 @@ namespace Aws
             creds.SetAWSSecretKey(roleCredentials.GetString("secretAccessKey"));
             creds.SetSessionToken(roleCredentials.GetString("sessionToken"));
             creds.SetExpiration(roleCredentials.GetInt64("expiration"));
+            creds.SetAccountId(roleCredentials.GetString("accountId"));
             SSOCredentialsClient::SSOGetRoleCredentialsResult result;
             result.creds = creds;
             return result;

--- a/tests/aws-cpp-sdk-core-tests/aws/auth/GeneralHTTPCredentialsProviderTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/aws/auth/GeneralHTTPCredentialsProviderTest.cpp
@@ -518,6 +518,7 @@ TEST_P(GeneralHTTPCredentialsProviderResponseHandlingTests, ResponseHandlingTest
       ASSERT_EQ(testCredentials.GetString("access_key_id"), credentials.GetAWSAccessKeyId());
       ASSERT_EQ(testCredentials.GetString("secret_access_key"), credentials.GetAWSSecretKey());
       ASSERT_EQ(testCredentials.GetString("session_token"), credentials.GetSessionToken());
+      ASSERT_EQ(testCredentials.GetString("account_id"), credentials.GetAccountId());
       ASSERT_EQ(Aws::Utils::DateTime(testCredentials.GetString("expiration"), Aws::Utils::DateFormat::ISO_8601), credentials.GetExpiration());
     }
   } else {

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressIdentityHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ExpressIdentityHeader.vm
@@ -60,6 +60,11 @@ namespace ${rootNamespace} {
                 return getExpiration();
             }
 
+            Aws::Crt::Optional<Aws::String> accountId() const override
+            {
+                return Aws::Crt::Optional<Aws::String>{};
+            }
+
 
         private:
             Aws::String m_accessKeyId;


### PR DESCRIPTION
*Description of changes:*

Adds the ability for support identity providers to retrieve Account ID when used.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
