### PR TITLE
Update crt fix chunked

### DIFF
--- a/prefetch_crt_dependency.sh
+++ b/prefetch_crt_dependency.sh
@@ -3,21 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 CRT_URI_PREFIX=https://codeload.github.com/awslabs
-CRT_URI=${CRT_URI_PREFIX}/aws-crt-cpp/zip/c776ab5b38036662ebd0569d2483b98a176f9819  # v0.31.0
+CRT_URI=${CRT_URI_PREFIX}/aws-crt-cpp/zip/0a27f7412660aeb2cbb0e8c2f08fdf2d8768c918  # v0.31.1
 
-AWS_C_AUTH_URI=${CRT_URI_PREFIX}/aws-c-auth/zip/2d85beff96bee7ee4734c21c7fc6b15e9d07b85e  # v0.8.5
-AWS_C_CAL_URI=${CRT_URI_PREFIX}/aws-c-cal/zip/7299c6ab9244595b140d604475cdd6c6921be8ae  # v0.8.3
-AWS_C_COMMON_URI=${CRT_URI_PREFIX}/aws-c-common/zip/6401c830ffcd82ee9c9e26255f2fadf7092c7321  # v0.11.1
+AWS_C_AUTH_URI=${CRT_URI_PREFIX}/aws-c-auth/zip/01dd06acd2b8865a4a6bc232380ee69a042af47d  # v0.8.6
+AWS_C_CAL_URI=${CRT_URI_PREFIX}/aws-c-cal/zip/d59c198db17c42a48e3ee105d12357f5a9efecf3  # v0.8.7
+AWS_C_COMMON_URI=${CRT_URI_PREFIX}/aws-c-common/zip/7fb0071ab88182bffcc18a4a09bdb4dd2a5751d8  # v0.12.0
 AWS_C_COMPRESSION_URI=${CRT_URI_PREFIX}/aws-c-compression/zip/f951ab2b819fc6993b6e5e6cfef64b1a1554bfc8  # v0.3.1
-AWS_C_EVENT_STREAM_URI=${CRT_URI_PREFIX}/aws-c-event-stream/zip/4bd476bd0c629e8fab4ec0ace92830efc6a79e6c  # v0.5.2
-AWS_C_HTTP_URI=${CRT_URI_PREFIX}/aws-c-http/zip/590c7b597f87e5edc080b8b77418690c30319832  # v0.9.3
-AWS_C_IO_URI=${CRT_URI_PREFIX}/aws-c-io/zip/5fcecfc621059e254f2dc0dcac46265fcba0bf3a  # v0.16.0
+AWS_C_EVENT_STREAM_URI=${CRT_URI_PREFIX}/aws-c-event-stream/zip/9312b052583183b98526aaeb91e5c72ec3db9627  # v0.5.4
+AWS_C_HTTP_URI=${CRT_URI_PREFIX}/aws-c-http/zip/e3a9cabc664630120df25c28ec710199b8e8b15b  # v0.9.5
+AWS_C_IO_URI=${CRT_URI_PREFIX}/aws-c-io/zip/318f7e57e7871e5b0d48a281cc5dcb7f79ccecdd  # v0.17.0
 AWS_C_MQTT_URI=${CRT_URI_PREFIX}/aws-c-mqtt/zip/f0cc34cb6f54e050275e3c859594c62776d46d83  # v0.12.2
-AWS_C_S3_URI=${CRT_URI_PREFIX}/aws-c-s3/zip/6eb8be530b100fed5c6d24ca48a57ee2e6098fbf  # v0.7.11
+AWS_C_S3_URI=${CRT_URI_PREFIX}/aws-c-s3/zip/169842b7e2f81d71d0719d4a77f9c3e186512f99  # v0.7.13
 AWS_C_SDKUTILS_URI=${CRT_URI_PREFIX}/aws-c-sdkutils/zip/ba6a28fab7ed5d7f1b3b1d12eb672088be093824  # v0.2.3
 AWS_CHECKSUMS_URI=${CRT_URI_PREFIX}/aws-checksums/zip/fb8bd0b8cff00c8c24a35d601fce1b4c611df6da  # v0.2.3
-AWS_LC_URI=${CRT_URI_PREFIX}/aws-lc/zip/becf5785c131012bb5a64f3da6cdb117ddc0f431  # v1.46.1
-S2N_URI=${CRT_URI_PREFIX}/s2n/zip/21cefc1091b3953ef543c9e72b932b6431fadc6e  # v1.5.13
+AWS_LC_URI=${CRT_URI_PREFIX}/aws-lc/zip/d3e6957b9db2d9c587e77396d7b428139047ec31  # v1.48.4
+S2N_URI=${CRT_URI_PREFIX}/s2n/zip/4ed4f1a658b70559ec4a18e91d1319daa14b0610  # v1.5.14
 
 
 echo "Removing CRT"


### PR DESCRIPTION
*Description of changes:*

* updates the CRT to version `v0.31.1`
* Fixes aws-chunked encoding in the CRT http cient, it did not work before.

A simple put object/get object with the CRT HTTP client and vanillia s3 client does not work before this patch as aws-chunked encoding was broken

i.e.

```c++
#include <aws/core/Aws.h>
#include <aws/s3/S3Client.h>
#include <aws/s3/model/GetObjectRequest.h>
#include <aws/s3/model/PutObjectRequest.h>

using namespace Aws;
using namespace Aws::Utils;
using namespace Aws::S3;
using namespace Aws::S3::Model;

namespace {
const char* LOG_TAG = "test-application";
}

auto main() -> int {
  SDKOptions options{};
  options.loggingOptions.logLevel = Logging::LogLevel::Debug;
  InitAPI(options);
  {
    S3Client client{};
    auto request = PutObjectRequest();
    request.SetBucket("sbiscigl");
    request.SetKey("test-crt-http-client");
    auto body = Aws::MakeShared<StringStream>(LOG_TAG, "some test string body");
    request.SetBody(body);
    const auto response = client.PutObject(request);
    assert(response.IsSuccess());
    auto get_object_request = GetObjectRequest();
    get_object_request.SetBucket(BUCKET_NAME);
    get_object_request.SetKey(KEY_NAME);
    const auto get_object_result = client.GetObject(get_object_request);
    assert(get_object_result.IsSuccess());
    std::cout << get_object_result.GetResult().GetBody().rdbuf() << std::endl;
  }
  ShutdownAPI(options);
  return 0;
}
```

This fixes the CRT HTTP client to use the same patch that we used for the original curl issuse(https://github.com/aws/aws-sdk-cpp/pull/3186).

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
