### PR TITLE
disable strong exception on bearer and sigv4

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/CppClientGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/CppClientGenerator.java
@@ -244,9 +244,11 @@ public abstract class CppClientGenerator implements ClientGenerator {
         if (c2jAuthList != null) {
             boolean hasSigV4AndBearer = c2jAuthList.contains("smithy.api#httpBearerAuth") &&
                     (c2jAuthList.contains("aws.auth#sigv4a") || c2jAuthList.contains("aws.auth#sigv4"));
+            /*TODO: re-enable after smithy identity migration is complete
             if (!serviceModel.isUseSmithyClient() && hasSigV4AndBearer) {
                 throw new RuntimeException("SDK Clients cannot mix AWS and Bearer Credentials without enabling Smithy Identity!");
             }
+            */
         }
     }
 


### PR DESCRIPTION
*Description of changes:*

Right now if a service model specifies sigv4 and bearer auth as a auth type, we will hard fail the codegen expierence. This removes that hard fail, and will default to using only sigv4.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
