### PR TITLE
only check response checksum for returned header

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
@@ -246,13 +246,19 @@ namespace Aws
             }
 
             //TODO: handle the read rate limiter here, once back pressure is setup.
+            assert(response);
             for (const auto& hashIterator : request->GetResponseValidationHashes())
             {
+              std::stringstream headerStr;
+              headerStr<<"x-amz-checksum-"<<hashIterator.first;
+              if(response->HasHeader(headerStr.str().c_str()))
+              {
                 hashIterator.second->Update(reinterpret_cast<unsigned char*>(body.ptr), body.len);
+                break;
+              }
             }
 
             // When data is received from the content body of the incoming response, just copy it to the output stream.
-            assert(response);
             response->GetResponseBody().write((const char*)body.ptr, static_cast<long>(body.len));
             if (response->GetResponseBody().fail()) {
                 const auto& ref = response->GetResponseBody();

--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -214,7 +214,13 @@ static size_t WriteData(char* ptr, size_t size, size_t nmemb, void* userdata)
 
         for (const auto& hashIterator : context->m_request->GetResponseValidationHashes())
         {
+          std::stringstream headerStr;
+          headerStr<<"x-amz-checksum-"<<hashIterator.first;
+          if(context->m_response->HasHeader(headerStr.str().c_str()))
+          {
             hashIterator.second->Update(reinterpret_cast<unsigned char*>(ptr), sizeToWrite);
+            break;
+          }
         }
 
         if (response->GetResponseBody().fail()) {

--- a/src/aws-cpp-sdk-core/source/http/windows/WinSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinSyncHttpClient.cpp
@@ -287,7 +287,13 @@ bool WinSyncHttpClient::BuildSuccessResponse(const std::shared_ptr<HttpRequest>&
                         {
                             for (const auto& hashIterator : request->GetResponseValidationHashes())
                             {
+                              std::stringstream headerStr;
+                              headerStr<<"x-amz-checksum-"<<hashIterator.first;
+                              if(response->HasHeader(headerStr.str().c_str()))
+                              {
                                 hashIterator.second->Update(reinterpret_cast<unsigned char*>(dst), static_cast<size_t>(read));
+                                break;
+                              }
                             }
 
                             auto& headersHandler = request->GetHeadersReceivedEventHandler();


### PR DESCRIPTION
*Description of changes:*

Only updates response validation hashes for the first checksum in the response

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
