### PR TITLE
[STS Credentials Provider]: update grace period from 5 sec to 5 min

### DIFF
--- a/src/aws-cpp-sdk-core/source/auth/STSCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/STSCredentialsProvider.cpp
@@ -30,7 +30,7 @@ using Aws::Utils::Threading::ReaderLockGuard;
 using Aws::Utils::Threading::WriterLockGuard;
 
 static const char STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG[] = "STSAssumeRoleWithWebIdentityCredentialsProvider";
-static const int STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD = 5 * 1000;
+static const int STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD = 5 * 60 * 1000; // 5 Minutes.
 
 STSAssumeRoleWebIdentityCredentialsProvider::STSAssumeRoleWebIdentityCredentialsProvider() :
     m_initialized(false)


### PR DESCRIPTION
### *Description of changes:*

A grace period of 5 seconds is too low:
- Recommended [guidance](https://repost.aws/questions/QUgE4lrlyBSimJZTpIO9o7Hw/the-provided-token-has-expired-aws-rds-with-s3) is 5 minutes.
- This is consistent with https://github.com/awslabs/aws-c-auth/pull/247
- It causes problems with premature expiration - see https://github.com/awslabs/aws-c-s3/issues/471#issuecomment-2825322230
   An `aws-c-s3` request can spend to about a minute in queued state.
- Other SDKs, e.g. `botocore`, also use refresh timeouts in the order of minutes.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.