### PR TITLE
avoid calculating cpp shape info more than once

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
@@ -333,6 +333,9 @@ public class CppViewHelper {
     public static Set<String> computeHeaderIncludes(String projectName, Shape shape) {
         Set<String> headers = new LinkedHashSet<>();
         Set<String> visited = new LinkedHashSet<>();
+        if (shape.getMembers() == null) {
+            return headers;
+        }
         Queue<Shape> toVisit = shape.getMembers().values().stream().map(ShapeMember::getShape).collect(Collectors.toCollection(() -> new LinkedList<>()));
         boolean includeUtilityHeader = false;
         boolean includeMemoryHeader = false;
@@ -399,6 +402,11 @@ public class CppViewHelper {
     public static Set<String> computeForwardDeclarations(Shape shape) {
         Set<String> forwardDeclarations = new LinkedHashSet<>();
         Set<String> visited = new LinkedHashSet<>();
+
+        if (shape.getMembers() == null) {
+            return forwardDeclarations;
+        }
+
         Queue<Shape> toVisit = shape.getMembers().values().stream().map(ShapeMember::getShape).collect(Collectors.toCollection(() -> new LinkedList<>()));
 
         while(!toVisit.isEmpty()) {
@@ -459,6 +467,9 @@ public class CppViewHelper {
     public static Set<String> computeSourceIncludes(String projectName, Shape shape) {
         Set<String> headers = new LinkedHashSet<>();
         Set<String> visited = new LinkedHashSet<>();
+        if (shape.getMembers() == null) {
+            return headers;
+        }
         Queue<Shape> toVisit = shape.getMembers().values().stream().map(ShapeMember::getShape).collect(Collectors.toCollection(() -> new LinkedList<>()));
 
         while(!toVisit.isEmpty()) {

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/QueryCppClientGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/QueryCppClientGenerator.java
@@ -15,7 +15,6 @@ import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -88,14 +87,14 @@ public class QueryCppClientGenerator extends CppClientGenerator {
     }
 
     @Override
-    protected SdkFileEntry generateModelHeaderFile(ServiceModel serviceModel, Map.Entry<String, Shape> shapeEntry) throws Exception {
+    protected SdkFileEntry generateModelHeaderFile(ServiceModel serviceModel, Map.Entry<String, Shape> shapeEntry, Map<String, CppShapeInformation> shapeInformationCache) {
         Shape shape = shapeEntry.getValue();
         if (shape.isException() && !shape.isXmlModeledException())
             return null;
 
         //we only want to handle results and internal structures. We don't want requests or enums.
         if (shape.isRequest() || shape.isEnum() || shape.hasEventPayloadMembers() && shape.hasBlobMembers()) {
-            return super.generateModelHeaderFile(serviceModel, shapeEntry);
+            return super.generateModelHeaderFile(serviceModel, shapeEntry, shapeInformationCache);
         }
 
         if (shape.isStructure() && shape.isReferenced()) {
@@ -121,13 +120,13 @@ public class QueryCppClientGenerator extends CppClientGenerator {
     }
 
     @Override
-    protected SdkFileEntry generateModelSourceFile(ServiceModel serviceModel, Map.Entry<String, Shape> shapeEntry) {
+    protected SdkFileEntry generateModelSourceFile(ServiceModel serviceModel, Map.Entry<String, Shape> shapeEntry, final Map<String, CppShapeInformation> shapeInformationCache) {
         Shape shape = shapeEntry.getValue();
         if (shape.isException() && !shape.isXmlModeledException())
             return null;
 
         if (shape.isEnum()) {
-            return super.generateModelSourceFile(serviceModel, shapeEntry);
+            return super.generateModelSourceFile(serviceModel, shapeEntry, shapeInformationCache);
         }
 
         Template template = null;

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/RestXmlCppClientGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/RestXmlCppClientGenerator.java
@@ -15,10 +15,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 
-import static com.amazonaws.util.awsclientgenerator.generators.cpp.CppClientGenerator.ResolverMapping;
-
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -99,7 +96,7 @@ public class RestXmlCppClientGenerator  extends CppClientGenerator {
     }
 
     @Override
-    protected SdkFileEntry generateModelHeaderFile(ServiceModel serviceModel, Map.Entry<String, Shape> shapeEntry) throws Exception {
+    protected SdkFileEntry generateModelHeaderFile(ServiceModel serviceModel, Map.Entry<String, Shape> shapeEntry, Map<String, CppShapeInformation> shapeInformationCache) {
 
         Shape shape = shapeEntry.getValue();
         if (shape.isException() && !shape.isXmlModeledException())
@@ -107,7 +104,7 @@ public class RestXmlCppClientGenerator  extends CppClientGenerator {
 
         //we only want to override json related stuff.
         if (shape.isRequest() || shape.isEnum() || shape.hasEventPayloadMembers() && shape.hasBlobMembers()) {
-            return super.generateModelHeaderFile(serviceModel, shapeEntry);
+            return super.generateModelHeaderFile(serviceModel, shapeEntry, shapeInformationCache);
         }
 
         // Will not generate source code if it's a shape of event, with empty member.
@@ -141,13 +138,13 @@ public class RestXmlCppClientGenerator  extends CppClientGenerator {
     }
 
     @Override
-    protected SdkFileEntry generateModelSourceFile(ServiceModel serviceModel, Map.Entry<String, Shape> shapeEntry) {
+    protected SdkFileEntry generateModelSourceFile(ServiceModel serviceModel, Map.Entry<String, Shape> shapeEntry, final Map<String, CppShapeInformation> shapeInformationCache) {
         Shape shape = shapeEntry.getValue();
         if (shape.isException() && !shape.isXmlModeledException())
             return null;
 
         if (shape.isEnum()) {
-            return super.generateModelSourceFile(serviceModel, shapeEntry);
+            return super.generateModelSourceFile(serviceModel, shapeEntry, shapeInformationCache);
         }
 
         if (shape.isStructure() && shape.isReferenced() &&

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/dynamodb/DynamoDBJsonCppClientGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/dynamodb/DynamoDBJsonCppClientGenerator.java
@@ -8,15 +8,12 @@ package com.amazonaws.util.awsclientgenerator.generators.cpp.dynamodb;
 import com.amazonaws.util.awsclientgenerator.domainmodels.SdkFileEntry;
 import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.ServiceModel;
 import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.Shape;
-import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.cpp.CppViewHelper;
+import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.cpp.CppShapeInformation;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.JsonCppClientGenerator;
 import org.apache.velocity.Template;
-import org.apache.velocity.VelocityContext;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -70,7 +67,7 @@ public class DynamoDBJsonCppClientGenerator extends JsonCppClientGenerator {
     }
 
     @Override
-    protected SdkFileEntry generateModelHeaderFile(ServiceModel serviceModel, Map.Entry<String, Shape> shapeEntry) throws Exception {
+    protected SdkFileEntry generateModelHeaderFile(ServiceModel serviceModel, Map.Entry<String, Shape> shapeEntry, Map<String, CppShapeInformation> shapeInformationCache) {
         switch(shapeEntry.getKey()) {
             case "AttributeValue": {
                 Template template = velocityEngine.getTemplate("/com/amazonaws/util/awsclientgenerator/velocity/cpp/dynamodb/AttributeValueHeader.vm", StandardCharsets.UTF_8.name());
@@ -81,12 +78,12 @@ public class DynamoDBJsonCppClientGenerator extends JsonCppClientGenerator {
                 return makeFile(template, createContext(serviceModel), "include/aws/dynamodb/model/AttributeValueValue.h", true);
             }
             default:
-                return super.generateModelHeaderFile(serviceModel, shapeEntry);
+                return super.generateModelHeaderFile(serviceModel, shapeEntry, shapeInformationCache);
         }
     }
 
     @Override
-    protected SdkFileEntry generateModelSourceFile(ServiceModel serviceModel, Map.Entry<String, Shape> shapeEntry) {
+    protected SdkFileEntry generateModelSourceFile(ServiceModel serviceModel, Map.Entry<String, Shape> shapeEntry, final Map<String, CppShapeInformation> shapeInformationCache) {
         switch(shapeEntry.getKey()) {
             case "AttributeValue": {
                 Template template = velocityEngine.getTemplate("/com/amazonaws/util/awsclientgenerator/velocity/cpp/dynamodb/AttributeValueSource.vm");
@@ -97,7 +94,7 @@ public class DynamoDBJsonCppClientGenerator extends JsonCppClientGenerator {
                 return makeFile(template, createContext(serviceModel), "source/model/AttributeValueValue.cpp", true);
             }
             default:
-                return super.generateModelSourceFile(serviceModel, shapeEntry);
+                return super.generateModelSourceFile(serviceModel, shapeEntry, shapeInformationCache);
         }
     }
 

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/s3/S3RestXmlCppClientGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/s3/S3RestXmlCppClientGenerator.java
@@ -569,7 +569,7 @@ public class S3RestXmlCppClientGenerator extends RestXmlCppClientGenerator {
     }
 
     @Override
-    protected SdkFileEntry generateModelSourceFile(ServiceModel serviceModel, Map.Entry<String, Shape> shapeEntry) {
+    protected SdkFileEntry generateModelSourceFile(ServiceModel serviceModel, Map.Entry<String, Shape> shapeEntry, final Map<String, CppShapeInformation> shapeInformationCache) {
         Template template = null;
         String fileName = "";
 
@@ -585,7 +585,7 @@ public class S3RestXmlCppClientGenerator extends RestXmlCppClientGenerator {
                 break;
             }
             default:
-                return super.generateModelSourceFile(serviceModel, shapeEntry);
+                return super.generateModelSourceFile(serviceModel, shapeEntry, shapeInformationCache);
         }
 
         Shape shape = shapeEntry.getValue();


### PR DESCRIPTION
*Description of changes:*

Avoids calling `new CppShapeInformation(shape, serviceModel)` more than once during codegen, keeping a active cache of all cpp information shapes instead of re-creating and deleting them.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
