### PR TITLE
Fix error header for bidirectional streaming models

### DIFF
--- a/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/FlowResponseStream.h
+++ b/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/FlowResponseStream.h
@@ -48,11 +48,11 @@ namespace Model
      * <p>The request is denied because of missing access permissions. Check your
      * permissions and retry your request.</p>
      */
-    inline const AccessDeniedException& GetAccessDeniedException() const { return m_accessDeniedException; }
+    inline const BedrockAgentRuntimeError& GetAccessDeniedException() const { return m_accessDeniedException; }
     inline bool AccessDeniedExceptionHasBeenSet() const { return m_accessDeniedExceptionHasBeenSet; }
-    template<typename AccessDeniedExceptionT = AccessDeniedException>
+    template<typename AccessDeniedExceptionT = BedrockAgentRuntimeError>
     void SetAccessDeniedException(AccessDeniedExceptionT&& value) { m_accessDeniedExceptionHasBeenSet = true; m_accessDeniedException = std::forward<AccessDeniedExceptionT>(value); }
-    template<typename AccessDeniedExceptionT = AccessDeniedException>
+    template<typename AccessDeniedExceptionT = BedrockAgentRuntimeError>
     FlowResponseStream& WithAccessDeniedException(AccessDeniedExceptionT&& value) { SetAccessDeniedException(std::forward<AccessDeniedExceptionT>(value)); return *this;}
     ///@}
 
@@ -74,11 +74,11 @@ namespace Model
      * <p>There was a conflict performing an operation. Resolve the conflict and retry
      * your request.</p>
      */
-    inline const ConflictException& GetConflictException() const { return m_conflictException; }
+    inline const BedrockAgentRuntimeError& GetConflictException() const { return m_conflictException; }
     inline bool ConflictExceptionHasBeenSet() const { return m_conflictExceptionHasBeenSet; }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = BedrockAgentRuntimeError>
     void SetConflictException(ConflictExceptionT&& value) { m_conflictExceptionHasBeenSet = true; m_conflictException = std::forward<ConflictExceptionT>(value); }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = BedrockAgentRuntimeError>
     FlowResponseStream& WithConflictException(ConflictExceptionT&& value) { SetConflictException(std::forward<ConflictExceptionT>(value)); return *this;}
     ///@}
 
@@ -162,11 +162,11 @@ namespace Model
      * <p>The specified resource Amazon Resource Name (ARN) was not found. Check the
      * Amazon Resource Name (ARN) and try your request again.</p>
      */
-    inline const ResourceNotFoundException& GetResourceNotFoundException() const { return m_resourceNotFoundException; }
+    inline const BedrockAgentRuntimeError& GetResourceNotFoundException() const { return m_resourceNotFoundException; }
     inline bool ResourceNotFoundExceptionHasBeenSet() const { return m_resourceNotFoundExceptionHasBeenSet; }
-    template<typename ResourceNotFoundExceptionT = ResourceNotFoundException>
+    template<typename ResourceNotFoundExceptionT = BedrockAgentRuntimeError>
     void SetResourceNotFoundException(ResourceNotFoundExceptionT&& value) { m_resourceNotFoundExceptionHasBeenSet = true; m_resourceNotFoundException = std::forward<ResourceNotFoundExceptionT>(value); }
-    template<typename ResourceNotFoundExceptionT = ResourceNotFoundException>
+    template<typename ResourceNotFoundExceptionT = BedrockAgentRuntimeError>
     FlowResponseStream& WithResourceNotFoundException(ResourceNotFoundExceptionT&& value) { SetResourceNotFoundException(std::forward<ResourceNotFoundExceptionT>(value)); return *this;}
     ///@}
 
@@ -175,11 +175,11 @@ namespace Model
      * <p>The number of requests exceeds the service quota. Resubmit your request
      * later.</p>
      */
-    inline const ServiceQuotaExceededException& GetServiceQuotaExceededException() const { return m_serviceQuotaExceededException; }
+    inline const BedrockAgentRuntimeError& GetServiceQuotaExceededException() const { return m_serviceQuotaExceededException; }
     inline bool ServiceQuotaExceededExceptionHasBeenSet() const { return m_serviceQuotaExceededExceptionHasBeenSet; }
-    template<typename ServiceQuotaExceededExceptionT = ServiceQuotaExceededException>
+    template<typename ServiceQuotaExceededExceptionT = BedrockAgentRuntimeError>
     void SetServiceQuotaExceededException(ServiceQuotaExceededExceptionT&& value) { m_serviceQuotaExceededExceptionHasBeenSet = true; m_serviceQuotaExceededException = std::forward<ServiceQuotaExceededExceptionT>(value); }
-    template<typename ServiceQuotaExceededExceptionT = ServiceQuotaExceededException>
+    template<typename ServiceQuotaExceededExceptionT = BedrockAgentRuntimeError>
     FlowResponseStream& WithServiceQuotaExceededException(ServiceQuotaExceededExceptionT&& value) { SetServiceQuotaExceededException(std::forward<ServiceQuotaExceededExceptionT>(value)); return *this;}
     ///@}
 
@@ -187,11 +187,11 @@ namespace Model
     /**
      * <p>The number of requests exceeds the limit. Resubmit your request later.</p>
      */
-    inline const ThrottlingException& GetThrottlingException() const { return m_throttlingException; }
+    inline const BedrockAgentRuntimeError& GetThrottlingException() const { return m_throttlingException; }
     inline bool ThrottlingExceptionHasBeenSet() const { return m_throttlingExceptionHasBeenSet; }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockAgentRuntimeError>
     void SetThrottlingException(ThrottlingExceptionT&& value) { m_throttlingExceptionHasBeenSet = true; m_throttlingException = std::forward<ThrottlingExceptionT>(value); }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockAgentRuntimeError>
     FlowResponseStream& WithThrottlingException(ThrottlingExceptionT&& value) { SetThrottlingException(std::forward<ThrottlingExceptionT>(value)); return *this;}
     ///@}
 
@@ -200,22 +200,22 @@ namespace Model
      * <p>Input validation failed. Check your request parameters and retry the
      * request.</p>
      */
-    inline const ValidationException& GetValidationException() const { return m_validationException; }
+    inline const BedrockAgentRuntimeError& GetValidationException() const { return m_validationException; }
     inline bool ValidationExceptionHasBeenSet() const { return m_validationExceptionHasBeenSet; }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockAgentRuntimeError>
     void SetValidationException(ValidationExceptionT&& value) { m_validationExceptionHasBeenSet = true; m_validationException = std::forward<ValidationExceptionT>(value); }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockAgentRuntimeError>
     FlowResponseStream& WithValidationException(ValidationExceptionT&& value) { SetValidationException(std::forward<ValidationExceptionT>(value)); return *this;}
     ///@}
   private:
 
-    AccessDeniedException m_accessDeniedException;
+    BedrockAgentRuntimeError m_accessDeniedException;
     bool m_accessDeniedExceptionHasBeenSet = false;
 
     BadGatewayException m_badGatewayException;
     bool m_badGatewayExceptionHasBeenSet = false;
 
-    ConflictException m_conflictException;
+    BedrockAgentRuntimeError m_conflictException;
     bool m_conflictExceptionHasBeenSet = false;
 
     DependencyFailedException m_dependencyFailedException;
@@ -236,16 +236,16 @@ namespace Model
     InternalServerException m_internalServerException;
     bool m_internalServerExceptionHasBeenSet = false;
 
-    ResourceNotFoundException m_resourceNotFoundException;
+    BedrockAgentRuntimeError m_resourceNotFoundException;
     bool m_resourceNotFoundExceptionHasBeenSet = false;
 
-    ServiceQuotaExceededException m_serviceQuotaExceededException;
+    BedrockAgentRuntimeError m_serviceQuotaExceededException;
     bool m_serviceQuotaExceededExceptionHasBeenSet = false;
 
-    ThrottlingException m_throttlingException;
+    BedrockAgentRuntimeError m_throttlingException;
     bool m_throttlingExceptionHasBeenSet = false;
 
-    ValidationException m_validationException;
+    BedrockAgentRuntimeError m_validationException;
     bool m_validationExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/InlineAgentResponseStream.h
+++ b/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/InlineAgentResponseStream.h
@@ -49,11 +49,11 @@ namespace Model
      * <p>The request is denied because of missing access permissions. Check your
      * permissions and retry your request.</p>
      */
-    inline const AccessDeniedException& GetAccessDeniedException() const { return m_accessDeniedException; }
+    inline const BedrockAgentRuntimeError& GetAccessDeniedException() const { return m_accessDeniedException; }
     inline bool AccessDeniedExceptionHasBeenSet() const { return m_accessDeniedExceptionHasBeenSet; }
-    template<typename AccessDeniedExceptionT = AccessDeniedException>
+    template<typename AccessDeniedExceptionT = BedrockAgentRuntimeError>
     void SetAccessDeniedException(AccessDeniedExceptionT&& value) { m_accessDeniedExceptionHasBeenSet = true; m_accessDeniedException = std::forward<AccessDeniedExceptionT>(value); }
-    template<typename AccessDeniedExceptionT = AccessDeniedException>
+    template<typename AccessDeniedExceptionT = BedrockAgentRuntimeError>
     InlineAgentResponseStream& WithAccessDeniedException(AccessDeniedExceptionT&& value) { SetAccessDeniedException(std::forward<AccessDeniedExceptionT>(value)); return *this;}
     ///@}
 
@@ -87,11 +87,11 @@ namespace Model
      * <p>There was a conflict performing an operation. Resolve the conflict and retry
      * your request. </p>
      */
-    inline const ConflictException& GetConflictException() const { return m_conflictException; }
+    inline const BedrockAgentRuntimeError& GetConflictException() const { return m_conflictException; }
     inline bool ConflictExceptionHasBeenSet() const { return m_conflictExceptionHasBeenSet; }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = BedrockAgentRuntimeError>
     void SetConflictException(ConflictExceptionT&& value) { m_conflictExceptionHasBeenSet = true; m_conflictException = std::forward<ConflictExceptionT>(value); }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = BedrockAgentRuntimeError>
     InlineAgentResponseStream& WithConflictException(ConflictExceptionT&& value) { SetConflictException(std::forward<ConflictExceptionT>(value)); return *this;}
     ///@}
 
@@ -138,11 +138,11 @@ namespace Model
      * <p>The specified resource Amazon Resource Name (ARN) was not found. Check the
      * Amazon Resource Name (ARN) and try your request again. </p>
      */
-    inline const ResourceNotFoundException& GetResourceNotFoundException() const { return m_resourceNotFoundException; }
+    inline const BedrockAgentRuntimeError& GetResourceNotFoundException() const { return m_resourceNotFoundException; }
     inline bool ResourceNotFoundExceptionHasBeenSet() const { return m_resourceNotFoundExceptionHasBeenSet; }
-    template<typename ResourceNotFoundExceptionT = ResourceNotFoundException>
+    template<typename ResourceNotFoundExceptionT = BedrockAgentRuntimeError>
     void SetResourceNotFoundException(ResourceNotFoundExceptionT&& value) { m_resourceNotFoundExceptionHasBeenSet = true; m_resourceNotFoundException = std::forward<ResourceNotFoundExceptionT>(value); }
-    template<typename ResourceNotFoundExceptionT = ResourceNotFoundException>
+    template<typename ResourceNotFoundExceptionT = BedrockAgentRuntimeError>
     InlineAgentResponseStream& WithResourceNotFoundException(ResourceNotFoundExceptionT&& value) { SetResourceNotFoundException(std::forward<ResourceNotFoundExceptionT>(value)); return *this;}
     ///@}
 
@@ -165,11 +165,11 @@ namespace Model
      * <p>The number of requests exceeds the service quota. Resubmit your request
      * later.</p>
      */
-    inline const ServiceQuotaExceededException& GetServiceQuotaExceededException() const { return m_serviceQuotaExceededException; }
+    inline const BedrockAgentRuntimeError& GetServiceQuotaExceededException() const { return m_serviceQuotaExceededException; }
     inline bool ServiceQuotaExceededExceptionHasBeenSet() const { return m_serviceQuotaExceededExceptionHasBeenSet; }
-    template<typename ServiceQuotaExceededExceptionT = ServiceQuotaExceededException>
+    template<typename ServiceQuotaExceededExceptionT = BedrockAgentRuntimeError>
     void SetServiceQuotaExceededException(ServiceQuotaExceededExceptionT&& value) { m_serviceQuotaExceededExceptionHasBeenSet = true; m_serviceQuotaExceededException = std::forward<ServiceQuotaExceededExceptionT>(value); }
-    template<typename ServiceQuotaExceededExceptionT = ServiceQuotaExceededException>
+    template<typename ServiceQuotaExceededExceptionT = BedrockAgentRuntimeError>
     InlineAgentResponseStream& WithServiceQuotaExceededException(ServiceQuotaExceededExceptionT&& value) { SetServiceQuotaExceededException(std::forward<ServiceQuotaExceededExceptionT>(value)); return *this;}
     ///@}
 
@@ -177,11 +177,11 @@ namespace Model
     /**
      * <p>The number of requests exceeds the limit. Resubmit your request later.</p>
      */
-    inline const ThrottlingException& GetThrottlingException() const { return m_throttlingException; }
+    inline const BedrockAgentRuntimeError& GetThrottlingException() const { return m_throttlingException; }
     inline bool ThrottlingExceptionHasBeenSet() const { return m_throttlingExceptionHasBeenSet; }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockAgentRuntimeError>
     void SetThrottlingException(ThrottlingExceptionT&& value) { m_throttlingExceptionHasBeenSet = true; m_throttlingException = std::forward<ThrottlingExceptionT>(value); }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockAgentRuntimeError>
     InlineAgentResponseStream& WithThrottlingException(ThrottlingExceptionT&& value) { SetThrottlingException(std::forward<ThrottlingExceptionT>(value)); return *this;}
     ///@}
 
@@ -207,16 +207,16 @@ namespace Model
      * <p>Input validation failed. Check your request parameters and retry the
      * request.</p>
      */
-    inline const ValidationException& GetValidationException() const { return m_validationException; }
+    inline const BedrockAgentRuntimeError& GetValidationException() const { return m_validationException; }
     inline bool ValidationExceptionHasBeenSet() const { return m_validationExceptionHasBeenSet; }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockAgentRuntimeError>
     void SetValidationException(ValidationExceptionT&& value) { m_validationExceptionHasBeenSet = true; m_validationException = std::forward<ValidationExceptionT>(value); }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockAgentRuntimeError>
     InlineAgentResponseStream& WithValidationException(ValidationExceptionT&& value) { SetValidationException(std::forward<ValidationExceptionT>(value)); return *this;}
     ///@}
   private:
 
-    AccessDeniedException m_accessDeniedException;
+    BedrockAgentRuntimeError m_accessDeniedException;
     bool m_accessDeniedExceptionHasBeenSet = false;
 
     BadGatewayException m_badGatewayException;
@@ -225,7 +225,7 @@ namespace Model
     InlineAgentPayloadPart m_chunk;
     bool m_chunkHasBeenSet = false;
 
-    ConflictException m_conflictException;
+    BedrockAgentRuntimeError m_conflictException;
     bool m_conflictExceptionHasBeenSet = false;
 
     DependencyFailedException m_dependencyFailedException;
@@ -237,22 +237,22 @@ namespace Model
     InternalServerException m_internalServerException;
     bool m_internalServerExceptionHasBeenSet = false;
 
-    ResourceNotFoundException m_resourceNotFoundException;
+    BedrockAgentRuntimeError m_resourceNotFoundException;
     bool m_resourceNotFoundExceptionHasBeenSet = false;
 
     InlineAgentReturnControlPayload m_returnControl;
     bool m_returnControlHasBeenSet = false;
 
-    ServiceQuotaExceededException m_serviceQuotaExceededException;
+    BedrockAgentRuntimeError m_serviceQuotaExceededException;
     bool m_serviceQuotaExceededExceptionHasBeenSet = false;
 
-    ThrottlingException m_throttlingException;
+    BedrockAgentRuntimeError m_throttlingException;
     bool m_throttlingExceptionHasBeenSet = false;
 
     InlineAgentTracePart m_trace;
     bool m_traceHasBeenSet = false;
 
-    ValidationException m_validationException;
+    BedrockAgentRuntimeError m_validationException;
     bool m_validationExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/OptimizedPromptStream.h
+++ b/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/OptimizedPromptStream.h
@@ -47,11 +47,11 @@ namespace Model
      * <p>The request is denied because of missing access permissions. Check your
      * permissions and retry your request.</p>
      */
-    inline const AccessDeniedException& GetAccessDeniedException() const { return m_accessDeniedException; }
+    inline const BedrockAgentRuntimeError& GetAccessDeniedException() const { return m_accessDeniedException; }
     inline bool AccessDeniedExceptionHasBeenSet() const { return m_accessDeniedExceptionHasBeenSet; }
-    template<typename AccessDeniedExceptionT = AccessDeniedException>
+    template<typename AccessDeniedExceptionT = BedrockAgentRuntimeError>
     void SetAccessDeniedException(AccessDeniedExceptionT&& value) { m_accessDeniedExceptionHasBeenSet = true; m_accessDeniedException = std::forward<AccessDeniedExceptionT>(value); }
-    template<typename AccessDeniedExceptionT = AccessDeniedException>
+    template<typename AccessDeniedExceptionT = BedrockAgentRuntimeError>
     OptimizedPromptStream& WithAccessDeniedException(AccessDeniedExceptionT&& value) { SetAccessDeniedException(std::forward<AccessDeniedExceptionT>(value)); return *this;}
     ///@}
 
@@ -125,11 +125,11 @@ namespace Model
      * href="https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html">Provisioned
      * Throughput</a> to increase the rate or number of tokens you can process.</p>
      */
-    inline const ThrottlingException& GetThrottlingException() const { return m_throttlingException; }
+    inline const BedrockAgentRuntimeError& GetThrottlingException() const { return m_throttlingException; }
     inline bool ThrottlingExceptionHasBeenSet() const { return m_throttlingExceptionHasBeenSet; }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockAgentRuntimeError>
     void SetThrottlingException(ThrottlingExceptionT&& value) { m_throttlingExceptionHasBeenSet = true; m_throttlingException = std::forward<ThrottlingExceptionT>(value); }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockAgentRuntimeError>
     OptimizedPromptStream& WithThrottlingException(ThrottlingExceptionT&& value) { SetThrottlingException(std::forward<ThrottlingExceptionT>(value)); return *this;}
     ///@}
 
@@ -138,16 +138,16 @@ namespace Model
      * <p>Input validation failed. Check your request parameters and retry the
      * request.</p>
      */
-    inline const ValidationException& GetValidationException() const { return m_validationException; }
+    inline const BedrockAgentRuntimeError& GetValidationException() const { return m_validationException; }
     inline bool ValidationExceptionHasBeenSet() const { return m_validationExceptionHasBeenSet; }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockAgentRuntimeError>
     void SetValidationException(ValidationExceptionT&& value) { m_validationExceptionHasBeenSet = true; m_validationException = std::forward<ValidationExceptionT>(value); }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockAgentRuntimeError>
     OptimizedPromptStream& WithValidationException(ValidationExceptionT&& value) { SetValidationException(std::forward<ValidationExceptionT>(value)); return *this;}
     ///@}
   private:
 
-    AccessDeniedException m_accessDeniedException;
+    BedrockAgentRuntimeError m_accessDeniedException;
     bool m_accessDeniedExceptionHasBeenSet = false;
 
     AnalyzePromptEvent m_analyzePromptEvent;
@@ -165,10 +165,10 @@ namespace Model
     OptimizedPromptEvent m_optimizedPromptEvent;
     bool m_optimizedPromptEventHasBeenSet = false;
 
-    ThrottlingException m_throttlingException;
+    BedrockAgentRuntimeError m_throttlingException;
     bool m_throttlingExceptionHasBeenSet = false;
 
-    ValidationException m_validationException;
+    BedrockAgentRuntimeError m_validationException;
     bool m_validationExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/ResponseStream.h
+++ b/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/ResponseStream.h
@@ -49,11 +49,11 @@ namespace Model
      * <p>The request is denied because of missing access permissions. Check your
      * permissions and retry your request.</p>
      */
-    inline const AccessDeniedException& GetAccessDeniedException() const { return m_accessDeniedException; }
+    inline const BedrockAgentRuntimeError& GetAccessDeniedException() const { return m_accessDeniedException; }
     inline bool AccessDeniedExceptionHasBeenSet() const { return m_accessDeniedExceptionHasBeenSet; }
-    template<typename AccessDeniedExceptionT = AccessDeniedException>
+    template<typename AccessDeniedExceptionT = BedrockAgentRuntimeError>
     void SetAccessDeniedException(AccessDeniedExceptionT&& value) { m_accessDeniedExceptionHasBeenSet = true; m_accessDeniedException = std::forward<AccessDeniedExceptionT>(value); }
-    template<typename AccessDeniedExceptionT = AccessDeniedException>
+    template<typename AccessDeniedExceptionT = BedrockAgentRuntimeError>
     ResponseStream& WithAccessDeniedException(AccessDeniedExceptionT&& value) { SetAccessDeniedException(std::forward<AccessDeniedExceptionT>(value)); return *this;}
     ///@}
 
@@ -87,11 +87,11 @@ namespace Model
      * <p>There was a conflict performing an operation. Resolve the conflict and retry
      * your request.</p>
      */
-    inline const ConflictException& GetConflictException() const { return m_conflictException; }
+    inline const BedrockAgentRuntimeError& GetConflictException() const { return m_conflictException; }
     inline bool ConflictExceptionHasBeenSet() const { return m_conflictExceptionHasBeenSet; }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = BedrockAgentRuntimeError>
     void SetConflictException(ConflictExceptionT&& value) { m_conflictExceptionHasBeenSet = true; m_conflictException = std::forward<ConflictExceptionT>(value); }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = BedrockAgentRuntimeError>
     ResponseStream& WithConflictException(ConflictExceptionT&& value) { SetConflictException(std::forward<ConflictExceptionT>(value)); return *this;}
     ///@}
 
@@ -141,11 +141,11 @@ namespace Model
      * href="https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html">Retry
      * behavior</a> in the <i>AWS SDKs and Tools</i> reference guide. </p>
      */
-    inline const ModelNotReadyException& GetModelNotReadyException() const { return m_modelNotReadyException; }
+    inline const BedrockAgentRuntimeError& GetModelNotReadyException() const { return m_modelNotReadyException; }
     inline bool ModelNotReadyExceptionHasBeenSet() const { return m_modelNotReadyExceptionHasBeenSet; }
-    template<typename ModelNotReadyExceptionT = ModelNotReadyException>
+    template<typename ModelNotReadyExceptionT = BedrockAgentRuntimeError>
     void SetModelNotReadyException(ModelNotReadyExceptionT&& value) { m_modelNotReadyExceptionHasBeenSet = true; m_modelNotReadyException = std::forward<ModelNotReadyExceptionT>(value); }
-    template<typename ModelNotReadyExceptionT = ModelNotReadyException>
+    template<typename ModelNotReadyExceptionT = BedrockAgentRuntimeError>
     ResponseStream& WithModelNotReadyException(ModelNotReadyExceptionT&& value) { SetModelNotReadyException(std::forward<ModelNotReadyExceptionT>(value)); return *this;}
     ///@}
 
@@ -154,11 +154,11 @@ namespace Model
      * <p>The specified resource Amazon Resource Name (ARN) was not found. Check the
      * Amazon Resource Name (ARN) and try your request again.</p>
      */
-    inline const ResourceNotFoundException& GetResourceNotFoundException() const { return m_resourceNotFoundException; }
+    inline const BedrockAgentRuntimeError& GetResourceNotFoundException() const { return m_resourceNotFoundException; }
     inline bool ResourceNotFoundExceptionHasBeenSet() const { return m_resourceNotFoundExceptionHasBeenSet; }
-    template<typename ResourceNotFoundExceptionT = ResourceNotFoundException>
+    template<typename ResourceNotFoundExceptionT = BedrockAgentRuntimeError>
     void SetResourceNotFoundException(ResourceNotFoundExceptionT&& value) { m_resourceNotFoundExceptionHasBeenSet = true; m_resourceNotFoundException = std::forward<ResourceNotFoundExceptionT>(value); }
-    template<typename ResourceNotFoundExceptionT = ResourceNotFoundException>
+    template<typename ResourceNotFoundExceptionT = BedrockAgentRuntimeError>
     ResponseStream& WithResourceNotFoundException(ResourceNotFoundExceptionT&& value) { SetResourceNotFoundException(std::forward<ResourceNotFoundExceptionT>(value)); return *this;}
     ///@}
 
@@ -181,11 +181,11 @@ namespace Model
      * <p>The number of requests exceeds the service quota. Resubmit your request
      * later.</p>
      */
-    inline const ServiceQuotaExceededException& GetServiceQuotaExceededException() const { return m_serviceQuotaExceededException; }
+    inline const BedrockAgentRuntimeError& GetServiceQuotaExceededException() const { return m_serviceQuotaExceededException; }
     inline bool ServiceQuotaExceededExceptionHasBeenSet() const { return m_serviceQuotaExceededExceptionHasBeenSet; }
-    template<typename ServiceQuotaExceededExceptionT = ServiceQuotaExceededException>
+    template<typename ServiceQuotaExceededExceptionT = BedrockAgentRuntimeError>
     void SetServiceQuotaExceededException(ServiceQuotaExceededExceptionT&& value) { m_serviceQuotaExceededExceptionHasBeenSet = true; m_serviceQuotaExceededException = std::forward<ServiceQuotaExceededExceptionT>(value); }
-    template<typename ServiceQuotaExceededExceptionT = ServiceQuotaExceededException>
+    template<typename ServiceQuotaExceededExceptionT = BedrockAgentRuntimeError>
     ResponseStream& WithServiceQuotaExceededException(ServiceQuotaExceededExceptionT&& value) { SetServiceQuotaExceededException(std::forward<ServiceQuotaExceededExceptionT>(value)); return *this;}
     ///@}
 
@@ -193,11 +193,11 @@ namespace Model
     /**
      * <p>The number of requests exceeds the limit. Resubmit your request later.</p>
      */
-    inline const ThrottlingException& GetThrottlingException() const { return m_throttlingException; }
+    inline const BedrockAgentRuntimeError& GetThrottlingException() const { return m_throttlingException; }
     inline bool ThrottlingExceptionHasBeenSet() const { return m_throttlingExceptionHasBeenSet; }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockAgentRuntimeError>
     void SetThrottlingException(ThrottlingExceptionT&& value) { m_throttlingExceptionHasBeenSet = true; m_throttlingException = std::forward<ThrottlingExceptionT>(value); }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockAgentRuntimeError>
     ResponseStream& WithThrottlingException(ThrottlingExceptionT&& value) { SetThrottlingException(std::forward<ThrottlingExceptionT>(value)); return *this;}
     ///@}
 
@@ -223,16 +223,16 @@ namespace Model
      * <p>Input validation failed. Check your request parameters and retry the
      * request.</p>
      */
-    inline const ValidationException& GetValidationException() const { return m_validationException; }
+    inline const BedrockAgentRuntimeError& GetValidationException() const { return m_validationException; }
     inline bool ValidationExceptionHasBeenSet() const { return m_validationExceptionHasBeenSet; }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockAgentRuntimeError>
     void SetValidationException(ValidationExceptionT&& value) { m_validationExceptionHasBeenSet = true; m_validationException = std::forward<ValidationExceptionT>(value); }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockAgentRuntimeError>
     ResponseStream& WithValidationException(ValidationExceptionT&& value) { SetValidationException(std::forward<ValidationExceptionT>(value)); return *this;}
     ///@}
   private:
 
-    AccessDeniedException m_accessDeniedException;
+    BedrockAgentRuntimeError m_accessDeniedException;
     bool m_accessDeniedExceptionHasBeenSet = false;
 
     BadGatewayException m_badGatewayException;
@@ -241,7 +241,7 @@ namespace Model
     PayloadPart m_chunk;
     bool m_chunkHasBeenSet = false;
 
-    ConflictException m_conflictException;
+    BedrockAgentRuntimeError m_conflictException;
     bool m_conflictExceptionHasBeenSet = false;
 
     DependencyFailedException m_dependencyFailedException;
@@ -253,25 +253,25 @@ namespace Model
     InternalServerException m_internalServerException;
     bool m_internalServerExceptionHasBeenSet = false;
 
-    ModelNotReadyException m_modelNotReadyException;
+    BedrockAgentRuntimeError m_modelNotReadyException;
     bool m_modelNotReadyExceptionHasBeenSet = false;
 
-    ResourceNotFoundException m_resourceNotFoundException;
+    BedrockAgentRuntimeError m_resourceNotFoundException;
     bool m_resourceNotFoundExceptionHasBeenSet = false;
 
     ReturnControlPayload m_returnControl;
     bool m_returnControlHasBeenSet = false;
 
-    ServiceQuotaExceededException m_serviceQuotaExceededException;
+    BedrockAgentRuntimeError m_serviceQuotaExceededException;
     bool m_serviceQuotaExceededExceptionHasBeenSet = false;
 
-    ThrottlingException m_throttlingException;
+    BedrockAgentRuntimeError m_throttlingException;
     bool m_throttlingExceptionHasBeenSet = false;
 
     TracePart m_trace;
     bool m_traceHasBeenSet = false;
 
-    ValidationException m_validationException;
+    BedrockAgentRuntimeError m_validationException;
     bool m_validationExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/RetrieveAndGenerateStreamResponseOutput.h
+++ b/generated/src/aws-cpp-sdk-bedrock-agent-runtime/include/aws/bedrock-agent-runtime/model/RetrieveAndGenerateStreamResponseOutput.h
@@ -49,11 +49,11 @@ namespace Model
      * href="https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-access-denied">AccessDeniedException</a>
      * in the Amazon Bedrock User Guide.</p>
      */
-    inline const AccessDeniedException& GetAccessDeniedException() const { return m_accessDeniedException; }
+    inline const BedrockAgentRuntimeError& GetAccessDeniedException() const { return m_accessDeniedException; }
     inline bool AccessDeniedExceptionHasBeenSet() const { return m_accessDeniedExceptionHasBeenSet; }
-    template<typename AccessDeniedExceptionT = AccessDeniedException>
+    template<typename AccessDeniedExceptionT = BedrockAgentRuntimeError>
     void SetAccessDeniedException(AccessDeniedExceptionT&& value) { m_accessDeniedExceptionHasBeenSet = true; m_accessDeniedException = std::forward<AccessDeniedExceptionT>(value); }
-    template<typename AccessDeniedExceptionT = AccessDeniedException>
+    template<typename AccessDeniedExceptionT = BedrockAgentRuntimeError>
     RetrieveAndGenerateStreamResponseOutput& WithAccessDeniedException(AccessDeniedExceptionT&& value) { SetAccessDeniedException(std::forward<AccessDeniedExceptionT>(value)); return *this;}
     ///@}
 
@@ -85,11 +85,11 @@ namespace Model
     /**
      * <p>Error occurred because of a conflict while performing an operation.</p>
      */
-    inline const ConflictException& GetConflictException() const { return m_conflictException; }
+    inline const BedrockAgentRuntimeError& GetConflictException() const { return m_conflictException; }
     inline bool ConflictExceptionHasBeenSet() const { return m_conflictExceptionHasBeenSet; }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = BedrockAgentRuntimeError>
     void SetConflictException(ConflictExceptionT&& value) { m_conflictExceptionHasBeenSet = true; m_conflictException = std::forward<ConflictExceptionT>(value); }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = BedrockAgentRuntimeError>
     RetrieveAndGenerateStreamResponseOutput& WithConflictException(ConflictExceptionT&& value) { SetConflictException(std::forward<ConflictExceptionT>(value)); return *this;}
     ///@}
 
@@ -148,11 +148,11 @@ namespace Model
      * href="https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-resource-not-found">ResourceNotFound</a>
      * in the Amazon Bedrock User Guide.</p>
      */
-    inline const ResourceNotFoundException& GetResourceNotFoundException() const { return m_resourceNotFoundException; }
+    inline const BedrockAgentRuntimeError& GetResourceNotFoundException() const { return m_resourceNotFoundException; }
     inline bool ResourceNotFoundExceptionHasBeenSet() const { return m_resourceNotFoundExceptionHasBeenSet; }
-    template<typename ResourceNotFoundExceptionT = ResourceNotFoundException>
+    template<typename ResourceNotFoundExceptionT = BedrockAgentRuntimeError>
     void SetResourceNotFoundException(ResourceNotFoundExceptionT&& value) { m_resourceNotFoundExceptionHasBeenSet = true; m_resourceNotFoundException = std::forward<ResourceNotFoundExceptionT>(value); }
-    template<typename ResourceNotFoundExceptionT = ResourceNotFoundException>
+    template<typename ResourceNotFoundExceptionT = BedrockAgentRuntimeError>
     RetrieveAndGenerateStreamResponseOutput& WithResourceNotFoundException(ResourceNotFoundExceptionT&& value) { SetResourceNotFoundException(std::forward<ResourceNotFoundExceptionT>(value)); return *this;}
     ///@}
 
@@ -163,11 +163,11 @@ namespace Model
      * href="https://docs.aws.amazon.com/servicequotas/latest/userguide/gs-request-quota.html">Viewing
      * service quotas</a>. You can resubmit your request later.</p>
      */
-    inline const ServiceQuotaExceededException& GetServiceQuotaExceededException() const { return m_serviceQuotaExceededException; }
+    inline const BedrockAgentRuntimeError& GetServiceQuotaExceededException() const { return m_serviceQuotaExceededException; }
     inline bool ServiceQuotaExceededExceptionHasBeenSet() const { return m_serviceQuotaExceededExceptionHasBeenSet; }
-    template<typename ServiceQuotaExceededExceptionT = ServiceQuotaExceededException>
+    template<typename ServiceQuotaExceededExceptionT = BedrockAgentRuntimeError>
     void SetServiceQuotaExceededException(ServiceQuotaExceededExceptionT&& value) { m_serviceQuotaExceededExceptionHasBeenSet = true; m_serviceQuotaExceededException = std::forward<ServiceQuotaExceededExceptionT>(value); }
-    template<typename ServiceQuotaExceededExceptionT = ServiceQuotaExceededException>
+    template<typename ServiceQuotaExceededExceptionT = BedrockAgentRuntimeError>
     RetrieveAndGenerateStreamResponseOutput& WithServiceQuotaExceededException(ServiceQuotaExceededExceptionT&& value) { SetServiceQuotaExceededException(std::forward<ServiceQuotaExceededExceptionT>(value)); return *this;}
     ///@}
 
@@ -178,11 +178,11 @@ namespace Model
      * href="https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-throttling-exception">ThrottlingException</a>
      * in the Amazon Bedrock User Guide.</p>
      */
-    inline const ThrottlingException& GetThrottlingException() const { return m_throttlingException; }
+    inline const BedrockAgentRuntimeError& GetThrottlingException() const { return m_throttlingException; }
     inline bool ThrottlingExceptionHasBeenSet() const { return m_throttlingExceptionHasBeenSet; }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockAgentRuntimeError>
     void SetThrottlingException(ThrottlingExceptionT&& value) { m_throttlingExceptionHasBeenSet = true; m_throttlingException = std::forward<ThrottlingExceptionT>(value); }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockAgentRuntimeError>
     RetrieveAndGenerateStreamResponseOutput& WithThrottlingException(ThrottlingExceptionT&& value) { SetThrottlingException(std::forward<ThrottlingExceptionT>(value)); return *this;}
     ///@}
 
@@ -193,16 +193,16 @@ namespace Model
      * href="https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-validation-error">ValidationError</a>
      * in the Amazon Bedrock User Guide.</p>
      */
-    inline const ValidationException& GetValidationException() const { return m_validationException; }
+    inline const BedrockAgentRuntimeError& GetValidationException() const { return m_validationException; }
     inline bool ValidationExceptionHasBeenSet() const { return m_validationExceptionHasBeenSet; }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockAgentRuntimeError>
     void SetValidationException(ValidationExceptionT&& value) { m_validationExceptionHasBeenSet = true; m_validationException = std::forward<ValidationExceptionT>(value); }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockAgentRuntimeError>
     RetrieveAndGenerateStreamResponseOutput& WithValidationException(ValidationExceptionT&& value) { SetValidationException(std::forward<ValidationExceptionT>(value)); return *this;}
     ///@}
   private:
 
-    AccessDeniedException m_accessDeniedException;
+    BedrockAgentRuntimeError m_accessDeniedException;
     bool m_accessDeniedExceptionHasBeenSet = false;
 
     BadGatewayException m_badGatewayException;
@@ -211,7 +211,7 @@ namespace Model
     CitationEvent m_citation;
     bool m_citationHasBeenSet = false;
 
-    ConflictException m_conflictException;
+    BedrockAgentRuntimeError m_conflictException;
     bool m_conflictExceptionHasBeenSet = false;
 
     DependencyFailedException m_dependencyFailedException;
@@ -226,16 +226,16 @@ namespace Model
     RetrieveAndGenerateOutputEvent m_output;
     bool m_outputHasBeenSet = false;
 
-    ResourceNotFoundException m_resourceNotFoundException;
+    BedrockAgentRuntimeError m_resourceNotFoundException;
     bool m_resourceNotFoundExceptionHasBeenSet = false;
 
-    ServiceQuotaExceededException m_serviceQuotaExceededException;
+    BedrockAgentRuntimeError m_serviceQuotaExceededException;
     bool m_serviceQuotaExceededExceptionHasBeenSet = false;
 
-    ThrottlingException m_throttlingException;
+    BedrockAgentRuntimeError m_throttlingException;
     bool m_throttlingExceptionHasBeenSet = false;
 
-    ValidationException m_validationException;
+    BedrockAgentRuntimeError m_validationException;
     bool m_validationExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/ConverseStreamOutput.h
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/ConverseStreamOutput.h
@@ -119,11 +119,11 @@ namespace Model
     /**
      * <p>An internal server error occurred. Retry your request.</p>
      */
-    inline const InternalServerException& GetInternalServerException() const { return m_internalServerException; }
+    inline const BedrockRuntimeError& GetInternalServerException() const { return m_internalServerException; }
     inline bool InternalServerExceptionHasBeenSet() const { return m_internalServerExceptionHasBeenSet; }
-    template<typename InternalServerExceptionT = InternalServerException>
+    template<typename InternalServerExceptionT = BedrockRuntimeError>
     void SetInternalServerException(InternalServerExceptionT&& value) { m_internalServerExceptionHasBeenSet = true; m_internalServerException = std::forward<InternalServerExceptionT>(value); }
-    template<typename InternalServerExceptionT = InternalServerException>
+    template<typename InternalServerExceptionT = BedrockRuntimeError>
     ConverseStreamOutput& WithInternalServerException(InternalServerExceptionT&& value) { SetInternalServerException(std::forward<InternalServerExceptionT>(value)); return *this;}
     ///@}
 
@@ -146,11 +146,11 @@ namespace Model
      * href="https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-validation-error">ValidationError</a>
      * in the Amazon Bedrock User Guide</p>
      */
-    inline const ValidationException& GetValidationException() const { return m_validationException; }
+    inline const BedrockRuntimeError& GetValidationException() const { return m_validationException; }
     inline bool ValidationExceptionHasBeenSet() const { return m_validationExceptionHasBeenSet; }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockRuntimeError>
     void SetValidationException(ValidationExceptionT&& value) { m_validationExceptionHasBeenSet = true; m_validationException = std::forward<ValidationExceptionT>(value); }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockRuntimeError>
     ConverseStreamOutput& WithValidationException(ValidationExceptionT&& value) { SetValidationException(std::forward<ValidationExceptionT>(value)); return *this;}
     ///@}
 
@@ -161,11 +161,11 @@ namespace Model
      * href="https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-throttling-exception">ThrottlingException</a>
      * in the Amazon Bedrock User Guide</p>
      */
-    inline const ThrottlingException& GetThrottlingException() const { return m_throttlingException; }
+    inline const BedrockRuntimeError& GetThrottlingException() const { return m_throttlingException; }
     inline bool ThrottlingExceptionHasBeenSet() const { return m_throttlingExceptionHasBeenSet; }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockRuntimeError>
     void SetThrottlingException(ThrottlingExceptionT&& value) { m_throttlingExceptionHasBeenSet = true; m_throttlingException = std::forward<ThrottlingExceptionT>(value); }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockRuntimeError>
     ConverseStreamOutput& WithThrottlingException(ThrottlingExceptionT&& value) { SetThrottlingException(std::forward<ThrottlingExceptionT>(value)); return *this;}
     ///@}
 
@@ -175,11 +175,11 @@ namespace Model
      * href="https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-service-unavailable">ServiceUnavailable</a>
      * in the Amazon Bedrock User Guide</p>
      */
-    inline const ServiceUnavailableException& GetServiceUnavailableException() const { return m_serviceUnavailableException; }
+    inline const BedrockRuntimeError& GetServiceUnavailableException() const { return m_serviceUnavailableException; }
     inline bool ServiceUnavailableExceptionHasBeenSet() const { return m_serviceUnavailableExceptionHasBeenSet; }
-    template<typename ServiceUnavailableExceptionT = ServiceUnavailableException>
+    template<typename ServiceUnavailableExceptionT = BedrockRuntimeError>
     void SetServiceUnavailableException(ServiceUnavailableExceptionT&& value) { m_serviceUnavailableExceptionHasBeenSet = true; m_serviceUnavailableException = std::forward<ServiceUnavailableExceptionT>(value); }
-    template<typename ServiceUnavailableExceptionT = ServiceUnavailableException>
+    template<typename ServiceUnavailableExceptionT = BedrockRuntimeError>
     ConverseStreamOutput& WithServiceUnavailableException(ServiceUnavailableExceptionT&& value) { SetServiceUnavailableException(std::forward<ServiceUnavailableExceptionT>(value)); return *this;}
     ///@}
   private:
@@ -202,19 +202,19 @@ namespace Model
     ConverseStreamMetadataEvent m_metadata;
     bool m_metadataHasBeenSet = false;
 
-    InternalServerException m_internalServerException;
+    BedrockRuntimeError m_internalServerException;
     bool m_internalServerExceptionHasBeenSet = false;
 
     ModelStreamErrorException m_modelStreamErrorException;
     bool m_modelStreamErrorExceptionHasBeenSet = false;
 
-    ValidationException m_validationException;
+    BedrockRuntimeError m_validationException;
     bool m_validationExceptionHasBeenSet = false;
 
-    ThrottlingException m_throttlingException;
+    BedrockRuntimeError m_throttlingException;
     bool m_throttlingExceptionHasBeenSet = false;
 
-    ServiceUnavailableException m_serviceUnavailableException;
+    BedrockRuntimeError m_serviceUnavailableException;
     bool m_serviceUnavailableExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/InvokeModelWithBidirectionalStreamOutput.h
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/InvokeModelWithBidirectionalStreamOutput.h
@@ -55,11 +55,11 @@ namespace Model
     /**
      * <p>The request encountered an unknown internal error.</p>
      */
-    inline const InternalServerException& GetInternalServerException() const { return m_internalServerException; }
+    inline const BedrockRuntimeError& GetInternalServerException() const { return m_internalServerException; }
     inline bool InternalServerExceptionHasBeenSet() const { return m_internalServerExceptionHasBeenSet; }
-    template<typename InternalServerExceptionT = InternalServerException>
+    template<typename InternalServerExceptionT = BedrockRuntimeError>
     void SetInternalServerException(InternalServerExceptionT&& value) { m_internalServerExceptionHasBeenSet = true; m_internalServerException = std::forward<InternalServerExceptionT>(value); }
-    template<typename InternalServerExceptionT = InternalServerException>
+    template<typename InternalServerExceptionT = BedrockRuntimeError>
     InvokeModelWithBidirectionalStreamOutput& WithInternalServerException(InternalServerExceptionT&& value) { SetInternalServerException(std::forward<InternalServerExceptionT>(value)); return *this;}
     ///@}
 
@@ -80,11 +80,11 @@ namespace Model
      * <p>The input fails to satisfy the constraints specified by an Amazon Web
      * Services service.</p>
      */
-    inline const ValidationException& GetValidationException() const { return m_validationException; }
+    inline const BedrockRuntimeError& GetValidationException() const { return m_validationException; }
     inline bool ValidationExceptionHasBeenSet() const { return m_validationExceptionHasBeenSet; }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockRuntimeError>
     void SetValidationException(ValidationExceptionT&& value) { m_validationExceptionHasBeenSet = true; m_validationException = std::forward<ValidationExceptionT>(value); }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockRuntimeError>
     InvokeModelWithBidirectionalStreamOutput& WithValidationException(ValidationExceptionT&& value) { SetValidationException(std::forward<ValidationExceptionT>(value)); return *this;}
     ///@}
 
@@ -92,11 +92,11 @@ namespace Model
     /**
      * <p>The request was denied due to request throttling.</p>
      */
-    inline const ThrottlingException& GetThrottlingException() const { return m_throttlingException; }
+    inline const BedrockRuntimeError& GetThrottlingException() const { return m_throttlingException; }
     inline bool ThrottlingExceptionHasBeenSet() const { return m_throttlingExceptionHasBeenSet; }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockRuntimeError>
     void SetThrottlingException(ThrottlingExceptionT&& value) { m_throttlingExceptionHasBeenSet = true; m_throttlingException = std::forward<ThrottlingExceptionT>(value); }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockRuntimeError>
     InvokeModelWithBidirectionalStreamOutput& WithThrottlingException(ThrottlingExceptionT&& value) { SetThrottlingException(std::forward<ThrottlingExceptionT>(value)); return *this;}
     ///@}
 
@@ -105,11 +105,11 @@ namespace Model
      * <p>The connection was closed because a request was not received within the
      * timeout period.</p>
      */
-    inline const ModelTimeoutException& GetModelTimeoutException() const { return m_modelTimeoutException; }
+    inline const BedrockRuntimeError& GetModelTimeoutException() const { return m_modelTimeoutException; }
     inline bool ModelTimeoutExceptionHasBeenSet() const { return m_modelTimeoutExceptionHasBeenSet; }
-    template<typename ModelTimeoutExceptionT = ModelTimeoutException>
+    template<typename ModelTimeoutExceptionT = BedrockRuntimeError>
     void SetModelTimeoutException(ModelTimeoutExceptionT&& value) { m_modelTimeoutExceptionHasBeenSet = true; m_modelTimeoutException = std::forward<ModelTimeoutExceptionT>(value); }
-    template<typename ModelTimeoutExceptionT = ModelTimeoutException>
+    template<typename ModelTimeoutExceptionT = BedrockRuntimeError>
     InvokeModelWithBidirectionalStreamOutput& WithModelTimeoutException(ModelTimeoutExceptionT&& value) { SetModelTimeoutException(std::forward<ModelTimeoutExceptionT>(value)); return *this;}
     ///@}
 
@@ -117,11 +117,11 @@ namespace Model
     /**
      * <p>The request has failed due to a temporary failure of the server.</p>
      */
-    inline const ServiceUnavailableException& GetServiceUnavailableException() const { return m_serviceUnavailableException; }
+    inline const BedrockRuntimeError& GetServiceUnavailableException() const { return m_serviceUnavailableException; }
     inline bool ServiceUnavailableExceptionHasBeenSet() const { return m_serviceUnavailableExceptionHasBeenSet; }
-    template<typename ServiceUnavailableExceptionT = ServiceUnavailableException>
+    template<typename ServiceUnavailableExceptionT = BedrockRuntimeError>
     void SetServiceUnavailableException(ServiceUnavailableExceptionT&& value) { m_serviceUnavailableExceptionHasBeenSet = true; m_serviceUnavailableException = std::forward<ServiceUnavailableExceptionT>(value); }
-    template<typename ServiceUnavailableExceptionT = ServiceUnavailableException>
+    template<typename ServiceUnavailableExceptionT = BedrockRuntimeError>
     InvokeModelWithBidirectionalStreamOutput& WithServiceUnavailableException(ServiceUnavailableExceptionT&& value) { SetServiceUnavailableException(std::forward<ServiceUnavailableExceptionT>(value)); return *this;}
     ///@}
   private:
@@ -129,22 +129,22 @@ namespace Model
     BidirectionalOutputPayloadPart m_chunk;
     bool m_chunkHasBeenSet = false;
 
-    InternalServerException m_internalServerException;
+    BedrockRuntimeError m_internalServerException;
     bool m_internalServerExceptionHasBeenSet = false;
 
     ModelStreamErrorException m_modelStreamErrorException;
     bool m_modelStreamErrorExceptionHasBeenSet = false;
 
-    ValidationException m_validationException;
+    BedrockRuntimeError m_validationException;
     bool m_validationExceptionHasBeenSet = false;
 
-    ThrottlingException m_throttlingException;
+    BedrockRuntimeError m_throttlingException;
     bool m_throttlingExceptionHasBeenSet = false;
 
-    ModelTimeoutException m_modelTimeoutException;
+    BedrockRuntimeError m_modelTimeoutException;
     bool m_modelTimeoutExceptionHasBeenSet = false;
 
-    ServiceUnavailableException m_serviceUnavailableException;
+    BedrockRuntimeError m_serviceUnavailableException;
     bool m_serviceUnavailableExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/ResponseStream.h
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/ResponseStream.h
@@ -54,11 +54,11 @@ namespace Model
     /**
      * <p>An internal server error occurred. Retry your request.</p>
      */
-    inline const InternalServerException& GetInternalServerException() const { return m_internalServerException; }
+    inline const BedrockRuntimeError& GetInternalServerException() const { return m_internalServerException; }
     inline bool InternalServerExceptionHasBeenSet() const { return m_internalServerExceptionHasBeenSet; }
-    template<typename InternalServerExceptionT = InternalServerException>
+    template<typename InternalServerExceptionT = BedrockRuntimeError>
     void SetInternalServerException(InternalServerExceptionT&& value) { m_internalServerExceptionHasBeenSet = true; m_internalServerException = std::forward<InternalServerExceptionT>(value); }
-    template<typename InternalServerExceptionT = InternalServerException>
+    template<typename InternalServerExceptionT = BedrockRuntimeError>
     ResponseStream& WithInternalServerException(InternalServerExceptionT&& value) { SetInternalServerException(std::forward<InternalServerExceptionT>(value)); return *this;}
     ///@}
 
@@ -79,11 +79,11 @@ namespace Model
      * <p>Input validation failed. Check your request parameters and retry the
      * request.</p>
      */
-    inline const ValidationException& GetValidationException() const { return m_validationException; }
+    inline const BedrockRuntimeError& GetValidationException() const { return m_validationException; }
     inline bool ValidationExceptionHasBeenSet() const { return m_validationExceptionHasBeenSet; }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockRuntimeError>
     void SetValidationException(ValidationExceptionT&& value) { m_validationExceptionHasBeenSet = true; m_validationException = std::forward<ValidationExceptionT>(value); }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = BedrockRuntimeError>
     ResponseStream& WithValidationException(ValidationExceptionT&& value) { SetValidationException(std::forward<ValidationExceptionT>(value)); return *this;}
     ///@}
 
@@ -94,11 +94,11 @@ namespace Model
      * href="https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html">Provisioned
      * Throughput</a> to increase the rate or number of tokens you can process.</p>
      */
-    inline const ThrottlingException& GetThrottlingException() const { return m_throttlingException; }
+    inline const BedrockRuntimeError& GetThrottlingException() const { return m_throttlingException; }
     inline bool ThrottlingExceptionHasBeenSet() const { return m_throttlingExceptionHasBeenSet; }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockRuntimeError>
     void SetThrottlingException(ThrottlingExceptionT&& value) { m_throttlingExceptionHasBeenSet = true; m_throttlingException = std::forward<ThrottlingExceptionT>(value); }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = BedrockRuntimeError>
     ResponseStream& WithThrottlingException(ThrottlingExceptionT&& value) { SetThrottlingException(std::forward<ThrottlingExceptionT>(value)); return *this;}
     ///@}
 
@@ -107,11 +107,11 @@ namespace Model
      * <p>The request took too long to process. Processing time exceeded the model
      * timeout length.</p>
      */
-    inline const ModelTimeoutException& GetModelTimeoutException() const { return m_modelTimeoutException; }
+    inline const BedrockRuntimeError& GetModelTimeoutException() const { return m_modelTimeoutException; }
     inline bool ModelTimeoutExceptionHasBeenSet() const { return m_modelTimeoutExceptionHasBeenSet; }
-    template<typename ModelTimeoutExceptionT = ModelTimeoutException>
+    template<typename ModelTimeoutExceptionT = BedrockRuntimeError>
     void SetModelTimeoutException(ModelTimeoutExceptionT&& value) { m_modelTimeoutExceptionHasBeenSet = true; m_modelTimeoutException = std::forward<ModelTimeoutExceptionT>(value); }
-    template<typename ModelTimeoutExceptionT = ModelTimeoutException>
+    template<typename ModelTimeoutExceptionT = BedrockRuntimeError>
     ResponseStream& WithModelTimeoutException(ModelTimeoutExceptionT&& value) { SetModelTimeoutException(std::forward<ModelTimeoutExceptionT>(value)); return *this;}
     ///@}
 
@@ -119,11 +119,11 @@ namespace Model
     /**
      * <p>The service isn't available. Try again later.</p>
      */
-    inline const ServiceUnavailableException& GetServiceUnavailableException() const { return m_serviceUnavailableException; }
+    inline const BedrockRuntimeError& GetServiceUnavailableException() const { return m_serviceUnavailableException; }
     inline bool ServiceUnavailableExceptionHasBeenSet() const { return m_serviceUnavailableExceptionHasBeenSet; }
-    template<typename ServiceUnavailableExceptionT = ServiceUnavailableException>
+    template<typename ServiceUnavailableExceptionT = BedrockRuntimeError>
     void SetServiceUnavailableException(ServiceUnavailableExceptionT&& value) { m_serviceUnavailableExceptionHasBeenSet = true; m_serviceUnavailableException = std::forward<ServiceUnavailableExceptionT>(value); }
-    template<typename ServiceUnavailableExceptionT = ServiceUnavailableException>
+    template<typename ServiceUnavailableExceptionT = BedrockRuntimeError>
     ResponseStream& WithServiceUnavailableException(ServiceUnavailableExceptionT&& value) { SetServiceUnavailableException(std::forward<ServiceUnavailableExceptionT>(value)); return *this;}
     ///@}
   private:
@@ -131,22 +131,22 @@ namespace Model
     PayloadPart m_chunk;
     bool m_chunkHasBeenSet = false;
 
-    InternalServerException m_internalServerException;
+    BedrockRuntimeError m_internalServerException;
     bool m_internalServerExceptionHasBeenSet = false;
 
     ModelStreamErrorException m_modelStreamErrorException;
     bool m_modelStreamErrorExceptionHasBeenSet = false;
 
-    ValidationException m_validationException;
+    BedrockRuntimeError m_validationException;
     bool m_validationExceptionHasBeenSet = false;
 
-    ThrottlingException m_throttlingException;
+    BedrockRuntimeError m_throttlingException;
     bool m_throttlingExceptionHasBeenSet = false;
 
-    ModelTimeoutException m_modelTimeoutException;
+    BedrockRuntimeError m_modelTimeoutException;
     bool m_modelTimeoutExceptionHasBeenSet = false;
 
-    ServiceUnavailableException m_serviceUnavailableException;
+    BedrockRuntimeError m_serviceUnavailableException;
     bool m_serviceUnavailableExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-iotsitewise/include/aws/iotsitewise/model/ResponseStream.h
+++ b/generated/src/aws-cpp-sdk-iotsitewise/include/aws/iotsitewise/model/ResponseStream.h
@@ -67,11 +67,11 @@ namespace Model
 
     ///@{
     
-    inline const AccessDeniedException& GetAccessDeniedException() const { return m_accessDeniedException; }
+    inline const IoTSiteWiseError& GetAccessDeniedException() const { return m_accessDeniedException; }
     inline bool AccessDeniedExceptionHasBeenSet() const { return m_accessDeniedExceptionHasBeenSet; }
-    template<typename AccessDeniedExceptionT = AccessDeniedException>
+    template<typename AccessDeniedExceptionT = IoTSiteWiseError>
     void SetAccessDeniedException(AccessDeniedExceptionT&& value) { m_accessDeniedExceptionHasBeenSet = true; m_accessDeniedException = std::forward<AccessDeniedExceptionT>(value); }
-    template<typename AccessDeniedExceptionT = AccessDeniedException>
+    template<typename AccessDeniedExceptionT = IoTSiteWiseError>
     ResponseStream& WithAccessDeniedException(AccessDeniedExceptionT&& value) { SetAccessDeniedException(std::forward<AccessDeniedExceptionT>(value)); return *this;}
     ///@}
 
@@ -87,51 +87,51 @@ namespace Model
 
     ///@{
     
-    inline const InternalFailureException& GetInternalFailureException() const { return m_internalFailureException; }
+    inline const IoTSiteWiseError& GetInternalFailureException() const { return m_internalFailureException; }
     inline bool InternalFailureExceptionHasBeenSet() const { return m_internalFailureExceptionHasBeenSet; }
-    template<typename InternalFailureExceptionT = InternalFailureException>
+    template<typename InternalFailureExceptionT = IoTSiteWiseError>
     void SetInternalFailureException(InternalFailureExceptionT&& value) { m_internalFailureExceptionHasBeenSet = true; m_internalFailureException = std::forward<InternalFailureExceptionT>(value); }
-    template<typename InternalFailureExceptionT = InternalFailureException>
+    template<typename InternalFailureExceptionT = IoTSiteWiseError>
     ResponseStream& WithInternalFailureException(InternalFailureExceptionT&& value) { SetInternalFailureException(std::forward<InternalFailureExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const InvalidRequestException& GetInvalidRequestException() const { return m_invalidRequestException; }
+    inline const IoTSiteWiseError& GetInvalidRequestException() const { return m_invalidRequestException; }
     inline bool InvalidRequestExceptionHasBeenSet() const { return m_invalidRequestExceptionHasBeenSet; }
-    template<typename InvalidRequestExceptionT = InvalidRequestException>
+    template<typename InvalidRequestExceptionT = IoTSiteWiseError>
     void SetInvalidRequestException(InvalidRequestExceptionT&& value) { m_invalidRequestExceptionHasBeenSet = true; m_invalidRequestException = std::forward<InvalidRequestExceptionT>(value); }
-    template<typename InvalidRequestExceptionT = InvalidRequestException>
+    template<typename InvalidRequestExceptionT = IoTSiteWiseError>
     ResponseStream& WithInvalidRequestException(InvalidRequestExceptionT&& value) { SetInvalidRequestException(std::forward<InvalidRequestExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const LimitExceededException& GetLimitExceededException() const { return m_limitExceededException; }
+    inline const IoTSiteWiseError& GetLimitExceededException() const { return m_limitExceededException; }
     inline bool LimitExceededExceptionHasBeenSet() const { return m_limitExceededExceptionHasBeenSet; }
-    template<typename LimitExceededExceptionT = LimitExceededException>
+    template<typename LimitExceededExceptionT = IoTSiteWiseError>
     void SetLimitExceededException(LimitExceededExceptionT&& value) { m_limitExceededExceptionHasBeenSet = true; m_limitExceededException = std::forward<LimitExceededExceptionT>(value); }
-    template<typename LimitExceededExceptionT = LimitExceededException>
+    template<typename LimitExceededExceptionT = IoTSiteWiseError>
     ResponseStream& WithLimitExceededException(LimitExceededExceptionT&& value) { SetLimitExceededException(std::forward<LimitExceededExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const ResourceNotFoundException& GetResourceNotFoundException() const { return m_resourceNotFoundException; }
+    inline const IoTSiteWiseError& GetResourceNotFoundException() const { return m_resourceNotFoundException; }
     inline bool ResourceNotFoundExceptionHasBeenSet() const { return m_resourceNotFoundExceptionHasBeenSet; }
-    template<typename ResourceNotFoundExceptionT = ResourceNotFoundException>
+    template<typename ResourceNotFoundExceptionT = IoTSiteWiseError>
     void SetResourceNotFoundException(ResourceNotFoundExceptionT&& value) { m_resourceNotFoundExceptionHasBeenSet = true; m_resourceNotFoundException = std::forward<ResourceNotFoundExceptionT>(value); }
-    template<typename ResourceNotFoundExceptionT = ResourceNotFoundException>
+    template<typename ResourceNotFoundExceptionT = IoTSiteWiseError>
     ResponseStream& WithResourceNotFoundException(ResourceNotFoundExceptionT&& value) { SetResourceNotFoundException(std::forward<ResourceNotFoundExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const ThrottlingException& GetThrottlingException() const { return m_throttlingException; }
+    inline const IoTSiteWiseError& GetThrottlingException() const { return m_throttlingException; }
     inline bool ThrottlingExceptionHasBeenSet() const { return m_throttlingExceptionHasBeenSet; }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = IoTSiteWiseError>
     void SetThrottlingException(ThrottlingExceptionT&& value) { m_throttlingExceptionHasBeenSet = true; m_throttlingException = std::forward<ThrottlingExceptionT>(value); }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = IoTSiteWiseError>
     ResponseStream& WithThrottlingException(ThrottlingExceptionT&& value) { SetThrottlingException(std::forward<ThrottlingExceptionT>(value)); return *this;}
     ///@}
   private:
@@ -142,25 +142,25 @@ namespace Model
     InvocationOutput m_output;
     bool m_outputHasBeenSet = false;
 
-    AccessDeniedException m_accessDeniedException;
+    IoTSiteWiseError m_accessDeniedException;
     bool m_accessDeniedExceptionHasBeenSet = false;
 
     ConflictingOperationException m_conflictingOperationException;
     bool m_conflictingOperationExceptionHasBeenSet = false;
 
-    InternalFailureException m_internalFailureException;
+    IoTSiteWiseError m_internalFailureException;
     bool m_internalFailureExceptionHasBeenSet = false;
 
-    InvalidRequestException m_invalidRequestException;
+    IoTSiteWiseError m_invalidRequestException;
     bool m_invalidRequestExceptionHasBeenSet = false;
 
-    LimitExceededException m_limitExceededException;
+    IoTSiteWiseError m_limitExceededException;
     bool m_limitExceededExceptionHasBeenSet = false;
 
-    ResourceNotFoundException m_resourceNotFoundException;
+    IoTSiteWiseError m_resourceNotFoundException;
     bool m_resourceNotFoundExceptionHasBeenSet = false;
 
-    ThrottlingException m_throttlingException;
+    IoTSiteWiseError m_throttlingException;
     bool m_throttlingExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-kinesis/include/aws/kinesis/model/SubscribeToShardEventStream.h
+++ b/generated/src/aws-cpp-sdk-kinesis/include/aws/kinesis/model/SubscribeToShardEventStream.h
@@ -56,81 +56,81 @@ namespace Model
 
     ///@{
     
-    inline const ResourceNotFoundException& GetResourceNotFoundException() const { return m_resourceNotFoundException; }
+    inline const KinesisError& GetResourceNotFoundException() const { return m_resourceNotFoundException; }
     inline bool ResourceNotFoundExceptionHasBeenSet() const { return m_resourceNotFoundExceptionHasBeenSet; }
-    template<typename ResourceNotFoundExceptionT = ResourceNotFoundException>
+    template<typename ResourceNotFoundExceptionT = KinesisError>
     void SetResourceNotFoundException(ResourceNotFoundExceptionT&& value) { m_resourceNotFoundExceptionHasBeenSet = true; m_resourceNotFoundException = std::forward<ResourceNotFoundExceptionT>(value); }
-    template<typename ResourceNotFoundExceptionT = ResourceNotFoundException>
+    template<typename ResourceNotFoundExceptionT = KinesisError>
     SubscribeToShardEventStream& WithResourceNotFoundException(ResourceNotFoundExceptionT&& value) { SetResourceNotFoundException(std::forward<ResourceNotFoundExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const ResourceInUseException& GetResourceInUseException() const { return m_resourceInUseException; }
+    inline const KinesisError& GetResourceInUseException() const { return m_resourceInUseException; }
     inline bool ResourceInUseExceptionHasBeenSet() const { return m_resourceInUseExceptionHasBeenSet; }
-    template<typename ResourceInUseExceptionT = ResourceInUseException>
+    template<typename ResourceInUseExceptionT = KinesisError>
     void SetResourceInUseException(ResourceInUseExceptionT&& value) { m_resourceInUseExceptionHasBeenSet = true; m_resourceInUseException = std::forward<ResourceInUseExceptionT>(value); }
-    template<typename ResourceInUseExceptionT = ResourceInUseException>
+    template<typename ResourceInUseExceptionT = KinesisError>
     SubscribeToShardEventStream& WithResourceInUseException(ResourceInUseExceptionT&& value) { SetResourceInUseException(std::forward<ResourceInUseExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const KMSDisabledException& GetKMSDisabledException() const { return m_kMSDisabledException; }
+    inline const KinesisError& GetKMSDisabledException() const { return m_kMSDisabledException; }
     inline bool KMSDisabledExceptionHasBeenSet() const { return m_kMSDisabledExceptionHasBeenSet; }
-    template<typename KMSDisabledExceptionT = KMSDisabledException>
+    template<typename KMSDisabledExceptionT = KinesisError>
     void SetKMSDisabledException(KMSDisabledExceptionT&& value) { m_kMSDisabledExceptionHasBeenSet = true; m_kMSDisabledException = std::forward<KMSDisabledExceptionT>(value); }
-    template<typename KMSDisabledExceptionT = KMSDisabledException>
+    template<typename KMSDisabledExceptionT = KinesisError>
     SubscribeToShardEventStream& WithKMSDisabledException(KMSDisabledExceptionT&& value) { SetKMSDisabledException(std::forward<KMSDisabledExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const KMSInvalidStateException& GetKMSInvalidStateException() const { return m_kMSInvalidStateException; }
+    inline const KinesisError& GetKMSInvalidStateException() const { return m_kMSInvalidStateException; }
     inline bool KMSInvalidStateExceptionHasBeenSet() const { return m_kMSInvalidStateExceptionHasBeenSet; }
-    template<typename KMSInvalidStateExceptionT = KMSInvalidStateException>
+    template<typename KMSInvalidStateExceptionT = KinesisError>
     void SetKMSInvalidStateException(KMSInvalidStateExceptionT&& value) { m_kMSInvalidStateExceptionHasBeenSet = true; m_kMSInvalidStateException = std::forward<KMSInvalidStateExceptionT>(value); }
-    template<typename KMSInvalidStateExceptionT = KMSInvalidStateException>
+    template<typename KMSInvalidStateExceptionT = KinesisError>
     SubscribeToShardEventStream& WithKMSInvalidStateException(KMSInvalidStateExceptionT&& value) { SetKMSInvalidStateException(std::forward<KMSInvalidStateExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const KMSAccessDeniedException& GetKMSAccessDeniedException() const { return m_kMSAccessDeniedException; }
+    inline const KinesisError& GetKMSAccessDeniedException() const { return m_kMSAccessDeniedException; }
     inline bool KMSAccessDeniedExceptionHasBeenSet() const { return m_kMSAccessDeniedExceptionHasBeenSet; }
-    template<typename KMSAccessDeniedExceptionT = KMSAccessDeniedException>
+    template<typename KMSAccessDeniedExceptionT = KinesisError>
     void SetKMSAccessDeniedException(KMSAccessDeniedExceptionT&& value) { m_kMSAccessDeniedExceptionHasBeenSet = true; m_kMSAccessDeniedException = std::forward<KMSAccessDeniedExceptionT>(value); }
-    template<typename KMSAccessDeniedExceptionT = KMSAccessDeniedException>
+    template<typename KMSAccessDeniedExceptionT = KinesisError>
     SubscribeToShardEventStream& WithKMSAccessDeniedException(KMSAccessDeniedExceptionT&& value) { SetKMSAccessDeniedException(std::forward<KMSAccessDeniedExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const KMSNotFoundException& GetKMSNotFoundException() const { return m_kMSNotFoundException; }
+    inline const KinesisError& GetKMSNotFoundException() const { return m_kMSNotFoundException; }
     inline bool KMSNotFoundExceptionHasBeenSet() const { return m_kMSNotFoundExceptionHasBeenSet; }
-    template<typename KMSNotFoundExceptionT = KMSNotFoundException>
+    template<typename KMSNotFoundExceptionT = KinesisError>
     void SetKMSNotFoundException(KMSNotFoundExceptionT&& value) { m_kMSNotFoundExceptionHasBeenSet = true; m_kMSNotFoundException = std::forward<KMSNotFoundExceptionT>(value); }
-    template<typename KMSNotFoundExceptionT = KMSNotFoundException>
+    template<typename KMSNotFoundExceptionT = KinesisError>
     SubscribeToShardEventStream& WithKMSNotFoundException(KMSNotFoundExceptionT&& value) { SetKMSNotFoundException(std::forward<KMSNotFoundExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const KMSOptInRequired& GetKMSOptInRequired() const { return m_kMSOptInRequired; }
+    inline const KinesisError& GetKMSOptInRequired() const { return m_kMSOptInRequired; }
     inline bool KMSOptInRequiredHasBeenSet() const { return m_kMSOptInRequiredHasBeenSet; }
-    template<typename KMSOptInRequiredT = KMSOptInRequired>
+    template<typename KMSOptInRequiredT = KinesisError>
     void SetKMSOptInRequired(KMSOptInRequiredT&& value) { m_kMSOptInRequiredHasBeenSet = true; m_kMSOptInRequired = std::forward<KMSOptInRequiredT>(value); }
-    template<typename KMSOptInRequiredT = KMSOptInRequired>
+    template<typename KMSOptInRequiredT = KinesisError>
     SubscribeToShardEventStream& WithKMSOptInRequired(KMSOptInRequiredT&& value) { SetKMSOptInRequired(std::forward<KMSOptInRequiredT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const KMSThrottlingException& GetKMSThrottlingException() const { return m_kMSThrottlingException; }
+    inline const KinesisError& GetKMSThrottlingException() const { return m_kMSThrottlingException; }
     inline bool KMSThrottlingExceptionHasBeenSet() const { return m_kMSThrottlingExceptionHasBeenSet; }
-    template<typename KMSThrottlingExceptionT = KMSThrottlingException>
+    template<typename KMSThrottlingExceptionT = KinesisError>
     void SetKMSThrottlingException(KMSThrottlingExceptionT&& value) { m_kMSThrottlingExceptionHasBeenSet = true; m_kMSThrottlingException = std::forward<KMSThrottlingExceptionT>(value); }
-    template<typename KMSThrottlingExceptionT = KMSThrottlingException>
+    template<typename KMSThrottlingExceptionT = KinesisError>
     SubscribeToShardEventStream& WithKMSThrottlingException(KMSThrottlingExceptionT&& value) { SetKMSThrottlingException(std::forward<KMSThrottlingExceptionT>(value)); return *this;}
     ///@}
 
@@ -139,11 +139,11 @@ namespace Model
      * <p>The processing of the request failed because of an unknown error, exception,
      * or failure.</p>
      */
-    inline const InternalFailureException& GetInternalFailureException() const { return m_internalFailureException; }
+    inline const KinesisError& GetInternalFailureException() const { return m_internalFailureException; }
     inline bool InternalFailureExceptionHasBeenSet() const { return m_internalFailureExceptionHasBeenSet; }
-    template<typename InternalFailureExceptionT = InternalFailureException>
+    template<typename InternalFailureExceptionT = KinesisError>
     void SetInternalFailureException(InternalFailureExceptionT&& value) { m_internalFailureExceptionHasBeenSet = true; m_internalFailureException = std::forward<InternalFailureExceptionT>(value); }
-    template<typename InternalFailureExceptionT = InternalFailureException>
+    template<typename InternalFailureExceptionT = KinesisError>
     SubscribeToShardEventStream& WithInternalFailureException(InternalFailureExceptionT&& value) { SetInternalFailureException(std::forward<InternalFailureExceptionT>(value)); return *this;}
     ///@}
   private:
@@ -151,31 +151,31 @@ namespace Model
     SubscribeToShardEvent m_subscribeToShardEvent;
     bool m_subscribeToShardEventHasBeenSet = false;
 
-    ResourceNotFoundException m_resourceNotFoundException;
+    KinesisError m_resourceNotFoundException;
     bool m_resourceNotFoundExceptionHasBeenSet = false;
 
-    ResourceInUseException m_resourceInUseException;
+    KinesisError m_resourceInUseException;
     bool m_resourceInUseExceptionHasBeenSet = false;
 
-    KMSDisabledException m_kMSDisabledException;
+    KinesisError m_kMSDisabledException;
     bool m_kMSDisabledExceptionHasBeenSet = false;
 
-    KMSInvalidStateException m_kMSInvalidStateException;
+    KinesisError m_kMSInvalidStateException;
     bool m_kMSInvalidStateExceptionHasBeenSet = false;
 
-    KMSAccessDeniedException m_kMSAccessDeniedException;
+    KinesisError m_kMSAccessDeniedException;
     bool m_kMSAccessDeniedExceptionHasBeenSet = false;
 
-    KMSNotFoundException m_kMSNotFoundException;
+    KinesisError m_kMSNotFoundException;
     bool m_kMSNotFoundExceptionHasBeenSet = false;
 
-    KMSOptInRequired m_kMSOptInRequired;
+    KinesisError m_kMSOptInRequired;
     bool m_kMSOptInRequiredHasBeenSet = false;
 
-    KMSThrottlingException m_kMSThrottlingException;
+    KinesisError m_kMSThrottlingException;
     bool m_kMSThrottlingExceptionHasBeenSet = false;
 
-    InternalFailureException m_internalFailureException;
+    KinesisError m_internalFailureException;
     bool m_internalFailureExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/model/StartConversationResponseEventStream.h
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/model/StartConversationResponseEventStream.h
@@ -112,11 +112,11 @@ namespace Model
      * expired. Also thrown when the credentials in the request do not have permission
      * to access the <code>StartConversation</code> operation.</p>
      */
-    inline const AccessDeniedException& GetAccessDeniedException() const { return m_accessDeniedException; }
+    inline const LexRuntimeV2Error& GetAccessDeniedException() const { return m_accessDeniedException; }
     inline bool AccessDeniedExceptionHasBeenSet() const { return m_accessDeniedExceptionHasBeenSet; }
-    template<typename AccessDeniedExceptionT = AccessDeniedException>
+    template<typename AccessDeniedExceptionT = LexRuntimeV2Error>
     void SetAccessDeniedException(AccessDeniedExceptionT&& value) { m_accessDeniedExceptionHasBeenSet = true; m_accessDeniedException = std::forward<AccessDeniedExceptionT>(value); }
-    template<typename AccessDeniedExceptionT = AccessDeniedException>
+    template<typename AccessDeniedExceptionT = LexRuntimeV2Error>
     StartConversationResponseEventStream& WithAccessDeniedException(AccessDeniedExceptionT&& value) { SetAccessDeniedException(std::forward<AccessDeniedExceptionT>(value)); return *this;}
     ///@}
 
@@ -125,11 +125,11 @@ namespace Model
      * <p>Exception thrown if one of the input parameters points to a resource that
      * does not exist. For example, if the bot ID specified does not exist.</p>
      */
-    inline const ResourceNotFoundException& GetResourceNotFoundException() const { return m_resourceNotFoundException; }
+    inline const LexRuntimeV2Error& GetResourceNotFoundException() const { return m_resourceNotFoundException; }
     inline bool ResourceNotFoundExceptionHasBeenSet() const { return m_resourceNotFoundExceptionHasBeenSet; }
-    template<typename ResourceNotFoundExceptionT = ResourceNotFoundException>
+    template<typename ResourceNotFoundExceptionT = LexRuntimeV2Error>
     void SetResourceNotFoundException(ResourceNotFoundExceptionT&& value) { m_resourceNotFoundExceptionHasBeenSet = true; m_resourceNotFoundException = std::forward<ResourceNotFoundExceptionT>(value); }
-    template<typename ResourceNotFoundExceptionT = ResourceNotFoundException>
+    template<typename ResourceNotFoundExceptionT = LexRuntimeV2Error>
     StartConversationResponseEventStream& WithResourceNotFoundException(ResourceNotFoundExceptionT&& value) { SetResourceNotFoundException(std::forward<ResourceNotFoundExceptionT>(value)); return *this;}
     ///@}
 
@@ -138,11 +138,11 @@ namespace Model
      * <p>Exception thrown when one or more parameters could not be validated. The
      * <code>message</code> contains the name of the field that isn't valid.</p>
      */
-    inline const ValidationException& GetValidationException() const { return m_validationException; }
+    inline const LexRuntimeV2Error& GetValidationException() const { return m_validationException; }
     inline bool ValidationExceptionHasBeenSet() const { return m_validationExceptionHasBeenSet; }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = LexRuntimeV2Error>
     void SetValidationException(ValidationExceptionT&& value) { m_validationExceptionHasBeenSet = true; m_validationException = std::forward<ValidationExceptionT>(value); }
-    template<typename ValidationExceptionT = ValidationException>
+    template<typename ValidationExceptionT = LexRuntimeV2Error>
     StartConversationResponseEventStream& WithValidationException(ValidationExceptionT&& value) { SetValidationException(std::forward<ValidationExceptionT>(value)); return *this;}
     ///@}
 
@@ -151,11 +151,11 @@ namespace Model
      * <p>Exception thrown when your application exceeds the maximum number of
      * concurrent requests. </p>
      */
-    inline const ThrottlingException& GetThrottlingException() const { return m_throttlingException; }
+    inline const LexRuntimeV2Error& GetThrottlingException() const { return m_throttlingException; }
     inline bool ThrottlingExceptionHasBeenSet() const { return m_throttlingExceptionHasBeenSet; }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = LexRuntimeV2Error>
     void SetThrottlingException(ThrottlingExceptionT&& value) { m_throttlingExceptionHasBeenSet = true; m_throttlingException = std::forward<ThrottlingExceptionT>(value); }
-    template<typename ThrottlingExceptionT = ThrottlingException>
+    template<typename ThrottlingExceptionT = LexRuntimeV2Error>
     StartConversationResponseEventStream& WithThrottlingException(ThrottlingExceptionT&& value) { SetThrottlingException(std::forward<ThrottlingExceptionT>(value)); return *this;}
     ///@}
 
@@ -163,11 +163,11 @@ namespace Model
     /**
      * <p>An error occurred with Amazon Lex V2.</p>
      */
-    inline const InternalServerException& GetInternalServerException() const { return m_internalServerException; }
+    inline const LexRuntimeV2Error& GetInternalServerException() const { return m_internalServerException; }
     inline bool InternalServerExceptionHasBeenSet() const { return m_internalServerExceptionHasBeenSet; }
-    template<typename InternalServerExceptionT = InternalServerException>
+    template<typename InternalServerExceptionT = LexRuntimeV2Error>
     void SetInternalServerException(InternalServerExceptionT&& value) { m_internalServerExceptionHasBeenSet = true; m_internalServerException = std::forward<InternalServerExceptionT>(value); }
-    template<typename InternalServerExceptionT = InternalServerException>
+    template<typename InternalServerExceptionT = LexRuntimeV2Error>
     StartConversationResponseEventStream& WithInternalServerException(InternalServerExceptionT&& value) { SetInternalServerException(std::forward<InternalServerExceptionT>(value)); return *this;}
     ///@}
 
@@ -176,31 +176,31 @@ namespace Model
      * <p>Exception thrown when two clients are using the same AWS account, Amazon Lex
      * V2 bot, and session ID.</p>
      */
-    inline const ConflictException& GetConflictException() const { return m_conflictException; }
+    inline const LexRuntimeV2Error& GetConflictException() const { return m_conflictException; }
     inline bool ConflictExceptionHasBeenSet() const { return m_conflictExceptionHasBeenSet; }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = LexRuntimeV2Error>
     void SetConflictException(ConflictExceptionT&& value) { m_conflictExceptionHasBeenSet = true; m_conflictException = std::forward<ConflictExceptionT>(value); }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = LexRuntimeV2Error>
     StartConversationResponseEventStream& WithConflictException(ConflictExceptionT&& value) { SetConflictException(std::forward<ConflictExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const DependencyFailedException& GetDependencyFailedException() const { return m_dependencyFailedException; }
+    inline const LexRuntimeV2Error& GetDependencyFailedException() const { return m_dependencyFailedException; }
     inline bool DependencyFailedExceptionHasBeenSet() const { return m_dependencyFailedExceptionHasBeenSet; }
-    template<typename DependencyFailedExceptionT = DependencyFailedException>
+    template<typename DependencyFailedExceptionT = LexRuntimeV2Error>
     void SetDependencyFailedException(DependencyFailedExceptionT&& value) { m_dependencyFailedExceptionHasBeenSet = true; m_dependencyFailedException = std::forward<DependencyFailedExceptionT>(value); }
-    template<typename DependencyFailedExceptionT = DependencyFailedException>
+    template<typename DependencyFailedExceptionT = LexRuntimeV2Error>
     StartConversationResponseEventStream& WithDependencyFailedException(DependencyFailedExceptionT&& value) { SetDependencyFailedException(std::forward<DependencyFailedExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const BadGatewayException& GetBadGatewayException() const { return m_badGatewayException; }
+    inline const LexRuntimeV2Error& GetBadGatewayException() const { return m_badGatewayException; }
     inline bool BadGatewayExceptionHasBeenSet() const { return m_badGatewayExceptionHasBeenSet; }
-    template<typename BadGatewayExceptionT = BadGatewayException>
+    template<typename BadGatewayExceptionT = LexRuntimeV2Error>
     void SetBadGatewayException(BadGatewayExceptionT&& value) { m_badGatewayExceptionHasBeenSet = true; m_badGatewayException = std::forward<BadGatewayExceptionT>(value); }
-    template<typename BadGatewayExceptionT = BadGatewayException>
+    template<typename BadGatewayExceptionT = LexRuntimeV2Error>
     StartConversationResponseEventStream& WithBadGatewayException(BadGatewayExceptionT&& value) { SetBadGatewayException(std::forward<BadGatewayExceptionT>(value)); return *this;}
     ///@}
   private:
@@ -223,28 +223,28 @@ namespace Model
     HeartbeatEvent m_heartbeatEvent;
     bool m_heartbeatEventHasBeenSet = false;
 
-    AccessDeniedException m_accessDeniedException;
+    LexRuntimeV2Error m_accessDeniedException;
     bool m_accessDeniedExceptionHasBeenSet = false;
 
-    ResourceNotFoundException m_resourceNotFoundException;
+    LexRuntimeV2Error m_resourceNotFoundException;
     bool m_resourceNotFoundExceptionHasBeenSet = false;
 
-    ValidationException m_validationException;
+    LexRuntimeV2Error m_validationException;
     bool m_validationExceptionHasBeenSet = false;
 
-    ThrottlingException m_throttlingException;
+    LexRuntimeV2Error m_throttlingException;
     bool m_throttlingExceptionHasBeenSet = false;
 
-    InternalServerException m_internalServerException;
+    LexRuntimeV2Error m_internalServerException;
     bool m_internalServerExceptionHasBeenSet = false;
 
-    ConflictException m_conflictException;
+    LexRuntimeV2Error m_conflictException;
     bool m_conflictExceptionHasBeenSet = false;
 
-    DependencyFailedException m_dependencyFailedException;
+    LexRuntimeV2Error m_dependencyFailedException;
     bool m_dependencyFailedExceptionHasBeenSet = false;
 
-    BadGatewayException m_badGatewayException;
+    LexRuntimeV2Error m_badGatewayException;
     bool m_badGatewayExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-logs/include/aws/logs/model/StartLiveTailResponseStream.h
+++ b/generated/src/aws-cpp-sdk-logs/include/aws/logs/model/StartLiveTailResponseStream.h
@@ -70,11 +70,11 @@ namespace Model
      * <p>This exception is returned in the stream when the Live Tail session times
      * out. Live Tail sessions time out after three hours.</p>
      */
-    inline const SessionTimeoutException& GetSessionTimeoutException() const { return m_sessionTimeoutException; }
+    inline const CloudWatchLogsError& GetSessionTimeoutException() const { return m_sessionTimeoutException; }
     inline bool SessionTimeoutExceptionHasBeenSet() const { return m_sessionTimeoutExceptionHasBeenSet; }
-    template<typename SessionTimeoutExceptionT = SessionTimeoutException>
+    template<typename SessionTimeoutExceptionT = CloudWatchLogsError>
     void SetSessionTimeoutException(SessionTimeoutExceptionT&& value) { m_sessionTimeoutExceptionHasBeenSet = true; m_sessionTimeoutException = std::forward<SessionTimeoutExceptionT>(value); }
-    template<typename SessionTimeoutExceptionT = SessionTimeoutException>
+    template<typename SessionTimeoutExceptionT = CloudWatchLogsError>
     StartLiveTailResponseStream& WithSessionTimeoutException(SessionTimeoutExceptionT&& value) { SetSessionTimeoutException(std::forward<SessionTimeoutExceptionT>(value)); return *this;}
     ///@}
 
@@ -82,11 +82,11 @@ namespace Model
     /**
      * <p>This exception is returned if an unknown error occurs.</p>
      */
-    inline const SessionStreamingException& GetSessionStreamingException() const { return m_sessionStreamingException; }
+    inline const CloudWatchLogsError& GetSessionStreamingException() const { return m_sessionStreamingException; }
     inline bool SessionStreamingExceptionHasBeenSet() const { return m_sessionStreamingExceptionHasBeenSet; }
-    template<typename SessionStreamingExceptionT = SessionStreamingException>
+    template<typename SessionStreamingExceptionT = CloudWatchLogsError>
     void SetSessionStreamingException(SessionStreamingExceptionT&& value) { m_sessionStreamingExceptionHasBeenSet = true; m_sessionStreamingException = std::forward<SessionStreamingExceptionT>(value); }
-    template<typename SessionStreamingExceptionT = SessionStreamingException>
+    template<typename SessionStreamingExceptionT = CloudWatchLogsError>
     StartLiveTailResponseStream& WithSessionStreamingException(SessionStreamingExceptionT&& value) { SetSessionStreamingException(std::forward<SessionStreamingExceptionT>(value)); return *this;}
     ///@}
   private:
@@ -97,10 +97,10 @@ namespace Model
     LiveTailSessionUpdate m_sessionUpdate;
     bool m_sessionUpdateHasBeenSet = false;
 
-    SessionTimeoutException m_sessionTimeoutException;
+    CloudWatchLogsError m_sessionTimeoutException;
     bool m_sessionTimeoutExceptionHasBeenSet = false;
 
-    SessionStreamingException m_sessionStreamingException;
+    CloudWatchLogsError m_sessionStreamingException;
     bool m_sessionStreamingExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-sagemaker-runtime/include/aws/sagemaker-runtime/model/ResponseStream.h
+++ b/generated/src/aws-cpp-sdk-sagemaker-runtime/include/aws/sagemaker-runtime/model/ResponseStream.h
@@ -75,11 +75,11 @@ namespace Model
      * <p>The stream processing failed because of an unknown error, exception or
      * failure. Try your request again.</p>
      */
-    inline const InternalStreamFailure& GetInternalStreamFailure() const { return m_internalStreamFailure; }
+    inline const SageMakerRuntimeError& GetInternalStreamFailure() const { return m_internalStreamFailure; }
     inline bool InternalStreamFailureHasBeenSet() const { return m_internalStreamFailureHasBeenSet; }
-    template<typename InternalStreamFailureT = InternalStreamFailure>
+    template<typename InternalStreamFailureT = SageMakerRuntimeError>
     void SetInternalStreamFailure(InternalStreamFailureT&& value) { m_internalStreamFailureHasBeenSet = true; m_internalStreamFailure = std::forward<InternalStreamFailureT>(value); }
-    template<typename InternalStreamFailureT = InternalStreamFailure>
+    template<typename InternalStreamFailureT = SageMakerRuntimeError>
     ResponseStream& WithInternalStreamFailure(InternalStreamFailureT&& value) { SetInternalStreamFailure(std::forward<InternalStreamFailureT>(value)); return *this;}
     ///@}
   private:
@@ -90,7 +90,7 @@ namespace Model
     ModelStreamError m_modelStreamError;
     bool m_modelStreamErrorHasBeenSet = false;
 
-    InternalStreamFailure m_internalStreamFailure;
+    SageMakerRuntimeError m_internalStreamFailure;
     bool m_internalStreamFailureHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/CallAnalyticsTranscriptResultStream.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/CallAnalyticsTranscriptResultStream.h
@@ -70,51 +70,51 @@ namespace Model
 
     ///@{
     
-    inline const BadRequestException& GetBadRequestException() const { return m_badRequestException; }
+    inline const TranscribeStreamingServiceError& GetBadRequestException() const { return m_badRequestException; }
     inline bool BadRequestExceptionHasBeenSet() const { return m_badRequestExceptionHasBeenSet; }
-    template<typename BadRequestExceptionT = BadRequestException>
+    template<typename BadRequestExceptionT = TranscribeStreamingServiceError>
     void SetBadRequestException(BadRequestExceptionT&& value) { m_badRequestExceptionHasBeenSet = true; m_badRequestException = std::forward<BadRequestExceptionT>(value); }
-    template<typename BadRequestExceptionT = BadRequestException>
+    template<typename BadRequestExceptionT = TranscribeStreamingServiceError>
     CallAnalyticsTranscriptResultStream& WithBadRequestException(BadRequestExceptionT&& value) { SetBadRequestException(std::forward<BadRequestExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const LimitExceededException& GetLimitExceededException() const { return m_limitExceededException; }
+    inline const TranscribeStreamingServiceError& GetLimitExceededException() const { return m_limitExceededException; }
     inline bool LimitExceededExceptionHasBeenSet() const { return m_limitExceededExceptionHasBeenSet; }
-    template<typename LimitExceededExceptionT = LimitExceededException>
+    template<typename LimitExceededExceptionT = TranscribeStreamingServiceError>
     void SetLimitExceededException(LimitExceededExceptionT&& value) { m_limitExceededExceptionHasBeenSet = true; m_limitExceededException = std::forward<LimitExceededExceptionT>(value); }
-    template<typename LimitExceededExceptionT = LimitExceededException>
+    template<typename LimitExceededExceptionT = TranscribeStreamingServiceError>
     CallAnalyticsTranscriptResultStream& WithLimitExceededException(LimitExceededExceptionT&& value) { SetLimitExceededException(std::forward<LimitExceededExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const InternalFailureException& GetInternalFailureException() const { return m_internalFailureException; }
+    inline const TranscribeStreamingServiceError& GetInternalFailureException() const { return m_internalFailureException; }
     inline bool InternalFailureExceptionHasBeenSet() const { return m_internalFailureExceptionHasBeenSet; }
-    template<typename InternalFailureExceptionT = InternalFailureException>
+    template<typename InternalFailureExceptionT = TranscribeStreamingServiceError>
     void SetInternalFailureException(InternalFailureExceptionT&& value) { m_internalFailureExceptionHasBeenSet = true; m_internalFailureException = std::forward<InternalFailureExceptionT>(value); }
-    template<typename InternalFailureExceptionT = InternalFailureException>
+    template<typename InternalFailureExceptionT = TranscribeStreamingServiceError>
     CallAnalyticsTranscriptResultStream& WithInternalFailureException(InternalFailureExceptionT&& value) { SetInternalFailureException(std::forward<InternalFailureExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const ConflictException& GetConflictException() const { return m_conflictException; }
+    inline const TranscribeStreamingServiceError& GetConflictException() const { return m_conflictException; }
     inline bool ConflictExceptionHasBeenSet() const { return m_conflictExceptionHasBeenSet; }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = TranscribeStreamingServiceError>
     void SetConflictException(ConflictExceptionT&& value) { m_conflictExceptionHasBeenSet = true; m_conflictException = std::forward<ConflictExceptionT>(value); }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = TranscribeStreamingServiceError>
     CallAnalyticsTranscriptResultStream& WithConflictException(ConflictExceptionT&& value) { SetConflictException(std::forward<ConflictExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const ServiceUnavailableException& GetServiceUnavailableException() const { return m_serviceUnavailableException; }
+    inline const TranscribeStreamingServiceError& GetServiceUnavailableException() const { return m_serviceUnavailableException; }
     inline bool ServiceUnavailableExceptionHasBeenSet() const { return m_serviceUnavailableExceptionHasBeenSet; }
-    template<typename ServiceUnavailableExceptionT = ServiceUnavailableException>
+    template<typename ServiceUnavailableExceptionT = TranscribeStreamingServiceError>
     void SetServiceUnavailableException(ServiceUnavailableExceptionT&& value) { m_serviceUnavailableExceptionHasBeenSet = true; m_serviceUnavailableException = std::forward<ServiceUnavailableExceptionT>(value); }
-    template<typename ServiceUnavailableExceptionT = ServiceUnavailableException>
+    template<typename ServiceUnavailableExceptionT = TranscribeStreamingServiceError>
     CallAnalyticsTranscriptResultStream& WithServiceUnavailableException(ServiceUnavailableExceptionT&& value) { SetServiceUnavailableException(std::forward<ServiceUnavailableExceptionT>(value)); return *this;}
     ///@}
   private:
@@ -125,19 +125,19 @@ namespace Model
     CategoryEvent m_categoryEvent;
     bool m_categoryEventHasBeenSet = false;
 
-    BadRequestException m_badRequestException;
+    TranscribeStreamingServiceError m_badRequestException;
     bool m_badRequestExceptionHasBeenSet = false;
 
-    LimitExceededException m_limitExceededException;
+    TranscribeStreamingServiceError m_limitExceededException;
     bool m_limitExceededExceptionHasBeenSet = false;
 
-    InternalFailureException m_internalFailureException;
+    TranscribeStreamingServiceError m_internalFailureException;
     bool m_internalFailureExceptionHasBeenSet = false;
 
-    ConflictException m_conflictException;
+    TranscribeStreamingServiceError m_conflictException;
     bool m_conflictExceptionHasBeenSet = false;
 
-    ServiceUnavailableException m_serviceUnavailableException;
+    TranscribeStreamingServiceError m_serviceUnavailableException;
     bool m_serviceUnavailableExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/MedicalScribeResultStream.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/MedicalScribeResultStream.h
@@ -53,51 +53,51 @@ namespace Model
 
     ///@{
     
-    inline const BadRequestException& GetBadRequestException() const { return m_badRequestException; }
+    inline const TranscribeStreamingServiceError& GetBadRequestException() const { return m_badRequestException; }
     inline bool BadRequestExceptionHasBeenSet() const { return m_badRequestExceptionHasBeenSet; }
-    template<typename BadRequestExceptionT = BadRequestException>
+    template<typename BadRequestExceptionT = TranscribeStreamingServiceError>
     void SetBadRequestException(BadRequestExceptionT&& value) { m_badRequestExceptionHasBeenSet = true; m_badRequestException = std::forward<BadRequestExceptionT>(value); }
-    template<typename BadRequestExceptionT = BadRequestException>
+    template<typename BadRequestExceptionT = TranscribeStreamingServiceError>
     MedicalScribeResultStream& WithBadRequestException(BadRequestExceptionT&& value) { SetBadRequestException(std::forward<BadRequestExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const LimitExceededException& GetLimitExceededException() const { return m_limitExceededException; }
+    inline const TranscribeStreamingServiceError& GetLimitExceededException() const { return m_limitExceededException; }
     inline bool LimitExceededExceptionHasBeenSet() const { return m_limitExceededExceptionHasBeenSet; }
-    template<typename LimitExceededExceptionT = LimitExceededException>
+    template<typename LimitExceededExceptionT = TranscribeStreamingServiceError>
     void SetLimitExceededException(LimitExceededExceptionT&& value) { m_limitExceededExceptionHasBeenSet = true; m_limitExceededException = std::forward<LimitExceededExceptionT>(value); }
-    template<typename LimitExceededExceptionT = LimitExceededException>
+    template<typename LimitExceededExceptionT = TranscribeStreamingServiceError>
     MedicalScribeResultStream& WithLimitExceededException(LimitExceededExceptionT&& value) { SetLimitExceededException(std::forward<LimitExceededExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const InternalFailureException& GetInternalFailureException() const { return m_internalFailureException; }
+    inline const TranscribeStreamingServiceError& GetInternalFailureException() const { return m_internalFailureException; }
     inline bool InternalFailureExceptionHasBeenSet() const { return m_internalFailureExceptionHasBeenSet; }
-    template<typename InternalFailureExceptionT = InternalFailureException>
+    template<typename InternalFailureExceptionT = TranscribeStreamingServiceError>
     void SetInternalFailureException(InternalFailureExceptionT&& value) { m_internalFailureExceptionHasBeenSet = true; m_internalFailureException = std::forward<InternalFailureExceptionT>(value); }
-    template<typename InternalFailureExceptionT = InternalFailureException>
+    template<typename InternalFailureExceptionT = TranscribeStreamingServiceError>
     MedicalScribeResultStream& WithInternalFailureException(InternalFailureExceptionT&& value) { SetInternalFailureException(std::forward<InternalFailureExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const ConflictException& GetConflictException() const { return m_conflictException; }
+    inline const TranscribeStreamingServiceError& GetConflictException() const { return m_conflictException; }
     inline bool ConflictExceptionHasBeenSet() const { return m_conflictExceptionHasBeenSet; }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = TranscribeStreamingServiceError>
     void SetConflictException(ConflictExceptionT&& value) { m_conflictExceptionHasBeenSet = true; m_conflictException = std::forward<ConflictExceptionT>(value); }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = TranscribeStreamingServiceError>
     MedicalScribeResultStream& WithConflictException(ConflictExceptionT&& value) { SetConflictException(std::forward<ConflictExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const ServiceUnavailableException& GetServiceUnavailableException() const { return m_serviceUnavailableException; }
+    inline const TranscribeStreamingServiceError& GetServiceUnavailableException() const { return m_serviceUnavailableException; }
     inline bool ServiceUnavailableExceptionHasBeenSet() const { return m_serviceUnavailableExceptionHasBeenSet; }
-    template<typename ServiceUnavailableExceptionT = ServiceUnavailableException>
+    template<typename ServiceUnavailableExceptionT = TranscribeStreamingServiceError>
     void SetServiceUnavailableException(ServiceUnavailableExceptionT&& value) { m_serviceUnavailableExceptionHasBeenSet = true; m_serviceUnavailableException = std::forward<ServiceUnavailableExceptionT>(value); }
-    template<typename ServiceUnavailableExceptionT = ServiceUnavailableException>
+    template<typename ServiceUnavailableExceptionT = TranscribeStreamingServiceError>
     MedicalScribeResultStream& WithServiceUnavailableException(ServiceUnavailableExceptionT&& value) { SetServiceUnavailableException(std::forward<ServiceUnavailableExceptionT>(value)); return *this;}
     ///@}
   private:
@@ -105,19 +105,19 @@ namespace Model
     MedicalScribeTranscriptEvent m_transcriptEvent;
     bool m_transcriptEventHasBeenSet = false;
 
-    BadRequestException m_badRequestException;
+    TranscribeStreamingServiceError m_badRequestException;
     bool m_badRequestExceptionHasBeenSet = false;
 
-    LimitExceededException m_limitExceededException;
+    TranscribeStreamingServiceError m_limitExceededException;
     bool m_limitExceededExceptionHasBeenSet = false;
 
-    InternalFailureException m_internalFailureException;
+    TranscribeStreamingServiceError m_internalFailureException;
     bool m_internalFailureExceptionHasBeenSet = false;
 
-    ConflictException m_conflictException;
+    TranscribeStreamingServiceError m_conflictException;
     bool m_conflictExceptionHasBeenSet = false;
 
-    ServiceUnavailableException m_serviceUnavailableException;
+    TranscribeStreamingServiceError m_serviceUnavailableException;
     bool m_serviceUnavailableExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/MedicalTranscriptResultStream.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/MedicalTranscriptResultStream.h
@@ -58,51 +58,51 @@ namespace Model
 
     ///@{
     
-    inline const BadRequestException& GetBadRequestException() const { return m_badRequestException; }
+    inline const TranscribeStreamingServiceError& GetBadRequestException() const { return m_badRequestException; }
     inline bool BadRequestExceptionHasBeenSet() const { return m_badRequestExceptionHasBeenSet; }
-    template<typename BadRequestExceptionT = BadRequestException>
+    template<typename BadRequestExceptionT = TranscribeStreamingServiceError>
     void SetBadRequestException(BadRequestExceptionT&& value) { m_badRequestExceptionHasBeenSet = true; m_badRequestException = std::forward<BadRequestExceptionT>(value); }
-    template<typename BadRequestExceptionT = BadRequestException>
+    template<typename BadRequestExceptionT = TranscribeStreamingServiceError>
     MedicalTranscriptResultStream& WithBadRequestException(BadRequestExceptionT&& value) { SetBadRequestException(std::forward<BadRequestExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const LimitExceededException& GetLimitExceededException() const { return m_limitExceededException; }
+    inline const TranscribeStreamingServiceError& GetLimitExceededException() const { return m_limitExceededException; }
     inline bool LimitExceededExceptionHasBeenSet() const { return m_limitExceededExceptionHasBeenSet; }
-    template<typename LimitExceededExceptionT = LimitExceededException>
+    template<typename LimitExceededExceptionT = TranscribeStreamingServiceError>
     void SetLimitExceededException(LimitExceededExceptionT&& value) { m_limitExceededExceptionHasBeenSet = true; m_limitExceededException = std::forward<LimitExceededExceptionT>(value); }
-    template<typename LimitExceededExceptionT = LimitExceededException>
+    template<typename LimitExceededExceptionT = TranscribeStreamingServiceError>
     MedicalTranscriptResultStream& WithLimitExceededException(LimitExceededExceptionT&& value) { SetLimitExceededException(std::forward<LimitExceededExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const InternalFailureException& GetInternalFailureException() const { return m_internalFailureException; }
+    inline const TranscribeStreamingServiceError& GetInternalFailureException() const { return m_internalFailureException; }
     inline bool InternalFailureExceptionHasBeenSet() const { return m_internalFailureExceptionHasBeenSet; }
-    template<typename InternalFailureExceptionT = InternalFailureException>
+    template<typename InternalFailureExceptionT = TranscribeStreamingServiceError>
     void SetInternalFailureException(InternalFailureExceptionT&& value) { m_internalFailureExceptionHasBeenSet = true; m_internalFailureException = std::forward<InternalFailureExceptionT>(value); }
-    template<typename InternalFailureExceptionT = InternalFailureException>
+    template<typename InternalFailureExceptionT = TranscribeStreamingServiceError>
     MedicalTranscriptResultStream& WithInternalFailureException(InternalFailureExceptionT&& value) { SetInternalFailureException(std::forward<InternalFailureExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const ConflictException& GetConflictException() const { return m_conflictException; }
+    inline const TranscribeStreamingServiceError& GetConflictException() const { return m_conflictException; }
     inline bool ConflictExceptionHasBeenSet() const { return m_conflictExceptionHasBeenSet; }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = TranscribeStreamingServiceError>
     void SetConflictException(ConflictExceptionT&& value) { m_conflictExceptionHasBeenSet = true; m_conflictException = std::forward<ConflictExceptionT>(value); }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = TranscribeStreamingServiceError>
     MedicalTranscriptResultStream& WithConflictException(ConflictExceptionT&& value) { SetConflictException(std::forward<ConflictExceptionT>(value)); return *this;}
     ///@}
 
     ///@{
     
-    inline const ServiceUnavailableException& GetServiceUnavailableException() const { return m_serviceUnavailableException; }
+    inline const TranscribeStreamingServiceError& GetServiceUnavailableException() const { return m_serviceUnavailableException; }
     inline bool ServiceUnavailableExceptionHasBeenSet() const { return m_serviceUnavailableExceptionHasBeenSet; }
-    template<typename ServiceUnavailableExceptionT = ServiceUnavailableException>
+    template<typename ServiceUnavailableExceptionT = TranscribeStreamingServiceError>
     void SetServiceUnavailableException(ServiceUnavailableExceptionT&& value) { m_serviceUnavailableExceptionHasBeenSet = true; m_serviceUnavailableException = std::forward<ServiceUnavailableExceptionT>(value); }
-    template<typename ServiceUnavailableExceptionT = ServiceUnavailableException>
+    template<typename ServiceUnavailableExceptionT = TranscribeStreamingServiceError>
     MedicalTranscriptResultStream& WithServiceUnavailableException(ServiceUnavailableExceptionT&& value) { SetServiceUnavailableException(std::forward<ServiceUnavailableExceptionT>(value)); return *this;}
     ///@}
   private:
@@ -110,19 +110,19 @@ namespace Model
     MedicalTranscriptEvent m_transcriptEvent;
     bool m_transcriptEventHasBeenSet = false;
 
-    BadRequestException m_badRequestException;
+    TranscribeStreamingServiceError m_badRequestException;
     bool m_badRequestExceptionHasBeenSet = false;
 
-    LimitExceededException m_limitExceededException;
+    TranscribeStreamingServiceError m_limitExceededException;
     bool m_limitExceededExceptionHasBeenSet = false;
 
-    InternalFailureException m_internalFailureException;
+    TranscribeStreamingServiceError m_internalFailureException;
     bool m_internalFailureExceptionHasBeenSet = false;
 
-    ConflictException m_conflictException;
+    TranscribeStreamingServiceError m_conflictException;
     bool m_conflictExceptionHasBeenSet = false;
 
-    ServiceUnavailableException m_serviceUnavailableException;
+    TranscribeStreamingServiceError m_serviceUnavailableException;
     bool m_serviceUnavailableExceptionHasBeenSet = false;
   };
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/TranscriptResultStream.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/TranscriptResultStream.h
@@ -57,11 +57,11 @@ namespace Model
      * <p>A client error occurred when the stream was created. Check the parameters of
      * the request and try your request again.</p>
      */
-    inline const BadRequestException& GetBadRequestException() const { return m_badRequestException; }
+    inline const TranscribeStreamingServiceError& GetBadRequestException() const { return m_badRequestException; }
     inline bool BadRequestExceptionHasBeenSet() const { return m_badRequestExceptionHasBeenSet; }
-    template<typename BadRequestExceptionT = BadRequestException>
+    template<typename BadRequestExceptionT = TranscribeStreamingServiceError>
     void SetBadRequestException(BadRequestExceptionT&& value) { m_badRequestExceptionHasBeenSet = true; m_badRequestException = std::forward<BadRequestExceptionT>(value); }
-    template<typename BadRequestExceptionT = BadRequestException>
+    template<typename BadRequestExceptionT = TranscribeStreamingServiceError>
     TranscriptResultStream& WithBadRequestException(BadRequestExceptionT&& value) { SetBadRequestException(std::forward<BadRequestExceptionT>(value)); return *this;}
     ///@}
 
@@ -71,11 +71,11 @@ namespace Model
      * typically the audio length limit. Break your audio stream into smaller chunks
      * and try your request again.</p>
      */
-    inline const LimitExceededException& GetLimitExceededException() const { return m_limitExceededException; }
+    inline const TranscribeStreamingServiceError& GetLimitExceededException() const { return m_limitExceededException; }
     inline bool LimitExceededExceptionHasBeenSet() const { return m_limitExceededExceptionHasBeenSet; }
-    template<typename LimitExceededExceptionT = LimitExceededException>
+    template<typename LimitExceededExceptionT = TranscribeStreamingServiceError>
     void SetLimitExceededException(LimitExceededExceptionT&& value) { m_limitExceededExceptionHasBeenSet = true; m_limitExceededException = std::forward<LimitExceededExceptionT>(value); }
-    template<typename LimitExceededExceptionT = LimitExceededException>
+    template<typename LimitExceededExceptionT = TranscribeStreamingServiceError>
     TranscriptResultStream& WithLimitExceededException(LimitExceededExceptionT&& value) { SetLimitExceededException(std::forward<LimitExceededExceptionT>(value)); return *this;}
     ///@}
 
@@ -84,11 +84,11 @@ namespace Model
      * <p>A problem occurred while processing the audio. Amazon Transcribe terminated
      * processing.</p>
      */
-    inline const InternalFailureException& GetInternalFailureException() const { return m_internalFailureException; }
+    inline const TranscribeStreamingServiceError& GetInternalFailureException() const { return m_internalFailureException; }
     inline bool InternalFailureExceptionHasBeenSet() const { return m_internalFailureExceptionHasBeenSet; }
-    template<typename InternalFailureExceptionT = InternalFailureException>
+    template<typename InternalFailureExceptionT = TranscribeStreamingServiceError>
     void SetInternalFailureException(InternalFailureExceptionT&& value) { m_internalFailureExceptionHasBeenSet = true; m_internalFailureException = std::forward<InternalFailureExceptionT>(value); }
-    template<typename InternalFailureExceptionT = InternalFailureException>
+    template<typename InternalFailureExceptionT = TranscribeStreamingServiceError>
     TranscriptResultStream& WithInternalFailureException(InternalFailureExceptionT&& value) { SetInternalFailureException(std::forward<InternalFailureExceptionT>(value)); return *this;}
     ///@}
 
@@ -97,11 +97,11 @@ namespace Model
      * <p>A new stream started with the same session ID. The current stream has been
      * terminated.</p>
      */
-    inline const ConflictException& GetConflictException() const { return m_conflictException; }
+    inline const TranscribeStreamingServiceError& GetConflictException() const { return m_conflictException; }
     inline bool ConflictExceptionHasBeenSet() const { return m_conflictExceptionHasBeenSet; }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = TranscribeStreamingServiceError>
     void SetConflictException(ConflictExceptionT&& value) { m_conflictExceptionHasBeenSet = true; m_conflictException = std::forward<ConflictExceptionT>(value); }
-    template<typename ConflictExceptionT = ConflictException>
+    template<typename ConflictExceptionT = TranscribeStreamingServiceError>
     TranscriptResultStream& WithConflictException(ConflictExceptionT&& value) { SetConflictException(std::forward<ConflictExceptionT>(value)); return *this;}
     ///@}
 
@@ -109,11 +109,11 @@ namespace Model
     /**
      * <p>The service is currently unavailable. Try your request later.</p>
      */
-    inline const ServiceUnavailableException& GetServiceUnavailableException() const { return m_serviceUnavailableException; }
+    inline const TranscribeStreamingServiceError& GetServiceUnavailableException() const { return m_serviceUnavailableException; }
     inline bool ServiceUnavailableExceptionHasBeenSet() const { return m_serviceUnavailableExceptionHasBeenSet; }
-    template<typename ServiceUnavailableExceptionT = ServiceUnavailableException>
+    template<typename ServiceUnavailableExceptionT = TranscribeStreamingServiceError>
     void SetServiceUnavailableException(ServiceUnavailableExceptionT&& value) { m_serviceUnavailableExceptionHasBeenSet = true; m_serviceUnavailableException = std::forward<ServiceUnavailableExceptionT>(value); }
-    template<typename ServiceUnavailableExceptionT = ServiceUnavailableException>
+    template<typename ServiceUnavailableExceptionT = TranscribeStreamingServiceError>
     TranscriptResultStream& WithServiceUnavailableException(ServiceUnavailableExceptionT&& value) { SetServiceUnavailableException(std::forward<ServiceUnavailableExceptionT>(value)); return *this;}
     ///@}
   private:
@@ -121,19 +121,19 @@ namespace Model
     TranscriptEvent m_transcriptEvent;
     bool m_transcriptEventHasBeenSet = false;
 
-    BadRequestException m_badRequestException;
+    TranscribeStreamingServiceError m_badRequestException;
     bool m_badRequestExceptionHasBeenSet = false;
 
-    LimitExceededException m_limitExceededException;
+    TranscribeStreamingServiceError m_limitExceededException;
     bool m_limitExceededExceptionHasBeenSet = false;
 
-    InternalFailureException m_internalFailureException;
+    TranscribeStreamingServiceError m_internalFailureException;
     bool m_internalFailureExceptionHasBeenSet = false;
 
-    ConflictException m_conflictException;
+    TranscribeStreamingServiceError m_conflictException;
     bool m_conflictExceptionHasBeenSet = false;
 
-    ServiceUnavailableException m_serviceUnavailableException;
+    TranscribeStreamingServiceError m_serviceUnavailableException;
     bool m_serviceUnavailableExceptionHasBeenSet = false;
   };
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassMembersAndInlines.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassMembersAndInlines.vm
@@ -14,6 +14,9 @@
 #if($CppViewHelper.isStreamingPayloadMember($shape, $member.key) && $shape.result)
 #set($cppType = "Aws::Utils::Stream::ResponseStream")
 #set($isStream = true)
+#elseif($member.value.shape.isException() && !$member.value.shape.isModeledException())
+#set($cppType = "${metadata.classNamePrefix}Error")
+#set($isStream = false)
 #else
 #set($cppType = $CppViewHelper.computeCppType($member.value.shape))
 #set($isStream = false)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/model/ServiceClientModelHeaderMemberDeclaration.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/model/ServiceClientModelHeaderMemberDeclaration.vm
@@ -7,6 +7,9 @@
 #set($isEventStreamInput = false)
 #end
 #set($cppType = $CppViewHelper.computeCppType($shape, $member.key))
+#if($member.value.shape.isException() && !$member.value.shape.isModeledException())
+#set($cppType = "${metadata.classNamePrefix}Error")
+#end
 #set($memberVariableName = $CppViewHelper.computeMemberVariableName($member.key))
 #if($member.value.shape.getName() == $shape.getName() && $member.value.shape.list)
     Aws::Vector<$cppType> $memberVariableName;


### PR DESCRIPTION
*Issue #, if available:*
Modeled errors that can be represented using a common error shape are not generated in CPP SDK, but still were referenced on some supposedly unused headers.
These unused headers is a different issue to be fixed.

*Description of changes:*
Change the type of certain errors referenced so they do exist.
Tested using https://github.com/aws/aws-sdk-cpp/pull/3391

PS: I've also tried to generate the following block in the errors header:
```
namespace Model {
using BadRequestException = Aws::Client::AWSError<TranscribeStreamingServiceErrors>;
using ConflictException = Aws::Client::AWSError<TranscribeStreamingServiceErrors>;
using InternalFailureException = Aws::Client::AWSError<TranscribeStreamingServiceErrors>;
using LimitExceededException = Aws::Client::AWSError<TranscribeStreamingServiceErrors>;
using ResourceNotFoundException = Aws::Client::AWSError<TranscribeStreamingServiceErrors>;
using ServiceUnavailableException = Aws::Client::AWSError<TranscribeStreamingServiceErrors>;
}  // namespace Model
```

However, the problem is that this block would be generated for almost any service present, unless a more complicated logic (if such error is present AND referenced by some other shape) is required to avoid huge diff.
*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
