### PR TITLE
Add constructor with s3Client factory to s3-encryption

### DIFF
--- a/src/aws-cpp-sdk-s3-encryption/include/aws/s3-encryption/S3EncryptionClient.h
+++ b/src/aws-cpp-sdk-s3-encryption/include/aws/s3-encryption/S3EncryptionClient.h
@@ -66,6 +66,14 @@ namespace Aws
             S3EncryptionClientBase(const std::shared_ptr<Aws::Utils::Crypto::EncryptionMaterials>& encryptionMaterials, const Aws::S3Encryption::CryptoConfiguration& cryptoConfig,
                 const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider, const Aws::Client::ClientConfiguration& clientConfiguration = Aws::Client::ClientConfiguration());
 
+            /*
+             * Initialize the S3EncryptionClientBase with encryption materials, crypto configuration, and a s3 client factory.
+             * The factory will be used to create the underlying S3 Client.
+             */
+            S3EncryptionClientBase(const std::shared_ptr<Aws::Utils::Crypto::EncryptionMaterials>& encryptionMaterials,
+              const Aws::S3Encryption::CryptoConfiguration& cryptoConfig,
+              const std::function<Aws::UniquePtr<Aws::S3::S3Client> ()>& s3ClientFactory);
+
             S3EncryptionClientBase(const S3EncryptionClientBase&) = delete;
             S3EncryptionClientBase& operator=(const S3EncryptionClientBase&) = delete;
 
@@ -176,6 +184,17 @@ namespace Aws
             S3EncryptionClientV2(const Aws::S3Encryption::CryptoConfigurationV2& cryptoConfig, const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentialsProvider,
                 const Aws::Client::ClientConfiguration& clientConfig = Aws::Client::ClientConfiguration())
                 : S3EncryptionClientBase(cryptoConfig.GetEncryptionMaterials(), CryptoConfiguration(), credentialsProvider, clientConfig)
+            {
+                Init(cryptoConfig);
+            }
+
+            /*
+             * Initialize the S3 Encryption Client V2 with crypto configuration v2, and a s3 client factory.
+             * The factory will be used to create the underlying S3 Client.
+             */
+            S3EncryptionClientV2(const Aws::S3Encryption::CryptoConfigurationV2& cryptoConfig,
+                const std::function<Aws::UniquePtr<Aws::S3::S3Client> ()>& s3ClientFactory)
+                : S3EncryptionClientBase(cryptoConfig.GetEncryptionMaterials(), CryptoConfiguration(), s3ClientFactory)
             {
                 Init(cryptoConfig);
             }

--- a/src/aws-cpp-sdk-s3-encryption/source/s3-encryption/S3EncryptionClient.cpp
+++ b/src/aws-cpp-sdk-s3-encryption/source/s3-encryption/S3EncryptionClient.cpp
@@ -48,6 +48,14 @@ namespace Aws
             m_s3Client->AppendToUserAgent("ft/S3CryptoV1n");
         }
 
+        S3EncryptionClientBase::S3EncryptionClientBase(const std::shared_ptr<EncryptionMaterials>& encryptionMaterials,
+            const Aws::S3Encryption::CryptoConfiguration& cryptoConfig,
+            const std::function<Aws::UniquePtr<S3::S3Client> ()>& s3ClientFactory) :
+            m_s3Client(s3ClientFactory()), m_cryptoModuleFactory(), m_encryptionMaterials(encryptionMaterials), m_cryptoConfig(cryptoConfig)
+        {
+            m_s3Client->AppendToUserAgent("ft/S3CryptoV1n");
+        }
+
         S3EncryptionPutObjectOutcome S3EncryptionClientBase::PutObject(const Aws::S3::Model::PutObjectRequest& request, const Aws::Map<Aws::String, Aws::String>& contextMap) const
         {
             auto module = m_cryptoModuleFactory.FetchCryptoModule(m_encryptionMaterials, m_cryptoConfig);


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/discussions/3388

*Description of changes:*

[Right now it is impossible for customers to create a S3 encryption client using a S3ClientConfiguration object](https://github.com/aws/aws-sdk-cpp/blob/main/src/aws-cpp-sdk-s3-encryption/include/aws/s3-encryption/S3EncryptionClient.h#L153-L181). Instead of adding more constructors to match each S3Client constructor, add factory method so user can bring their own S3Client. i.e.

```c++
#include <aws/core/Aws.h>
#include <aws/s3-encryption/S3EncryptionClient.h>

using namespace Aws;
using namespace Aws::S3Encryption;
using namespace Aws::S3;
using namespace Aws::Utils;

namespace {
const char* LOG_TAG = "test-app";
}

auto main() -> int {
  SDKOptions options{};
  options.loggingOptions.logLevel = Logging::LogLevel::Debug;
  InitAPI(options);
  {
    CryptoBuffer symmetric_key{ByteBuffer{"symmetric_key"}};
    const auto simple_materials =
        Aws::MakeShared<Materials::SimpleEncryptionMaterialsWithGCMAAD>(
            LOG_TAG, symmetric_key);
    CryptoConfigurationV2 configuration_v2{simple_materials};
    S3ClientConfiguration client_configuration{};
    client_configuration.useVirtualAddressing = true;
    S3EncryptionClientV2 client_v2{
        configuration_v2, [&client_configuration]() -> UniquePtr<S3Client> {
          return Aws::MakeUnique<S3Client>(LOG_TAG, client_configuration);
        }};
  }
  ShutdownAPI(options);
  return 0;
}
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
