### PR TITLE
Don't merge: Add a GitHub Actions workflow for mingw-w64 with MSYS2

### DIFF
--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -1,0 +1,65 @@
+name: mingw-w64
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    name: Build
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        with-patch:
+          - true
+          - false
+    env:
+      MINGW_PACKAGE_PREFIX: mingw-w64-ucrt-x86_64
+      MSYSTEM: UCRT64
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: dependencies
+        shell: c:\msys64\usr\bin\bash.exe -e -l {0}
+        run: |
+          pacman \
+            --needed \
+            --noconfirm \
+            --sync \
+            ${MINGW_PACKAGE_PREFIX}-cc \
+            ${MINGW_PACKAGE_PREFIX}-cmake \
+            ${MINGW_PACKAGE_PREFIX}-curl \
+            ${MINGW_PACKAGE_PREFIX}-ninja \
+            ${MINGW_PACKAGE_PREFIX}-openssl \
+            ${MINGW_PACKAGE_PREFIX}-zlib
+      - name: patch
+        if: matrix.with-patch
+        shell: c:\msys64\usr\bin\bash.exe -e -l {0}
+        run: |
+          pacman \
+            --needed \
+            --noconfirm \
+            --sync \
+            patch
+          cd ${GITHUB_WORKSPACE}
+          curl https://raw.githubusercontent.com/msys2/MINGW-packages/refs/heads/master/mingw-w64-aws-sdk-cpp/aws-sdk-cpp-pr-1333.patch | \
+            patch -p1
+      - name: configure
+        shell: c:\msys64\usr\bin\bash.exe -e -l {0}
+        run: |
+          set -x
+          cmake \
+            -B build \
+            -DAWS_SDK_WARNINGS_ARE_ERRORS=OFF \
+            -DBUILD_ONLY="s3;s3-crt;dynamodb;logs;kms;sqs;firehose;kinesis;sns;mediastore;mediastore-data;monitoring;secretsmanager;athena;kafka;cognito-idp;rds;ecs" \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DENABLE_TESTING=OFF \
+            -GNinja \
+            -S ${GITHUB_WORKSPACE}
+      - name: build
+        shell: c:\msys64\usr\bin\bash.exe -e -l {0}
+        run: |
+          cmake --build build


### PR DESCRIPTION
*Issue #, if available:* #3315

*Description of changes:*

This just shows how to setup mingw-w64 build environment with MSYS2.

This uses GitHub Actions but we'll use internal CI build system instead of GitHub Actions.

The added workflow has 2 jobs. One job applies a patch ( https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-aws-sdk-cpp/aws-sdk-cpp-pr-1333.patch ) in MSYS2 and another job builds aws-sdk-cpp as-is.

Both jobs do the followings:
 
1. Setup build environment with MSYS2
2. Run `cmake`
3. Build

I'll add review comments for details.

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
