### PR TITLE
fix warning treated as error

### DIFF
--- a/src/aws-cpp-sdk-core/source/config/AWSConfigFileProfileConfigLoader.cpp
+++ b/src/aws-cpp-sdk-core/source/config/AWSConfigFileProfileConfigLoader.cpp
@@ -12,8 +12,8 @@
 #include <fstream>
 
 namespace {
-Aws::Array<const char*, 4> COMMENT_START_SEQ{" #", " ;", "\t#", "\t;"};
-Aws::Array<const char, 2> COMMENT_CHARS{'#', ';'};
+Aws::Array<const char*, 4> COMMENT_START_SEQ{{" #", " ;", "\t#", "\t;"}};
+Aws::Array<const char, 2> COMMENT_CHARS{{'#', ';'}};
 }
 
 namespace Aws


### PR DESCRIPTION
*Issue #, if available:*
Prior change introduced warnings thats treated as errors
```
aws-sdk-cpp/src/aws-cpp-sdk-core/source/config/AWSConfigFileProfileConfigLoader.cpp:15:70: error: missing braces around initializer for 'std::__array_traits<const char*, 4>::_Type {aka const char* [4]}' [-Werror=missing-braces]
Aws::Array<const char*, 4> COMMENT_START_SEQ{" #", " ;", "\t#", "\t;"};
```

*Description of changes:*
When initializing an array of pointers (char*). The outer braces {} initialize the Aws::Array, and the inner braces {{...}} initialize the array of pointers.

*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
