### PR TITLE
Codegen: don't include exception classes that are not generated

### DIFF
--- a/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/FlowResponseStream.h
+++ b/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/FlowResponseStream.h
@@ -5,19 +5,13 @@
 
 #pragma once
 #include <aws/bedrock-agent-runtime/BedrockAgentRuntime_EXPORTS.h>
-#include <aws/bedrock-agent-runtime/model/AccessDeniedException.h>
 #include <aws/bedrock-agent-runtime/model/BadGatewayException.h>
-#include <aws/bedrock-agent-runtime/model/ConflictException.h>
 #include <aws/bedrock-agent-runtime/model/DependencyFailedException.h>
 #include <aws/bedrock-agent-runtime/model/FlowCompletionEvent.h>
 #include <aws/bedrock-agent-runtime/model/FlowMultiTurnInputRequestEvent.h>
 #include <aws/bedrock-agent-runtime/model/FlowOutputEvent.h>
 #include <aws/bedrock-agent-runtime/model/FlowTraceEvent.h>
 #include <aws/bedrock-agent-runtime/model/InternalServerException.h>
-#include <aws/bedrock-agent-runtime/model/ResourceNotFoundException.h>
-#include <aws/bedrock-agent-runtime/model/ServiceQuotaExceededException.h>
-#include <aws/bedrock-agent-runtime/model/ThrottlingException.h>
-#include <aws/bedrock-agent-runtime/model/ValidationException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/InlineAgentResponseStream.h
+++ b/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/InlineAgentResponseStream.h
@@ -5,19 +5,13 @@
 
 #pragma once
 #include <aws/bedrock-agent-runtime/BedrockAgentRuntime_EXPORTS.h>
-#include <aws/bedrock-agent-runtime/model/AccessDeniedException.h>
 #include <aws/bedrock-agent-runtime/model/BadGatewayException.h>
 #include <aws/bedrock-agent-runtime/model/InlineAgentPayloadPart.h>
-#include <aws/bedrock-agent-runtime/model/ConflictException.h>
 #include <aws/bedrock-agent-runtime/model/DependencyFailedException.h>
 #include <aws/bedrock-agent-runtime/model/InlineAgentFilePart.h>
 #include <aws/bedrock-agent-runtime/model/InternalServerException.h>
-#include <aws/bedrock-agent-runtime/model/ResourceNotFoundException.h>
 #include <aws/bedrock-agent-runtime/model/InlineAgentReturnControlPayload.h>
-#include <aws/bedrock-agent-runtime/model/ServiceQuotaExceededException.h>
-#include <aws/bedrock-agent-runtime/model/ThrottlingException.h>
 #include <aws/bedrock-agent-runtime/model/InlineAgentTracePart.h>
-#include <aws/bedrock-agent-runtime/model/ValidationException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/OptimizedPromptStream.h
+++ b/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/OptimizedPromptStream.h
@@ -5,14 +5,11 @@
 
 #pragma once
 #include <aws/bedrock-agent-runtime/BedrockAgentRuntime_EXPORTS.h>
-#include <aws/bedrock-agent-runtime/model/AccessDeniedException.h>
 #include <aws/bedrock-agent-runtime/model/AnalyzePromptEvent.h>
 #include <aws/bedrock-agent-runtime/model/BadGatewayException.h>
 #include <aws/bedrock-agent-runtime/model/DependencyFailedException.h>
 #include <aws/bedrock-agent-runtime/model/InternalServerException.h>
 #include <aws/bedrock-agent-runtime/model/OptimizedPromptEvent.h>
-#include <aws/bedrock-agent-runtime/model/ThrottlingException.h>
-#include <aws/bedrock-agent-runtime/model/ValidationException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/ResponseStream.h
+++ b/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/ResponseStream.h
@@ -5,20 +5,13 @@
 
 #pragma once
 #include <aws/bedrock-agent-runtime/BedrockAgentRuntime_EXPORTS.h>
-#include <aws/bedrock-agent-runtime/model/AccessDeniedException.h>
 #include <aws/bedrock-agent-runtime/model/BadGatewayException.h>
 #include <aws/bedrock-agent-runtime/model/PayloadPart.h>
-#include <aws/bedrock-agent-runtime/model/ConflictException.h>
 #include <aws/bedrock-agent-runtime/model/DependencyFailedException.h>
 #include <aws/bedrock-agent-runtime/model/FilePart.h>
 #include <aws/bedrock-agent-runtime/model/InternalServerException.h>
-#include <aws/bedrock-agent-runtime/model/ModelNotReadyException.h>
-#include <aws/bedrock-agent-runtime/model/ResourceNotFoundException.h>
 #include <aws/bedrock-agent-runtime/model/ReturnControlPayload.h>
-#include <aws/bedrock-agent-runtime/model/ServiceQuotaExceededException.h>
-#include <aws/bedrock-agent-runtime/model/ThrottlingException.h>
 #include <aws/bedrock-agent-runtime/model/TracePart.h>
-#include <aws/bedrock-agent-runtime/model/ValidationException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/RetrieveAndGenerateStreamResponseOutput.h
+++ b/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/RetrieveAndGenerateStreamResponseOutput.h
@@ -5,18 +5,12 @@
 
 #pragma once
 #include <aws/bedrock-agent-runtime/BedrockAgentRuntime_EXPORTS.h>
-#include <aws/bedrock-agent-runtime/model/AccessDeniedException.h>
 #include <aws/bedrock-agent-runtime/model/BadGatewayException.h>
 #include <aws/bedrock-agent-runtime/model/CitationEvent.h>
-#include <aws/bedrock-agent-runtime/model/ConflictException.h>
 #include <aws/bedrock-agent-runtime/model/DependencyFailedException.h>
 #include <aws/bedrock-agent-runtime/model/GuardrailEvent.h>
 #include <aws/bedrock-agent-runtime/model/InternalServerException.h>
 #include <aws/bedrock-agent-runtime/model/RetrieveAndGenerateOutputEvent.h>
-#include <aws/bedrock-agent-runtime/model/ResourceNotFoundException.h>
-#include <aws/bedrock-agent-runtime/model/ServiceQuotaExceededException.h>
-#include <aws/bedrock-agent-runtime/model/ThrottlingException.h>
-#include <aws/bedrock-agent-runtime/model/ValidationException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/ConverseStreamOutput.h
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/ConverseStreamOutput.h
@@ -11,11 +11,7 @@
 #include <aws/bedrock-runtime/model/ContentBlockStopEvent.h>
 #include <aws/bedrock-runtime/model/MessageStopEvent.h>
 #include <aws/bedrock-runtime/model/ConverseStreamMetadataEvent.h>
-#include <aws/bedrock-runtime/model/InternalServerException.h>
 #include <aws/bedrock-runtime/model/ModelStreamErrorException.h>
-#include <aws/bedrock-runtime/model/ValidationException.h>
-#include <aws/bedrock-runtime/model/ThrottlingException.h>
-#include <aws/bedrock-runtime/model/ServiceUnavailableException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/InvokeModelWithBidirectionalStreamOutput.h
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/InvokeModelWithBidirectionalStreamOutput.h
@@ -6,12 +6,7 @@
 #pragma once
 #include <aws/bedrock-runtime/BedrockRuntime_EXPORTS.h>
 #include <aws/bedrock-runtime/model/BidirectionalOutputPayloadPart.h>
-#include <aws/bedrock-runtime/model/InternalServerException.h>
 #include <aws/bedrock-runtime/model/ModelStreamErrorException.h>
-#include <aws/bedrock-runtime/model/ValidationException.h>
-#include <aws/bedrock-runtime/model/ThrottlingException.h>
-#include <aws/bedrock-runtime/model/ModelTimeoutException.h>
-#include <aws/bedrock-runtime/model/ServiceUnavailableException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/ResponseStream.h
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/ResponseStream.h
@@ -6,12 +6,7 @@
 #pragma once
 #include <aws/bedrock-runtime/BedrockRuntime_EXPORTS.h>
 #include <aws/bedrock-runtime/model/PayloadPart.h>
-#include <aws/bedrock-runtime/model/InternalServerException.h>
 #include <aws/bedrock-runtime/model/ModelStreamErrorException.h>
-#include <aws/bedrock-runtime/model/ValidationException.h>
-#include <aws/bedrock-runtime/model/ThrottlingException.h>
-#include <aws/bedrock-runtime/model/ModelTimeoutException.h>
-#include <aws/bedrock-runtime/model/ServiceUnavailableException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-iotsitewise/include/aws/iotsitewise/model/ResponseStream.h
+++ b/generated/src/aws-cpp-sdk-iotsitewise/include/aws/iotsitewise/model/ResponseStream.h
@@ -7,13 +7,7 @@
 #include <aws/iotsitewise/IoTSiteWise_EXPORTS.h>
 #include <aws/iotsitewise/model/Trace.h>
 #include <aws/iotsitewise/model/InvocationOutput.h>
-#include <aws/iotsitewise/model/AccessDeniedException.h>
 #include <aws/iotsitewise/model/ConflictingOperationException.h>
-#include <aws/iotsitewise/model/InternalFailureException.h>
-#include <aws/iotsitewise/model/InvalidRequestException.h>
-#include <aws/iotsitewise/model/LimitExceededException.h>
-#include <aws/iotsitewise/model/ResourceNotFoundException.h>
-#include <aws/iotsitewise/model/ThrottlingException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-kinesis/include/aws/kinesis/model/SubscribeToShardEventStream.h
+++ b/generated/src/aws-cpp-sdk-kinesis/include/aws/kinesis/model/SubscribeToShardEventStream.h
@@ -6,15 +6,6 @@
 #pragma once
 #include <aws/kinesis/Kinesis_EXPORTS.h>
 #include <aws/kinesis/model/SubscribeToShardEvent.h>
-#include <aws/kinesis/model/ResourceNotFoundException.h>
-#include <aws/kinesis/model/ResourceInUseException.h>
-#include <aws/kinesis/model/KMSDisabledException.h>
-#include <aws/kinesis/model/KMSInvalidStateException.h>
-#include <aws/kinesis/model/KMSAccessDeniedException.h>
-#include <aws/kinesis/model/KMSNotFoundException.h>
-#include <aws/kinesis/model/KMSOptInRequired.h>
-#include <aws/kinesis/model/KMSThrottlingException.h>
-#include <aws/kinesis/model/InternalFailureException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/model/StartConversationResponseEventStream.h
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/model/StartConversationResponseEventStream.h
@@ -11,14 +11,6 @@
 #include <aws/lexv2-runtime/model/TextResponseEvent.h>
 #include <aws/lexv2-runtime/model/AudioResponseEvent.h>
 #include <aws/lexv2-runtime/model/HeartbeatEvent.h>
-#include <aws/lexv2-runtime/model/AccessDeniedException.h>
-#include <aws/lexv2-runtime/model/ResourceNotFoundException.h>
-#include <aws/lexv2-runtime/model/ValidationException.h>
-#include <aws/lexv2-runtime/model/ThrottlingException.h>
-#include <aws/lexv2-runtime/model/InternalServerException.h>
-#include <aws/lexv2-runtime/model/ConflictException.h>
-#include <aws/lexv2-runtime/model/DependencyFailedException.h>
-#include <aws/lexv2-runtime/model/BadGatewayException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-logs/include/aws/logs/model/StartLiveTailResponseStream.h
+++ b/generated/src/aws-cpp-sdk-logs/include/aws/logs/model/StartLiveTailResponseStream.h
@@ -7,8 +7,6 @@
 #include <aws/logs/CloudWatchLogs_EXPORTS.h>
 #include <aws/logs/model/LiveTailSessionStart.h>
 #include <aws/logs/model/LiveTailSessionUpdate.h>
-#include <aws/logs/model/SessionTimeoutException.h>
-#include <aws/logs/model/SessionStreamingException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-sagemaker-runtime/include/aws/sagemaker-runtime/model/ResponseStream.h
+++ b/generated/src/aws-cpp-sdk-sagemaker-runtime/include/aws/sagemaker-runtime/model/ResponseStream.h
@@ -7,7 +7,6 @@
 #include <aws/sagemaker-runtime/SageMakerRuntime_EXPORTS.h>
 #include <aws/sagemaker-runtime/model/PayloadPart.h>
 #include <aws/sagemaker-runtime/model/ModelStreamError.h>
-#include <aws/sagemaker-runtime/model/InternalStreamFailure.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/CallAnalyticsTranscriptResultStream.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/CallAnalyticsTranscriptResultStream.h
@@ -7,11 +7,6 @@
 #include <aws/transcribestreaming/TranscribeStreamingService_EXPORTS.h>
 #include <aws/transcribestreaming/model/UtteranceEvent.h>
 #include <aws/transcribestreaming/model/CategoryEvent.h>
-#include <aws/transcribestreaming/model/BadRequestException.h>
-#include <aws/transcribestreaming/model/LimitExceededException.h>
-#include <aws/transcribestreaming/model/InternalFailureException.h>
-#include <aws/transcribestreaming/model/ConflictException.h>
-#include <aws/transcribestreaming/model/ServiceUnavailableException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/MedicalScribeResultStream.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/MedicalScribeResultStream.h
@@ -6,11 +6,6 @@
 #pragma once
 #include <aws/transcribestreaming/TranscribeStreamingService_EXPORTS.h>
 #include <aws/transcribestreaming/model/MedicalScribeTranscriptEvent.h>
-#include <aws/transcribestreaming/model/BadRequestException.h>
-#include <aws/transcribestreaming/model/LimitExceededException.h>
-#include <aws/transcribestreaming/model/InternalFailureException.h>
-#include <aws/transcribestreaming/model/ConflictException.h>
-#include <aws/transcribestreaming/model/ServiceUnavailableException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/MedicalTranscriptResultStream.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/MedicalTranscriptResultStream.h
@@ -6,11 +6,6 @@
 #pragma once
 #include <aws/transcribestreaming/TranscribeStreamingService_EXPORTS.h>
 #include <aws/transcribestreaming/model/MedicalTranscriptEvent.h>
-#include <aws/transcribestreaming/model/BadRequestException.h>
-#include <aws/transcribestreaming/model/LimitExceededException.h>
-#include <aws/transcribestreaming/model/InternalFailureException.h>
-#include <aws/transcribestreaming/model/ConflictException.h>
-#include <aws/transcribestreaming/model/ServiceUnavailableException.h>
 #include <utility>
 
 namespace Aws

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/TranscriptResultStream.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/TranscriptResultStream.h
@@ -6,11 +6,6 @@
 #pragma once
 #include <aws/transcribestreaming/TranscribeStreamingService_EXPORTS.h>
 #include <aws/transcribestreaming/model/TranscriptEvent.h>
-#include <aws/transcribestreaming/model/BadRequestException.h>
-#include <aws/transcribestreaming/model/LimitExceededException.h>
-#include <aws/transcribestreaming/model/InternalFailureException.h>
-#include <aws/transcribestreaming/model/ConflictException.h>
-#include <aws/transcribestreaming/model/ServiceUnavailableException.h>
 #include <utility>
 
 namespace Aws

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/Shape.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/Shape.java
@@ -123,6 +123,10 @@ public class Shape {
         return members.keySet().parallelStream().anyMatch(key -> !key.equals("Message") && !key.equals("message"));
     }
 
+    public boolean isModeledException() {
+        return isXmlModeledException() || isJsonModeledException();
+    }
+
     public boolean isMemberRequired(String member) {
         ShapeMember shapeMember = members.get(member);
         return shapeMember != null && members.get(member).isRequired();

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
@@ -353,6 +353,11 @@ public class CppViewHelper {
                 }
             }
             if(!next.isPrimitive()) {
+                if (next.isException() && !next.isModeledException()) {
+                    // C++ SDK code generator skips generating exceptions that can be expressed using
+                    // a purely built-in C++ SDK Core exception class, so they must not be included.
+                    continue;
+                }
                 // if `next` is a direct member of a `shape` and they are mutually referenced
                 if(next.isMutuallyReferencedWith(shape) &&
                         shape.getMembers().values().parallelStream().anyMatch(member -> member.getShape().getName().equals(next.getName()))) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/issues/3389
*Description of changes:*
SDK Codegen historically skips generation for shapes that are the "modeled exceptions" (if the exception on the model has only "Message" member), with a reasoning that those exceptions can be represented by a CoreError exception class.
So they must not be included.

Note: exception means AWS c2j/smithy exception shape not C++ exception here.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
