### PR TITLE
Log fatal error on undefined behavior on Outcome::Get<Result/Error>

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/Outcome.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/Outcome.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <aws/core/Core_EXPORTS.h>
+#include <aws/core/utils/logging/LogMacros.h>
 
 #include <cassert>
 #include <utility>
@@ -14,6 +15,7 @@ namespace Aws
 {
     namespace Utils
     {
+        static const char OUTCOME_LOG_TAG[] = "Outcome";
 
         /**
          * Template class representing the outcome of making a request.  It will contain
@@ -130,11 +132,17 @@ namespace Aws
 
             inline const R& GetResult() const
             {
+                if (!success) {
+                    AWS_LOGSTREAM_FATAL(OUTCOME_LOG_TAG, "GetResult called on a failed outcome! Result is not initialized!");
+                }
                 return result;
             }
 
             inline R& GetResult()
             {
+                if (!success) {
+                    AWS_LOGSTREAM_FATAL(OUTCOME_LOG_TAG, "GetResult called on a failed outcome! Result is not initialized!");
+                }
                 return result;
             }
 
@@ -144,17 +152,26 @@ namespace Aws
              */
             inline R&& GetResultWithOwnership()
             {
+                if (!success) {
+                    AWS_LOGSTREAM_FATAL(OUTCOME_LOG_TAG, "GetResult called on a failed outcome! Result is not initialized!");
+                }
                 return std::move(result);
             }
 
             inline const E& GetError() const
             {
+                if (success) {
+                    AWS_LOGSTREAM_FATAL(OUTCOME_LOG_TAG, "GetError called on a success outcome! Error is not initialized!");
+                }
                 return error;
             }
 
             template<typename T>
             inline T GetError()
             {
+                if (success) {
+                    AWS_LOGSTREAM_FATAL(OUTCOME_LOG_TAG, "GetError called on a success outcome! Error is not initialized!");
+                }
                 return error.template GetModeledError<T>();
             }
 


### PR DESCRIPTION
*Issue #, if available:*
Provided logs often loose important last 100 lines due to application crash on UB and log caching.
*Description of changes:*
Log fatal error to report UB and force flush log cache.
*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
