### PR TITLE
Fix high CPU utilization regression on event streaming

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSClientAsyncCRTP.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSClientAsyncCRTP.h
@@ -14,6 +14,8 @@ namespace Aws
 namespace Client
 {
     class AsyncCallerContext;
+    template <typename OutcomeT, typename ClientT, typename AWSEndpointT, typename RequestT, typename HandlerT>
+    class BidirectionalEventStreamingTask;
 
     /**
      * A helper to determine if AWS Operation is EventStream-enabled or not (based on const-ness of the request)
@@ -204,6 +206,9 @@ namespace Client
             return Aws::Client::MakeCallableOperation(AwsServiceClientT::GetAllocationTag(), operationFunc, clientThis, clientThis->m_clientConfiguration.executor.get());
         }
     protected:
+        template <typename OutcomeT, typename ClientT, typename AWSEndpointT, typename RequestT, typename HandlerT>
+        friend class BidirectionalEventStreamingTask; // allow BidirectionalEventStreamingTask to access m_isInitialized
+
         std::atomic<bool> m_isInitialized;
         mutable std::atomic<size_t> m_operationsProcessed;
         mutable std::condition_variable m_shutdownSignal;

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/logging/ErrorMacros.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/logging/ErrorMacros.h
@@ -64,7 +64,7 @@ if(!m_isInitialized) \
   AWS_LOGSTREAM_ERROR(#OPERATION, "Unable to call " #OPERATION ": client is not initialized (or already terminated)"); \
   return Aws::Client::AWSError<CoreErrors>(CoreErrors::NOT_INITIALIZED, "NOT_INITIALIZED", "Client is not initialized or already terminated", false); \
 } \
-Aws::Utils::RAIICounter(this->m_operationsProcessed, &this->m_shutdownSignal)
+Aws::Utils::RAIICounter raiiGuard(this->m_operationsProcessed, &this->m_shutdownSignal)
 
 #define AWS_ASYNC_OPERATION_GUARD(OPERATION) \
 if(!m_isInitialized) \
@@ -72,4 +72,4 @@ if(!m_isInitialized) \
   AWS_LOGSTREAM_ERROR(#OPERATION, "Unable to call " #OPERATION ": client is not initialized (or already terminated)"); \
   return handler(this, request, Aws::Client::AWSError<CoreErrors>(CoreErrors::NOT_INITIALIZED, "NOT_INITIALIZED", "Client is not initialized or already terminated", false), handlerContext); \
 } \
-Aws::Utils::RAIICounter(this->m_operationsProcessed, &this->m_shutdownSignal)
+Aws::Utils::RAIICounter raiiGuard(this->m_operationsProcessed, &this->m_shutdownSignal)

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/stream/ConcurrentStreamBuf.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/stream/ConcurrentStreamBuf.h
@@ -41,6 +41,11 @@ namespace Aws
                  */
                 bool WaitForDrain(int64_t timeoutMs);
 
+                /**
+                 * A flag returned by underflow() if there is no data available at the moment but stream must not be closed yet.
+                 */
+                static const int noData;
+
             protected:
                 std::streampos seekoff(std::streamoff off, std::ios_base::seekdir dir, std::ios_base::openmode which = std::ios_base::in | std::ios_base::out) override;
                 std::streampos seekpos(std::streampos pos, std::ios_base::openmode which = std::ios_base::in | std::ios_base::out) override;

--- a/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -357,6 +357,14 @@ HttpResponseOutcome AWSClient::AttemptExhaustively(const Aws::Http::URI& uri,
         {
             break;
         }
+        if (request.IsEventStreamRequest() &&
+             (request.GetBody()->eof() ||
+             (outcome.GetError().GetResponseCode() != Http::HttpResponseCode::REQUEST_NOT_MADE &&
+              outcome.GetError().GetResponseCode() != Http::HttpResponseCode::NETWORK_CONNECT_TIMEOUT &&
+              outcome.GetError().GetResponseCode() != Http::HttpResponseCode::SERVICE_UNAVAILABLE))) {
+          AWS_LOGSTREAM_ERROR(AWS_CLIENT_LOG_TAG, "SDK is not able to retry EventStream request after the connection was established");
+          break;
+        }
 
         AWS_LOGSTREAM_WARN(AWS_CLIENT_LOG_TAG, "Request failed, now waiting " << sleepMillis << " ms before attempting again.");
         if(request.GetBody())

--- a/src/aws-cpp-sdk-core/source/utils/threading/DefaultExecutor.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/threading/DefaultExecutor.cpp
@@ -126,7 +126,6 @@ void DefaultExecutor::impl::Detach(std::thread::id id) {
   assert(it != m_tasks.end());
   it->second.first.detach();
   m_tasks.erase(it);
-  m_state = State::Free;
   m_cv.notify_one();
 }
 

--- a/tests/aws-cpp-sdk-transcribestreaming-integ-tests/TranscribeErrorCaseTests.cpp
+++ b/tests/aws-cpp-sdk-transcribestreaming-integ-tests/TranscribeErrorCaseTests.cpp
@@ -217,7 +217,7 @@ TEST_F(TranscribeStreamingErrorTests, TranscribeTerminateByLowSpeedLimit) {
         }
         TestTrace(Aws::String("Writing good event"));
         if (!stream.WriteAudioEvent(event)) {
-          AWS_ADD_FAILURE("Failed to write an audio event");
+          // the stream may be force closed by timeout, no test assertion here.
           break;
         }
       }


### PR DESCRIPTION
*Issue #, if available:*
introduced by #3302
The CPU utilization got back to 100% for a streaming because of input stream polling

*Description of changes:*
Introduce another stream special value `int` returned by peak, with a value of `amzn`, to represent the condition when: we have nothing to send AND session is still open.
Regular EOF aka -1 will also always close the stream. 'a' and 'z' are also invalid values because they can also represent a valid byte from the stream.

tested by running streaming session and observing `htop`

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
