### PR TITLE
Fix smithy client copy assignment

### DIFF
--- a/cmake/sdksCommon.cmake
+++ b/cmake/sdksCommon.cmake
@@ -95,7 +95,7 @@ list(APPEND SDK_TEST_PROJECT_LIST "elasticfilesystem:tests/aws-cpp-sdk-elasticfi
 list(APPEND SDK_TEST_PROJECT_LIST "identity-management:tests/aws-cpp-sdk-identity-management-tests")
 list(APPEND SDK_TEST_PROJECT_LIST "kinesis:tests/aws-cpp-sdk-kinesis-integration-tests")
 list(APPEND SDK_TEST_PROJECT_LIST "lambda:tests/aws-cpp-sdk-lambda-integration-tests")
-list(APPEND SDK_TEST_PROJECT_LIST "logs:tests/aws-cpp-sdk-logs-integration-tests")
+list(APPEND SDK_TEST_PROJECT_LIST "logs:tests/aws-cpp-sdk-logs-integration-tests,tests/aws-cpp-sdk-logs-unit-tests")
 list(APPEND SDK_TEST_PROJECT_LIST "mediastore-data:tests/aws-cpp-sdk-mediastore-data-integration-tests")
 list(APPEND SDK_TEST_PROJECT_LIST "monitoring:tests/aws-cpp-sdk-monitoring-integration-tests")
 list(APPEND SDK_TEST_PROJECT_LIST "rds:tests/aws-cpp-sdk-rds-integration-tests")

--- a/tests/aws-cpp-sdk-logs-integration-tests/CloudWatchLogsTests.cpp
+++ b/tests/aws-cpp-sdk-logs-integration-tests/CloudWatchLogsTests.cpp
@@ -59,7 +59,8 @@ namespace
             ClientConfiguration config;
             config.scheme = Scheme::HTTPS;
             config.region = AWS_TEST_REGION;
-            m_client = Aws::MakeUnique<Aws::CloudWatchLogs::CloudWatchLogsClient>(ALLOCATION_TAG, config);
+            CloudWatchLogsClient tmpClient(config);  // test copy c-tor
+            m_client = Aws::MakeUnique<CloudWatchLogsClient>(ALLOCATION_TAG, tmpClient);
             CreateLogsGroup(BuildResourceName(BASE_CLOUD_WATCH_LOGS_GROUP));
 
             auto accountId = Aws::Environment::GetEnv("CATAPULT_TEST_ACCOUNT");

--- a/tests/aws-cpp-sdk-logs-unit-tests/CMakeLists.txt
+++ b/tests/aws-cpp-sdk-logs-unit-tests/CMakeLists.txt
@@ -1,0 +1,33 @@
+add_project(aws-cpp-sdk-logs-unit-tests
+        "Unit Tests for the CloudWatch Logs Client"
+        aws-cpp-sdk-logs
+        testing-resources
+        aws_test_main
+        aws-cpp-sdk-core)
+
+add_definitions(-DRESOURCES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/resources")
+
+if(MSVC AND BUILD_SHARED_LIBS)
+    add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
+endif()
+
+enable_testing()
+
+if(PLATFORM_ANDROID AND BUILD_SHARED_LIBS)
+    add_library(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/CloudWatchLogsUnitTests.cpp)
+else()
+    add_executable(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/CloudWatchLogsUnitTests.cpp)
+endif()
+
+set_compiler_flags(${PROJECT_NAME})
+set_compiler_warnings(${PROJECT_NAME})
+
+target_link_libraries(${PROJECT_NAME} ${PROJECT_LIBS})
+
+if(MSVC AND BUILD_SHARED_LIBS)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DELAYLOAD:aws-cpp-sdk-logs.dll /DELAYLOAD:aws-cpp-sdk-core.dll")
+    target_link_libraries(${PROJECT_NAME} delayimp.lib)
+endif()
+
+include(GoogleTest)
+gtest_add_tests(TARGET ${PROJECT_NAME})

--- a/tests/aws-cpp-sdk-logs-unit-tests/CloudWatchLogsUnitTests.cpp
+++ b/tests/aws-cpp-sdk-logs-unit-tests/CloudWatchLogsUnitTests.cpp
@@ -1,0 +1,163 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/core/auth/AWSCredentials.h>
+#include <aws/core/http/standard/StandardHttpRequest.h>
+#include <aws/core/http/standard/StandardHttpResponse.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/logs/CloudWatchLogsClient.h>
+#include <aws/logs/model/PutLogEventsRequest.h>
+#include <aws/testing/AwsCppSdkGTestSuite.h>
+#include <aws/testing/AwsTestHelpers.h>
+#include <aws/testing/mocks/http/MockHttpClient.h>
+#include <gtest/gtest.h>
+
+using namespace Aws::Auth;
+using namespace Aws::Http;
+using namespace Aws::Client;
+using namespace Aws::CloudWatchLogs;
+using namespace Aws::CloudWatchLogs::Model;
+
+const char* LOG_TAG = "CloudWatchLogsTest";
+
+class CloudWatchLogsTest : public Aws::Testing::AwsCppSdkGTestSuite {
+ protected:
+  std::shared_ptr<MockHttpClient> m_mockHttpClient;
+  std::shared_ptr<MockHttpClientFactory> m_mockHttpClientFactory;
+
+  void SetUp() {
+    m_mockHttpClient = Aws::MakeShared<MockHttpClient>(LOG_TAG);
+    m_mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(LOG_TAG);
+    m_mockHttpClientFactory->SetClient(m_mockHttpClient);
+    SetHttpClientFactory(m_mockHttpClientFactory);
+  }
+
+  void TearDown() {
+    m_mockHttpClient->Reset();
+    m_mockHttpClient = nullptr;
+    m_mockHttpClientFactory = nullptr;
+    Aws::Http::CleanupHttp();
+    Aws::Http::InitHttp();
+  }
+};
+
+class ClientHolder {
+ public:
+  ClientHolder() : client(makeClient()) {
+    // init client again
+    client = makeClient();
+  }
+
+  PutLogEventsOutcome Foo() {
+    const auto response = client.PutLogEvents(PutLogEventsRequest{});
+    return response;
+  }
+
+  const CloudWatchLogsClient& getClient() { return client; }
+
+  CloudWatchLogsClient&& moveClient() { return std::move(client); }
+
+ private:
+  CloudWatchLogsClient makeClient() {
+    Aws::Client::ClientConfigurationInitValues cfgInit;
+    cfgInit.shouldDisableIMDS = true;
+    Aws::Client::ClientConfiguration clientConfig(cfgInit);
+    clientConfig.region = Aws::Region::US_EAST_1;
+    AWSCredentials credentials{"mock", "credentials"};
+    return CloudWatchLogsClient(credentials, clientConfig);
+  }
+
+  CloudWatchLogsClient client;
+};
+
+TEST_F(CloudWatchLogsTest, ClientOperatorCopyMoveEquals) {
+  auto mockResponse = [this]() {
+    std::shared_ptr<HttpRequest> requestTmp =
+        CreateHttpRequest(Aws::Http::URI("dummy"), Aws::Http::HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+    auto successResponse = Aws::MakeShared<Standard::StandardHttpResponse>(LOG_TAG, requestTmp);
+    successResponse->SetResponseCode(HttpResponseCode::OK);
+    successResponse->GetResponseBody() << "{}";
+    m_mockHttpClient->AddResponseToReturn(successResponse);
+  };
+
+  // Check typical user wrapper
+  mockResponse();
+  ClientHolder wrapped{};
+  auto resWrapped = wrapped.Foo();
+  AWS_ASSERT_SUCCESS(resWrapped);
+
+  // check copy constructed
+  {
+    mockResponse();
+    CloudWatchLogsClient copied(wrapped.getClient());
+    auto resCopied = copied.PutLogEvents(PutLogEventsRequest{});
+    AWS_ASSERT_SUCCESS(resCopied);
+  }
+
+  // check that the original is still alive
+  {
+    mockResponse();
+    auto resWrappedAfterCopy = wrapped.Foo();
+    AWS_ASSERT_SUCCESS(resWrappedAfterCopy);
+  }
+
+  // check move construction
+  {
+    mockResponse();
+    CloudWatchLogsClient moved(std::move(wrapped.moveClient()));
+    auto resMoved = moved.PutLogEvents(PutLogEventsRequest{});
+    AWS_ASSERT_SUCCESS(resMoved);
+  }
+
+  // check that original is "unspecified but valid state" after move
+  {
+    mockResponse();
+    auto resWrappedAfterMove = wrapped.Foo();
+    // move is actually redirected to copy because the generated client does not generate move c-tor, so it results in a copy
+    AWS_ASSERT_SUCCESS(resWrappedAfterMove);
+  }
+
+  ClientHolder anotherWrapper{};
+  // operator=(const &)
+  {
+    Aws::Client::ClientConfigurationInitValues cfgInit;
+    cfgInit.shouldDisableIMDS = true;
+    Aws::Client::ClientConfiguration clientConfig(cfgInit);
+    CloudWatchLogsClient copyAssigned(clientConfig);
+
+    mockResponse();
+    copyAssigned = anotherWrapper.getClient();
+    auto resCopyAssigned = copyAssigned.PutLogEvents(PutLogEventsRequest{});
+    AWS_ASSERT_SUCCESS(resCopyAssigned);
+  }
+
+  // check that the original is still alive
+  {
+    mockResponse();
+    auto resWrappedAfterCopyAssign = anotherWrapper.Foo();
+    AWS_ASSERT_SUCCESS(resWrappedAfterCopyAssign);
+  }
+
+  // operator=(&&)
+  {
+    Aws::Client::ClientConfigurationInitValues cfgInit;
+    cfgInit.shouldDisableIMDS = true;
+    Aws::Client::ClientConfiguration clientConfig(cfgInit);
+    CloudWatchLogsClient moveAssigned(clientConfig);
+
+    mockResponse();
+    moveAssigned = std::move(anotherWrapper.moveClient());
+    auto resMoveAssigned = moveAssigned.PutLogEvents(PutLogEventsRequest{});
+    AWS_ASSERT_SUCCESS(resMoveAssigned);
+  }
+
+  // check that original is "unspecified but valid state" after move
+  {
+    mockResponse();
+    auto resWrappedAfterMoveAssign = anotherWrapper.Foo();
+    // move is actually redirected to copy because the generated client does not generate operator(&&), so it results in a copy
+    AWS_ASSERT_SUCCESS(resWrappedAfterMoveAssign);
+  }
+}

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/SmithyS3ClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/SmithyS3ClientHeader.vm
@@ -110,15 +110,15 @@ namespace ${rootNamespace}
 #if($serviceModel.enableVirtualOperations)
 #set($finalClass = "")
 #end
-    class ${CppViewHelper.computeExportValue($metadata.classNamePrefix)} ${className}${finalClass} : public smithy::client::AwsSmithyClientT<${rootNamespace}::${serviceNamespace}::SERVICE_NAME,
-      ${serviceConfiguration},
-      smithy::${AuthSchemeResolver}<${metadata.classNamePrefix}EndpointProvider, ${serviceConfiguration}>,
-      ${rootNamespace}::Crt::Variant<${AuthSchemeVariants}>,
-      ${metadata.classNamePrefix}EndpointProviderBase,
-      smithy::client::$serializer,
-      smithy::client::$serializerOutcome,
-      Aws::Client::${metadata.classNamePrefix}ErrorMarshaller>,
-    Aws::Client::ClientWithAsyncTemplateMethods<${className}>
+    class ${CppViewHelper.computeExportValue($metadata.classNamePrefix)} ${className}${finalClass} : Aws::Client::ClientWithAsyncTemplateMethods<${className}>,
+      public smithy::client::AwsSmithyClientT<${rootNamespace}::${serviceNamespace}::SERVICE_NAME,
+        ${serviceConfiguration},
+        smithy::${AuthSchemeResolver}<${metadata.classNamePrefix}EndpointProvider, ${serviceConfiguration}>,
+        ${rootNamespace}::Crt::Variant<${AuthSchemeVariants}>,
+        ${metadata.classNamePrefix}EndpointProviderBase,
+        smithy::client::$serializer,
+        smithy::client::$serializerOutcome,
+        Aws::Client::${metadata.classNamePrefix}ErrorMarshaller>,
     {
     public:
         static const char* GetServiceName();

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyClientHeader.vm
@@ -42,15 +42,15 @@ namespace ${serviceNamespace}
 #if($serviceModel.enableVirtualOperations)
 #set($finalClass = "")
 #end
-  class ${CppViewHelper.computeExportValue($metadata.classNamePrefix)} ${className}${finalClass} : smithy::client::AwsSmithyClientT<${rootNamespace}::${serviceNamespace}::SERVICE_NAME,
+  class ${CppViewHelper.computeExportValue($metadata.classNamePrefix)} ${className}${finalClass} : Aws::Client::ClientWithAsyncTemplateMethods<${className}>,
+    smithy::client::AwsSmithyClientT<${rootNamespace}::${serviceNamespace}::SERVICE_NAME,
       ${serviceConfiguration},
       smithy::${AuthSchemeResolver}<>,
       ${rootNamespace}::Crt::Variant<${AuthSchemeVariants}>,
       ${metadata.classNamePrefix}EndpointProviderBase,
       smithy::client::$serializer,
       smithy::client::$serializerOutcome,
-      Aws::Client::${metadata.classNamePrefix}ErrorMarshaller>,
-    Aws::Client::ClientWithAsyncTemplateMethods<${className}>
+      Aws::Client::${metadata.classNamePrefix}ErrorMarshaller>
   {
     public:
       static const char* GetServiceName();


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/pull/3325
*Description of changes:*
Smithy client failed to successfully perform implicit or explicit copy assignment.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
