### PR TITLE
handle empty vendor params in smoke tests

### DIFF
--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmokeTestData.java
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmokeTestData.java
@@ -8,11 +8,14 @@ import lombok.Data;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
+
+import software.amazon.smithy.aws.smoketests.model.BaseAwsVendorParams;
 import software.amazon.smithy.codegen.core.Symbol;
 @Data
 public final class SmokeTestData {
     public String testcaseName;
-    public ClientConfiguration config;
+    public Supplier<Optional<BaseAwsVendorParams>> vendorParamsSupplier;
     public String operationName;
     public String inputShapeName;
     public String outputShapeName;

--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmokeTestsParser.java
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmokeTestsParser.java
@@ -4,6 +4,7 @@
  */
 package com.amazonaws.util.awsclientsmithygenerator.generators;
 
+import software.amazon.smithy.aws.smoketests.model.BaseAwsVendorParams;
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.aws.traits.auth.SigV4ATrait;
 import software.amazon.smithy.aws.traits.auth.SigV4Trait;
@@ -234,17 +235,12 @@ public class SmokeTestsParser implements Runnable{
                 }
             }
 
-            //get configuration properties
-            if(AwsSmokeTestModel.hasAwsVendorParams(testcase))
-            {
-                ClientConfiguration config = new ClientConfiguration(AwsSmokeTestModel.getAwsVendorParams(testcase).get());
-                test.setConfig(config);
-            }
-            else if (serviceShape.getId().getName().equalsIgnoreCase("s3") && 
-                AwsSmokeTestModel.hasS3VendorParams(testcase))
-            {
-                ClientConfiguration config = new ClientConfiguration(AwsSmokeTestModel.getS3VendorParams(testcase).get());
-                test.setConfig(config);               
+            if(AwsSmokeTestModel.hasS3VendorParams(testcase)) {
+                test.setVendorParamsSupplier(() -> AwsSmokeTestModel.getS3VendorParams(testcase)
+                        .map(params -> (BaseAwsVendorParams) params));
+            } else {
+                test.setVendorParamsSupplier(() -> AwsSmokeTestModel.getAwsVendorParams(testcase)
+                        .map(params -> (BaseAwsVendorParams) params));
             }
             test.setTestcaseName(testcase.getId());
 

--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmokeTestsSourceWriter.java
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmokeTestsSourceWriter.java
@@ -6,7 +6,6 @@
 package com.amazonaws.util.awsclientsmithygenerator.generators;
 
 import software.amazon.smithy.codegen.core.SymbolWriter;
-import software.amazon.smithy.aws.smoketests.model.AwsVendorParams;
 import java.util.List;
 import java.util.Objects;
 
@@ -46,17 +45,14 @@ public final class SmokeTestsSourceWriter extends SymbolWriter<SmokeTestsSourceW
         //declare test fixture
         write("TEST_F($LSmokeTestSuite, $L )",clientNamespace, test.getTestcaseName()).write("{").indent().
         write("Aws::$L::$LClientConfiguration clientConfiguration;", clientNamespace,clientNamespace);
-        if(test.getConfig().getParams() instanceof AwsVendorParams)
-        {
-            AwsVendorParams configParams = (AwsVendorParams) test.getConfig().getParams();
-            if(!configParams.getRegion().isEmpty())
+        test.vendorParamsSupplier.get().ifPresent(awsVendorParams -> {
+            if(!awsVendorParams.getRegion().isEmpty())
             {
-                write("clientConfiguration.region = \"$L\";",configParams.getRegion());
+                write("clientConfiguration.region = \"$L\";",awsVendorParams.getRegion());
             }
-            write("clientConfiguration.useFIPS = $L;",configParams.useFips())
-            .write("clientConfiguration.useDualStack = $L;",configParams.useDualstack());
-        }
-        //for s3, needs to be handled when client code is ready to use the parameters passed in client configuration
+            write("clientConfiguration.useFIPS = $L;",awsVendorParams.useFips())
+                    .write("clientConfiguration.useDualStack = $L;",awsVendorParams.useDualstack());
+        });
 
         if(Objects.equals(test.getAuth(), "sigv4") || Objects.equals(test.getAuth(), "sigv4a"))
         {


### PR DESCRIPTION
*Description of changes:*

in the event that both `AwsSmokeTestModel.hasAwsVendorParams` and `AwsSmokeTestModel.hasS3VendorParams` were both to return empty, a smoke test would fail generation with a null pointer exception. this fixes it to honor the optional-ness of this event. if there are no vendor params for s3 or aws, gracefully continue by just using default client configuration

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
