### PR TITLE
fix verify ssl on windows, add option for anonymous auth

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -453,6 +453,18 @@ namespace Aws
              * Provide TelemetryProvider here or via a factory method.
              */
             std::shared_ptr<smithy::components::tracing::TelemetryProvider> telemetryProvider;
+
+            /**
+             * Configuration that is specifically used for the windows http client
+             */
+            struct WinHTTPOptions {
+              /**
+               * Sets the windows http client to use WINHTTP_NO_CLIENT_CERT_CONTEXT when connecting
+               * to a service, specifically only useful when disabling ssl verification and using
+               * a different type of authentication.
+               */
+              bool useAnonymousAuth = false;
+            } winHTTPOptions;
         };
 
         /**

--- a/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinHttpSyncHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinHttpSyncHttpClient.h
@@ -59,6 +59,7 @@ namespace Aws
 
             bool m_usingProxy = false;
             bool m_verifySSL = true;
+            bool m_useAnonymousAuth = false;
             Aws::Http::Version m_version = Aws::Http::Version::HTTP_VERSION_2TLS;
             Aws::WString m_proxyUserName;
             Aws::WString m_proxyPassword;


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/3008

*Description of changes:*

We made a previous change to [disable TLS when verify ssl was set to false](https://github.com/aws/aws-sdk-cpp/pull/2864). This was the incorrect behavior, we should try to use TLS but ignore certificate errors. This reverts that behavior changes and adds additional SSL verifications to ignore.

This adds another change that should have been the first fix, which is to allow for anonymous auth which is what the change was initially made to address https://github.com/aws/aws-sdk-cpp/issues/1445. the optional as stated by the [microsoft docs](https://learn.microsoft.com/en-us/windows/win32/winhttp/option-flags)

> When the server requests a client certificate, [WinHttpSendRequest](https://learn.microsoft.com/en-us/windows/win32/api/Winhttp/nf-winhttp-winhttpsendrequest), or [WinHttpReceiveResponse](https://learn.microsoft.com/en-us/windows/win32/api/Winhttp/nf-winhttp-winhttpreceiveresponse) returns an [ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED](https://learn.microsoft.com/en-us/windows/win32/winhttp/error-messages) error. If the server requests the certificate but doesn't require it, the application can specify this option to indicate that it doesn't have a certificate. The server can choose another authentication scheme or allow anonymous access to the server. The application provides the WINHTTP_NO_CLIENT_CERT_CONTEXT macro in the lpBuffer parameter of [WinHttpSetOption](https://learn.microsoft.com/en-us/windows/win32/api/Winhttp/nf-winhttp-winhttpsetoption) as shown in the following code example.

This allowed for the basic auth as seen by the original opensearch example

```cpp
#include <aws/core/Aws.h>
#include <aws/core/http/HttpClient.h>
#include <aws/core/utils/HashingUtils.h>

using namespace Aws;

auto main() -> int {
    SDKOptions options;
    options.loggingOptions.logLevel = Utils::Logging::LogLevel::Trace;
    InitAPI(options); {
        // Set client configuration
        Client::ClientConfiguration config;
        config. windowsHttpOptions. useAnonmousAuth = true
        config.verifySSL = false;

        const auto client = Aws::Http::CreateHttpClient(config);

        // Generate http request
        const auto request = CreateHttpRequest(
          String("https://localhost:9200/_cat/plugins?format=json"),
          Http::HttpMethod::HTTP_GET,
          Utils::Stream::DefaultResponseStreamFactoryMethod);

        // Set Authentication
        std::string authString = "admin:admin";
        Utils::Array<unsigned char> userpw_arr(reinterpret_cast<const unsigned char *>(authString.c_str()),authString.length());
        const auto basicAuth = Utils::HashingUtils::Base64Encode(userpw_arr);
        request->SetAuthorization("Basic " + basicAuth);

        // Issue request
        const auto response = client->MakeRequest(request);
        //assert(response->GetResponseCode() == Http::HttpResponseCode::OK);
        std::stringstream ss;
        ss << response->GetResponseBody().rdbuf();
        std::cout << ss.str() << "\n";
    }
    ShutdownAPI(options);
    return 0;
}
```

As stated before you likely should not be turning off verify ssl or using basic credentials unless explicitly using a development environment.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
