### PR TITLE
add new metric correct connect time in curl.

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/monitoring/HttpClientMetrics.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/monitoring/HttpClientMetrics.h
@@ -35,11 +35,7 @@ namespace Aws
             ConnectionReused,
 
             /**
-             * Requires the SDK to recognize that a new connection was established to make the request,
-             * contains the time interval (in milliseconds) between the construction of the http request and when a connection was fully established.
-             * If the SDK is able to estimate this time despite not having a perfectly accurate callback for the specific event, then it should.
-             * For example, if the http client includes user-level data write functions that are guaranteed to be called shortly after connection establishment,
-             * then the first call could be used as a reasonable time marker for ConnectLatency
+             * Deprecated, maintained for backwards compatibility, use TimeToConnect instead,
              */
             ConnectLatency,
 
@@ -84,7 +80,21 @@ namespace Aws
             /**
              * Unknow Metrics Type
              */
-            Unknown
+            Unknown,
+
+            /**
+             * Time between http client initialization and first byte transferred.
+             */
+            TimeToFirstByte,
+
+            /**
+             * Requires the SDK to recognize that a new connection was established to make the request,
+             * contains the time interval (in milliseconds) between the construction of the http request and when a connection was fully established.
+             * If the SDK is able to estimate this time despite not having a perfectly accurate callback for the specific event, then it should.
+             * For example, if the http client includes user-level data write functions that are guaranteed to be called shortly after connection establishment,
+             * then the first call could be used as a reasonable time marker for ConnectLatency
+             */
+            TimeToConnect,
         };
 
         typedef Aws::Map<Aws::String, int64_t> HttpClientMetricsCollection;

--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -933,6 +933,13 @@ std::shared_ptr<HttpResponse> CurlHttpClient::MakeRequest(const std::shared_ptr<
         if (ret == CURLE_OK)
         {
             request->AddRequestMetric(GetHttpClientMetricNameByType(HttpClientMetricsType::ConnectLatency), static_cast<int64_t>(timep * 1000));
+            request->AddRequestMetric(GetHttpClientMetricNameByType(HttpClientMetricsType::TimeToFirstByte), static_cast<int64_t>(timep * 1000));
+        }
+
+        ret = curl_easy_getinfo(connectionHandle, CURLINFO_PRETRANSFER_TIME, &timep);
+        if (ret == CURLE_OK)
+        {
+          request->AddRequestMetric(GetHttpClientMetricNameByType(HttpClientMetricsType::TimeToConnect), static_cast<int64_t>(timep * 1000));
         }
 
 #if LIBCURL_VERSION_NUM >= 0x073D00 // 7.61.0

--- a/src/aws-cpp-sdk-core/source/monitoring/DefaultMonitoring.cpp
+++ b/src/aws-cpp-sdk-core/source/monitoring/DefaultMonitoring.cpp
@@ -187,6 +187,8 @@ namespace Aws
             ExportHttpMetricsToJson(json, metricsFromCore.httpClientMetrics, HttpClientMetricsType::RequestLatency);
             ExportHttpMetricsToJson(json, metricsFromCore.httpClientMetrics, HttpClientMetricsType::SslLatency);
             ExportHttpMetricsToJson(json, metricsFromCore.httpClientMetrics, HttpClientMetricsType::TcpLatency);
+            ExportHttpMetricsToJson(json, metricsFromCore.httpClientMetrics, HttpClientMetricsType::TimeToFirstByte);
+            ExportHttpMetricsToJson(json, metricsFromCore.httpClientMetrics, HttpClientMetricsType::TimeToConnect);
         }
 
         DefaultMonitoring::DefaultMonitoring(const Aws::String& clientId, const Aws::String& host, unsigned short port):

--- a/src/aws-cpp-sdk-core/source/monitoring/HttpClientMetrics.cpp
+++ b/src/aws-cpp-sdk-core/source/monitoring/HttpClientMetrics.cpp
@@ -21,9 +21,11 @@ namespace Aws
         static const char HTTP_CLIENT_METRICS_DOWNLOAD_SPEED[] = "DownloadSpeed";
         static const char HTTP_CLIENT_METRICS_THROUGHPUT[] = "Throughput";
         static const char HTTP_CLIENT_METRICS_UPLOAD_SPEED[] = "UploadSpeed";
+        static const char HTTP_CLIENT_METRICS_TIME_TO_FIRST_BYTE[] = "TimeToFirstByte";
+        static const char HTTP_CLIENT_METRICS_TIME_TO_CONNECT[] = "TimeToConnect";
         static const char HTTP_CLIENT_METRICS_UNKNOWN[] = "Unknown";
 
-        static const Aws::Array<std::pair<HttpClientMetricsType, const char*>, 12> httpClientMetricsNames =
+        static const Aws::Array<std::pair<HttpClientMetricsType, const char*>, 14> httpClientMetricsNames =
         {
             std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::DestinationIp, HTTP_CLIENT_METRICS_DESTINATION_IP),
             std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::AcquireConnectionLatency, HTTP_CLIENT_METRICS_ACQUIRE_CONNECTION_LATENCY),
@@ -37,6 +39,8 @@ namespace Aws
             std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::Throughput, HTTP_CLIENT_METRICS_THROUGHPUT),
             std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::UploadSpeed, HTTP_CLIENT_METRICS_UPLOAD_SPEED),
             std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::Unknown, HTTP_CLIENT_METRICS_UNKNOWN),
+            std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::TimeToFirstByte, HTTP_CLIENT_METRICS_TIME_TO_FIRST_BYTE),
+            std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::TimeToConnect, HTTP_CLIENT_METRICS_TIME_TO_CONNECT),
         };
 
         HttpClientMetricsType GetHttpClientMetricTypeByName(const Aws::String& name)


### PR DESCRIPTION
*Description of changes:*

There was a metric that was named `ConnectLatency` that was confusing some customers. It actuall functionally meant "Time to Ffrst byte". Adding a metric that is named correctly. Adding a metric that correctly captures the spirit of the metric wanted which is [`CURLINFO_PRETRANSFER_TIME`](https://curl.se/libcurl/c/CURLINFO_PRETRANSFER_TIME.html) which is defined as

> Pass a pointer to a double to receive the time, in seconds, it took from the start until the file transfer is just about to begin.

this metrics is one that customers wanted and now will exist and named as `TimeToStartRequest`. when running a simple std::cout example

```cpp
#include <aws/core/Aws.h>
#include <aws/s3/S3Client.h>
#include <aws/s3/model/GetObjectRequest.h>
#include <aws/core/monitoring/MonitoringInterface.h>
#include <aws/core/monitoring/MonitoringFactory.h>

using namespace Aws;
using namespace Aws::Monitoring;
using namespace Aws::S3;
using namespace Aws::S3::Model;
using namespace Aws::Utils;

namespace {
const char * LOG_TAG = "...";
const char * BUCKET_NAME = "....";
const char * KEY_NAME = "...";
}

class StdOutMonitoring: public Monitoring::MonitoringInterface {
 public:
  ~StdOutMonitoring() override = default;
  void* OnRequestStarted(
    const Aws::String& serviceName,
    const Aws::String& requestName,
    const std::shared_ptr<const Aws::Http::HttpRequest>&
    request) const override
  {
    std::cout << "started!\n";
    return nullptr;
  }

  void OnRequestSucceeded(
      const Aws::String& serviceName,
      const Aws::String& requestName,
      const std::shared_ptr<const Aws::Http::HttpRequest>& request,
      const Aws::Client::HttpResponseOutcome& outcome,
      const Monitoring::CoreMetricsCollection& metricsFromCore,
      void* context) const override
  {
    std::cout << "succeeded!\n";
    for (const auto& metric: metricsFromCore.httpClientMetrics) {
      std::cout << metric.first << ": " << metric.second << "\n";
    }
  }

  void OnRequestFailed(
      const Aws::String& serviceName,
      const Aws::String& requestName,
      const std::shared_ptr<const Aws::Http::HttpRequest>& request,
      const Aws::Client::HttpResponseOutcome& outcome,
      const Monitoring::CoreMetricsCollection& metricsFromCore,
      void* context) const override
  {
    std::cout << "failed!\n";
    for (const auto& metric: metricsFromCore.httpClientMetrics) {
      std::cout << metric.first << ": " << metric.second << "\n";
    }
  }

  void OnRequestRetry(
      const Aws::String& serviceName,
      const Aws::String& requestName,
      const std::shared_ptr<const Aws::Http::HttpRequest>& request,
      void* context) const override
  {
    std::cout << "retried!\n";
  }

  void OnFinish(
    const Aws::String& serviceName,
    const Aws::String& requestName,
    const std::shared_ptr<const Aws::Http::HttpRequest>& request,
    void* context) const override
  {
    std::cout << "finished!\n";
  }
};

class StdOutMonitoringFactory: public MonitoringFactory {
 public:
  ~StdOutMonitoringFactory() override = default;
  Aws::UniquePtr<MonitoringInterface> CreateMonitoringInstance() const override {
    return Aws::MakeUnique<StdOutMonitoring>(LOG_TAG);
  };
};

auto main() -> int {
  SDKOptions options{};
  options.monitoringOptions.customizedMonitoringFactory_create_fn = {
    []() -> Aws::UniquePtr<MonitoringFactory> {
      return Aws::MakeUnique<StdOutMonitoringFactory>(LOG_TAG);
    }
  };
  options.loggingOptions.logLevel = Logging::LogLevel::Debug;
  InitAPI(options);
  {
    S3ClientConfiguration configuration{};
    S3Client client{};
    const auto outcome = client.GetObject(GetObjectRequest().WithBucket(BUCKET_NAME).WithKey(KEY_NAME));
    assert(outcome.IsSuccess());
  }
  ShutdownAPI(options);
  return 0;
}
```

we see the metrics

```
started!
succeeded!
ConnectLatency: 303
DnsLatency: 90
DownloadSpeed: 2887894
RequestLatency: 1816
SslLatency: 122580000
Throughput: 2887894
TimeToConnect: 122
TimeToFirstByte: 303
UploadSpeed: 0
finished!
```

NOTE: `ConnectLatency` was not measured in any http client besides curl thus they are not included in the PR.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
