### PR TITLE
disable dsp fixer to fix search box

### DIFF
--- a/docs/doxygen/doxygen_wrapper.py
+++ b/docs/doxygen/doxygen_wrapper.py
@@ -235,9 +235,10 @@ class DoxygenWrapper(object):
             future.result()
 
         self._cleanup_temp_files()
-        print("Update CSP")
-        cspfixer = CSPFixer()
-        cspfixer.update_files(Path(self.output_dir))
+        # TODO: fix CSP fixer for search box
+        # print("Update CSP")
+        # cspfixer = CSPFixer()
+        # cspfixer.update_files(Path(self.output_dir))
 
         return dependency_map
 


### PR DESCRIPTION
*Description of changes:*

removes csp fixer to fix search bar on doxygen website.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
