### PR TITLE
add if match statement to download

### DIFF
--- a/src/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
+++ b/src/aws-cpp-sdk-transfer/include/aws/transfer/TransferHandle.h
@@ -298,6 +298,12 @@ namespace Aws
             void SetVersionId(const Aws::String& versionId) { std::lock_guard<std::mutex> locker(m_getterSetterLock); m_versionId = versionId; }
 
             /**
+             * (Download only) ETAG of the object to retrieve.
+            */
+            const Aws::String GetEtag() const { std::lock_guard<std::mutex> locker(m_getterSetterLock); return m_etag; }
+            void SetEtag(const Aws::String& etag) { std::lock_guard<std::mutex> locker(m_getterSetterLock); m_etag = etag; }
+
+            /**
              * Upload or Download?
              */
             inline TransferDirection GetTransferDirection() const { return m_direction; }
@@ -405,6 +411,7 @@ namespace Aws
             Aws::String m_fileName;
             Aws::String m_contentType;
             Aws::String m_versionId;
+            Aws::String m_etag;
             Aws::Map<Aws::String, Aws::String> m_metadata;
             TransferStatus m_status;
             Aws::Client::AWSError<Aws::S3::S3Errors> m_lastError;

--- a/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -931,6 +931,7 @@ namespace Aws
                 handle->SetBytesTotalSize(downloadSize);
                 handle->SetContentType(headObjectOutcome.GetResult().GetContentType());
                 handle->SetMetadata(headObjectOutcome.GetResult().GetMetadata());
+                handle->SetEtag(headObjectOutcome.GetResult().GetETag());
                 /* When bucket versioning is suspended, head object will return "null" for unversioned object.
                  * Send following GetObject with "null" as versionId will result in 403 access denied error if your IAM role or policy
                  * doesn't have GetObjectVersion permission.
@@ -1012,6 +1013,7 @@ namespace Aws
                     getObjectRangeRequest.WithKey(handle->GetKey());
                     getObjectRangeRequest.SetRange(FormatRangeSpecifier(rangeStart, rangeEnd));
                     getObjectRangeRequest.SetResponseStreamFactory(responseStreamFunction);
+                    getObjectRangeRequest.SetIfMatch(handle->GetEtag());
                     if(handle->GetVersionId().size() > 0)
                     {
                         getObjectRangeRequest.SetVersionId(handle->GetVersionId());


### PR DESCRIPTION
*Description of changes:*

Adds a etag [if match statement](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestSyntax) to the ranged get functionality of the transfer manager. Will error in the event a file is changed mid operation.

i.e.
```cpp
#include <aws/core/Aws.h>
#include <aws/core/utils/threading/PooledThreadExecutor.h>
#include <aws/transfer/TransferManager.h>

using namespace Aws;
using namespace Aws::S3;
using namespace Aws::Transfer;
using namespace Aws::Utils;
using namespace Aws::Utils::Threading;
namespace {
const char * LOG_TAG = "test-app";
const char * BUCKET_NAME = "somebucket";
const char * KEY_NAME = "somekey";
}

auto main() -> int {
  SDKOptions options{};
  options.loggingOptions.logLevel = Logging::LogLevel::Debug;
  InitAPI(options);
  {
    const auto executor = Aws::MakeUnique<PooledThreadExecutor>(LOG_TAG, std::thread::hardware_concurrency());
    TransferManagerConfiguration configuration{executor.get()};
    configuration.s3Client = Aws::MakeShared<S3Client>(LOG_TAG);
    configuration.transferInitiatedCallback = [](const TransferManager*, const std::shared_ptr<const TransferHandle>&) {
      std::cout << "started transfer\n";
    };

    configuration.errorCallback = [](const TransferManager*, const std::shared_ptr<const TransferHandle>&, const Aws::Client::AWSError<Aws::S3::S3Errors>& error) {
      std::cout << "error: " << error.GetMessage() << "\n";
    };

    configuration.transferStatusUpdatedCallback = [](const TransferManager*, const std::shared_ptr<const TransferHandle>& handle) {
      if (handle->GetStatus() == TransferStatus::COMPLETED) {
        std::cout << "completed transfer\n";
      } else if (handle->GetStatus() == TransferStatus::FAILED) {
        std::cout << "failed\n";
      }
    };

    const auto transferManager = TransferManager::Create(configuration);

    const auto handle = transferManager->DownloadFile(BUCKET_NAME, KEY_NAME, KEY_NAME);

    transferManager->WaitUntilAllFinished();
  }
  ShutdownAPI(options);
  return 0;
}
```

will result in the output 

```
error: Unable to parse ExceptionName: PreconditionFailed Message: At least one of the pre-conditions you specified did not hold
failed
finished transfer
```

when run when a objects etag changes and objects are not versioned. No file will be downloaded.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Not adding a test as it requires a race condition i cannot force in sdk code

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
