### PR TITLE
correctly set payload for renamed shape in codegen

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
@@ -809,7 +809,7 @@ public class C2jModelToGeneratorModelTransformer {
                             member.getShape().getName(),
                             reservedMapping.getValue().remappingName,
                             member.getShape().getName(),
-                            false);
+                            reservedMapping.getKey().equals(shape.getPayload()));
                 });
         }
     }


### PR DESCRIPTION
*Description of changes:*

There was a issue in codegen where if we renamed a member variable to avoid colliding with one of our named types, the payload on the request would be incorrectly calculated.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
