### PR TITLE
fix mapping of disabled request retry for s3 crt client

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClientConfiguration.cpp
@@ -150,9 +150,8 @@ S3CrtClientConfiguration::S3CrtConfigFactories S3CrtClientConfiguration::S3CrtCo
 
     if (strategyToUse == CrtRetryStrategyType::NO_RETRY)
     {
-      aws_standard_retry_options options {};
-      options.initial_bucket_capacity = 1;
-      return aws_retry_strategy_new_standard(Aws::get_aws_allocator(), &options);
+      aws_no_retry_options options {};
+      return aws_retry_strategy_new_no_retry(Aws::get_aws_allocator(), &options);
     }
 
     return nullptr;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtClientConfigSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtClientConfigSource.vm
@@ -49,9 +49,8 @@ S3CrtClientConfiguration::S3CrtConfigFactories S3CrtClientConfiguration::S3CrtCo
 
     if (strategyToUse == CrtRetryStrategyType::NO_RETRY)
     {
-      aws_standard_retry_options options {};
-      options.initial_bucket_capacity = 1;
-      return aws_retry_strategy_new_standard(Aws::get_aws_allocator(), &options);
+      aws_no_retry_options options {};
+      return aws_retry_strategy_new_no_retry(Aws::get_aws_allocator(), &options);
     }
 
     return nullptr;


### PR DESCRIPTION
*Issue #, if available:*
Unable to disable request retry on S3 CRT client 
https://github.com/aws/aws-sdk-cpp/issues/2594
https://github.com/awslabs/aws-c-io/pull/694/files
*Description of changes:*
CRT fixed the support of disabling retries by creating an explicit no retry strategy (instead of using the standard one), so SDK needs to use it.
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
