### PR TITLE
wire smithy client to use account id resolved from identity for endpoint parameters

### DIFF
--- a/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientAsyncRequestContext.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientAsyncRequestContext.h
@@ -70,6 +70,7 @@ namespace smithy
             ResponseHandlerFunc m_responseHandler;
             std::shared_ptr<Aws::Utils::Threading::Executor> m_pExecutor;
             std::shared_ptr<interceptor::InterceptorContext> m_interceptorContext;
+            std::shared_ptr<smithy::AwsIdentity> m_awsIdentity;
         };
     } // namespace client
 } // namespace smithy

--- a/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientBase.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientBase.h
@@ -18,6 +18,7 @@
 #include <aws/core/utils/FutureOutcome.h>
 #include <aws/core/utils/memory/stl/AWSMap.h>
 #include <aws/core/utils/Outcome.h>
+#include <aws/core/NoResult.h>
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/client/AWSErrorMarshaller.h>
 #include <aws/core/AmazonWebServiceResult.h>
@@ -84,6 +85,8 @@ namespace client
         using SelectAuthSchemeOptionOutcome = Aws::Utils::Outcome<AuthSchemeOption, AWSCoreError>;
         using ResolveEndpointOutcome = Aws::Utils::Outcome<Aws::Endpoint::AWSEndpoint, AWSCoreError>;
         using StreamOutcome = Aws::Utils::Outcome<Aws::AmazonWebServiceResult<Aws::Utils::Stream::ResponseStream>, AWSCoreError >;
+        using IdentityOutcome = Aws::Utils::Outcome<std::shared_ptr<smithy::AwsIdentity>, AWSCoreError>;
+        using GetContextEndpointParametersOutcome = Aws::Utils::Outcome<Aws::Vector<Aws::Endpoint::EndpointParameter>, AWSCoreError>;
 
         /* primary constructor */
         AwsSmithyClientBase(Aws::UniquePtr<Aws::Client::ClientConfiguration>&& clientConfig,
@@ -199,8 +202,10 @@ namespace client
 
         virtual ResolveEndpointOutcome ResolveEndpoint(const Aws::Endpoint::EndpointParameters& endpointParameters, EndpointUpdateCallback&& epCallback) const = 0;
         virtual SelectAuthSchemeOptionOutcome SelectAuthSchemeOption(const AwsSmithyClientAsyncRequestContext& ctx) const = 0;
-        virtual SigningOutcome SignHttpRequest(std::shared_ptr<HttpRequest> httpRequest, const AuthSchemeOption& targetAuthSchemeOption) const = 0;
+        virtual SigningOutcome SignHttpRequest(std::shared_ptr<HttpRequest> httpRequest, const AwsSmithyClientAsyncRequestContext& ctx) const = 0;
         virtual bool AdjustClockSkew(HttpResponseOutcome& outcome, const AuthSchemeOption& authSchemeOption) const = 0;
+        virtual IdentityOutcome ResolveIdentity(const AwsSmithyClientAsyncRequestContext& ctx) const = 0;
+        virtual GetContextEndpointParametersOutcome GetContextEndpointParameters(const AwsSmithyClientAsyncRequestContext& ctx) const = 0;
 
         /* AwsSmithyClientT class binds its config reference to this pointer, so don't remove const and don't re-allocate it.
          * This is done to avoid duplication of config object between this base and actual service template classes.

--- a/src/aws-cpp-sdk-core/include/smithy/client/common/AwsSmithyRequestSigning.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/common/AwsSmithyRequestSigning.h
@@ -38,12 +38,42 @@ namespace smithy
         using SigningError = Aws::Client::AWSError<Aws::Client::CoreErrors>;
         using SigningOutcome = Aws::Utils::FutureOutcome<std::shared_ptr<HttpRequest>, SigningError>;
         using HttpResponseOutcome = Aws::Utils::Outcome<std::shared_ptr<Aws::Http::HttpResponse>, Aws::Client::AWSError<Aws::Client::CoreErrors>>;
+        using IdentityOutcome = Aws::Utils::Outcome<std::shared_ptr<smithy::AwsIdentity>, Aws::Client::AWSError<Aws::Client::CoreErrors>>;
 
-        static SigningOutcome SignRequest(std::shared_ptr<HttpRequest> HTTPRequest, const AuthSchemeOption& authSchemeOption,
-                                          const Aws::UnorderedMap<Aws::String, AuthSchemesVariantT>& authSchemes)
+        static IdentityOutcome ResolveIdentity(const client::AwsSmithyClientAsyncRequestContext& ctx,
+          const Aws::UnorderedMap<Aws::String, AuthSchemesVariantT>& authSchemes)
         {
+          auto authSchemeIt = authSchemes.find(ctx.m_authSchemeOption.schemeId);
+          if (authSchemeIt == authSchemes.end())
+          {
+            assert(!"Auth scheme has not been found for a given auth option!");
+            return (SigningError(Aws::Client::CoreErrors::CLIENT_SIGNING_FAILURE,
+                                 "",
+                                 "Requested AuthSchemeOption was not found within client Auth Schemes",
+                                 false/*retryable*/));
+          }
 
-            auto authSchemeIt = authSchemes.find(authSchemeOption.schemeId);
+          const AuthSchemesVariantT& authScheme = authSchemeIt->second;
+          IdentityVisitor visitor(ctx);
+          AuthSchemesVariantT authSchemesVariantCopy(authScheme); // TODO: allow const visiting
+          authSchemesVariantCopy.Visit(visitor);
+
+          if (!visitor.result)
+          {
+            return (SigningError(Aws::Client::CoreErrors::CLIENT_SIGNING_FAILURE,
+                                 "",
+                                 "Failed to sign with an unknown error",
+                                 false/*retryable*/));
+          }
+
+          return std::move(*visitor.result);
+        }
+
+        static SigningOutcome SignRequest(std::shared_ptr<HttpRequest> HTTPRequest,
+          const client::AwsSmithyClientAsyncRequestContext& ctx,
+          const Aws::UnorderedMap<Aws::String, AuthSchemesVariantT>& authSchemes)
+        {
+            auto authSchemeIt = authSchemes.find(ctx.m_authSchemeOption.schemeId);
             if (authSchemeIt == authSchemes.end())
             {
                 assert(!"Auth scheme has not been found for a given auth option!");
@@ -55,8 +85,9 @@ namespace smithy
 
             const AuthSchemesVariantT& authScheme = authSchemeIt->second;
 
-            return SignWithAuthScheme(std::move(HTTPRequest), authScheme, authSchemeOption);
+            return SignWithAuthScheme(std::move(HTTPRequest), authScheme, ctx);
         }
+
         static SigningOutcome PreSignRequest(std::shared_ptr<HttpRequest> httpRequest,
                                   const AuthSchemeOption& authSchemeOption,
                                   const Aws::UnorderedMap<Aws::String, AuthSchemesVariantT>& authSchemes,
@@ -113,15 +144,62 @@ namespace smithy
 
 
     protected:
+        struct IdentityVisitor
+        {
+            IdentityVisitor(const client::AwsSmithyClientAsyncRequestContext& ctx): m_requestContext(ctx)
+            {
+            }
+
+            const client::AwsSmithyClientAsyncRequestContext& m_requestContext;
+            Aws::Crt::Optional<IdentityOutcome> result;
+
+            template <typename AuthSchemeAlternativeT>
+            void operator()(AuthSchemeAlternativeT& authScheme)
+            {
+              using IdentityT = typename std::remove_reference<decltype(authScheme)>::type::IdentityT;
+              using IdentityResolver = IdentityResolverBase<IdentityT>;
+
+              std::shared_ptr<IdentityResolver> identityResolver = authScheme.identityResolver();
+              if (!identityResolver)
+              {
+                result.emplace(SigningError(Aws::Client::CoreErrors::CLIENT_SIGNING_FAILURE,
+                                            "",
+                                            "Auth scheme provided a nullptr identityResolver",
+                                            false/*retryable*/));
+                return;
+              }
+
+              //relay service params in additional properties which will be relevant in credential resolution
+              // example: bucket Name
+              Aws::UnorderedMap<Aws::String, Aws::Crt::Variant<Aws::String, bool>> additionalIdentityProperties;
+              const auto& serviceSpecificParameters = m_requestContext.m_pRequest->GetServiceSpecificParameters();
+              if(serviceSpecificParameters)
+              {
+                for(const auto& propPair : serviceSpecificParameters->parameterMap)
+                {
+                  additionalIdentityProperties.emplace(propPair.first,Aws::Crt::Variant<Aws::String, bool>{propPair.second} );
+                }
+              }
+
+              auto identityResult = identityResolver->getIdentity(m_requestContext.m_authSchemeOption.identityProperties(), additionalIdentityProperties);
+              if (!identityResult.IsSuccess())
+              {
+                result.emplace(identityResult.GetError());
+                return;
+              }
+              result.emplace(std::move(identityResult.GetResultWithOwnership()));
+            }
+        };
+
         struct SignerVisitor
         {
-            SignerVisitor(std::shared_ptr<HttpRequest> httpRequest, const AuthSchemeOption& targetAuthSchemeOption)
-                : m_httpRequest(std::move(httpRequest)), m_targetAuthSchemeOption(targetAuthSchemeOption)
+            SignerVisitor(std::shared_ptr<HttpRequest> httpRequest, const client::AwsSmithyClientAsyncRequestContext& ctx)
+                : m_httpRequest(std::move(httpRequest)), m_requestContext(ctx)
             {
             }
 
             const std::shared_ptr<HttpRequest> m_httpRequest;
-            const AuthSchemeOption& m_targetAuthSchemeOption;
+            const client::AwsSmithyClientAsyncRequestContext& m_requestContext;
 
             Aws::Crt::Optional<SigningOutcome> result;
 
@@ -129,42 +207,10 @@ namespace smithy
             void operator()(AuthSchemeAlternativeT& authScheme)
             {
                 // Auth Scheme Variant alternative contains the requested auth option
-                assert(strcmp(authScheme.schemeId, m_targetAuthSchemeOption.schemeId) == 0);
+                assert(strcmp(authScheme.schemeId, m_requestContext.m_authSchemeOption.schemeId) == 0);
 
                 using IdentityT = typename std::remove_reference<decltype(authScheme)>::type::IdentityT;
-                using IdentityResolver = IdentityResolverBase<IdentityT>;
                 using Signer = AwsSignerBase<IdentityT>;
-
-                std::shared_ptr<IdentityResolver> identityResolver = authScheme.identityResolver();
-                if (!identityResolver)
-                {
-                    result.emplace(SigningError(Aws::Client::CoreErrors::CLIENT_SIGNING_FAILURE,
-                                                "",
-                                                "Auth scheme provided a nullptr identityResolver",
-                                                false/*retryable*/));
-                    return;
-                }
-
-                //relay service params in additional properties which will be relevant in credential resolution
-                // example: bucket Name
-                Aws::UnorderedMap<Aws::String, Aws::Crt::Variant<Aws::String, bool>> additionalIdentityProperties;
-                const auto& serviceSpecificParameters = m_httpRequest->GetServiceSpecificParameters();
-                if(serviceSpecificParameters)
-                {
-                    for(const auto& propPair : serviceSpecificParameters->parameterMap)
-                    {
-                        additionalIdentityProperties.emplace(propPair.first,Aws::Crt::Variant<Aws::String, bool>{propPair.second} );
-                    }
-                }
-
-                auto identityResult = identityResolver->getIdentity(m_targetAuthSchemeOption.identityProperties(), additionalIdentityProperties);
-
-                if (!identityResult.IsSuccess())
-                {
-                    result.emplace(identityResult.GetError());
-                    return;
-                }
-                auto identity = std::move(identityResult.GetResultWithOwnership());
 
                 std::shared_ptr<Signer> signer = authScheme.signer();
                 if (!signer)
@@ -176,7 +222,9 @@ namespace smithy
                     return;
                 }
 
-                result.emplace(signer->sign(m_httpRequest, *identity, m_targetAuthSchemeOption.signerProperties()));
+                result.emplace(signer->sign(m_httpRequest,
+                  *static_cast<IdentityT*>(m_requestContext.m_awsIdentity.get()),
+                  m_requestContext.m_authSchemeOption.signerProperties()));
             }
         };
 
@@ -236,11 +284,11 @@ namespace smithy
           }
         };
 
-        static
-        SigningOutcome SignWithAuthScheme(std::shared_ptr<HttpRequest> httpRequest, const AuthSchemesVariantT& authSchemesVariant,
-                                          const AuthSchemeOption& targetAuthSchemeOption)
+        static SigningOutcome SignWithAuthScheme(std::shared_ptr<HttpRequest> httpRequest,
+          const AuthSchemesVariantT& authSchemesVariant,
+          const client::AwsSmithyClientAsyncRequestContext& ctx)
         {
-            SignerVisitor visitor(httpRequest, targetAuthSchemeOption);
+            SignerVisitor visitor(httpRequest, ctx);
             AuthSchemesVariantT authSchemesVariantCopy(authSchemesVariant); // TODO: allow const visiting
             authSchemesVariantCopy.Visit(visitor);
 

--- a/src/aws-cpp-sdk-core/include/smithy/identity/identity/impl/AwsCredentialIdentityImpl.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/identity/impl/AwsCredentialIdentityImpl.h
@@ -25,6 +25,6 @@ namespace smithy {
     }
 
     inline Aws::Crt::Optional<Aws::String> AwsCredentialIdentity::accountId() const {
-        return m_sessionToken;
+        return m_accountId;
     }
 }

--- a/src/aws-cpp-sdk-core/include/smithy/identity/resolver/built-in/DefaultAwsCredentialIdentityResolver.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/resolver/built-in/DefaultAwsCredentialIdentityResolver.h
@@ -50,7 +50,7 @@ namespace smithy {
                                                                      legacyCreds.GetAWSSecretKey(),
                                                                      legacyCreds.GetSessionToken().empty()? Aws::Crt::Optional<Aws::String>() : legacyCreds.GetSessionToken(),
                                                                      legacyCreds.GetExpiration(),
-                                                                     legacyCreds.GetAccountId().empty()? Aws::Crt::Optional<Aws::String>() : legacyCreds.GetSessionToken());
+                                                                     legacyCreds.GetAccountId().empty()? Aws::Crt::Optional<Aws::String>() : legacyCreds.GetAccountId());
 
             return ResolveIdentityFutureOutcome(std::move(smithyCreds));
         }

--- a/tests/aws-cpp-sdk-dynamodb-unit-tests/DynamoDBUnitTests.cpp
+++ b/tests/aws-cpp-sdk-dynamodb-unit-tests/DynamoDBUnitTests.cpp
@@ -1,20 +1,28 @@
 /**
-* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
-
-#include <gtest/gtest.h>
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentials.h>
+#include <aws/core/auth/GeneralHTTPCredentialsProvider.h>
+#include <aws/core/auth/SSOCredentialsProvider.h>
+#include <aws/core/auth/STSCredentialsProvider.h>
 #include <aws/core/client/RetryStrategy.h>
-#include <aws/core/monitoring/MonitoringInterface.h>
+#include <aws/core/internal/AWSHttpResourceClient.h>
 #include <aws/core/monitoring/MonitoringFactory.h>
+#include <aws/core/monitoring/MonitoringInterface.h>
+#include <aws/core/platform/Environment.h>
+#include <aws/core/utils/FileSystemUtils.h>
 #include <aws/dynamodb/DynamoDBClient.h>
-#include <aws/dynamodb/DynamoDBEndpointProvider.h>
 #include <aws/dynamodb/DynamoDBClientConfiguration.h>
-#include <aws/testing/mocks/http/MockHttpClient.h>
+#include <aws/dynamodb/DynamoDBEndpointProvider.h>
 #include <aws/testing/AwsTestHelpers.h>
 #include <aws/testing/MemoryTesting.h>
+#include <aws/testing/mocks/aws/auth/MockAWSHttpResourceClient.h>
+#include <aws/testing/mocks/http/MockHttpClient.h>
+#include <aws/testing/platform/PlatformTesting.h>
+#include <gtest/gtest.h>
+
 #include <memory>
 
 using namespace Aws;
@@ -28,6 +36,8 @@ using namespace Aws::Http::Standard;
 namespace {
 const char* LOG_TAG = "DynamoDBUnitTest";
 const int MAX_RETRIES = 2;
+const char* CONFIGURATION_FILE_ENV_VAR = "AWS_CONFIG_FILE";
+const char* CREDS_FILE_ENV_VAR = "AWS_SHARED_CREDENTIALS_FILE";
 }  // namespace
 
 class  MonitoringContext
@@ -178,7 +188,28 @@ protected:
   void SetUp() override
   {
     monitoring_context_->Reset();
+
+    auto profileDirectory = ProfileConfigFileAWSCredentialsProvider::GetProfileDirectory();
+    Aws::FileSystem::CreateDirectoryIfNotExists(profileDirectory.c_str());
+    Aws::StringStream ssCachedTokenDirectory;
+    ssCachedTokenDirectory << profileDirectory << FileSystem::PATH_DELIM << "sso";
+    Aws::FileSystem::CreateDirectoryIfNotExists(ssCachedTokenDirectory.str().c_str());
+    ssCachedTokenDirectory << FileSystem::PATH_DELIM << "cache";
+    Aws::FileSystem::CreateDirectoryIfNotExists(ssCachedTokenDirectory.str().c_str());
+
+    // setting up token file for tests
+    Aws::StringStream ssToken;
+    ssToken << ssCachedTokenDirectory.str();
+    auto ssoTokenDirectory = ssToken.str();
+    // SHA1 of "https://d-92671207e4.awsapps.com/start" -> 13f9d35043871d073ab260e020f0ffde092cb14b
+    ssToken << FileSystem::PATH_DELIM << "13f9d35043871d073ab260e020f0ffde092cb14b.json";
+    m_ssoTokenFileName = ssToken.str();
   };
+
+  void TearDown() override
+  {
+    Aws::FileSystem::RemoveFileIfExists(m_ssoTokenFileName.c_str());
+  }
 
   static void TearDownTestSuite() {
     mock_client_factory_.reset();
@@ -207,6 +238,26 @@ protected:
 #ifdef USE_AWS_MEMORY_MANAGEMENT
   static std::unique_ptr<ExactTestMemorySystem> test_memory_system;
 #endif
+  Aws::String m_ssoTokenFileName;
+  Environment::EnvironmentRAII m_unsetEnvVare{{
+      {"AWS_SHARED_CREDENTIALS_FILE", ""},
+      {"AWS_CONFIG_FILE", ""},
+      {"AWS_DEFAULT_PROFILE", ""},
+      {"AWS_PROFILE", ""},
+      {"AWS_ACCESS_KEY_ID", ""},
+      {"AWS_SECRET_ACCESS_KEY", ""},
+      {"AWS_EC2_METADATA_DISABLED", ""},
+      {"AWS_ACCOUNT_ID", ""},
+      {"AWS_ACCESS_KEY_ID", ""},
+      {"AWS_SECRET_ACCESS_KEY", ""},
+      {"AWS_SESSION_TOKEN", ""},
+      {"AWS_ROLE_SESSION_NAME", ""},
+      {"AWS_PROFILE", ""},
+      {"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", ""},
+      {"AWS_DEFAULT_REGION", ""},
+      {"AWS_REGION", ""},
+      {"profile", ""},
+    }};
 };
 
 SDKOptions DynamoDBUnitTest::options_;
@@ -217,6 +268,15 @@ std::shared_ptr<MonitoringContext> DynamoDBUnitTest::monitoring_context_= nullpt
 #ifdef USE_AWS_MEMORY_MANAGEMENT
   std::unique_ptr<ExactTestMemorySystem> DynamoDBUnitTest::test_memory_system = nullptr;
 #endif
+
+static Aws::String WrapEchoStringWithSingleQuoteForUnixShell(Aws::String str)
+{
+#ifndef _WIN32
+  str.insert(0, 1, '\'');
+  str.append(1, '\'');
+#endif
+  return str;
+}
 
 TEST_F(DynamoDBUnitTest, RetryShouldWork)
 {
@@ -332,7 +392,7 @@ TEST_F(DynamoDBUnitTest, ListTablesShouldHaveCorrectUserAgent)
   EXPECT_TRUE(archMetadata < businessMetrics);
 }
 
-TEST_F(DynamoDBUnitTest, ShouldUseAccountIDEndpoint)
+TEST_F(DynamoDBUnitTest, ShouldUseAccountIDEndpointSetOnConfiguration)
 {
   // create client with account id configuration
   AWSCredentials credentials{"mock", "credentials"};
@@ -356,4 +416,327 @@ TEST_F(DynamoDBUnitTest, ShouldUseAccountIDEndpoint)
   EXPECT_TRUE(listTablesOutcome.IsSuccess());
   const auto requestSeen = mock_http_client_->GetMostRecentHttpRequest();
   EXPECT_EQ("https://123456789012.ddb.us-east-1.amazonaws.com", requestSeen.GetUri().GetURIString());
+}
+
+TEST_F(DynamoDBUnitTest, ShouldUseStandardEndpointIfAccountIdMissingFromCredentialsFile)
+{
+  // create shared credentials file with account id
+  Utils::TempFile configFile(std::ios_base::out | std::ios_base::trunc);
+  ASSERT_TRUE(configFile.good());
+  configFile << "[default]" << std::endl;
+  configFile << "aws_access_key_id = ballad" << std::endl;
+  configFile << "aws_secret_access_key = of-fallen" << std::endl;
+  configFile << "aws_session_token = angels" << std::endl;
+  configFile.close();
+  Environment::EnvironmentRAII envVars{{{CREDS_FILE_ENV_VAR, configFile.GetFileName().c_str()}}};
+  Aws::Config::ReloadCachedCredentialsFile();
+
+  DynamoDBClientConfiguration configuration;
+  configuration.region = "us-east-1";
+  const auto accountIdClient = Aws::MakeShared<DynamoDBClient>(LOG_TAG, configuration);
+
+  // mock response
+  auto successStream = Aws::MakeShared<StandardHttpRequest>(LOG_TAG, "cowboy.bebop/planets", HttpMethod::HTTP_GET);
+  successStream->SetResponseStreamFactory([]() -> IOStream* {
+    auto listTablesString =  R"({"LastEvaluatedTableName": "Planets","TableNames": ["Planets"]}))";
+    return Aws::New<StringStream>(LOG_TAG, listTablesString, std::ios_base::in | std::ios_base::binary);
+  });
+  auto successResponse = Aws::MakeShared<StandardHttpResponse>(LOG_TAG, successStream);
+  successResponse->SetResponseCode(HttpResponseCode::OK);
+
+  mock_http_client_->AddResponseToReturn(successResponse);
+  const auto listTablesOutcome = accountIdClient->ListTables();
+  EXPECT_TRUE(listTablesOutcome.IsSuccess());
+  const auto requestSeen = mock_http_client_->GetMostRecentHttpRequest();
+  EXPECT_EQ("https://dynamodb.us-east-1.amazonaws.com", requestSeen.GetUri().GetURIString());
+}
+
+
+TEST_F(DynamoDBUnitTest, ShouldUseAccountIDEndpointFromCredentialsFile)
+{
+  // create shared credentials file with account id
+  Utils::TempFile configFile(std::ios_base::out | std::ios_base::trunc);
+  ASSERT_TRUE(configFile.good());
+  configFile << "[default]" << std::endl;
+  configFile << "aws_access_key_id = ballad" << std::endl;
+  configFile << "aws_secret_access_key = of-fallen" << std::endl;
+  configFile << "aws_session_token = angels" << std::endl;
+  configFile << "aws_account_id = spike-spiegel" << std::endl;;
+  configFile.close();
+  Environment::EnvironmentRAII envVars{{{CREDS_FILE_ENV_VAR, configFile.GetFileName().c_str()}}};
+  Aws::Config::ReloadCachedCredentialsFile();
+
+  DynamoDBClientConfiguration configuration;
+  configuration.region = "us-east-1";
+
+  auto credsProvider = Aws::MakeShared<ProfileConfigFileAWSCredentialsProvider>(LOG_TAG);
+
+  const auto accountIdClient = Aws::MakeShared<DynamoDBClient>(LOG_TAG, std::move(credsProvider), nullptr, configuration);
+
+  // mock response
+  auto successStream = Aws::MakeShared<StandardHttpRequest>(LOG_TAG, "cowboy.bebop/planets", HttpMethod::HTTP_GET);
+  successStream->SetResponseStreamFactory([]() -> IOStream* {
+    auto listTablesString =  R"({"LastEvaluatedTableName": "Planets","TableNames": ["Planets"]}))";
+    return Aws::New<StringStream>(LOG_TAG, listTablesString, std::ios_base::in | std::ios_base::binary);
+  });
+  auto successResponse = Aws::MakeShared<StandardHttpResponse>(LOG_TAG, successStream);
+  successResponse->SetResponseCode(HttpResponseCode::OK);
+
+  mock_http_client_->AddResponseToReturn(successResponse);
+  const auto listTablesOutcome = accountIdClient->ListTables();
+  EXPECT_TRUE(listTablesOutcome.IsSuccess());
+  const auto requestSeen = mock_http_client_->GetMostRecentHttpRequest();
+  EXPECT_EQ("https://spike-spiegel.ddb.us-east-1.amazonaws.com", requestSeen.GetUri().GetURIString());
+}
+
+TEST_F(DynamoDBUnitTest, ShouldUseAccountIDEndpointFromEnviornmentCredentialsProvider)
+{
+  // create enviornment variables with account id
+  const Environment::EnvironmentRAII environmentVariables{
+    {
+      {"AWS_ACCESS_KEY_ID", "stray"},
+      {"AWS_SECRET_ACCESS_KEY", "dog"},
+      {"AWS_SESSION_TOKEN", "strut"},
+      {"AWS_ACCOUNT_ID", "ein"},
+    }};
+
+  DynamoDBClientConfiguration configuration;
+  configuration.region = "us-east-1";
+
+  auto credsProvider = Aws::MakeShared<EnvironmentAWSCredentialsProvider>(LOG_TAG);
+
+  const auto accountIdClient = Aws::MakeShared<DynamoDBClient>(LOG_TAG, std::move(credsProvider), nullptr, configuration);
+
+  // mock response
+  auto successStream = Aws::MakeShared<StandardHttpRequest>(LOG_TAG, "cowboy.bebop/planets", HttpMethod::HTTP_GET);
+  successStream->SetResponseStreamFactory([]() -> IOStream* {
+    auto listTablesString =  R"({"LastEvaluatedTableName": "Planets","TableNames": ["Planets"]}))";
+    return Aws::New<StringStream>(LOG_TAG, listTablesString, std::ios_base::in | std::ios_base::binary);
+  });
+  auto successResponse = Aws::MakeShared<StandardHttpResponse>(LOG_TAG, successStream);
+  successResponse->SetResponseCode(HttpResponseCode::OK);
+
+  mock_http_client_->AddResponseToReturn(successResponse);
+  const auto listTablesOutcome = accountIdClient->ListTables();
+  EXPECT_TRUE(listTablesOutcome.IsSuccess());
+  const auto requestSeen = mock_http_client_->GetMostRecentHttpRequest();
+  EXPECT_EQ("https://ein.ddb.us-east-1.amazonaws.com", requestSeen.GetUri().GetURIString());
+}
+
+TEST_F(DynamoDBUnitTest, ShouldUseAccountIDEndpointFromProcessCredentialsProvider)
+{
+  // create configruation file with process credentials provider with account id
+  Utils::TempFile configFile(std::ios_base::out | std::ios_base::trunc);
+  ASSERT_TRUE(configFile.good());
+  configFile << "[default]" << std::endl;
+  configFile << "credential_process = echo " << WrapEchoStringWithSingleQuoteForUnixShell("{\"Version\": 1, \"AccessKeyId\": \"honky\", \"SecretAccessKey\": \"tonk\", \"SecretAccessKey\": \"woman\", \"AccountId\": \"faye\"}") << std::endl;
+  configFile.close();
+  Environment::EnvironmentRAII envVars{{{CONFIGURATION_FILE_ENV_VAR, configFile.GetFileName().c_str()}}};
+  Aws::Config::ReloadCachedConfigFile();
+
+  DynamoDBClientConfiguration configuration;
+  configuration.region = "us-east-1";
+
+  auto credsProvider = Aws::MakeShared<ProcessCredentialsProvider>(LOG_TAG);
+
+  const auto accountIdClient = Aws::MakeShared<DynamoDBClient>(LOG_TAG, std::move(credsProvider), nullptr, configuration);
+
+  // mock response
+  auto successStream = Aws::MakeShared<StandardHttpRequest>(LOG_TAG, "cowboy.bebop/planets", HttpMethod::HTTP_GET);
+  successStream->SetResponseStreamFactory([]() -> IOStream* {
+    auto listTablesString =  R"({"LastEvaluatedTableName": "Planets","TableNames": ["Planets"]}))";
+    return Aws::New<StringStream>(LOG_TAG, listTablesString, std::ios_base::in | std::ios_base::binary);
+  });
+  auto successResponse = Aws::MakeShared<StandardHttpResponse>(LOG_TAG, successStream);
+  successResponse->SetResponseCode(HttpResponseCode::OK);
+
+  mock_http_client_->AddResponseToReturn(successResponse);
+  const auto listTablesOutcome = accountIdClient->ListTables();
+  EXPECT_TRUE(listTablesOutcome.IsSuccess());
+  const auto requestSeen = mock_http_client_->GetMostRecentHttpRequest();
+  EXPECT_EQ("https://faye.ddb.us-east-1.amazonaws.com", requestSeen.GetUri().GetURIString());
+}
+
+TEST_F(DynamoDBUnitTest, ShouldUseAccountIDEndpointFromSTSCredentialsProvider)
+{
+  Utils::TempFile tokenFile(std::ios_base::out | std::ios_base::trunc);
+  ASSERT_TRUE(tokenFile.good());
+  Aws::String token = "seeyoulaterspacecowboy";
+  tokenFile << token;
+  tokenFile.close();
+
+  Utils::TempFile configFile(std::ios_base::out | std::ios_base::trunc);
+  configFile << "[default]" << std::endl;
+  configFile << "web_identity_token_file = " << tokenFile.GetFileName() << std::endl;
+  configFile << "role_arn = arn:aws:iam::rocco:role/bounty " << std::endl;
+  configFile << "role_session_name = session_8" << std::endl;
+  configFile << std::endl;
+  configFile.close();
+  Environment::EnvironmentRAII envVars{{{CONFIGURATION_FILE_ENV_VAR, configFile.GetFileName().c_str()}}};
+  Aws::Config::ReloadCachedConfigFile();
+
+  ClientConfigurationInitValues initValues{};
+  initValues.shouldDisableIMDS = true;
+  DynamoDBClientConfiguration configuration{initValues};
+  configuration.region = "us-east-1";
+
+  auto credsProvider = Aws::MakeShared<STSAssumeRoleWebIdentityCredentialsProvider>(LOG_TAG);
+
+  const auto accountIdClient = Aws::MakeShared<DynamoDBClient>(LOG_TAG, std::move(credsProvider), nullptr, configuration);
+
+  // make up sts response
+  std::shared_ptr<HttpRequest> requestTmp = CreateHttpRequest(URI{}, HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+  Aws::String stsResponse = "<AssumeRoleWithWebIdentityResult><Credentials><AccessKeyId>waltz</AccessKeyId><SecretAccessKey>for</SecretAccessKey><SessionToken>venuz</SessionToken><AssumedRoleUser><Arn>arn:aws:sts::rocco:assumed-role/FederatedWebIdentityRole/musicbox</Arn><AssumedRoleId>stella</AssumedRoleId></AssumedRoleUser></Credentials></AssumeRoleWithWebIdentityResult>";
+  auto response = Aws::MakeShared<StandardHttpResponse>(LOG_TAG, requestTmp);
+  response->SetResponseCode(HttpResponseCode::OK);
+  response->GetResponseBody() << stsResponse;
+  mock_http_client_->AddResponseToReturn(std::move(response));
+
+  // mock response
+  auto successStream = Aws::MakeShared<StandardHttpRequest>(LOG_TAG, "cowboy.bebop/planets", HttpMethod::HTTP_GET);
+  successStream->SetResponseStreamFactory([]() -> IOStream* {
+    auto listTablesString =  R"({"LastEvaluatedTableName": "Planets","TableNames": ["Planets"]}))";
+    return Aws::New<StringStream>(LOG_TAG, listTablesString, std::ios_base::in | std::ios_base::binary);
+  });
+  auto successResponse = Aws::MakeShared<StandardHttpResponse>(LOG_TAG, successStream);
+  successResponse->SetResponseCode(HttpResponseCode::OK);
+
+  mock_http_client_->AddResponseToReturn(successResponse);
+  const auto listTablesOutcome = accountIdClient->ListTables();
+  EXPECT_TRUE(listTablesOutcome.IsSuccess());
+  const auto requestSeen = mock_http_client_->GetMostRecentHttpRequest();
+  EXPECT_EQ("https://rocco.ddb.us-east-1.amazonaws.com", requestSeen.GetUri().GetURIString());
+}
+
+TEST_F(DynamoDBUnitTest, ShouldUseAccountIDEndpointFromSSOCredentialsProvider)
+{
+  Aws::OFStream tokenFile(m_ssoTokenFileName.c_str(), Aws::OFStream::out | Aws::OFStream::trunc);;
+  tokenFile << R"({
+    "accessToken": "base64string",
+    "expiresAt": ")";
+  tokenFile << Utils::DateTime::Now().GetYear() + 1;
+  tokenFile << R"(-01-02T00:00:00Z",
+    "region": "us-west-2",
+    "startUrl": "https://d-92671207e4.awsapps.com/start"
+})";
+  tokenFile.close();
+
+  Utils::TempFile configFile(std::ios_base::out | std::ios_base::trunc);
+  configFile << "[default]" << std::endl;
+  configFile << "sso_account_id = 012345678901" << std::endl;
+  configFile << "sso_region = us-east-1" << std::endl;
+  configFile << "sso_role_name = SampleRole" << std::endl;
+  configFile << "sso_start_url = https://d-92671207e4.awsapps.com/start" << std::endl;
+  configFile << std::endl;
+  configFile.close();
+  Environment::EnvironmentRAII envVars{{{CONFIGURATION_FILE_ENV_VAR, configFile.GetFileName().c_str()}}};
+  Aws::Config::ReloadCachedConfigFile();
+
+  ClientConfigurationInitValues initValues{};
+  initValues.shouldDisableIMDS = true;
+  DynamoDBClientConfiguration configuration{initValues};
+  configuration.region = "us-east-1";
+
+  auto credsProvider = Aws::MakeShared<SSOCredentialsProvider>(LOG_TAG);
+
+  const auto accountIdClient = Aws::MakeShared<DynamoDBClient>(LOG_TAG, std::move(credsProvider), nullptr, configuration);
+
+  std::shared_ptr<HttpRequest> requestTmp = CreateHttpRequest(URI{}, HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+  Aws::String goodResult = R"({
+   "roleCredentials": {
+      "accessKeyId": "Ganymede",
+      "expiration": 2303614800000,
+      "secretAccessKey": "Elegy",
+      "sessionToken": "session_10",
+      "accountId": "jet"
+   }
+}
+)";
+
+  std::shared_ptr<StandardHttpResponse> goodResponse = Aws::MakeShared<StandardHttpResponse>(LOG_TAG, requestTmp);
+  goodResponse->SetResponseCode(HttpResponseCode::OK);
+  goodResponse->GetResponseBody() << goodResult;
+  mock_http_client_->AddResponseToReturn(goodResponse);
+
+  // mock response
+  auto successStream = Aws::MakeShared<StandardHttpRequest>(LOG_TAG, "cowboy.bebop/planets", HttpMethod::HTTP_GET);
+  successStream->SetResponseStreamFactory([]() -> IOStream* {
+    auto listTablesString =  R"({"LastEvaluatedTableName": "Planets","TableNames": ["Planets"]}))";
+    return Aws::New<StringStream>(LOG_TAG, listTablesString, std::ios_base::in | std::ios_base::binary);
+  });
+  auto successResponse = Aws::MakeShared<StandardHttpResponse>(LOG_TAG, successStream);
+  successResponse->SetResponseCode(HttpResponseCode::OK);
+
+  mock_http_client_->AddResponseToReturn(successResponse);
+  const auto listTablesOutcome = accountIdClient->ListTables();
+  EXPECT_TRUE(listTablesOutcome.IsSuccess());
+  const auto requestSeen = mock_http_client_->GetMostRecentHttpRequest();
+  EXPECT_EQ("https://jet.ddb.us-east-1.amazonaws.com", requestSeen.GetUri().GetURIString());
+}
+
+TEST_F(DynamoDBUnitTest, ShouldUseAccountIDEndpointFromContainerCredentialsProvider)
+{
+  ClientConfigurationInitValues initValues{};
+  initValues.shouldDisableIMDS = true;
+  DynamoDBClientConfiguration configuration{initValues};
+  configuration.region = "us-east-1";
+
+
+  auto mockClient = Aws::MakeShared<MockECSCredentialsClient>(LOG_TAG, "/see/you/later");
+  const char* validCredentials = R"({"AccessKeyId": "Jupiter", "SecretAccessKey": "Jazz", "Token": "Gren", "AccountId": "Vicious"})";
+  mockClient->SetMockedCredentialsValue(validCredentials);
+
+  auto credsProvider = Aws::MakeShared<GeneralHTTPCredentialsProvider>(LOG_TAG, std::move(mockClient));
+
+  const auto accountIdClient = Aws::MakeShared<DynamoDBClient>(LOG_TAG, std::move(credsProvider), nullptr, configuration);
+
+  // mock response
+  auto successStream = Aws::MakeShared<StandardHttpRequest>(LOG_TAG, "cowboy.bebop/planets", HttpMethod::HTTP_GET);
+  successStream->SetResponseStreamFactory([]() -> IOStream* {
+    auto listTablesString =  R"({"LastEvaluatedTableName": "Planets","TableNames": ["Planets"]}))";
+    return Aws::New<StringStream>(LOG_TAG, listTablesString, std::ios_base::in | std::ios_base::binary);
+  });
+  auto successResponse = Aws::MakeShared<StandardHttpResponse>(LOG_TAG, successStream);
+  successResponse->SetResponseCode(HttpResponseCode::OK);
+
+  mock_http_client_->AddResponseToReturn(successResponse);
+  const auto listTablesOutcome = accountIdClient->ListTables();
+  EXPECT_TRUE(listTablesOutcome.IsSuccess());
+  const auto requestSeen = mock_http_client_->GetMostRecentHttpRequest();
+  EXPECT_EQ("https://Vicious.ddb.us-east-1.amazonaws.com", requestSeen.GetUri().GetURIString());
+}
+
+TEST_F(DynamoDBUnitTest, ShouldNotUseAccountIDEndpointWhenDisabled)
+{
+  // create enviornment variables with account id
+  const Environment::EnvironmentRAII environmentVariables{
+        {
+          {"AWS_ACCESS_KEY_ID", "the"},
+          {"AWS_SECRET_ACCESS_KEY", "real"},
+          {"AWS_SESSION_TOKEN", "folk"},
+          {"AWS_ACCOUNT_ID", "blues"},
+        }};
+
+  DynamoDBClientConfiguration configuration;
+  configuration.region = "us-east-1";
+  configuration.accountIdEndpointMode = "disabled";
+
+  auto credsProvider = Aws::MakeShared<EnvironmentAWSCredentialsProvider>(LOG_TAG);
+
+  const auto accountIdClient = Aws::MakeShared<DynamoDBClient>(LOG_TAG, std::move(credsProvider), nullptr, configuration);
+
+  // mock response
+  auto successStream = Aws::MakeShared<StandardHttpRequest>(LOG_TAG, "cowboy.bebop/planets", HttpMethod::HTTP_GET);
+  successStream->SetResponseStreamFactory([]() -> IOStream* {
+    auto listTablesString =  R"({"LastEvaluatedTableName": "Planets","TableNames": ["Planets"]}))";
+    return Aws::New<StringStream>(LOG_TAG, listTablesString, std::ios_base::in | std::ios_base::binary);
+  });
+  auto successResponse = Aws::MakeShared<StandardHttpResponse>(LOG_TAG, successStream);
+  successResponse->SetResponseCode(HttpResponseCode::OK);
+
+  mock_http_client_->AddResponseToReturn(successResponse);
+  const auto listTablesOutcome = accountIdClient->ListTables();
+  EXPECT_TRUE(listTablesOutcome.IsSuccess());
+  const auto requestSeen = mock_http_client_->GetMostRecentHttpRequest();
+  EXPECT_EQ("https://dynamodb.us-east-1.amazonaws.com", requestSeen.GetUri().GetURIString());
 }


### PR DESCRIPTION
*Description of changes:*

Changes clients that support account id endpoints provided by credentials providers, to use them. i.e. dynamo.

Given credentials that have a accountId associated with them i.e. environment variables
```
AWS_ACCESS_KEY_ID=ACCESS_KEY
AWS_SECRET_ACCESS_KEY=SECRET_ACCESS
AWS_SESSION_TOKEN=SESSION_TOKEN
AWS_ACCOUNT_ID=123456789012
```

When calling dynamo with the follow code
```cpp
#include <aws/core/Aws.h>
#include <aws/dynamodb/DynamoDBClient.h>

using namespace Aws;
using namespace Aws::Utils;
using namespace Aws::DynamoDB;

auto main() -> int {
  SDKOptions options{};
  options.loggingOptions.logLevel = Logging::LogLevel::Debug;
  InitAPI(options);
  {
    DynamoDBClient client{};
    const auto outcome = client.ListTables();
    assert(outcome.IsSuccess());
  }
  ShutdownAPI(options);
  return 0;
}
```

You should see the endpoint resolved using the account id.
> [DEBUG] Aws::Endpoint::DefaultEndpointProvider Endpoint rules engine evaluated the endpoint: https://123456789012.ddb.us-east-1.amazonaws.com

AccountID based endpoints help ensure scalability and performance. [Please refer to the related documentation for further explanation](https://docs.aws.amazon.com/sdkref/latest/guide/feature-account-endpoints.html).

This feature can be completely disabled by providing the configuration
```cpp
#include <aws/core/Aws.h>
#include <aws/dynamodb/DynamoDBClient.h>

using namespace Aws;
using namespace Aws::Utils;
using namespace Aws::DynamoDB;

auto main() -> int {
  SDKOptions options{};
  options.loggingOptions.logLevel = Logging::LogLevel::Debug;
  InitAPI(options);
  {
    DynamoDBClientConfiguration config;
    config.accountIdEndpointMode = "disabled";
    DynamoDBClient client{config};
    const auto outcome = client.ListTables();
    assert(outcome.IsSuccess());
  }
  ShutdownAPI(options);
  return 0;
}
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
