### PR TITLE
Fix event stream generation if the shape has a single blob member

### DIFF
--- a/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/PayloadPart.h
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/PayloadPart.h
@@ -10,10 +10,19 @@
 
 namespace Aws
 {
+namespace Utils
+{
+namespace Json
+{
+  class JsonValue;
+  class JsonView;
+} // namespace Json
+} // namespace Utils
 namespace BedrockRuntime
 {
 namespace Model
 {
+
   /**
    * <p>Payload content included in the response.</p><p><h3>See Also:</h3>   <a
    * href="http://docs.aws.amazon.com/goto/WebAPI/bedrock-runtime-2023-09-30/PayloadPart">AWS
@@ -23,23 +32,25 @@ namespace Model
   {
   public:
     AWS_BEDROCKRUNTIME_API PayloadPart() = default;
-    AWS_BEDROCKRUNTIME_API PayloadPart(Aws::Vector<unsigned char>&& value) { m_bytes = std::move(value); }
+    AWS_BEDROCKRUNTIME_API PayloadPart(Aws::Utils::Json::JsonView jsonValue);
+    AWS_BEDROCKRUNTIME_API PayloadPart& operator=(Aws::Utils::Json::JsonView jsonValue);
+    AWS_BEDROCKRUNTIME_API Aws::Utils::Json::JsonValue Jsonize() const;
+
 
     ///@{
     /**
      * <p>Base64-encoded bytes of payload data.</p>
      */
-    inline const Aws::Vector<unsigned char>& GetBytes() const { return m_bytes; }
-    inline Aws::Vector<unsigned char>&& GetBytesWithOwnership() { return std::move(m_bytes); }
-    inline void SetBytes(const Aws::Vector<unsigned char>& value) { m_bytesHasBeenSet = true; m_bytes = value; }
-    inline void SetBytes(Aws::Vector<unsigned char>&& value) { m_bytesHasBeenSet = true; m_bytes = std::move(value); }
-    inline PayloadPart& WithBytes(const Aws::Vector<unsigned char>& value) { SetBytes(value); return *this;}
-    inline PayloadPart& WithBytes(Aws::Vector<unsigned char>&& value) { SetBytes(std::move(value)); return *this;}
+    inline const Aws::Utils::CryptoBuffer& GetBytes() const { return m_bytes; }
+    inline bool BytesHasBeenSet() const { return m_bytesHasBeenSet; }
+    template<typename BytesT = Aws::Utils::CryptoBuffer>
+    void SetBytes(BytesT&& value) { m_bytesHasBeenSet = true; m_bytes = std::forward<BytesT>(value); }
+    template<typename BytesT = Aws::Utils::CryptoBuffer>
+    PayloadPart& WithBytes(BytesT&& value) { SetBytes(std::forward<BytesT>(value)); return *this;}
     ///@}
-
   private:
 
-    Aws::Vector<unsigned char> m_bytes;
+    Aws::Utils::CryptoBuffer m_bytes{};
     bool m_bytesHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/source/model/InvokeModelWithResponseStreamHandler.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/source/model/InvokeModelWithResponseStreamHandler.cpp
@@ -105,8 +105,14 @@ namespace Model
 
         case InvokeModelWithResponseStreamEventType::CHUNK:
         {
-            PayloadPart event(GetEventPayloadWithOwnership());
-            m_onPayloadPart(event);
+            JsonValue json(GetEventPayloadAsString());
+            if (!json.WasParseSuccessful())
+            {
+                AWS_LOGSTREAM_WARN(INVOKEMODELWITHRESPONSESTREAM_HANDLER_CLASS_TAG, "Unable to generate a proper PayloadPart object from the response in JSON format.");
+                break;
+            }
+
+            m_onPayloadPart(PayloadPart{json.View()});
             break;
         }
         default:

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/source/model/PayloadPart.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/source/model/PayloadPart.cpp
@@ -1,0 +1,51 @@
+﻿/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/bedrock-runtime/model/PayloadPart.h>
+#include <aws/core/utils/json/JsonSerializer.h>
+#include <aws/core/utils/HashingUtils.h>
+
+#include <utility>
+
+using namespace Aws::Utils::Json;
+using namespace Aws::Utils;
+
+namespace Aws
+{
+namespace BedrockRuntime
+{
+namespace Model
+{
+
+PayloadPart::PayloadPart(JsonView jsonValue)
+{
+  *this = jsonValue;
+}
+
+PayloadPart& PayloadPart::operator =(JsonView jsonValue)
+{
+  if(jsonValue.ValueExists("bytes"))
+  {
+    m_bytes = HashingUtils::Base64Decode(jsonValue.GetString("bytes"));
+    m_bytesHasBeenSet = true;
+  }
+  return *this;
+}
+
+JsonValue PayloadPart::Jsonize() const
+{
+  JsonValue payload;
+
+  if(m_bytesHasBeenSet)
+  {
+   payload.WithString("bytes", HashingUtils::Base64Encode(m_bytes));
+  }
+
+  return payload;
+}
+
+} // namespace Model
+} // namespace BedrockRuntime
+} // namespace Aws

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
@@ -343,14 +343,15 @@ public class C2jModelToGeneratorModelTransformer {
                              * - we need to determine how to serialize events in eventstream
                              * - to specify payload there is an eventpayload trait
                              * - but what happens if that trait is not specified
-                             * - if there is one field and its a string, blob or struct then we assume that field is event payload
-                             *  (note: this might not be completely correct, spec is vague on that and other sdks do implicit struct around string and blob)
+                             * - if there is one field and its a string or struct then we assume that field is event payload
+                             * - if there is one field and its a blob within structure and not explicitly marked as eventpayload then parent shape is eventpayload
                              * - if that one field is of any other type then treat parent shape as eventpayload
                              * - if there is more than one field then parent shape is the payload
                              */
                             Shape memberShape = memberEntry.getValue().getShape();
                             if (memberShape.isString() ||
-                                memberShape.isBlob() ||
+                                memberShape.isBlob() && !shape.isStructure() ||
+                                memberShape.isBlob() && memberEntry.getValue().isEventPayload() ||
                                 memberShape.isStructure()) {
                                 memberEntry.getValue().setEventPayload(true);
                                 shape.setEventPayloadMemberName(memberEntry.getKey());

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/EventStreamHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/EventStreamHeader.vm
@@ -48,7 +48,15 @@ namespace Model
     ${typeInfo.className}& Write${entry.value.shape.name}(const ${entry.value.shape.name}& value)
     {
        Aws::Utils::Event::Message msg;
-#if(!$entry.value.shape.eventPayloadType.equals("blob"))
+#if($entry.value.shape.eventPayloadType.equals("blob"))
+       if(!value.Get$CppViewHelper.capitalizeFirstChar(${entry.value.shape.eventPayloadMemberName})().empty())
+       {
+           msg.InsertEventHeader(":message-type", Aws::String("event"));
+           msg.InsertEventHeader(":event-type", Aws::String("${entry.key}"));
+           msg.InsertEventHeader(":content-type", Aws::String("application/octet-stream"));
+           msg.WriteEventPayload(value.Get$CppViewHelper.capitalizeFirstChar(${entry.value.shape.eventPayloadMemberName})());
+       }
+#else
        msg.InsertEventHeader(":message-type", Aws::String("event"));
        msg.InsertEventHeader(":event-type", Aws::String("${entry.key}"));
 #if($entry.value.shape.eventPayloadType.equals("string"))
@@ -60,15 +68,7 @@ namespace Model
 #else
        AWS_UNREFERENCED_PARAM(value);
 #end
-#else##if($entry.value.shape.eventPayloadType.equals("blob"))
-       if(!value.Get$CppViewHelper.capitalizeFirstChar(${entry.value.shape.eventPayloadMemberName})().empty())
-       {
-           msg.InsertEventHeader(":message-type", Aws::String("event"));
-           msg.InsertEventHeader(":event-type", Aws::String("${entry.key}"));
-           msg.InsertEventHeader(":content-type", Aws::String("application/octet-stream"));
-           msg.WriteEventPayload(value.Get$CppViewHelper.capitalizeFirstChar(${entry.value.shape.eventPayloadMemberName})());
-       }
-#end
+#end##if($entry.value.shape.eventPayloadType.equals("blob"))
        WriteEvent(msg);
        return *this;
     }

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonEventStreamHandlerSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonEventStreamHandlerSource.vm
@@ -130,7 +130,7 @@ namespace Model
 #end
 #end
 ##the only member is blob member
-#if($eventShape.members.size() == 1 && $onlyEventMember.isBlob())
+#if($eventShape.members.size() == 1 && $onlyEventMember.isBlob() && $eventShape.eventPayloadType.equals("blob"))
             ${eventShape.name} event(GetEventPayloadWithOwnership());
             m_on${eventShape.name}(event);
             break;

--- a/tools/code-generation/generator/src/test/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformerTest.java
+++ b/tools/code-generation/generator/src/test/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformerTest.java
@@ -437,15 +437,14 @@ public class C2jModelToGeneratorModelTransformerTest {
         assertTrue(shapes.get("EventStreamShape").isEventStream());
         assertEquals("EventShape", shapes.get("EventShape").getName());
         assertTrue(shapes.get("EventShape").isEvent());
-        assertEquals("blob", shapes.get("EventShape").getEventPayloadType());
-        assertEquals("BlobShape", shapes.get("EventShape").getEventPayloadMemberName());
+        assertEquals("structure", shapes.get("EventShape").getEventPayloadType());
         assertEquals("BlobShape", shapes.get("BlobShape").getName());
         assertEquals("blob", shapes.get("BlobShape").getType());
         assertEquals(2, shapes.get("EventStreamShape").getMembers().size());
         assertEquals("EventShape", shapes.get("EventStreamShape").getMembers().get("EventShape").getShape().getName());
         assertEquals(1, shapes.get("EventShape").getMembers().size());
         assertEquals("BlobShape", shapes.get("EventShape").getMembers().get("BlobShape").getShape().getName());
-        assertTrue(shapes.get("EventShape").getMembers().get("BlobShape").isEventPayload());
+        assertFalse(shapes.get("EventShape").getMembers().get("BlobShape").isEventPayload());
 
         assertFalse(shapes.get("EventEnumShape").getMembers().get("EnumShape").isEventPayload());
         assertEquals("structure", shapes.get("EventEnumShape").getEventPayloadType());


### PR DESCRIPTION
*Issue #, if available:*
cpp sdk should send a json with 
`{"bytes": "base64blob"}` instead of just `blob` in the event steam messages.
*Description of changes:*
if the model is not explicitly setting the member as a whole streaming binary blob -> then keep sending structured data instead of raw blob.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
