### PR TITLE
Fix tls disabled if verifySSL is not ON on Windows

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
@@ -533,7 +533,7 @@ void* WinHttpSyncHttpClient::OpenRequest(const std::shared_ptr<HttpRequest>& req
 {
     LPCWSTR accept[2] = { nullptr, nullptr };
 
-    DWORD requestFlags = request->GetUri().GetScheme() == Scheme::HTTPS && m_verifySSL ? WINHTTP_FLAG_SECURE : 0;
+    DWORD requestFlags = request->GetUri().GetScheme() == Scheme::HTTPS ? WINHTTP_FLAG_SECURE : 0;
     if (m_usingProxy) {
         // Avoid force adding "Cache-Control: no-cache" header.
         requestFlags |= WINHTTP_FLAG_REFRESH;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/issues/3008

*Description of changes:*
Basically reverting https://github.com/aws/aws-sdk-cpp/commit/6805ec77535cbd9b3fdf9175188e21b17af1a165
Maintainers agree with the fact that this is an issue: https://github.com/aws/aws-sdk-cpp/issues/3008#issuecomment-2179130108

TLS connection should not be coupled whether verifying certificate, regardless of platform.
The issue has been found affecting Windows only


*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
