### PR TITLE
Copy bi-directional event stream request

### DIFF
--- a/generated/src/aws-cpp-sdk-kinesis/include/aws/kinesis/model/SubscribeToShardHandler.h
+++ b/generated/src/aws-cpp-sdk-kinesis/include/aws/kinesis/model/SubscribeToShardHandler.h
@@ -36,6 +36,7 @@ namespace Model
     public:
         AWS_KINESIS_API SubscribeToShardHandler();
         AWS_KINESIS_API SubscribeToShardHandler& operator=(const SubscribeToShardHandler&) = default;
+        AWS_KINESIS_API SubscribeToShardHandler(const SubscribeToShardHandler&) = default;
 
         AWS_KINESIS_API virtual void OnEvent() override;
 

--- a/generated/src/aws-cpp-sdk-kinesis/include/aws/kinesis/model/SubscribeToShardRequest.h
+++ b/generated/src/aws-cpp-sdk-kinesis/include/aws/kinesis/model/SubscribeToShardRequest.h
@@ -45,7 +45,7 @@ namespace Model
     /**
      * Underlying Event Stream Handler which is used to define callback functions.
      */
-    inline const SubscribeToShardHandler& GetEventStreamHandler() const { return m_handler; }
+    inline SubscribeToShardHandler& GetEventStreamHandler() { return m_handler; }
 
     /**
      * Underlying Event Stream Handler which is used to define callback functions.

--- a/generated/src/aws-cpp-sdk-lambda/include/aws/lambda/model/InvokeWithResponseStreamHandler.h
+++ b/generated/src/aws-cpp-sdk-lambda/include/aws/lambda/model/InvokeWithResponseStreamHandler.h
@@ -39,6 +39,7 @@ namespace Model
     public:
         AWS_LAMBDA_API InvokeWithResponseStreamHandler();
         AWS_LAMBDA_API InvokeWithResponseStreamHandler& operator=(const InvokeWithResponseStreamHandler&) = default;
+        AWS_LAMBDA_API InvokeWithResponseStreamHandler(const InvokeWithResponseStreamHandler&) = default;
 
         AWS_LAMBDA_API virtual void OnEvent() override;
 

--- a/generated/src/aws-cpp-sdk-lambda/include/aws/lambda/model/InvokeWithResponseStreamRequest.h
+++ b/generated/src/aws-cpp-sdk-lambda/include/aws/lambda/model/InvokeWithResponseStreamRequest.h
@@ -51,7 +51,7 @@ namespace Model
     /**
      * Underlying Event Stream Handler which is used to define callback functions.
      */
-    inline const InvokeWithResponseStreamHandler& GetEventStreamHandler() const { return m_handler; }
+    inline InvokeWithResponseStreamHandler& GetEventStreamHandler() { return m_handler; }
 
     /**
      * Underlying Event Stream Handler which is used to define callback functions.

--- a/generated/src/aws-cpp-sdk-lambda/source/model/InvokeWithResponseStreamRequest.cpp
+++ b/generated/src/aws-cpp-sdk-lambda/source/model/InvokeWithResponseStreamRequest.cpp
@@ -27,13 +27,6 @@ InvokeWithResponseStreamRequest::InvokeWithResponseStreamRequest() :
     m_qualifierHasBeenSet(false),
     m_handler(), m_decoder(Aws::Utils::Event::EventStreamDecoder(&m_handler))
 {
-    AmazonWebServiceRequest::SetHeadersReceivedEventHandler([this](const Http::HttpRequest*, Http::HttpResponse* response)
-    {
-        auto& initialResponseHandler = m_handler.GetInitialResponseCallbackEx();
-        if (initialResponseHandler) {
-            initialResponseHandler(InvokeWithResponseStreamInitialResponse(response->GetHeaders()), Utils::Event::InitialResponseType::ON_RESPONSE);
-        }
-    });
 }
 
 

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/model/StartConversationHandler.h
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/model/StartConversationHandler.h
@@ -51,6 +51,7 @@ namespace Model
     public:
         AWS_LEXRUNTIMEV2_API StartConversationHandler();
         AWS_LEXRUNTIMEV2_API StartConversationHandler& operator=(const StartConversationHandler&) = default;
+        AWS_LEXRUNTIMEV2_API StartConversationHandler(const StartConversationHandler&) = default;
 
         AWS_LEXRUNTIMEV2_API virtual void OnEvent() override;
 

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/model/StartConversationRequest.h
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/model/StartConversationRequest.h
@@ -50,7 +50,7 @@ namespace Model
     /**
      * Underlying Event Stream Handler which is used to define callback functions.
      */
-    inline const StartConversationHandler& GetEventStreamHandler() const { return m_handler; }
+    inline StartConversationHandler& GetEventStreamHandler() { return m_handler; }
 
     /**
      * Underlying Event Stream Handler which is used to define callback functions.

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/source/LexRuntimeV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/source/LexRuntimeV2Client.cpp
@@ -17,6 +17,7 @@
 #include <aws/core/utils/DNS.h>
 #include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/logging/ErrorMacros.h>
+#include <aws/core/client/AWSClientEventStreamingAsyncTask.h>
 #include <aws/core/utils/event/EventStream.h>
 
 #include <aws/lexv2-runtime/LexRuntimeV2Client.h>
@@ -502,29 +503,21 @@ void LexRuntimeV2Client::StartConversationAsync(Model::StartConversationRequest&
   endpointResolutionOutcome.GetResult().AddPathSegments("/sessions/");
   endpointResolutionOutcome.GetResult().AddPathSegment(request.GetSessionId());
   endpointResolutionOutcome.GetResult().AddPathSegments("/conversation");
-  request.SetResponseStreamFactory(
-      [&] { request.GetEventStreamDecoder().Reset(); return Aws::New<Aws::Utils::Event::EventDecoderStream>(ALLOCATION_TAG, request.GetEventStreamDecoder()); }
-  );
 
   auto eventEncoderStream = Aws::MakeShared<Model::StartConversationRequestEventStream>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
-  request.SetRequestEventStream(eventEncoderStream); // this becomes the body of the request
-  auto sem = Aws::MakeShared<Aws::Utils::Threading::Semaphore>(ALLOCATION_TAG, 0, 1);
-  request.SetRequestSignedHandler([eventEncoderStream, sem](const Aws::Http::HttpRequest& httpRequest) { eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(httpRequest)); sem->ReleaseAll(); });
+  auto requestCopy = Aws::MakeShared<StartConversationRequest>("StartConversation", request);
+  requestCopy->SetRequestEventStream(eventEncoderStream); // this becomes the body of the request
+  request.SetRequestEventStream(eventEncoderStream);
 
-  m_clientConfiguration.executor->Submit([this, endpointResolutionOutcome, &request, handler, handlerContext] () mutable {
-      JsonOutcome outcome = MakeRequest(request, endpointResolutionOutcome.GetResult(), Aws::Http::HttpMethod::HTTP_POST, Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
-      if(outcome.IsSuccess())
-      {
-        handler(this, request, StartConversationOutcome(NoResult()), handlerContext);
-      }
-      else
-      {
-        request.GetRequestEventStream()->Close();
-        handler(this, request, StartConversationOutcome(outcome.GetError()), handlerContext);
-      }
-      return StartConversationOutcome(NoResult());
-  });
+  auto asyncTask = CreateBidirectionalEventStreamTask<StartConversationOutcome>(this,
+                                         endpointResolutionOutcome.GetResultWithOwnership(),
+                                         requestCopy,
+                                         handler,
+                                         handlerContext,
+                                         eventEncoderStream);
+  auto sem = asyncTask.GetSemaphore();
+  m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
-  streamReadyHandler(*request.GetRequestEventStream());
+  streamReadyHandler(*eventEncoderStream);
 }

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/source/model/StartConversationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/source/model/StartConversationRequest.cpp
@@ -23,13 +23,6 @@ StartConversationRequest::StartConversationRequest() :
     m_conversationModeHasBeenSet(false),
     m_handler(), m_decoder(Aws::Utils::Event::EventStreamDecoder(&m_handler))
 {
-    AmazonWebServiceRequest::SetHeadersReceivedEventHandler([this](const Http::HttpRequest*, Http::HttpResponse* response)
-    {
-        auto& initialResponseHandler = m_handler.GetInitialResponseCallbackEx();
-        if (initialResponseHandler) {
-            initialResponseHandler(StartConversationInitialResponse(response->GetHeaders()), Utils::Event::InitialResponseType::ON_RESPONSE);
-        }
-    });
 }
 
 std::shared_ptr<Aws::IOStream> StartConversationRequest::GetBody() const

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/SelectObjectContentHandler.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/SelectObjectContentHandler.h
@@ -46,6 +46,7 @@ namespace Model
     public:
         AWS_S3_API SelectObjectContentHandler();
         AWS_S3_API SelectObjectContentHandler& operator=(const SelectObjectContentHandler&) = default;
+        AWS_S3_API SelectObjectContentHandler(const SelectObjectContentHandler&) = default;
 
         AWS_S3_API virtual void OnEvent() override;
 

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/SelectObjectContentRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/SelectObjectContentRequest.h
@@ -72,7 +72,7 @@ namespace Model
     /**
      * Underlying Event Stream Handler which is used to define callback functions.
      */
-    inline const SelectObjectContentHandler& GetEventStreamHandler() const { return m_handler; }
+    inline SelectObjectContentHandler& GetEventStreamHandler() { return m_handler; }
 
     /**
      * Underlying Event Stream Handler which is used to define callback functions.

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartCallAnalyticsStreamTranscriptionHandler.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartCallAnalyticsStreamTranscriptionHandler.h
@@ -39,6 +39,7 @@ namespace Model
     public:
         AWS_TRANSCRIBESTREAMINGSERVICE_API StartCallAnalyticsStreamTranscriptionHandler();
         AWS_TRANSCRIBESTREAMINGSERVICE_API StartCallAnalyticsStreamTranscriptionHandler& operator=(const StartCallAnalyticsStreamTranscriptionHandler&) = default;
+        AWS_TRANSCRIBESTREAMINGSERVICE_API StartCallAnalyticsStreamTranscriptionHandler(const StartCallAnalyticsStreamTranscriptionHandler&) = default;
 
         AWS_TRANSCRIBESTREAMINGSERVICE_API virtual void OnEvent() override;
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartCallAnalyticsStreamTranscriptionRequest.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartCallAnalyticsStreamTranscriptionRequest.h
@@ -55,7 +55,7 @@ namespace Model
     /**
      * Underlying Event Stream Handler which is used to define callback functions.
      */
-    inline const StartCallAnalyticsStreamTranscriptionHandler& GetEventStreamHandler() const { return m_handler; }
+    inline StartCallAnalyticsStreamTranscriptionHandler& GetEventStreamHandler() { return m_handler; }
 
     /**
      * Underlying Event Stream Handler which is used to define callback functions.

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartMedicalScribeStreamHandler.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartMedicalScribeStreamHandler.h
@@ -36,6 +36,7 @@ namespace Model
     public:
         AWS_TRANSCRIBESTREAMINGSERVICE_API StartMedicalScribeStreamHandler();
         AWS_TRANSCRIBESTREAMINGSERVICE_API StartMedicalScribeStreamHandler& operator=(const StartMedicalScribeStreamHandler&) = default;
+        AWS_TRANSCRIBESTREAMINGSERVICE_API StartMedicalScribeStreamHandler(const StartMedicalScribeStreamHandler&) = default;
 
         AWS_TRANSCRIBESTREAMINGSERVICE_API virtual void OnEvent() override;
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartMedicalScribeStreamRequest.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartMedicalScribeStreamRequest.h
@@ -51,7 +51,7 @@ namespace Model
     /**
      * Underlying Event Stream Handler which is used to define callback functions.
      */
-    inline const StartMedicalScribeStreamHandler& GetEventStreamHandler() const { return m_handler; }
+    inline StartMedicalScribeStreamHandler& GetEventStreamHandler() { return m_handler; }
 
     /**
      * Underlying Event Stream Handler which is used to define callback functions.

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartMedicalStreamTranscriptionHandler.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartMedicalStreamTranscriptionHandler.h
@@ -36,6 +36,7 @@ namespace Model
     public:
         AWS_TRANSCRIBESTREAMINGSERVICE_API StartMedicalStreamTranscriptionHandler();
         AWS_TRANSCRIBESTREAMINGSERVICE_API StartMedicalStreamTranscriptionHandler& operator=(const StartMedicalStreamTranscriptionHandler&) = default;
+        AWS_TRANSCRIBESTREAMINGSERVICE_API StartMedicalStreamTranscriptionHandler(const StartMedicalStreamTranscriptionHandler&) = default;
 
         AWS_TRANSCRIBESTREAMINGSERVICE_API virtual void OnEvent() override;
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartMedicalStreamTranscriptionRequest.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartMedicalStreamTranscriptionRequest.h
@@ -54,7 +54,7 @@ namespace Model
     /**
      * Underlying Event Stream Handler which is used to define callback functions.
      */
-    inline const StartMedicalStreamTranscriptionHandler& GetEventStreamHandler() const { return m_handler; }
+    inline StartMedicalStreamTranscriptionHandler& GetEventStreamHandler() { return m_handler; }
 
     /**
      * Underlying Event Stream Handler which is used to define callback functions.

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartStreamTranscriptionHandler.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartStreamTranscriptionHandler.h
@@ -36,6 +36,7 @@ namespace Model
     public:
         AWS_TRANSCRIBESTREAMINGSERVICE_API StartStreamTranscriptionHandler();
         AWS_TRANSCRIBESTREAMINGSERVICE_API StartStreamTranscriptionHandler& operator=(const StartStreamTranscriptionHandler&) = default;
+        AWS_TRANSCRIBESTREAMINGSERVICE_API StartStreamTranscriptionHandler(const StartStreamTranscriptionHandler&) = default;
 
         AWS_TRANSCRIBESTREAMINGSERVICE_API virtual void OnEvent() override;
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartStreamTranscriptionRequest.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/StartStreamTranscriptionRequest.h
@@ -55,7 +55,7 @@ namespace Model
     /**
      * Underlying Event Stream Handler which is used to define callback functions.
      */
-    inline const StartStreamTranscriptionHandler& GetEventStreamHandler() const { return m_handler; }
+    inline StartStreamTranscriptionHandler& GetEventStreamHandler() { return m_handler; }
 
     /**
      * Underlying Event Stream Handler which is used to define callback functions.

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
@@ -17,6 +17,7 @@
 #include <aws/core/utils/DNS.h>
 #include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/logging/ErrorMacros.h>
+#include <aws/core/client/AWSClientEventStreamingAsyncTask.h>
 #include <aws/core/utils/event/EventStream.h>
 
 #include <aws/transcribestreaming/TranscribeStreamingServiceClient.h>
@@ -243,31 +244,23 @@ void TranscribeStreamingServiceClient::StartCallAnalyticsStreamTranscriptionAsyn
       return;
   }
   endpointResolutionOutcome.GetResult().AddPathSegments("/call-analytics-stream-transcription");
-  request.SetResponseStreamFactory(
-      [&] { request.GetEventStreamDecoder().Reset(); return Aws::New<Aws::Utils::Event::EventDecoderStream>(ALLOCATION_TAG, request.GetEventStreamDecoder()); }
-  );
 
   auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
-  request.SetAudioStream(eventEncoderStream); // this becomes the body of the request
-  auto sem = Aws::MakeShared<Aws::Utils::Threading::Semaphore>(ALLOCATION_TAG, 0, 1);
-  request.SetRequestSignedHandler([eventEncoderStream, sem](const Aws::Http::HttpRequest& httpRequest) { eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(httpRequest)); sem->ReleaseAll(); });
+  auto requestCopy = Aws::MakeShared<StartCallAnalyticsStreamTranscriptionRequest>("StartCallAnalyticsStreamTranscription", request);
+  requestCopy->SetAudioStream(eventEncoderStream); // this becomes the body of the request
+  request.SetAudioStream(eventEncoderStream);
 
-  m_clientConfiguration.executor->Submit([this, endpointResolutionOutcome, &request, handler, handlerContext] () mutable {
-      JsonOutcome outcome = MakeRequest(request, endpointResolutionOutcome.GetResult(), Aws::Http::HttpMethod::HTTP_POST, Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
-      if(outcome.IsSuccess())
-      {
-        handler(this, request, StartCallAnalyticsStreamTranscriptionOutcome(NoResult()), handlerContext);
-      }
-      else
-      {
-        request.GetAudioStream()->Close();
-        handler(this, request, StartCallAnalyticsStreamTranscriptionOutcome(outcome.GetError()), handlerContext);
-      }
-      return StartCallAnalyticsStreamTranscriptionOutcome(NoResult());
-  });
+  auto asyncTask = CreateBidirectionalEventStreamTask<StartCallAnalyticsStreamTranscriptionOutcome>(this,
+                                         endpointResolutionOutcome.GetResultWithOwnership(),
+                                         requestCopy,
+                                         handler,
+                                         handlerContext,
+                                         eventEncoderStream);
+  auto sem = asyncTask.GetSemaphore();
+  m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
-  streamReadyHandler(*request.GetAudioStream());
+  streamReadyHandler(*eventEncoderStream);
 }
 void TranscribeStreamingServiceClient::StartMedicalScribeStreamAsync(Model::StartMedicalScribeStreamRequest& request,
                 const StartMedicalScribeStreamStreamReadyHandler& streamReadyHandler,
@@ -309,31 +302,23 @@ void TranscribeStreamingServiceClient::StartMedicalScribeStreamAsync(Model::Star
       return;
   }
   endpointResolutionOutcome.GetResult().AddPathSegments("/medical-scribe-stream");
-  request.SetResponseStreamFactory(
-      [&] { request.GetEventStreamDecoder().Reset(); return Aws::New<Aws::Utils::Event::EventDecoderStream>(ALLOCATION_TAG, request.GetEventStreamDecoder()); }
-  );
 
   auto eventEncoderStream = Aws::MakeShared<Model::MedicalScribeInputStream>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
-  request.SetInputStream(eventEncoderStream); // this becomes the body of the request
-  auto sem = Aws::MakeShared<Aws::Utils::Threading::Semaphore>(ALLOCATION_TAG, 0, 1);
-  request.SetRequestSignedHandler([eventEncoderStream, sem](const Aws::Http::HttpRequest& httpRequest) { eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(httpRequest)); sem->ReleaseAll(); });
+  auto requestCopy = Aws::MakeShared<StartMedicalScribeStreamRequest>("StartMedicalScribeStream", request);
+  requestCopy->SetInputStream(eventEncoderStream); // this becomes the body of the request
+  request.SetInputStream(eventEncoderStream);
 
-  m_clientConfiguration.executor->Submit([this, endpointResolutionOutcome, &request, handler, handlerContext] () mutable {
-      JsonOutcome outcome = MakeRequest(request, endpointResolutionOutcome.GetResult(), Aws::Http::HttpMethod::HTTP_POST, Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
-      if(outcome.IsSuccess())
-      {
-        handler(this, request, StartMedicalScribeStreamOutcome(NoResult()), handlerContext);
-      }
-      else
-      {
-        request.GetInputStream()->Close();
-        handler(this, request, StartMedicalScribeStreamOutcome(outcome.GetError()), handlerContext);
-      }
-      return StartMedicalScribeStreamOutcome(NoResult());
-  });
+  auto asyncTask = CreateBidirectionalEventStreamTask<StartMedicalScribeStreamOutcome>(this,
+                                         endpointResolutionOutcome.GetResultWithOwnership(),
+                                         requestCopy,
+                                         handler,
+                                         handlerContext,
+                                         eventEncoderStream);
+  auto sem = asyncTask.GetSemaphore();
+  m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
-  streamReadyHandler(*request.GetInputStream());
+  streamReadyHandler(*eventEncoderStream);
 }
 void TranscribeStreamingServiceClient::StartMedicalStreamTranscriptionAsync(Model::StartMedicalStreamTranscriptionRequest& request,
                 const StartMedicalStreamTranscriptionStreamReadyHandler& streamReadyHandler,
@@ -387,31 +372,23 @@ void TranscribeStreamingServiceClient::StartMedicalStreamTranscriptionAsync(Mode
       return;
   }
   endpointResolutionOutcome.GetResult().AddPathSegments("/medical-stream-transcription");
-  request.SetResponseStreamFactory(
-      [&] { request.GetEventStreamDecoder().Reset(); return Aws::New<Aws::Utils::Event::EventDecoderStream>(ALLOCATION_TAG, request.GetEventStreamDecoder()); }
-  );
 
   auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
-  request.SetAudioStream(eventEncoderStream); // this becomes the body of the request
-  auto sem = Aws::MakeShared<Aws::Utils::Threading::Semaphore>(ALLOCATION_TAG, 0, 1);
-  request.SetRequestSignedHandler([eventEncoderStream, sem](const Aws::Http::HttpRequest& httpRequest) { eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(httpRequest)); sem->ReleaseAll(); });
+  auto requestCopy = Aws::MakeShared<StartMedicalStreamTranscriptionRequest>("StartMedicalStreamTranscription", request);
+  requestCopy->SetAudioStream(eventEncoderStream); // this becomes the body of the request
+  request.SetAudioStream(eventEncoderStream);
 
-  m_clientConfiguration.executor->Submit([this, endpointResolutionOutcome, &request, handler, handlerContext] () mutable {
-      JsonOutcome outcome = MakeRequest(request, endpointResolutionOutcome.GetResult(), Aws::Http::HttpMethod::HTTP_POST, Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
-      if(outcome.IsSuccess())
-      {
-        handler(this, request, StartMedicalStreamTranscriptionOutcome(NoResult()), handlerContext);
-      }
-      else
-      {
-        request.GetAudioStream()->Close();
-        handler(this, request, StartMedicalStreamTranscriptionOutcome(outcome.GetError()), handlerContext);
-      }
-      return StartMedicalStreamTranscriptionOutcome(NoResult());
-  });
+  auto asyncTask = CreateBidirectionalEventStreamTask<StartMedicalStreamTranscriptionOutcome>(this,
+                                         endpointResolutionOutcome.GetResultWithOwnership(),
+                                         requestCopy,
+                                         handler,
+                                         handlerContext,
+                                         eventEncoderStream);
+  auto sem = asyncTask.GetSemaphore();
+  m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
-  streamReadyHandler(*request.GetAudioStream());
+  streamReadyHandler(*eventEncoderStream);
 }
 void TranscribeStreamingServiceClient::StartStreamTranscriptionAsync(Model::StartStreamTranscriptionRequest& request,
                 const StartStreamTranscriptionStreamReadyHandler& streamReadyHandler,
@@ -447,29 +424,21 @@ void TranscribeStreamingServiceClient::StartStreamTranscriptionAsync(Model::Star
       return;
   }
   endpointResolutionOutcome.GetResult().AddPathSegments("/stream-transcription");
-  request.SetResponseStreamFactory(
-      [&] { request.GetEventStreamDecoder().Reset(); return Aws::New<Aws::Utils::Event::EventDecoderStream>(ALLOCATION_TAG, request.GetEventStreamDecoder()); }
-  );
 
   auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
-  request.SetAudioStream(eventEncoderStream); // this becomes the body of the request
-  auto sem = Aws::MakeShared<Aws::Utils::Threading::Semaphore>(ALLOCATION_TAG, 0, 1);
-  request.SetRequestSignedHandler([eventEncoderStream, sem](const Aws::Http::HttpRequest& httpRequest) { eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(httpRequest)); sem->ReleaseAll(); });
+  auto requestCopy = Aws::MakeShared<StartStreamTranscriptionRequest>("StartStreamTranscription", request);
+  requestCopy->SetAudioStream(eventEncoderStream); // this becomes the body of the request
+  request.SetAudioStream(eventEncoderStream);
 
-  m_clientConfiguration.executor->Submit([this, endpointResolutionOutcome, &request, handler, handlerContext] () mutable {
-      JsonOutcome outcome = MakeRequest(request, endpointResolutionOutcome.GetResult(), Aws::Http::HttpMethod::HTTP_POST, Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
-      if(outcome.IsSuccess())
-      {
-        handler(this, request, StartStreamTranscriptionOutcome(NoResult()), handlerContext);
-      }
-      else
-      {
-        request.GetAudioStream()->Close();
-        handler(this, request, StartStreamTranscriptionOutcome(outcome.GetError()), handlerContext);
-      }
-      return StartStreamTranscriptionOutcome(NoResult());
-  });
+  auto asyncTask = CreateBidirectionalEventStreamTask<StartStreamTranscriptionOutcome>(this,
+                                         endpointResolutionOutcome.GetResultWithOwnership(),
+                                         requestCopy,
+                                         handler,
+                                         handlerContext,
+                                         eventEncoderStream);
+  auto sem = asyncTask.GetSemaphore();
+  m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
-  streamReadyHandler(*request.GetAudioStream());
+  streamReadyHandler(*eventEncoderStream);
 }

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartCallAnalyticsStreamTranscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartCallAnalyticsStreamTranscriptionRequest.cpp
@@ -38,13 +38,6 @@ StartCallAnalyticsStreamTranscriptionRequest::StartCallAnalyticsStreamTranscript
     m_piiEntityTypesHasBeenSet(false),
     m_handler(), m_decoder(Aws::Utils::Event::EventStreamDecoder(&m_handler))
 {
-    AmazonWebServiceRequest::SetHeadersReceivedEventHandler([this](const Http::HttpRequest*, Http::HttpResponse* response)
-    {
-        auto& initialResponseHandler = m_handler.GetInitialResponseCallbackEx();
-        if (initialResponseHandler) {
-            initialResponseHandler(StartCallAnalyticsStreamTranscriptionInitialResponse(response->GetHeaders()), Utils::Event::InitialResponseType::ON_RESPONSE);
-        }
-    });
 }
 
 std::shared_ptr<Aws::IOStream> StartCallAnalyticsStreamTranscriptionRequest::GetBody() const

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartMedicalScribeStreamRequest.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartMedicalScribeStreamRequest.cpp
@@ -24,13 +24,6 @@ StartMedicalScribeStreamRequest::StartMedicalScribeStreamRequest() :
     m_mediaEncodingHasBeenSet(false),
     m_handler(), m_decoder(Aws::Utils::Event::EventStreamDecoder(&m_handler))
 {
-    AmazonWebServiceRequest::SetHeadersReceivedEventHandler([this](const Http::HttpRequest*, Http::HttpResponse* response)
-    {
-        auto& initialResponseHandler = m_handler.GetInitialResponseCallbackEx();
-        if (initialResponseHandler) {
-            initialResponseHandler(StartMedicalScribeStreamInitialResponse(response->GetHeaders()), Utils::Event::InitialResponseType::ON_RESPONSE);
-        }
-    });
 }
 
 std::shared_ptr<Aws::IOStream> StartMedicalScribeStreamRequest::GetBody() const

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartMedicalStreamTranscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartMedicalStreamTranscriptionRequest.cpp
@@ -37,13 +37,6 @@ StartMedicalStreamTranscriptionRequest::StartMedicalStreamTranscriptionRequest()
     m_contentIdentificationTypeHasBeenSet(false),
     m_handler(), m_decoder(Aws::Utils::Event::EventStreamDecoder(&m_handler))
 {
-    AmazonWebServiceRequest::SetHeadersReceivedEventHandler([this](const Http::HttpRequest*, Http::HttpResponse* response)
-    {
-        auto& initialResponseHandler = m_handler.GetInitialResponseCallbackEx();
-        if (initialResponseHandler) {
-            initialResponseHandler(StartMedicalStreamTranscriptionInitialResponse(response->GetHeaders()), Utils::Event::InitialResponseType::ON_RESPONSE);
-        }
-    });
 }
 
 std::shared_ptr<Aws::IOStream> StartMedicalStreamTranscriptionRequest::GetBody() const

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartStreamTranscriptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/model/StartStreamTranscriptionRequest.cpp
@@ -53,13 +53,6 @@ StartStreamTranscriptionRequest::StartStreamTranscriptionRequest() :
     m_vocabularyFilterNamesHasBeenSet(false),
     m_handler(), m_decoder(Aws::Utils::Event::EventStreamDecoder(&m_handler))
 {
-    AmazonWebServiceRequest::SetHeadersReceivedEventHandler([this](const Http::HttpRequest*, Http::HttpResponse* response)
-    {
-        auto& initialResponseHandler = m_handler.GetInitialResponseCallbackEx();
-        if (initialResponseHandler) {
-            initialResponseHandler(StartStreamTranscriptionInitialResponse(response->GetHeaders()), Utils::Event::InitialResponseType::ON_RESPONSE);
-        }
-    });
 }
 
 std::shared_ptr<Aws::IOStream> StartStreamTranscriptionRequest::GetBody() const

--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSClientEventStreamingAsyncTask.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSClientEventStreamingAsyncTask.h
@@ -1,0 +1,130 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+#include <aws/core/Core_EXPORTS.h>
+#include <aws/core/NoResult.h>
+#include <aws/core/client/AWSClient.h>
+#include <aws/core/utils/event/EventDecoderStream.h>
+#include <aws/core/utils/event/EventEncoderStream.h>
+#include <aws/core/utils/event/EventStreamHandler.h>
+#include <aws/core/utils/logging/ErrorMacros.h>
+
+namespace Aws {
+namespace Client {
+
+class AsyncCallerContext;
+
+/**
+ * A template class to create bi-directional eventstreaming async task.
+ * This is essentially a C++14 capture-by-move lambda
+ */
+template <typename OutcomeT, typename ClientT, typename AWSEndpointT, typename RequestT, typename HandlerT>
+class AWS_CORE_LOCAL BidirectionalEventStreamingTask final {
+ public:
+  BidirectionalEventStreamingTask(const ClientT* pClientThis, AWSEndpointT&& endpoint, const std::shared_ptr<RequestT>& pRequest,
+                                  const HandlerT& handler, const std::shared_ptr<const Aws::Client::AsyncCallerContext>& handlerContext,
+                                  const std::shared_ptr<Utils::Event::EventEncoderStream>& stream, const Http::HttpMethod method,
+                                  char const* const signerName)
+      : m_clientThis(pClientThis),
+        m_endpoint(std::move(endpoint)),
+        m_pRequest(pRequest),
+        m_handler(handler),
+        m_handlerContext(handlerContext),
+        m_stream(stream),
+        m_method(method),
+        m_signerName(signerName),
+        m_sem(Aws::MakeShared<Aws::Utils::Threading::Semaphore>("BidirectionalEventStreamingTask", 0, 1)) {
+    assert(m_clientThis);
+    assert(m_pRequest);
+    assert(m_signerName);
+
+    // Reset EventStream handler as it still has a raw dangling pointer of the original user request
+    m_pRequest->SetEventStreamHandler(m_pRequest->GetEventStreamHandler());
+
+    // Perform synchronization logic extracted from generated code
+    // Setup a signal to notify the submitter thread that the task has actually started
+    std::shared_ptr<Aws::Utils::Threading::Semaphore> sem = m_sem;
+    m_pRequest->SetRequestSignedHandler([stream, sem](const Aws::Http::HttpRequest& httpRequest) {
+      stream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(httpRequest));
+      sem->ReleaseAll();
+    });
+
+    std::weak_ptr<RequestT> wRequest = m_pRequest;
+    // Setup InitialResponse handler to use the new actual request object
+    if (!m_pRequest->GetHeadersReceivedEventHandler()) {
+      m_pRequest->SetHeadersReceivedEventHandler([wRequest](const Http::HttpRequest*, Http::HttpResponse* response) {
+        auto request = wRequest.lock();
+        AWS_CHECK_PTR(ClientT::GetAllocationTag(), request);
+        AWS_CHECK_PTR(ClientT::GetAllocationTag(), response);
+
+        auto& initialResponseHandler = request->GetEventStreamHandler().GetInitialResponseCallbackEx();
+        if (initialResponseHandler) {
+          initialResponseHandler({response->GetHeaders()}, Utils::Event::InitialResponseType::ON_RESPONSE);
+        }
+      });
+    }
+
+    // Setup ResponseStreamFactory to provide EventStream decoder based on the new actual request object, not the original one.
+    m_pRequest->SetResponseStreamFactory([wRequest]() -> Aws::IOStream* {
+      auto request = wRequest.lock();
+      if (!request) {
+        AWS_LOGSTREAM_FATAL(ClientT::GetAllocationTag(),
+                            "Unexpected nullptr bi-directional streaming request on response streaming factory call!");
+        assert(false);
+        return nullptr;
+      }
+      request->GetEventStreamDecoder().Reset();
+      return Aws::New<Aws::Utils::Event::EventDecoderStream>("BidirectionalEventStreamingTask", request->GetEventStreamDecoder());
+    });
+  }
+
+  const std::shared_ptr<Aws::Utils::Threading::Semaphore>& GetSemaphore() const { return m_sem; }
+
+  ~BidirectionalEventStreamingTask() = default;
+
+  /**
+   * Execute EventStreaming task.
+   * @return OutcomeT, operation response, NoResult on success. (Check InitialResponse for the actual service reply).
+   */
+  OutcomeT operator()() {
+    const auto outcome = m_clientThis->MakeRequest(*m_pRequest, m_endpoint, m_method, m_signerName);
+    if (outcome.IsSuccess()) {
+      m_handler(m_clientThis, *m_pRequest, OutcomeT(NoResult()), m_handlerContext);
+    } else {
+      if (m_stream) {
+        m_stream->Close();
+      }
+      m_handler(m_clientThis, *m_pRequest, OutcomeT(outcome.GetError()), m_handlerContext);
+    }
+    return OutcomeT(NoResult());
+  }
+
+ private:
+  const ClientT* m_clientThis;
+  const AWSEndpointT m_endpoint;
+  std::shared_ptr<RequestT> m_pRequest;
+  HandlerT m_handler;
+  std::shared_ptr<const Aws::Client::AsyncCallerContext> m_handlerContext;
+  std::shared_ptr<Utils::Event::EventEncoderStream> m_stream;
+  const Http::HttpMethod m_method;
+  char const* const m_signerName;
+  std::shared_ptr<Aws::Utils::Threading::Semaphore> m_sem;
+};
+
+// A helper template factory to avoid providing all typenames for BidirectionalEventStreamingTask in the generated code
+// It looks like a wall of code, you can thank clang-format for this.
+template <typename OutcomeT, typename ClientT, typename AWSEndpointT, typename RequestT, typename HandlerT>
+static BidirectionalEventStreamingTask<OutcomeT, ClientT, AWSEndpointT, RequestT, HandlerT> CreateBidirectionalEventStreamTask(
+    const ClientT* pClientThis, AWSEndpointT&& endpoint, const std::shared_ptr<RequestT>& pRequest, const HandlerT& handler,
+    const std::shared_ptr<const Aws::Client::AsyncCallerContext>& handlerContext,
+    const std::shared_ptr<Utils::Event::EventEncoderStream>& stream, const Http::HttpMethod method = Aws::Http::HttpMethod::HTTP_POST,
+    char const* const signerName = Aws::Auth::EVENTSTREAM_SIGV4_SIGNER) {
+  return BidirectionalEventStreamingTask<OutcomeT, ClientT, AWSEndpointT, RequestT, HandlerT>(
+      pClientThis, std::forward<AWSEndpointT>(endpoint), pRequest, handler, handlerContext, stream, method, signerName);
+}
+}  // namespace Client
+}  // namespace Aws

--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSJsonClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSJsonClient.h
@@ -22,7 +22,11 @@ namespace Aws
 
     namespace Client
     {
-        typedef Utils::Outcome<AmazonWebServiceResult<Utils::Json::JsonValue>, AWSError<CoreErrors>> JsonOutcome;
+        using JsonOutcome = Utils::Outcome<AmazonWebServiceResult<Utils::Json::JsonValue>, AWSError<CoreErrors>>;
+
+        template <typename OutcomeT, typename ClientT, typename AWSEndpointT, typename RequestT, typename HandlerT>
+        class BidirectionalEventStreamingTask;
+
         /**
          *  AWSClient that handles marshalling json response bodies. You would inherit from this class
          *  to create a client that uses Json as its payload format.
@@ -49,6 +53,8 @@ namespace Aws
             virtual ~AWSJsonClient() = default;
 
         protected:
+            template <typename OutcomeT, typename ClientT, typename AWSEndpointT, typename RequestT, typename HandlerT>
+            friend class BidirectionalEventStreamingTask; // allow BidirectionalEventStreamingTask to MakeRequests
             /**
              * Converts/Parses an http response into a meaningful AWSError object using the json message structure.
              */

--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSXmlClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSXmlClient.h
@@ -22,7 +22,10 @@ namespace Aws
 
     namespace Client
     {
-        typedef Utils::Outcome<AmazonWebServiceResult<Utils::Xml::XmlDocument>, AWSError<CoreErrors>> XmlOutcome;
+        using XmlOutcome = Utils::Outcome<AmazonWebServiceResult<Utils::Xml::XmlDocument>, AWSError<CoreErrors>>;
+
+        template <typename OutcomeT, typename ClientT, typename AWSEndpointT, typename RequestT, typename HandlerT>
+        class BidirectionalEventStreamingTask;
 
         /**
         *  AWSClient that handles marshalling xml response bodies. You would inherit from this class
@@ -44,6 +47,9 @@ namespace Aws
             virtual ~AWSXMLClient() = default;
 
         protected:
+            template <typename OutcomeT, typename ClientT, typename AWSEndpointT, typename RequestT, typename HandlerT>
+            friend class BidirectionalEventStreamingTask; // allow BidirectionalEventStreamingTask to MakeRequests
+
             /**
              * Converts/Parses an http response into a meaningful AWSError object. Using the XML message structure.
              */

--- a/src/aws-cpp-sdk-core/include/aws/core/http/HttpRequest.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/HttpRequest.h
@@ -581,10 +581,10 @@ namespace Aws
             Aws::String GetResolvedRemoteHost() const { return m_resolvedRemoteHost; }
             void SetResolvedRemoteHost(const Aws::String& ip) { m_resolvedRemoteHost = ip; }
 
-            bool IsEventStreamRequest() { return m_isEvenStreamRequest; }
+            bool IsEventStreamRequest() const { return m_isEvenStreamRequest; }
             void SetEventStreamRequest(bool eventStreamRequest) { m_isEvenStreamRequest = eventStreamRequest; }
             
-            bool HasEventStreamResponse() { return m_hasEvenStreamResponse; }
+            bool HasEventStreamResponse() const { return m_hasEvenStreamResponse; }
             void SetHasEventStreamResponse(bool hasEventStreamResponse) { m_hasEvenStreamResponse = hasEventStreamResponse; }
 
             virtual std::shared_ptr<Aws::Crt::Http::HttpRequest> ToCrtHttpRequest();

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/event/EventEncoderStream.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/event/EventEncoderStream.h
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+#pragma once
 
 #include <aws/core/Core_EXPORTS.h>
 #include <aws/core/utils/stream/ConcurrentStreamBuf.h>

--- a/src/aws-cpp-sdk-core/source/AmazonWebServiceRequest.cpp
+++ b/src/aws-cpp-sdk-core/source/AmazonWebServiceRequest.cpp
@@ -8,6 +8,8 @@
 
 using namespace Aws;
 
+static const char AWS_REQUEST_TAG[] = "AmazonWebServiceRequest";
+
 AmazonWebServiceRequest::AmazonWebServiceRequest() :
     m_responseStreamFactory(Aws::Utils::Stream::DefaultResponseStreamFactoryMethod),
     m_onDataReceived(nullptr),
@@ -31,4 +33,10 @@ const Aws::Http::HeaderValueCollection& AmazonWebServiceRequest::GetAdditionalCu
 void AmazonWebServiceRequest::SetAdditionalCustomHeaderValue(const Aws::String& headerName, const Aws::String& headerValue)
 {
     m_additionalCustomHeaders[Utils::StringUtils::ToLower(headerName.c_str())] = Utils::StringUtils::Trim(headerValue.c_str());
+}
+
+const char* AmazonWebServiceRequest::GetServiceRequestName() const
+{
+  AWS_LOGSTREAM_ERROR(AWS_REQUEST_TAG, "GetServiceRequestName has been called on a base abstract request class!");
+  return "AmazonWebServiceRequest";
 }

--- a/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -305,7 +305,8 @@ HttpResponseOutcome AWSClient::AttemptExhaustively(const Aws::Http::URI& uri,
         coreMetrics.httpClientMetrics = httpRequest->GetRequestMetrics();
         TracingUtils::EmitCoreHttpMetrics(httpRequest->GetRequestMetrics(),
             *m_telemetryProvider->getMeter(this->GetServiceClientName(), {}),
-            {{TracingUtils::SMITHY_METHOD_DIMENSION, request.GetServiceRequestName()},{TracingUtils::SMITHY_SERVICE_DIMENSION, this->GetServiceClientName()}});
+            {{TracingUtils::SMITHY_METHOD_DIMENSION, request.GetServiceRequestName()},
+             {TracingUtils::SMITHY_SERVICE_DIMENSION, this->GetServiceClientName()}});
         if (outcome.IsSuccess())
         {
             Aws::Monitoring::OnRequestSucceeded(this->GetServiceClientName(), request.GetServiceRequestName(), httpRequest, outcome, coreMetrics, contexts);

--- a/src/aws-cpp-sdk-core/source/utils/event/EventStreamDecoder.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/event/EventStreamDecoder.cpp
@@ -53,6 +53,7 @@ namespace Aws
 
             void EventStreamDecoder::ResetEventStreamHandler(EventStreamHandler* handler)
             {
+                m_eventStreamHandler = handler;
                 aws_event_stream_streaming_decoder_init(&m_decoder, get_aws_allocator(),
                     onPayloadSegment,
                     onPreludeReceived,

--- a/tests/aws-cpp-sdk-transcribestreaming-integ-tests/TranscribeErrorCaseTests.cpp
+++ b/tests/aws-cpp-sdk-transcribestreaming-integ-tests/TranscribeErrorCaseTests.cpp
@@ -149,9 +149,190 @@ TEST_F(TranscribeStreamingErrorTests, TranscribeAudioFile) {
                                          const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) { semaphore.ReleaseAll(); };
 
   client->StartStreamTranscriptionAsync(request, OnStreamReady, OnResponseCallback, nullptr /*context*/);
-  semaphore.WaitOne();
+  EXPECT_TRUE(semaphore.WaitOneFor(180000)) << "Streaming did not finish after 3 min";
 
   EXPECT_FALSE(operationRequestId.empty()) << "Did not receive a request id for the StartStreamTranscription";
+}
+
+TEST_F(TranscribeStreamingErrorTests, TranscribeTerminateByLowSpeedLimit) {
+  Aws::Client::ClientConfigurationInitValues cfgInit;
+  cfgInit.shouldDisableIMDS = true;
+  Aws::Client::ClientConfiguration config(cfgInit);
+  config.httpLibPerfMode = Http::TransferLibPerformanceMode::REGULAR;
+  config.enableHttpClientTrace = true;
+  config.lowSpeedLimit = 10;
+  config.requestTimeoutMs = 6000;
+  config.connectTimeoutMs = 3000;
+
+  Aws::UniquePtr<TranscribeStreamingServiceClient> client = Aws::MakeUnique<TranscribeStreamingServiceClient>(ALLOC_TAG, config);
+
+  Aws::String transcribedResult;
+  StartStreamTranscriptionHandler handler;
+  handler.SetTranscriptEventCallback([&transcribedResult](const TranscriptEvent& ev) {
+    const auto& results = ev.GetTranscript().GetResults();
+    if (results.empty()) {
+      return;
+    }
+    const auto& last = results.back();
+    const auto& alternatives = last.GetAlternatives();
+    if (alternatives.empty()) {
+      return;
+    }
+    transcribedResult = alternatives.back().GetTranscript();
+  });
+
+  Aws::String operationRequestId;
+  handler.SetInitialResponseCallback([&](const StartStreamTranscriptionInitialResponse& initialResponse) {
+    operationRequestId = initialResponse.GetRequestId();
+    if (operationRequestId.empty()) {
+      AWS_ADD_FAILURE("InitialResponseCallback is called but received empty RequestId");
+      TestTrace(Aws::String("initialResponse was: ") + initialResponse.Jsonize().View().AsString());
+    }
+    TestTrace(Aws::String("InitialResponse aws RequestId: ") + operationRequestId);
+    TestTrace(Aws::String("InitialResponse transcribe SessionId: ") + initialResponse.GetSessionId());
+  });
+  handler.SetOnErrorCallback([this](const Aws::Client::AWSError<TranscribeStreamingServiceErrors>& errors) {
+    TestTrace(Aws::String("OnErrorCallback: ") + errors.GetMessage());
+  });
+
+  StartStreamTranscriptionRequest request;
+  request.SetMediaSampleRateHertz(8000);
+  request.SetLanguageCode(LanguageCode::en_US);
+  request.SetMediaEncoding(MediaEncoding::pcm);
+  request.SetEventStreamHandler(handler);
+
+  auto OnStreamReady = [this](AudioStream& stream) {
+    TestTrace(Aws::String("OnStreamReady"));
+
+    for (size_t i = 0; i < 2; ++i) {
+      Aws::FStream file(TEST_FILE_NAME, std::ios_base::in | std::ios_base::binary);
+      ASSERT_TRUE(file);
+      char buf[2048];
+      while (file) {
+        file.read(buf, sizeof(buf));
+        Aws::Vector<unsigned char> bits{buf, buf + file.gcount()};
+        AudioEvent event(std::move(bits));
+        if (!stream) {
+          break;
+        }
+        TestTrace(Aws::String("Writing good event"));
+        if (!stream.WriteAudioEvent(event)) {
+          AWS_ADD_FAILURE("Failed to write an audio event");
+          break;
+        }
+      }
+      if (i == 0) {
+        TestTrace(Aws::String("Sleeping 16s, shoud get terminated"));
+        std::this_thread::sleep_for(std::chrono::seconds(16));
+      }
+    }
+
+    TestTrace(Aws::String("Sending final empty frame"));
+    stream.WriteAudioEvent({});
+    TestTrace(Aws::String("Flushing and closing the stream"));
+    stream.flush();
+    stream.Close();
+  };
+
+  std::mutex onResponseMtx;
+  std::condition_variable onResponseCV;
+  bool onResponseCalled = false;
+  auto OnResponseCallback = [&, this](const TranscribeStreamingServiceClient*, const StartStreamTranscriptionRequest&,
+                                      const StartStreamTranscriptionOutcome& outcome,
+                                      const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) {
+    if (outcome.IsSuccess()) {
+      TestTrace(Aws::String("OnResponseCallback, success"));
+    } else {
+      TestTrace(Aws::String("OnResponseCallback, error: ") + outcome.GetError().GetMessage());
+    }
+    std::unique_lock<std::mutex> lock(onResponseMtx);
+    onResponseCalled = true;
+    onResponseCV.notify_one();
+  };
+  for (size_t i = 0; i < 2; ++i) {
+    onResponseCalled = false;
+    client->StartStreamTranscriptionAsync(request, OnStreamReady, OnResponseCallback, nullptr /*context*/);
+    std::unique_lock<std::mutex> lock(onResponseMtx);
+    EXPECT_TRUE(onResponseCV.wait_for(lock, std::chrono::seconds(180), [&onResponseCalled]{ return onResponseCalled; })) << "Async event streaming did not start after 3 min";
+  }
+  EXPECT_FALSE(operationRequestId.empty()) << "Did not receive a request id for the StartStreamTranscription";
+}
+
+TEST_F(TranscribeStreamingErrorTests, TranscribeRequestGoesOutOfScope) {
+  Aws::Client::ClientConfigurationInitValues cfgInit;
+  cfgInit.shouldDisableIMDS = true;
+  Aws::Client::ClientConfiguration config(cfgInit);
+  config.httpLibPerfMode = Http::TransferLibPerformanceMode::REGULAR;
+  config.enableHttpClientTrace = true;
+
+  StartStreamTranscriptionHandler handler;
+  handler.SetTranscriptEventCallback([this](const TranscriptEvent& ev) {
+    TestTrace(Aws::String("TranscriptEventCallback: ") + ev.Jsonize().View().AsString());
+  });
+  handler.SetInitialResponseCallback([&](const StartStreamTranscriptionInitialResponse& initialResponse) {
+    TestTrace(Aws::String("InitialResponseCallback: ") + initialResponse.Jsonize().View().AsString());
+  });
+  handler.SetOnErrorCallback([this](const Aws::Client::AWSError<TranscribeStreamingServiceErrors>& errors) {
+    TestTrace(Aws::String("OnErrorCallback: ") + errors.GetMessage());
+  });
+  Aws::UniquePtr<StartStreamTranscriptionRequest> pRequest;
+  {
+    StartStreamTranscriptionRequest request; // also test copy construction
+    request.SetMediaSampleRateHertz(8000);
+    request.SetLanguageCode(LanguageCode::en_US);
+    request.SetMediaEncoding(MediaEncoding::pcm);
+    request.SetEventStreamHandler(handler);
+    pRequest = Aws::MakeUnique<StartStreamTranscriptionRequest>("TranscribeRequestGoesOutOfScope", request);
+  }
+  Aws::UniquePtr<StartStreamTranscriptionRequest>* ppRequest = &pRequest;
+
+  Aws::UniquePtr<TranscribeStreamingServiceClient> client = Aws::MakeUnique<TranscribeStreamingServiceClient>(ALLOC_TAG, config);
+
+  std::atomic<bool> requestAlive = {true};
+  auto OnStreamReady = [&](AudioStream& stream) {
+    TestTrace(Aws::String("OnStreamReady"));
+    // This is the main thread.
+    // the event stream worker thread must be already running at this point because this callback is called after
+    // sem->WaitOne(); which is notified by the worker thread.
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::future<bool> requestDestroyFuture = std::async(std::launch::async,
+                                    [&]() -> bool {
+                                      EXPECT_TRUE(requestAlive.load());
+                                      TestTrace(Aws::String("Destroying the request object"));
+                                      // destroy request object, simulates some other thread invalidating the request
+                                      ppRequest->reset();
+                                      ppRequest = nullptr;
+                                      TestTrace(Aws::String("The request is destroyed now"));
+                                      requestAlive.store(false);
+                                      return true;
+                                    });
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    ASSERT_TRUE(requestDestroyFuture.get());
+    EXPECT_FALSE(requestAlive.load());
+    stream.WriteAudioEvent({}); // otherwise service will complain
+    stream.Close();
+  };
+
+  Aws::Utils::Threading::Semaphore semaphore(0, 1);
+  bool gotError = false;
+  auto OnResponseCallback = [&semaphore, &gotError, this](const TranscribeStreamingServiceClient*, const StartStreamTranscriptionRequest&,
+                                         const StartStreamTranscriptionOutcome& outcome,
+                                         const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) {
+    if (outcome.IsSuccess()) {
+      TestTrace(Aws::String("OnResponseCallback, success"));
+    } else {
+      gotError = true;
+      TestTrace(Aws::String("OnResponseCallback, error: ") + outcome.GetError().GetMessage());
+    }
+    semaphore.ReleaseAll();
+  };
+
+  {
+    client->StartStreamTranscriptionAsync(*pRequest, OnStreamReady, OnResponseCallback, nullptr /*context*/);
+    TestTrace(Aws::String("StartStreamTranscriptionAsync has been submitted"));
+  }
+  EXPECT_TRUE(semaphore.WaitOneFor(180000)) << "Streaming did not finish after 3 min";
+  ASSERT_FALSE(requestAlive.load());
 }
 
 #endif

--- a/tests/aws-cpp-sdk-transcribestreaming-integ-tests/TranscribeTests.cpp
+++ b/tests/aws-cpp-sdk-transcribestreaming-integ-tests/TranscribeTests.cpp
@@ -578,6 +578,10 @@ Aws::String TranscribeStreamingTests::RunTestLikeSample(
         ) << "Did not get a response after " << Aws::Utils::StringUtils::to_string(timeoutMs) << " ms";
     EXPECT_FALSE(operationRequestId.empty()) << "Did not receive a request id for the StartStreamTranscription";
 
+    /* TODO: this API legacy contract is the final piece preventing us from making the async
+     * request to be const ref. Otherwise, the request is fully copied and independent from the original one now.
+     * (i.e. nothing prevents from going const ref but someone might still use the function below)
+     */
     request.GetAudioStream()->Close();
     shouldContinue = false;
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/RequestEventStreamHandlerHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/RequestEventStreamHandlerHeader.vm
@@ -57,6 +57,7 @@ namespace Model
     public:
         ${exportMacro} ${operation.name}Handler();
         ${exportMacro} ${operation.name}Handler& operator=(const ${operation.name}Handler&) = default;
+        ${exportMacro} ${operation.name}Handler(const ${operation.name}Handler&) = default;
 
         ${exportMacro} virtual void OnEvent() override;
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/RequestHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/RequestHeader.vm
@@ -137,7 +137,7 @@ namespace Model
     /**
      * Underlying Event Stream Handler which is used to define callback functions.
      */
-    inline const ${operation.name}Handler& GetEventStreamHandler() const { return m_handler; }
+    inline ${operation.name}Handler& GetEventStreamHandler() { return m_handler; }
 
     /**
      * Underlying Event Stream Handler which is used to define callback functions.

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderOperations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderOperations.vm
@@ -26,6 +26,7 @@
          * The streamReadyHandler is triggered when the stream is ready to be written to.
          * The handler is triggered when the request is finished.
          */
+##TODO 1.12: add const to the request
         $virtual void ${operation.name}Async(Model::${operation.request.shape.name}& request,
                 const ${operation.name}StreamReadyHandler& streamReadyHandler,
                 const ${operation.name}ResponseReceivedHandler& handler,

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceHeaders.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceHeaders.vm
@@ -1,10 +1,17 @@
-#set($hasEventStream = false)
+#set($hasEventStreamResult = false)
+#set($hasEventStreamRequest = false)
 #foreach($operation in $serviceModel.operations)
 #if($operation.result.shape.hasEventStreamMembers())
-    #set($hasEventStream = true)
+#set($hasEventStreamResult = true)
+#end
+#if($operation.request.shape.hasEventStreamMembers())
+#set($hasEventStreamRequest = true)
 #end
 #end
-#if($hasEventStream)
+#if($hasEventStreamResult)
+#if($hasEventStreamRequest)
+\#include <aws/core/client/AWSClientEventStreamingAsyncTask.h>
+#end
 \#include <aws/core/utils/event/EventStream.h>
 #end
 #if($arnEndpointSupported || $metadata.hasEndpointDiscoveryTrait)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/StreamRequestSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/StreamRequestSource.vm
@@ -29,15 +29,6 @@ using namespace Aws;
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassMembersGenerateInitializers.vm")
 ${typeInfo.className}::${typeInfo.className}()$initializers
 {
-#if ($typeInfo.shape.isRequest() && $operation.result && $operation.result.shape.hasEventStreamMembers())
-    AmazonWebServiceRequest::SetHeadersReceivedEventHandler([this](const Http::HttpRequest*, Http::HttpResponse* response)
-    {
-        auto& initialResponseHandler = m_handler.GetInitialResponseCallbackEx();
-        if (initialResponseHandler) {
-            initialResponseHandler(${operation.name}InitialResponse(response->GetHeaders()), Utils::Event::InitialResponseType::ON_RESPONSE);
-        }
-    });
-#end
 }
 
 #if($shape.hasEventStreamMembers())

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/eventbridge/PutEvents_OperationOutcome.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/eventbridge/PutEvents_OperationOutcome.vm
@@ -43,6 +43,14 @@ ${operation.name}Outcome ${className}::${operation.name}(${constText}${operation
     request.SetResponseStreamFactory(
         [&] { request.GetEventStreamDecoder().Reset(); return Aws::New<Aws::Utils::Event::EventDecoderStream>(ALLOCATION_TAG, request.GetEventStreamDecoder()); }
   );
+  if (!request.GetHeadersReceivedEventHandler()) {
+    request.SetHeadersReceivedEventHandler([&request](const Http::HttpRequest*, Http::HttpResponse* response) {
+      AWS_CHECK_PTR("${operation.name}", response);
+      if (const auto initialResponseHandler = request.GetEventStreamHandler().GetInitialResponseCallbackEx()) {
+        initialResponseHandler({response->GetHeaders()}, Utils::Event::InitialResponseType::ON_RESPONSE);
+      }
+    });
+  }
 #if($serviceModel.endpointRules)
     return ${operation.name}Outcome(MakeRequest(request, endpointResolutionOutcome.GetResult(), Aws::Http::HttpMethod::HTTP_${operation.http.method}));
 #else

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceEventStreamOperationsSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceEventStreamOperationsSource.vm
@@ -8,9 +8,6 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientOperationRequestRequiredMemberValidate.vm")
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/common/UriRequestQueryParams.vm")
 #if($operation.result && $operation.result.shape.hasEventStreamMembers())
-  request.SetResponseStreamFactory(
-      [&] { request.GetEventStreamDecoder().Reset(); return Aws::New<Aws::Utils::Event::EventDecoderStream>(ALLOCATION_TAG, request.GetEventStreamDecoder()); }
-  );
 #else
 #if($serviceModel.endpointRules)
   JsonOutcome outcome = MakeRequest(request, endpointResolutionOutcome.GetResult(), Aws::Http::HttpMethod::HTTP_${operation.http.method}, ${operation.signerName});
@@ -30,23 +27,19 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
 #set($streamModelNameWithFirstLetterCapitalized = $CppViewHelper.capitalizeFirstChar($streamModelName))
   auto eventEncoderStream = Aws::MakeShared<Model::$streamModelType>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
-  request.Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream); // this becomes the body of the request
-  auto sem = Aws::MakeShared<Aws::Utils::Threading::Semaphore>(ALLOCATION_TAG, 0, 1);
-  request.SetRequestSignedHandler([eventEncoderStream, sem](const Aws::Http::HttpRequest& httpRequest) { eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(httpRequest)); sem->ReleaseAll(); });
+  auto requestCopy = Aws::MakeShared<${operation.request.shape.name}>("${operation.name}", request);
+  requestCopy->Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream); // this becomes the body of the request
+##TODO 1.12: remove next line
+  request.Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream);
 
-  m_clientConfiguration.executor->Submit([this, endpointResolutionOutcome, &request, handler, handlerContext] () mutable {
-      JsonOutcome outcome = MakeRequest(request, endpointResolutionOutcome.GetResult(), Aws::Http::HttpMethod::HTTP_POST, Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
-      if(outcome.IsSuccess())
-      {
-        handler(this, request, ${operation.name}Outcome(NoResult()), handlerContext);
-      }
-      else
-      {
-        request.Get${streamModelNameWithFirstLetterCapitalized}()->Close();
-        handler(this, request, ${operation.name}Outcome(outcome.GetError()), handlerContext);
-      }
-      return ${operation.name}Outcome(NoResult());
-  });
+  auto asyncTask = CreateBidirectionalEventStreamTask<${operation.name}Outcome>(this,
+                                         endpointResolutionOutcome.GetResultWithOwnership(),
+                                         requestCopy,
+                                         handler,
+                                         handlerContext,
+                                         eventEncoderStream);
+  auto sem = asyncTask.GetSemaphore();
+  m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
-  streamReadyHandler(*request.Get${streamModelNameWithFirstLetterCapitalized}());
+  streamReadyHandler(*eventEncoderStream);
 }

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/serviceoperations/withrequest/OperationOutcome.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/serviceoperations/withrequest/OperationOutcome.vm
@@ -23,6 +23,14 @@ ${operation.name}Outcome ${className}::${operation.name}(${constText}${operation
       request.SetResponseStreamFactory(
           [&] { request.GetEventStreamDecoder().Reset(); return Aws::New<Aws::Utils::Event::EventDecoderStream>(ALLOCATION_TAG, request.GetEventStreamDecoder()); }
       );
+      if (!request.GetHeadersReceivedEventHandler()) {
+        request.SetHeadersReceivedEventHandler([&request](const Http::HttpRequest*, Http::HttpResponse* response) {
+          AWS_CHECK_PTR("${operation.name}", response);
+          if (const auto initialResponseHandler = request.GetEventStreamHandler().GetInitialResponseCallbackEx()) {
+            initialResponseHandler({response->GetHeaders()}, Utils::Event::InitialResponseType::ON_RESPONSE);
+          }
+        });
+      }
 #if($serviceModel.endpointRules)
       return ${operation.name}Outcome(MakeRequest(request, endpointResolutionOutcome.GetResult(), Aws::Http::HttpMethod::HTTP_${operation.http.method}));
 #else

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyJsonServiceEventStreamOperationsSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyJsonServiceEventStreamOperationsSource.vm
@@ -11,6 +11,14 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
   request.SetResponseStreamFactory(
       [&] { request.GetEventStreamDecoder().Reset(); return Aws::New<Aws::Utils::Event::EventDecoderStream>(ALLOCATION_TAG, request.GetEventStreamDecoder()); }
   );
+  if (!request.GetHeadersReceivedEventHandler()) {
+    request.SetHeadersReceivedEventHandler([&request](const Http::HttpRequest*, Http::HttpResponse* response) {
+      AWS_CHECK_PTR("${operation.name}", response);
+      if (const auto initialResponseHandler = request.GetEventStreamHandler().GetInitialResponseCallbackEx()) {
+        initialResponseHandler({response->GetHeaders()}, Utils::Event::InitialResponseType::ON_RESPONSE);
+      }
+    });
+  }
 #else
       JsonOutcome outcome = MakeRequestDeserialize(&request, request.GetServiceRequestName(), Aws::Http::HttpMethod::HTTP_${operation.http.method}, 
       [ & #if($hasEndPointOverrides) , endpointOverrides #end](Aws::Endpoint::AWSEndpoint& resolvedEndpoint) ->  void {

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyServiceOperationsSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyServiceOperationsSource.vm
@@ -15,6 +15,14 @@ ${operation.name}Outcome ${className}::${operation.name}(${constText}${operation
       request.SetResponseStreamFactory(
           [&] { request.GetEventStreamDecoder().Reset(); return Aws::New<Aws::Utils::Event::EventDecoderStream>(ALLOCATION_TAG, request.GetEventStreamDecoder()); }
       );
+      if (!request.GetHeadersReceivedEventHandler()) {
+        request.SetHeadersReceivedEventHandler([&request](const Http::HttpRequest*, Http::HttpResponse* response) {
+          AWS_CHECK_PTR("${operation.name}", response);
+          if (const auto initialResponseHandler = request.GetEventStreamHandler().GetInitialResponseCallbackEx()) {
+            initialResponseHandler({response->GetHeaders()}, Utils::Event::InitialResponseType::ON_RESPONSE);
+          }
+        });
+      }
 #end
       return ${operation.name}Outcome(MakeRequestDeserialize(&request, request.GetServiceRequestName(), Aws::Http::HttpMethod::HTTP_${operation.http.method}, [&#if($hasEndPointOverrides) , endpointOverrides #end](Aws::Endpoint::AWSEndpoint& resolvedEndpoint) ->  void {
 #parse("/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyEndpointClosure.vm")


### PR DESCRIPTION
*Issue #, if available:*
Undefined behavior:
* on request copying;
* undefined behavior if the lifetime of the request is not maintained by user
 
*Description of changes:*
Create a request copy for async execution.
Avoid capturing objects by raw pointers into lambdas factories to avoid dangling pointers/reference.

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
