### PR TITLE
improve s3 integ test error messages, add strong consistency to dynamo tests

### DIFF
--- a/tests/aws-cpp-sdk-dynamodb-integration-tests/TableOperationTest.cpp
+++ b/tests/aws-cpp-sdk-dynamodb-integration-tests/TableOperationTest.cpp
@@ -928,6 +928,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         GetItemRequest getItemRequest;
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(attributeValueTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
         Aws::Vector<Aws::String> attributesToGet;
         attributesToGet.push_back(HASH_KEY_NAME);
@@ -969,6 +970,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         GetItemRequest getItemRequest;
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(attributeValueTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
         Aws::Vector<Aws::String> attributesToGet;
         attributesToGet.push_back(HASH_KEY_NAME);
@@ -1004,6 +1006,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         GetItemRequest getItemRequest;
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(attributeValueTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
         Aws::Vector<Aws::String> attributesToGet;
         attributesToGet.push_back(HASH_KEY_NAME);
@@ -1040,6 +1043,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         GetItemRequest getItemRequest;
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(attributeValueTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
         Aws::Vector<Aws::String> attributesToGet;
         attributesToGet.push_back(HASH_KEY_NAME);
@@ -1078,6 +1082,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         GetItemRequest getItemRequest;
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(attributeValueTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
         Aws::Vector<Aws::String> attributesToGet;
         attributesToGet.push_back(HASH_KEY_NAME);
@@ -1120,6 +1125,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         GetItemRequest getItemRequest;
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(attributeValueTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
         Aws::Vector<Aws::String> attributesToGet;
         attributesToGet.push_back(HASH_KEY_NAME);
@@ -1166,6 +1172,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         GetItemRequest getItemRequest;
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(attributeValueTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
         Aws::Vector<Aws::String> attributesToGet;
         attributesToGet.push_back(HASH_KEY_NAME);
@@ -1218,6 +1225,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         GetItemRequest getItemRequest;
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(attributeValueTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
         Aws::Vector<Aws::String> attributesToGet;
         attributesToGet.push_back(HASH_KEY_NAME);
@@ -1275,6 +1283,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         GetItemRequest getItemRequest;
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(attributeValueTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
         GetItemOutcome getOutcome = m_client->GetItem(getItemRequest);
         AWS_ASSERT_SUCCESS(getOutcome);
@@ -1310,6 +1319,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         GetItemRequest getItemRequest;
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(attributeValueTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
         Aws::Vector<Aws::String> attributesToGet;
         attributesToGet.push_back(HASH_KEY_NAME);
@@ -1372,6 +1382,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         GetItemRequest getItemRequest;
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(attributeValueTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
         GetItemOutcome getOutcome = m_client->GetItem(getItemRequest);
         AWS_ASSERT_SUCCESS(getOutcome);
@@ -1406,6 +1417,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         GetItemRequest getItemRequest;
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(attributeValueTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
         Aws::Vector<Aws::String> attributesToGet;
         attributesToGet.push_back(HASH_KEY_NAME);
@@ -1440,6 +1452,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         GetItemRequest getItemRequest;
         getItemRequest.AddKey(HASH_KEY_NAME, hashKey);
         getItemRequest.SetTableName(attributeValueTestTableName);
+        getItemRequest.SetConsistentRead(true);
 
         Aws::Vector<Aws::String> attributesToGet;
         attributesToGet.push_back(HASH_KEY_NAME);

--- a/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
@@ -2547,7 +2547,7 @@ namespace
             Aws::MakeShared<StringStream>(ALLOCATION_TAG, testCase.body, std::ios_base::in | std::ios_base::binary);
         request.SetBody(body);
         const auto response = Client->PutObject(request);
-        EXPECT_TRUE(response.IsSuccess());
+        AWS_EXPECT_SUCCESS(response);
       }
     }
 

--- a/tests/aws-cpp-sdk-s3-integration-tests/S3ExpressTest.cpp
+++ b/tests/aws-cpp-sdk-s3-integration-tests/S3ExpressTest.cpp
@@ -456,11 +456,10 @@ namespace {
           Aws::MakeShared<StringStream>(ALLOCATION_TAG, testCase.body, std::ios_base::in | std::ios_base::binary);
       request.SetBody(body);
       const auto response = client->PutObject(request);
-      if (!response.IsSuccess()) {
-        EXPECT_EQ(testCase.responseCode, response.GetError().GetResponseCode());
+      if (testCase.responseCode == HttpResponseCode::OK) {
+        AWS_EXPECT_SUCCESS(response);
       } else {
-        EXPECT_EQ(testCase.responseCode, HttpResponseCode::OK);
-        EXPECT_TRUE(response.IsSuccess());
+        EXPECT_EQ(testCase.responseCode, response.GetError().GetResponseCode());
       }
     }
   }

--- a/tests/testing-resources/include/aws/testing/AwsTestHelpers.h
+++ b/tests/testing-resources/include/aws/testing/AwsTestHelpers.h
@@ -17,12 +17,14 @@
 #define AWS_ASSERT_SUCCESS(awsCppSdkOutcome) \
   ASSERT_TRUE(awsCppSdkOutcome.IsSuccess()) << "Error details: " << awsCppSdkOutcome.GetError() \
                                             << "\nRetries: " << awsCppSdkOutcome.GetRetryCount() \
-                                            << "\nNow timestamp: " << Aws::Utils::DateTime::Now().ToGmtString(Aws::Utils::DateFormat::ISO_8601_BASIC)
+                                            << "\nNow timestamp: " << Aws::Utils::DateTime::Now().ToGmtString(Aws::Utils::DateFormat::ISO_8601_BASIC) \
+                                            << "\nRequestId: " << awsCppSdkOutcome.GetError().GetRequestId()
 
 #define AWS_EXPECT_SUCCESS(awsCppSdkOutcome) \
   EXPECT_TRUE(awsCppSdkOutcome.IsSuccess()) << "Error details: " << awsCppSdkOutcome.GetError() \
                                             << "\nRetries: " << awsCppSdkOutcome.GetRetryCount() \
-                                            << "\nNow timestamp: " << Aws::Utils::DateTime::Now().ToGmtString(Aws::Utils::DateFormat::ISO_8601_BASIC)
+                                            << "\nNow timestamp: " << Aws::Utils::DateTime::Now().ToGmtString(Aws::Utils::DateFormat::ISO_8601_BASIC) \
+                                            << "\nRequestId: " << awsCppSdkOutcome.GetError().GetRequestId()
 
 /**
  * AWS-CPP-SDK test utility helper function to un-conditionally retry not succeeded operation call.


### PR DESCRIPTION
*Description of changes:*
* some s3 integration tests dont print the full error message, nor request id of the request, this is useful for debugging, adding those.
* adds strong consistency on dynamo tests that we have seen fail without it.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
