### PR TITLE
add option and doc for AWS_APPSTORE_SAFE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ if (LEGACY_BUILD)
     option(ENABLE_SMOKE_TESTS "Enable smoke tests" OFF)
     option(ENABLE_PROTOCOL_TESTS "Enable protocol tests" OFF)
     option(DISABLE_DNS_REQUIRED_TESTS "Disable unit tests that require DNS lookup to succeed, useful when using a http client that does not perform DNS lookup" OFF)
+    option(AWS_APPSTORE_SAFE "Remove reference to private Apple APIs for AES GCM in Common Crypto. If set to OFF you application will get rejected from the apple app store." OFF)
 
 
     set(AWS_USER_AGENT_CUSTOMIZATION "" CACHE STRING "User agent extension")
@@ -93,6 +94,10 @@ if (LEGACY_BUILD)
 
     if (DISABLE_DNS_REQUIRED_TESTS)
         add_definitions(-DDISABLE_DNS_REQUIRED_TESTS)
+    endif ()
+
+    if (AWS_APPSTORE_SAFE)
+        add_definitions(-DAWS_APPSTORE_SAFE)
     endif ()
 
     #From https://stackoverflow.com/questions/18968979/how-to-get-colorized-output-with-cmake

--- a/docs/CMake_Parameters.md
+++ b/docs/CMake_Parameters.md
@@ -177,3 +177,7 @@ An override path for where the build system should find the Android NDK.  By def
 
 ### AWS_USE_CRYPTO_SHARED_LIBS
 Forces FindCrypto to use a shared crypto library if found. regardless of the value of BUILD_SHARED_LIBS
+
+
+### AWS_APPSTORE_SAFE
+One of our dependencies [aws-c-cal](https://github.com/awslabs/aws-c-cal) links against several [CommonCrypto](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/Common%20Crypto.3cc.html) APIs that will cause a binary application using these APIs to be rejected from the apple appstore. This will set the corresponding [definition ia aws-c-cal](https://github.com/awslabs/aws-c-cal/blob/027d9760908c649d1f53e397d74d907babbde059/source/darwin/commoncrypto_aes.c#L12-L16) that will no-op AES-GCM functionality. This option is turned `OFF` by default as to no t break AWS-GCM functionality by default.   


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/3405

*Description of changes:*

Right now aws-c-cal will build and link with platform specific crypto libraries to avoid binary bloat. On mac this becomes troublesome as the use of private AES-GCM APIs cause binaries using them to be rejected from the appstore. This PR creates a option to set the define `AWS_APPSTORE_SAFE` that is currently honored in aws-c-cal but adds documentation and default behavior around it.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
