### PR TITLE
fix refresh interval for STS profile credentials provider

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentials.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentials.h
@@ -91,6 +91,14 @@ namespace Aws
 
             inline bool IsExpired() const { return m_expiration <= Aws::Utils::DateTime::Now(); }
 
+            /**
+             * Checks to see if the credentials will expire in a threshold of time
+             *
+             * @param millisecondThreshold the milliseconds of threshold we will check for expiry.
+             * @return true if the credentials will expire before the threshold
+             */
+            inline bool ExpiresSoon(int64_t millisecondThreshold = 5000) const { return (m_expiration - Aws::Utils::DateTime::Now()).count() < millisecondThreshold; }
+
             inline bool IsExpiredOrEmpty() const { return IsEmpty() || IsExpired(); }
 
             /**

--- a/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
@@ -274,7 +274,7 @@ bool InstanceProfileCredentialsProvider::ExpiresSoon() const
         credentials = profileIter->second.GetCredentials();
     }
 
-    return ((credentials.GetExpiration() - Aws::Utils::DateTime::Now()).count() < AWS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD);
+    return credentials.ExpiresSoon(AWS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD);
 }
 
 void InstanceProfileCredentialsProvider::Reload()

--- a/src/aws-cpp-sdk-identity-management/source/auth/STSProfileCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-identity-management/source/auth/STSProfileCredentialsProvider.cpp
@@ -45,13 +45,13 @@ AWSCredentials STSProfileCredentialsProvider::GetAWSCredentials()
 void STSProfileCredentialsProvider::RefreshIfExpired()
 {
     Utils::Threading::ReaderLockGuard guard(m_reloadLock);
-    if (!IsTimeToRefresh(static_cast<long>(m_reloadFrequency.count())) || !m_credentials.IsExpiredOrEmpty())
+    if (!IsTimeToRefresh(static_cast<long>(m_reloadFrequency.count())) && !m_credentials.IsEmpty() && !m_credentials.ExpiresSoon(m_reloadFrequency.count()))
     {
        return;
     }
 
     guard.UpgradeToWriterLock();
-    if (!IsTimeToRefresh(static_cast<long>(m_reloadFrequency.count())) || !m_credentials.IsExpiredOrEmpty()) // double-checked lock to avoid refreshing twice
+    if (!IsTimeToRefresh(static_cast<long>(m_reloadFrequency.count())) && !m_credentials.IsEmpty() && !m_credentials.ExpiresSoon(m_reloadFrequency.count())) // double-checked lock to avoid refreshing twice
     {
         return;
     }


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/3305

*Description of changes:*

Fixes a issue where "refresh if expiring soon" did not make it to all the places it needed to. adding a method on AWS credentials to help unify the logic.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
