### PR TITLE
fix exeception type from RDS

### DIFF
--- a/tests/aws-cpp-sdk-rds-integration-tests/RDSTest.cpp
+++ b/tests/aws-cpp-sdk-rds-integration-tests/RDSTest.cpp
@@ -226,7 +226,7 @@ namespace
 
         auto copyDBClusterSnapshotOutcome = m_rdsClient.CopyDBClusterSnapshot(copyDBClusterSnapshotRequest);
         ASSERT_FALSE(copyDBClusterSnapshotOutcome.IsSuccess());
-        ASSERT_EQ(RDSErrors::INVALID_PARAMETER_COMBINATION, copyDBClusterSnapshotOutcome.GetError().GetErrorType());
+        ASSERT_EQ(RDSErrors::D_B_CLUSTER_SNAPSHOT_NOT_FOUND_FAULT, copyDBClusterSnapshotOutcome.GetError().GetErrorType());
         Aws::String preSignedUrl = ExtractPreSignedUrlFromPayload(TestingMonitoringMetrics::s_lastPayload.c_str());
         QueryStringParameterCollection parameters(URI(preSignedUrl).GetQueryStringParameters());
         ASSERT_NE(parameters.end(), parameters.find("Action"));
@@ -251,7 +251,7 @@ namespace
         copyDBClusterSnapshotRequest.SetPreSignedUrl(TESTING_PRESIGNED_URL);
         copyDBClusterSnapshotOutcome = m_rdsClient.CopyDBClusterSnapshot(copyDBClusterSnapshotRequest);
         ASSERT_FALSE(copyDBClusterSnapshotOutcome.IsSuccess());
-        ASSERT_EQ(RDSErrors::INVALID_PARAMETER_COMBINATION, copyDBClusterSnapshotOutcome.GetError().GetErrorType());
+        ASSERT_EQ(RDSErrors::D_B_CLUSTER_SNAPSHOT_NOT_FOUND_FAULT, copyDBClusterSnapshotOutcome.GetError().GetErrorType());
         preSignedUrl = ExtractPreSignedUrlFromPayload(TestingMonitoringMetrics::s_lastPayload.c_str());
         ASSERT_STREQ(TESTING_PRESIGNED_URL, preSignedUrl.c_str());
     }


### PR DESCRIPTION
*Description of changes:*

RDS changed their runtime exception type from `INVALID_PARAMETER_COMBINATION` to `D_B_CLUSTER_SNAPSHOT_NOT_FOUND_FAULT` and its causing CI tests to fail.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
