### PR TITLE
handle brackets in ipv6 authority string

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/http/URI.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/URI.h
@@ -71,12 +71,14 @@ namespace Aws
             void SetScheme(Scheme value);
 
             /**
-            * Gets the domain portion of the uri
+            * Gets the authority portion of the URI. Differs from the authority definition in RFC 3986. user information
+            * and the port information are not included. It is functionally the host as defined by  RFC 3986 with encoding included.
             */
             inline const Aws::String& GetAuthority() const { return m_authority; }
 
             /**
-            * Sets the domain portion of the uri
+            * Sets the authority portion of the URI. Differs from the authority definition in RFC 3986. user information
+            * and the port information are not included. It is functionally the host as defined by  RFC 3986 with encoding included.
             */
             inline void SetAuthority(const Aws::String& value) { m_authority = value; }
 
@@ -212,6 +214,17 @@ namespace Aws
              * URLEncodes the path portion of the URI according to RFC3986
              */
             static Aws::String URLEncodePathRFC3986(const Aws::String& path, bool rfcCompliantEncoding = false);
+
+            /**
+             * The host portion of the URI as described in rfc3986.
+             *
+             * The host subcomponent of authority is identified by an IPv6 literal
+             * encapsulated within square brackets, an IPv4 address in dotted-
+             * decimal form, or a registered name.
+             *
+             * @return The host portion of the URI
+             */
+            Aws::String GetHost() const;
 
         private:
             void ParseURIParts(const Aws::String& uri);

--- a/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -259,7 +259,7 @@ HttpResponseOutcome AWSClient::AttemptExhaustively(const Aws::Http::URI& uri,
     const char* signerRegionOverride,
     const char* signerServiceNameOverride) const
 {
-    if (!Aws::Utils::IsValidHost(uri.GetAuthority()))
+    if (!Aws::Utils::IsValidHost(uri.GetHost()))
     {
         return HttpResponseOutcome(AWSError<CoreErrors>(CoreErrors::VALIDATION, "", "Invalid DNS Label found in URI host", false/*retryable*/));
     }
@@ -415,7 +415,7 @@ HttpResponseOutcome AWSClient::AttemptExhaustively(const Aws::Http::URI& uri,
     const char* signerRegionOverride,
     const char* signerServiceNameOverride) const
 {
-    if (!Aws::Utils::IsValidHost(uri.GetAuthority()))
+    if (!Aws::Utils::IsValidHost(uri.GetHost()))
     {
         return HttpResponseOutcome(AWSError<CoreErrors>(CoreErrors::VALIDATION, "", "Invalid DNS Label found in URI host", false/*retryable*/));
     }

--- a/src/aws-cpp-sdk-core/source/http/URI.cpp
+++ b/src/aws-cpp-sdk-core/source/http/URI.cpp
@@ -600,3 +600,15 @@ bool URI::CompareURIParts(const URI& other) const
 {
     return m_scheme == other.m_scheme && m_authority == other.m_authority && GetPath() == other.GetPath() && m_queryString == other.m_queryString;
 }
+
+Aws::String URI::GetHost() const {
+  Aws::String host{m_authority};
+  const auto begin = host.find('[');
+  const auto end = host.rfind(']');
+  if (begin != Aws::String::npos && end != Aws::String::npos && begin + 1 < end) {
+    host = host.substr(begin + 1, end - begin - 1);
+  } else if (begin != Aws::String::npos && end != Aws::String::npos && begin + 1 == end) {
+    host = "";
+  }
+  return host;
+}

--- a/tests/aws-cpp-sdk-core-tests/http/URITest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/http/URITest.cpp
@@ -383,3 +383,35 @@ TEST_F(URITest, TestGetRFC3986URLEncodedPathCompliant)
 
     Aws::Http::SetCompliantRfc3986Encoding(false);
 }
+
+TEST_F(URITest, TestHostParsesCorrectly) {
+    URI uri = "https://test.com";
+    EXPECT_STREQ("test.com", uri.GetHost().c_str());
+
+    uri = "https://test.com:9000";
+    EXPECT_STREQ("test.com", uri.GetHost().c_str());
+
+    uri = "https://[::]";
+    EXPECT_STREQ("::", uri.GetHost().c_str());
+
+    uri = "https://[::]:9000";
+    EXPECT_STREQ("::", uri.GetHost().c_str());
+
+    uri = "https://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]";
+    EXPECT_STREQ("2001:0db8:85a3:0000:0000:8a2e:0370:7334", uri.GetHost().c_str());
+
+    uri = "https://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:9000";
+    EXPECT_STREQ("2001:0db8:85a3:0000:0000:8a2e:0370:7334", uri.GetHost().c_str());
+
+    uri = "https://[]";
+    EXPECT_STREQ("", uri.GetHost().c_str());
+
+    uri = "https://[]:9000";
+    EXPECT_STREQ("", uri.GetHost().c_str());
+
+    uri = "https://127.0.0.1";
+    EXPECT_STREQ("127.0.0.1", uri.GetHost().c_str());
+
+    uri = "https://127.0.0.1:9000";
+    EXPECT_STREQ("127.0.0.1", uri.GetHost().c_str());
+}


### PR DESCRIPTION
*Description of changes:*

Right now a ipv6 override with brackets does not function correctly, i.e.

```cpp
#include <aws/core/Aws.h>
#include <aws/s3/S3Client.h>

using namespace Aws;
using namespace Aws::S3;
using namespace Aws::Utils;

namespace {
const char* LOG_TAG = "test-app";
}

auto main() -> int {
  SDKOptions options{};
  options.loggingOptions.logLevel = Logging::LogLevel::Debug;
  InitAPI(options);
  {
    S3ClientConfiguration client_configuration{};
    client_configuration.endpointOverride = "http://[::]:9000/";
    S3Client client{client_configuration};
    const auto list_buckets_response = client.ListBuckets();
    if (list_buckets_response.IsSuccess()) {
      std::cout << "Found buckets:\n";
      for (const auto& bucket : list_buckets_response.GetResult().GetBuckets()) {
        std::cout << bucket.GetName() << "\n";
      }
    } else {
      std::cout << "Call failed\n";
      std::cout << list_buckets_response.GetError().GetExceptionName() << "\n";
      std::cout << list_buckets_response.GetError().GetMessage() << "\n";
    }
  }
  ShutdownAPI(options);
  return 0;
}
```

This is because we pass the result of `GetAuthority` from our [URI class](https://github.com/aws/aws-sdk-cpp/blob/main/src/aws-cpp-sdk-core/include/aws/core/http/URI.h#L73-L76) to check if the host is valid. This authority included the brackets.

In this change we now strip out the brackets that we pass to CRT when we check for host validity.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
