### PR TITLE
Add definition of `INTERNET_OPTION_ENABLE_HTTP_PROTOCOL` if missing.

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/windows/WinINetSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinINetSyncHttpClient.cpp
@@ -31,6 +31,10 @@ using namespace Aws::Utils::Logging;
 static const DWORD HTTP_PROTOCOL_FLAG_HTTP2 = 0x2;
 #endif
 
+#ifndef INTERNET_OPTION_ENABLE_HTTP_PROTOCOL
+static const DWORD INTERNET_OPTION_ENABLE_HTTP_PROTOCOL = 148;
+#endif
+
 static void WinINetEnableHttp2(void* handle)
 {
     DWORD http2 = HTTP_PROTOCOL_FLAG_HTTP2;


### PR DESCRIPTION
Fixes builds with old Windows SDK or MinGW-w64 versions.

*Issue #, if available:*

*Description of changes:*

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [X] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [X] Other Platforms (MinGW-w64)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
