### PR TITLE
fix additional params evaluation to include string array params

### DIFF
--- a/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClient.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClient.h
@@ -169,12 +169,15 @@ namespace client
                 const auto& epParams = ctx.m_pRequest->GetEndpointContextParams();
                 for (const auto& epParam : epParams) {
                     using ParameterType = Aws::Endpoint::EndpointParameter::ParameterType;
-                    if(epParam.GetStoredType() == ParameterType::STRING)
-                        identityParams.additionalProperties.insert({epParam.GetName(), epParam.GetStrValueNoCheck()});
-                    else if (epParam.GetStoredType() == ParameterType::BOOLEAN)
-                        identityParams.additionalProperties.insert({epParam.GetName(), epParam.GetBoolValueNoCheck()});
-                    else
-                        assert(!"Unknown endpoint parameter!");
+                    if(epParam.GetStoredType() == ParameterType::STRING) {
+                      identityParams.additionalProperties.insert({epParam.GetName(), epParam.GetStrValueNoCheck()});
+                    } else if (epParam.GetStoredType() == ParameterType::BOOLEAN) {
+                      identityParams.additionalProperties.insert({epParam.GetName(), epParam.GetBoolValueNoCheck()});
+                    } else if (epParam.GetStoredType() == ParameterType::STRING_ARRAY) {
+                      identityParams.additionalProperties.insert({epParam.GetName(), epParam.GetStrArrayValueNoCheck()});
+                    } else {
+                      assert(!"Unknown endpoint parameter!");
+                    }
                 }
                 const auto& serviceParams = ctx.m_pRequest->GetServiceSpecificParameters();
                 if (serviceParams) {

--- a/src/aws-cpp-sdk-core/include/smithy/identity/auth/AuthSchemeResolverBase.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/auth/AuthSchemeResolverBase.h
@@ -26,7 +26,8 @@ public:
   Aws::UnorderedMap<Aws::String, Aws::Crt::Variant<Aws::String,
           bool,
           Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy,
-          Aws::Auth::AWSSigningAlgorithm > > additionalProperties;
+          Aws::Auth::AWSSigningAlgorithm,
+          Aws::Vector<Aws::String>>> additionalProperties;
 
 };
 


### PR DESCRIPTION
*Description of changes:*

There was a bug in endpoint param evaluation that broke for string array params on batch get item. adding a test for it as well.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
