### PR TITLE
fix rule of 5 for client configuration

### DIFF
--- a/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/DynamoDBClientConfiguration.h
@@ -21,13 +21,17 @@ namespace Aws
 
             DynamoDBClientConfiguration(const DynamoDBClientConfiguration& other)
                 : Aws::Client::GenericClientConfiguration(other),
-                  enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery)
+                  enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery),
+                  accountId{other.accountId},
+                  accountIdEndpointMode{other.accountIdEndpointMode}
             {
             }
 
             DynamoDBClientConfiguration(DynamoDBClientConfiguration&& other) noexcept
                 : Aws::Client::GenericClientConfiguration(std::move(other)),
-                  enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery)
+                  enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery),
+                  accountId{std::move(other.accountId)},
+                  accountIdEndpointMode{std::move(other.accountIdEndpointMode)}
             {
             }
 
@@ -36,6 +40,8 @@ namespace Aws
                 if (this == &other)
                     return *this;
                 Aws::Client::GenericClientConfiguration::operator =(other);
+                accountId = other.accountId;
+                accountIdEndpointMode = other.accountIdEndpointMode;
                 return *this;
             }
 
@@ -44,6 +50,8 @@ namespace Aws
                 if (this == &other)
                     return *this;
                 Aws::Client::GenericClientConfiguration::operator =(std::move(other));
+                accountId = std::move(other.accountId);
+                accountIdEndpointMode = std::move(other.accountIdEndpointMode);
                 return *this;
             }
 

--- a/generated/src/aws-cpp-sdk-s3control/include/aws/s3control/S3ControlClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3control/include/aws/s3control/S3ControlClientConfiguration.h
@@ -18,6 +18,36 @@ namespace Aws
         {
             using BaseClientConfigClass = Aws::Client::GenericClientConfiguration;
 
+            S3ControlClientConfiguration(const S3ControlClientConfiguration& other)
+                : Aws::Client::GenericClientConfiguration(other),
+                  accountId{other.accountId}
+            {
+            }
+
+            S3ControlClientConfiguration(S3ControlClientConfiguration&& other) noexcept
+                : Aws::Client::GenericClientConfiguration(std::move(other)),
+                  accountId{std::move(other.accountId)}
+            {
+            }
+
+            S3ControlClientConfiguration& operator=(const S3ControlClientConfiguration& other)
+            {
+                if (this == &other)
+                    return *this;
+                Aws::Client::GenericClientConfiguration::operator =(other);
+                accountId = other.accountId;
+                return *this;
+            }
+
+            S3ControlClientConfiguration& operator=(S3ControlClientConfiguration&& other) noexcept
+            {
+                if (this == &other)
+                    return *this;
+                Aws::Client::GenericClientConfiguration::operator =(std::move(other));
+                accountId = std::move(other.accountId);
+                return *this;
+            }
+
             S3ControlClientConfiguration(const Client::ClientConfigurationInitValues &configuration = {});
 
             /**

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationHeader.vm
@@ -50,32 +50,68 @@ namespace ${rootNamespace}
 #end
 #end
 
+#set($copyCtorStatements = [])
+#set($moveCtorStatements = [])
+#set($copyAssignmentStatements = [])
+#set($moveAssignemntStatements = [])
 #if($metadata.hasEndpointDiscoveryTrait)
+#set($addArgDummy = $copyCtorStatements.add("enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery)"))
+#set($addArgDummy = $moveCtorStatements.add("enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery)"))
+#end
+#if($serviceModel.endpointRuleSetModel.parameters.containsKey("AccountId"))
+#set($addArgDummy = $copyCtorStatements.add("accountId{other.accountId}"))
+#set($addArgDummy = $moveCtorStatements.add("accountId{std::move(other.accountId)}"))
+#set($addArgDummy = $copyAssignmentStatements.add("accountId = other.accountId;"))
+#set($addArgDummy = $moveAssignemntStatements.add("accountId = std::move(other.accountId);"))
+#end
+#if($serviceModel.endpointRuleSetModel.parameters.containsKey("AccountIdEndpointMode"))
+#set($addArgDummy = $copyCtorStatements.add("accountIdEndpointMode{other.accountIdEndpointMode}"))
+#set($addArgDummy = $moveCtorStatements.add("accountIdEndpointMode{std::move(other.accountIdEndpointMode)}"))
+#set($addArgDummy = $copyAssignmentStatements.add("accountIdEndpointMode = other.accountIdEndpointMode;"))
+#set($addArgDummy = $moveAssignemntStatements.add("accountIdEndpointMode = std::move(other.accountIdEndpointMode);"))
+#end
+#if(!$copyCtorStatements.isEmpty())
             ${metadata.classNamePrefix}ClientConfiguration(const ${metadata.classNamePrefix}ClientConfiguration& other)
                 : Aws::Client::GenericClientConfiguration(other),
-                  enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery)
+                  #foreach($statement in $copyCtorStatements)$statement#if($foreach.hasNext),
+                  #end#end
+
             {
             }
 
+#end
+#if(!$moveCtorStatements.isEmpty())
             ${metadata.classNamePrefix}ClientConfiguration(${metadata.classNamePrefix}ClientConfiguration&& other) noexcept
                 : Aws::Client::GenericClientConfiguration(std::move(other)),
-                  enableEndpointDiscovery(BaseClientConfigClass::enableEndpointDiscovery)
+                  #foreach($statement in $moveCtorStatements)$statement#if($foreach.hasNext),
+                  #end#end
+
             {
             }
 
+#end
+#if(!$copyAssignmentStatements.isEmpty() || $metadata.hasEndpointDiscoveryTrait)
             ${metadata.classNamePrefix}ClientConfiguration& operator=(const ${metadata.classNamePrefix}ClientConfiguration& other)
             {
                 if (this == &other)
                     return *this;
                 Aws::Client::GenericClientConfiguration::operator =(other);
+#foreach($statment in ${copyAssignmentStatements})
+                ${statment}
+#end
                 return *this;
             }
 
+#end
+#if(!$moveAssignemntStatements.isEmpty() || $metadata.hasEndpointDiscoveryTrait)
             ${metadata.classNamePrefix}ClientConfiguration& operator=(${metadata.classNamePrefix}ClientConfiguration&& other) noexcept
             {
                 if (this == &other)
                     return *this;
                 Aws::Client::GenericClientConfiguration::operator =(std::move(other));
+#foreach($statment in ${moveAssignemntStatements})
+                ${statment}
+#end
                 return *this;
             }
 


### PR DESCRIPTION
*Description of changes:*

Fixes a issue on dynamo where if client configuration uses a account id, a account id based endpoint will not be used.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
