### PR TITLE
Update CRT to v0.31.0

### DIFF
--- a/prefetch_crt_dependency.sh
+++ b/prefetch_crt_dependency.sh
@@ -3,21 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 CRT_URI_PREFIX=https://codeload.github.com/awslabs
-CRT_URI=${CRT_URI_PREFIX}/aws-crt-cpp/zip/9a820b302264b2bfe2e3f61a443fb1c652e6bd79  # v0.30.1
+CRT_URI=${CRT_URI_PREFIX}/aws-crt-cpp/zip/c776ab5b38036662ebd0569d2483b98a176f9819  # v0.31.0
 
-AWS_C_AUTH_URI=${CRT_URI_PREFIX}/aws-c-auth/zip/b513db4bf82429a1134fecbd6d12e5fda45255a6  # v0.8.4
+AWS_C_AUTH_URI=${CRT_URI_PREFIX}/aws-c-auth/zip/2d85beff96bee7ee4734c21c7fc6b15e9d07b85e  # v0.8.5
 AWS_C_CAL_URI=${CRT_URI_PREFIX}/aws-c-cal/zip/7299c6ab9244595b140d604475cdd6c6921be8ae  # v0.8.3
-AWS_C_COMMON_URI=${CRT_URI_PREFIX}/aws-c-common/zip/0e7637fa852a472bd4c37fc07a325a09c942a5fc  # v0.11.0
+AWS_C_COMMON_URI=${CRT_URI_PREFIX}/aws-c-common/zip/6401c830ffcd82ee9c9e26255f2fadf7092c7321  # v0.11.1
 AWS_C_COMPRESSION_URI=${CRT_URI_PREFIX}/aws-c-compression/zip/f951ab2b819fc6993b6e5e6cfef64b1a1554bfc8  # v0.3.1
-AWS_C_EVENT_STREAM_URI=${CRT_URI_PREFIX}/aws-c-event-stream/zip/9422ef78aac566414d1bebb1a5431a4c53a7547c  # v0.5.1
+AWS_C_EVENT_STREAM_URI=${CRT_URI_PREFIX}/aws-c-event-stream/zip/4bd476bd0c629e8fab4ec0ace92830efc6a79e6c  # v0.5.2
 AWS_C_HTTP_URI=${CRT_URI_PREFIX}/aws-c-http/zip/590c7b597f87e5edc080b8b77418690c30319832  # v0.9.3
-AWS_C_IO_URI=${CRT_URI_PREFIX}/aws-c-io/zip/3041dabfc13fe9bc9a0467e15aa1d5a09c7fc06f  # v0.15.4
-AWS_C_MQTT_URI=${CRT_URI_PREFIX}/aws-c-mqtt/zip/83247bde8268905018327891fcf0147f3e438a80  # v0.12.1
+AWS_C_IO_URI=${CRT_URI_PREFIX}/aws-c-io/zip/5fcecfc621059e254f2dc0dcac46265fcba0bf3a  # v0.16.0
+AWS_C_MQTT_URI=${CRT_URI_PREFIX}/aws-c-mqtt/zip/f0cc34cb6f54e050275e3c859594c62776d46d83  # v0.12.2
 AWS_C_S3_URI=${CRT_URI_PREFIX}/aws-c-s3/zip/6eb8be530b100fed5c6d24ca48a57ee2e6098fbf  # v0.7.11
 AWS_C_SDKUTILS_URI=${CRT_URI_PREFIX}/aws-c-sdkutils/zip/ba6a28fab7ed5d7f1b3b1d12eb672088be093824  # v0.2.3
 AWS_CHECKSUMS_URI=${CRT_URI_PREFIX}/aws-checksums/zip/fb8bd0b8cff00c8c24a35d601fce1b4c611df6da  # v0.2.3
-AWS_LC_URI=${CRT_URI_PREFIX}/aws-lc/zip/ffd6fb71b1e1582a620149337b77706f2391578d  # v1.43.0
-S2N_URI=${CRT_URI_PREFIX}/s2n/zip/493b77167dc367c394de23cfe78a029298e2a254  # v1.5.9
+AWS_LC_URI=${CRT_URI_PREFIX}/aws-lc/zip/becf5785c131012bb5a64f3da6cdb117ddc0f431  # v1.46.1
+S2N_URI=${CRT_URI_PREFIX}/s2n/zip/21cefc1091b3953ef543c9e72b932b6431fadc6e  # v1.5.13
 
 
 echo "Removing CRT"


### PR DESCRIPTION
*Issue #, if available:*
CRT event stream decoder has removed the limitation of a single event size.
*Description of changes:*
Updating CRT dependency version
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
