### PR TITLE
Earlier credential refresh for STSCredentialsProvider

### DIFF
--- a/src/aws-cpp-sdk-identity-management/source/auth/STSProfileCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-identity-management/source/auth/STSProfileCredentialsProvider.cpp
@@ -45,13 +45,13 @@ AWSCredentials STSProfileCredentialsProvider::GetAWSCredentials()
 void STSProfileCredentialsProvider::RefreshIfExpired()
 {
     Utils::Threading::ReaderLockGuard guard(m_reloadLock);
-    if (!IsTimeToRefresh(static_cast<long>(m_reloadFrequency.count())) || !m_credentials.IsExpiredOrEmpty())
+    if (!IsTimeToRefresh(static_cast<long>(m_reloadFrequency.count())) && !m_credentials.IsExpiredOrEmpty())
     {
        return;
     }
 
     guard.UpgradeToWriterLock();
-    if (!IsTimeToRefresh(static_cast<long>(m_reloadFrequency.count())) || !m_credentials.IsExpiredOrEmpty()) // double-checked lock to avoid refreshing twice
+    if (!IsTimeToRefresh(static_cast<long>(m_reloadFrequency.count())) && !m_credentials.IsExpiredOrEmpty()) // double-checked lock to avoid refreshing twice
     {
         return;
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/issues/3305
*Description of changes:*
Change the condition of refresh from both `IsTimeToRefresh(static_cast<long>(m_reloadFrequency.count()))` and `m_credentials.IsExpiredOrEmpty()` true to either one of them true will trigger a refresh

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
