### PR TITLE
Fix missing braces around initializer for std array

### DIFF
--- a/src/aws-cpp-sdk-core/source/monitoring/HttpClientMetrics.cpp
+++ b/src/aws-cpp-sdk-core/source/monitoring/HttpClientMetrics.cpp
@@ -26,7 +26,7 @@ namespace Aws
         static const char HTTP_CLIENT_METRICS_UNKNOWN[] = "Unknown";
 
         static const Aws::Array<std::pair<HttpClientMetricsType, const char*>, 14> httpClientMetricsNames =
-        {
+        {{
             std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::DestinationIp, HTTP_CLIENT_METRICS_DESTINATION_IP),
             std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::AcquireConnectionLatency, HTTP_CLIENT_METRICS_ACQUIRE_CONNECTION_LATENCY),
             std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::ConnectionReused, HTTP_CLIENT_METRICS_CONNECTION_REUSED),
@@ -41,7 +41,7 @@ namespace Aws
             std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::Unknown, HTTP_CLIENT_METRICS_UNKNOWN),
             std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::TimeToFirstByte, HTTP_CLIENT_METRICS_TIME_TO_FIRST_BYTE),
             std::pair<HttpClientMetricsType, const char *>(HttpClientMetricsType::TimeToConnect, HTTP_CLIENT_METRICS_TIME_TO_CONNECT),
-        };
+        }};
 
         HttpClientMetricsType GetHttpClientMetricTypeByName(const Aws::String& name)
         {


### PR DESCRIPTION
*Issue #, if available:*
```
HttpClientMetrics.cpp:44:9: error: missing braces around initializer for 
'std::__array_traits<std::pair<Aws::Monitoring::HttpClientMetricsType, const char*>, 14>::_Type 
{aka std::pair<Aws::Monitoring::HttpClientMetricsType, const char*> [14]}'
[-Werror=missing-braces]}; 
```
*Description of changes:*
Add more braces.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
