### PR TITLE
add missing transform for auth list from c2j to domain object

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
@@ -261,6 +261,7 @@ public class C2jModelToGeneratorModelTransformer {
             metadata.setProtocol(c2jMetadata.getProtocol());
         }
         metadata.setProtocols(c2jMetadata.getProtocols());
+        metadata.setAuth(c2jMetadata.getAuth());
         metadata.setNamespace(c2jMetadata.getServiceAbbreviation());
         metadata.setServiceFullName(c2jMetadata.getServiceFullName());
         metadata.setSignatureVersion(c2jMetadata.getSignatureVersion());


### PR DESCRIPTION
*Description of changes:*

We forgot to add a transform from the c2j model to the internal domain object in the generator causing failures when clients provide a auth list.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
