### PR TITLE
Pick hash algorithm from http response header

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -214,7 +214,13 @@ static size_t WriteData(char* ptr, size_t size, size_t nmemb, void* userdata)
 
         for (const auto& hashIterator : context->m_request->GetResponseValidationHashes())
         {
+          std::stringstream headerStr;
+          headerStr<<"x-amz-checksum-"<<hashIterator.first;
+          if(context->m_response->HasHeader(headerStr.str().c_str()))
+          {
             hashIterator.second->Update(reinterpret_cast<unsigned char*>(ptr), sizeToWrite);
+            break;
+          }
         }
 
         if (response->GetResponseBody().fail()) {


### PR DESCRIPTION
*Issue #, if available:*
Currently in http client, we don't pick the hash algorithm indicated in http response. This is a fix for picking the intersection of supported response checksum and one indicated in http response if any

*Description of changes:*

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
