### PR TITLE
add OVERFLOW to forbidden codegen words

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/PlatformAndKeywordSanitizer.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/PlatformAndKeywordSanitizer.java
@@ -148,6 +148,7 @@ public class PlatformAndKeywordSanitizer {
         words.add("STATIC");
         words.add("T_CHAR");
         words.add("DOMAIN");
+        words.add("OVERFLOW");
         words.add("*");
         //ok you get the idea... add them as you encounter them.
         FORBIDDEN_WORDS = Collections.unmodifiableSet(words);


### PR DESCRIPTION
*Description of changes:*

Adds the word `OVERFLOW` to the forbidden list of words in codegen. it was `#define`-d in `math.h` [in glibc until 2017](https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=813378e9fe17e029caf627cab76fe23eb46815fa), and is still present in msvc and older toolchains.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
