### PR TITLE
improve error messaging when unsupported vendor shape used

### DIFF
--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmokeTestsParser.java
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/SmokeTestsParser.java
@@ -235,16 +235,16 @@ public class SmokeTestsParser implements Runnable{
             }
 
             //get configuration properties
-            if(AwsSmokeTestModel.hasAwsVendorParams(testcase))
-            {
+            if(AwsSmokeTestModel.hasAwsVendorParams(testcase)) {
                 ClientConfiguration config = new ClientConfiguration(AwsSmokeTestModel.getAwsVendorParams(testcase).get());
                 test.setConfig(config);
-            }
-            else if (serviceShape.getId().getName().equalsIgnoreCase("s3") && 
-                AwsSmokeTestModel.hasS3VendorParams(testcase))
-            {
+            } else if (serviceShape.getId().getName().equalsIgnoreCase("s3") && AwsSmokeTestModel.hasS3VendorParams(testcase)) {
                 ClientConfiguration config = new ClientConfiguration(AwsSmokeTestModel.getS3VendorParams(testcase).get());
                 test.setConfig(config);               
+            } else {
+                throw testcase.getVendorParamsShape()
+                        .map(shapeId -> new RuntimeException(String.format("Unsupported vendor shape %s, must be aws.test#AwsVendorParams or aws.test#S3VendorParams", shapeId.getName())))
+                        .orElseThrow(() -> new RuntimeException("No Vendor parameter shape found, must be aws.test#AwsVendorParams or aws.test#S3VendorParams"));
             }
             test.setTestcaseName(testcase.getId());
 


### PR DESCRIPTION
*Description of changes:*

Right now in smoke test generation if the vendor shape is not `aws.test#AwsVendorParams` or `aws.test#S3VendorParams` we will throw a null pointer exception. in reality those should be the only two vendor shapes supported, and we should be giving a intelligent error message if they are not present. this will now error with something like

```
Projection $YOUR_PROJECT failed: java.lang.RuntimeException: Unsupported vendor shape SomeShape, must be aws.test#AwsVendorParams or aws.test#S3VendorParams
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
