### PR TITLE
Remove maps built on each call of some conversion functions.

### DIFF
--- a/src/aws-cpp-sdk-core/include/smithy/tracing/TracingUtils.h
+++ b/src/aws-cpp-sdk-core/include/smithy/tracing/TracingUtils.h
@@ -134,32 +134,21 @@ namespace smithy {
                  * @return A tuple of metric name to measurement unit.
                  */
                 static std::pair<Aws::String, Aws::String> ConvertCoreMetricToSmithy(const Aws::String &name) {
-                    //TODO: Make static map, Aws::Map cannot be made static with a customer memory manager as of the moment.
-                    Aws::Map<int, std::pair<Aws::String, Aws::String>> metricsTypeToName =
-                        {
-                            std::pair<int, std::pair<Aws::String, Aws::String>>(
-                                static_cast<int>(Aws::Monitoring::HttpClientMetricsType::DnsLatency),
-                                std::make_pair(SMITHY_METRICS_DNS_DURATION, MICROSECOND_METRIC_TYPE)),
-                            std::pair<int, std::pair<Aws::String, Aws::String>>(
-                                static_cast<int>(Aws::Monitoring::HttpClientMetricsType::ConnectLatency),
-                                std::make_pair(SMITHY_METRICS_CONNECT_DURATION, MICROSECOND_METRIC_TYPE)),
-                            std::pair<int, std::pair<Aws::String, Aws::String>>(
-                                static_cast<int>(Aws::Monitoring::HttpClientMetricsType::SslLatency),
-                                std::make_pair(SMITHY_METRICS_SSL_DURATION, MICROSECOND_METRIC_TYPE)),
-                            std::pair<int, std::pair<Aws::String, Aws::String>>(
-                                static_cast<int>(Aws::Monitoring::HttpClientMetricsType::DownloadSpeed),
-                                std::make_pair(SMITHY_METRICS_DOWNLOAD_SPEED_METRIC, BYTES_PER_SECOND_METRIC_TYPE)),
-                            std::pair<int, std::pair<Aws::String, Aws::String>>(
-                                static_cast<int>(Aws::Monitoring::HttpClientMetricsType::UploadSpeed),
-                                std::make_pair(SMITHY_METRICS_UPLOAD_SPEED_METRIC, BYTES_PER_SECOND_METRIC_TYPE)),
-                        };
-
-                    auto metricType = Aws::Monitoring::GetHttpClientMetricTypeByName(name);
-                    auto it = metricsTypeToName.find(static_cast<int>(metricType));
-                    if (it == metricsTypeToName.end()) {
-                        return std::make_pair(SMITHY_METRICS_UNKNOWN_METRIC, "unknown");
+                    switch (Aws::Monitoring::GetHttpClientMetricTypeByName(name))
+                    {
+                        case Aws::Monitoring::HttpClientMetricsType::DnsLatency:
+                            return std::make_pair(SMITHY_METRICS_DNS_DURATION, MICROSECOND_METRIC_TYPE);
+                        case Aws::Monitoring::HttpClientMetricsType::ConnectLatency:
+                            return std::make_pair(SMITHY_METRICS_CONNECT_DURATION, MICROSECOND_METRIC_TYPE);
+                        case Aws::Monitoring::HttpClientMetricsType::SslLatency:
+                            return std::make_pair(SMITHY_METRICS_SSL_DURATION, MICROSECOND_METRIC_TYPE);
+                        case Aws::Monitoring::HttpClientMetricsType::DownloadSpeed:
+                            return std::make_pair(SMITHY_METRICS_DOWNLOAD_SPEED_METRIC, BYTES_PER_SECOND_METRIC_TYPE);
+                        case Aws::Monitoring::HttpClientMetricsType::UploadSpeed:
+                            return std::make_pair(SMITHY_METRICS_UPLOAD_SPEED_METRIC, BYTES_PER_SECOND_METRIC_TYPE);
+                        default:
+                            return std::make_pair(SMITHY_METRICS_UNKNOWN_METRIC, "unknown");
                     }
-                    return it->second;
                 }
             };
         }

--- a/src/aws-cpp-sdk-core/source/monitoring/HttpClientMetrics.cpp
+++ b/src/aws-cpp-sdk-core/source/monitoring/HttpClientMetrics.cpp
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-#include <aws/core/utils/HashingUtils.h>
+#include <aws/core/utils/memory/stl/AWSArray.h>
 #include <aws/core/monitoring/HttpClientMetrics.h>
 
 namespace Aws
@@ -18,64 +18,45 @@ namespace Aws
         static const char HTTP_CLIENT_METRICS_DNS_LATENCY[] = "DnsLatency";
         static const char HTTP_CLIENT_METRICS_TCP_LATENCY[] = "TcpLatency";
         static const char HTTP_CLIENT_METRICS_SSL_LATENCY[] = "SslLatency";
-        static const char HTTP_CLIENT_METRICS_THROUGHPUT[] = "Throughput";
         static const char HTTP_CLIENT_METRICS_DOWNLOAD_SPEED[] = "DownloadSpeed";
+        static const char HTTP_CLIENT_METRICS_THROUGHPUT[] = "Throughput";
         static const char HTTP_CLIENT_METRICS_UPLOAD_SPEED[] = "UploadSpeed";
         static const char HTTP_CLIENT_METRICS_UNKNOWN[] = "Unknown";
 
-        using namespace Aws::Utils;
+        static const Aws::Array<std::pair<HttpClientMetricsType, const char*>, 12> httpClientMetricsNames =
+        {
+            std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::DestinationIp, HTTP_CLIENT_METRICS_DESTINATION_IP),
+            std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::AcquireConnectionLatency, HTTP_CLIENT_METRICS_ACQUIRE_CONNECTION_LATENCY),
+            std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::ConnectionReused, HTTP_CLIENT_METRICS_CONNECTION_REUSED),
+            std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::ConnectLatency, HTTP_CLIENT_METRICS_CONNECTION_LATENCY),
+            std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::RequestLatency, HTTP_CLIENT_METRICS_REQUEST_LATENCY),
+            std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::DnsLatency, HTTP_CLIENT_METRICS_DNS_LATENCY),
+            std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::TcpLatency, HTTP_CLIENT_METRICS_TCP_LATENCY),
+            std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::SslLatency, HTTP_CLIENT_METRICS_SSL_LATENCY),
+            std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::DownloadSpeed, HTTP_CLIENT_METRICS_DOWNLOAD_SPEED),
+            std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::Throughput, HTTP_CLIENT_METRICS_THROUGHPUT),
+            std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::UploadSpeed, HTTP_CLIENT_METRICS_UPLOAD_SPEED),
+            std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::Unknown, HTTP_CLIENT_METRICS_UNKNOWN),
+        };
+
         HttpClientMetricsType GetHttpClientMetricTypeByName(const Aws::String& name)
         {
-            //TODO: Make static map, Aws::Map cannot be made static with a customer memory manager as of the moment.
-            Aws::Map<int, HttpClientMetricsType> metricsNameHashToType =
-            {
-                std::pair<int, HttpClientMetricsType>(HashingUtils::HashString(HTTP_CLIENT_METRICS_DESTINATION_IP), HttpClientMetricsType::DestinationIp),
-                std::pair<int, HttpClientMetricsType>(HashingUtils::HashString(HTTP_CLIENT_METRICS_ACQUIRE_CONNECTION_LATENCY), HttpClientMetricsType::AcquireConnectionLatency),
-                std::pair<int, HttpClientMetricsType>(HashingUtils::HashString(HTTP_CLIENT_METRICS_CONNECTION_REUSED), HttpClientMetricsType::ConnectionReused),
-                std::pair<int, HttpClientMetricsType>(HashingUtils::HashString(HTTP_CLIENT_METRICS_CONNECTION_LATENCY), HttpClientMetricsType::ConnectLatency),
-                std::pair<int, HttpClientMetricsType>(HashingUtils::HashString(HTTP_CLIENT_METRICS_REQUEST_LATENCY), HttpClientMetricsType::RequestLatency),
-                std::pair<int, HttpClientMetricsType>(HashingUtils::HashString(HTTP_CLIENT_METRICS_DNS_LATENCY), HttpClientMetricsType::DnsLatency),
-                std::pair<int, HttpClientMetricsType>(HashingUtils::HashString(HTTP_CLIENT_METRICS_TCP_LATENCY), HttpClientMetricsType::TcpLatency),
-                std::pair<int, HttpClientMetricsType>(HashingUtils::HashString(HTTP_CLIENT_METRICS_SSL_LATENCY), HttpClientMetricsType::SslLatency),
-                std::pair<int, HttpClientMetricsType>(HashingUtils::HashString(HTTP_CLIENT_METRICS_THROUGHPUT), HttpClientMetricsType::Throughput),
-                std::pair<int, HttpClientMetricsType>(HashingUtils::HashString(HTTP_CLIENT_METRICS_DOWNLOAD_SPEED), HttpClientMetricsType::DownloadSpeed),
-                std::pair<int, HttpClientMetricsType>(HashingUtils::HashString(HTTP_CLIENT_METRICS_UPLOAD_SPEED), HttpClientMetricsType::UploadSpeed),
-            };
-
-            int nameHash = HashingUtils::HashString(name.c_str());
-            auto it = metricsNameHashToType.find(nameHash);
-            if (it == metricsNameHashToType.end())
-            {
-                return HttpClientMetricsType::Unknown;
-            }
-            return it->second;
+             auto it = std::find_if(httpClientMetricsNames.begin(), httpClientMetricsNames.end(), [&](const std::pair<HttpClientMetricsType, const char *>& pair) { return name == pair.second; });
+             if (it == httpClientMetricsNames.end())
+             {
+                 return HttpClientMetricsType::Unknown;
+             }
+             return it->first;
         }
 
         Aws::String GetHttpClientMetricNameByType(HttpClientMetricsType type)
         {
-            //TODO: Make static map, Aws::Map cannot be made static with a customer memory manager as of the moment.
-            Aws::Map<int, Aws::String> metricsTypeToName =
-            {
-                std::pair<int, Aws::String>(static_cast<int>(HttpClientMetricsType::DestinationIp), HTTP_CLIENT_METRICS_DESTINATION_IP),
-                std::pair<int, Aws::String>(static_cast<int>(HttpClientMetricsType::AcquireConnectionLatency), HTTP_CLIENT_METRICS_ACQUIRE_CONNECTION_LATENCY),
-                std::pair<int, Aws::String>(static_cast<int>(HttpClientMetricsType::ConnectionReused), HTTP_CLIENT_METRICS_CONNECTION_REUSED),
-                std::pair<int, Aws::String>(static_cast<int>(HttpClientMetricsType::ConnectLatency), HTTP_CLIENT_METRICS_CONNECTION_LATENCY),
-                std::pair<int, Aws::String>(static_cast<int>(HttpClientMetricsType::RequestLatency), HTTP_CLIENT_METRICS_REQUEST_LATENCY),
-                std::pair<int, Aws::String>(static_cast<int>(HttpClientMetricsType::DnsLatency), HTTP_CLIENT_METRICS_DNS_LATENCY),
-                std::pair<int, Aws::String>(static_cast<int>(HttpClientMetricsType::TcpLatency), HTTP_CLIENT_METRICS_TCP_LATENCY),
-                std::pair<int, Aws::String>(static_cast<int>(HttpClientMetricsType::SslLatency), HTTP_CLIENT_METRICS_SSL_LATENCY),
-                std::pair<int, Aws::String>(static_cast<int>(HttpClientMetricsType::Throughput), HTTP_CLIENT_METRICS_THROUGHPUT),
-                std::pair<int, Aws::String>(static_cast<int>(HttpClientMetricsType::DownloadSpeed), HTTP_CLIENT_METRICS_DOWNLOAD_SPEED),
-                std::pair<int, Aws::String>(static_cast<int>(HttpClientMetricsType::UploadSpeed), HTTP_CLIENT_METRICS_UPLOAD_SPEED),
-                std::pair<int, Aws::String>(static_cast<int>(HttpClientMetricsType::Unknown), HTTP_CLIENT_METRICS_UNKNOWN),
-            };
-
-            auto it = metricsTypeToName.find(static_cast<int>(type));
-            if (it == metricsTypeToName.end())
-            {
+            assert(static_cast<unsigned>(type) < httpClientMetricsNames.size());
+            if (static_cast<unsigned>(type) >= httpClientMetricsNames.size())
                 return HTTP_CLIENT_METRICS_UNKNOWN;
-            }
-            return Aws::String(it->second.c_str());
+
+            assert(httpClientMetricsNames[static_cast<int>(type)].first == type);
+            return Aws::String(httpClientMetricsNames[static_cast<int>(type)].second);
         }
 
     }


### PR DESCRIPTION
The said map should have been static as a 'TODO' in the code explains. Since the static keyword was removed when the `std::map` was changed to an `Aws::Map`, the map is rebuilt at each calls, which is a lot of work, and calls to `malloc`/`free`. Although the search is now linear instead of logarithmic, the number of entries is quite small and it's always better than rebuilding the map at each call.

This saves about 300 mallocs per PutObject request for example.

*Issue #, if available:*

*Description of changes:*

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
