### PR TITLE
fix, and enable lambda integration tests

### DIFF
--- a/tests/aws-cpp-sdk-lambda-integration-tests/FunctionTest.cpp
+++ b/tests/aws-cpp-sdk-lambda-integration-tests/FunctionTest.cpp
@@ -31,7 +31,6 @@
 #include <aws/lambda/model/GetEventSourceMappingRequest.h>
 #include <aws/lambda/model/UpdateEventSourceMappingRequest.h>
 #include <aws/lambda/model/DeleteEventSourceMappingRequest.h>
-#include <aws/lambda/model/ResourceNotFoundException.h>
 
 #include <aws/kinesis/KinesisClient.h>
 #include <aws/kinesis/model/CreateStreamRequest.h>
@@ -247,14 +246,14 @@ protected:
 
         functionCode.SetZipFile(Aws::Utils::ByteBuffer((unsigned char*)buffer.str().c_str(), buffer.str().length()));
         createFunctionRequest.SetCode(functionCode);
-        createFunctionRequest.SetRuntime(Aws::Lambda::Model::Runtime::nodejs12_x);
+        createFunctionRequest.SetRuntime(Aws::Lambda::Model::Runtime::nodejs22_x);
 
         CreateFunctionOutcome createFunctionOutcome = m_client->CreateFunction(createFunctionRequest);
         AWS_ASSERT_SUCCESS(createFunctionOutcome);
         ASSERT_EQ(functionName,createFunctionOutcome.GetResult().GetFunctionName());
         ASSERT_EQ("test.handler",createFunctionOutcome.GetResult().GetHandler());
         ASSERT_EQ(roleARN,createFunctionOutcome.GetResult().GetRole());
-        ASSERT_EQ(Aws::Lambda::Model::Runtime::nodejs12_x, createFunctionOutcome.GetResult().GetRuntime());
+        ASSERT_EQ(Aws::Lambda::Model::Runtime::nodejs22_x, createFunctionOutcome.GetResult().GetRuntime());
         functionArnMapping[functionName] = createFunctionOutcome.GetResult().GetFunctionArn();
 
         WaitForFunctionStatus(functionName, Aws::Lambda::Model::State::Active);
@@ -316,7 +315,7 @@ TEST_F(FunctionTest, TestGetFunction)
     AWS_EXPECT_SUCCESS(getFunctionOutcome);
 
     GetFunctionResult getFunctionResult = getFunctionOutcome.GetResult();
-    EXPECT_EQ(Runtime::nodejs12_x, getFunctionResult.GetConfiguration().GetRuntime());
+    EXPECT_EQ(Runtime::nodejs22_x, getFunctionResult.GetConfiguration().GetRuntime());
     EXPECT_EQ("test.handler",getFunctionResult.GetConfiguration().GetHandler());
     EXPECT_EQ(simpleFunctionName,getFunctionResult.GetConfiguration().GetFunctionName());
     //Just see that is looks like an aws url
@@ -334,7 +333,7 @@ TEST_F(FunctionTest, TestGetFunctionConfiguration)
     AWS_EXPECT_SUCCESS(getFunctionConfigurationOutcome);
 
     GetFunctionConfigurationResult getFunctionConfigurationResult = getFunctionConfigurationOutcome.GetResult();
-    EXPECT_EQ(Runtime::nodejs12_x, getFunctionConfigurationResult.GetRuntime());
+    EXPECT_EQ(Runtime::nodejs22_x, getFunctionConfigurationResult.GetRuntime());
     EXPECT_EQ("test.handler",getFunctionConfigurationResult.GetHandler());
     EXPECT_EQ(simpleFunctionName,getFunctionConfigurationResult.GetFunctionName());
 }
@@ -490,7 +489,6 @@ TEST_F(FunctionTest, TestPermissions)
     if (!getRemovedPolicyOutcome.IsSuccess())
     {
        EXPECT_EQ(LambdaErrors::RESOURCE_NOT_FOUND, getRemovedPolicyOutcome.GetError().GetErrorType());
-       EXPECT_STREQ("User", getRemovedPolicyOutcome.GetError<ResourceNotFoundException>().GetType().c_str());
     }
     //Now we should get an empty policy a GetPolicy because we just removed it
     else

--- a/tools/scripts/build-tests/run-al2-integ-tests.sh
+++ b/tools/scripts/build-tests/run-al2-integ-tests.sh
@@ -21,7 +21,7 @@ AWS_ROLE_SESSION_NAME="$3"
 
 echo "Setting the run environment"
 export TEST_ASSUME_ROLE_ARN=arn:aws:iam::${AWS_ACCOUNT}:role/IntegrationTest
-export TEST_LAMBDA_CODE_PATH=${PREFIX_DIR}/aws-sdk-cpp/tools/aws-cpp-sdk-lambda-integration-tests/resources
+export TEST_LAMBDA_CODE_PATH=${PREFIX_DIR}/aws-sdk-cpp/tests/aws-cpp-sdk-lambda-integration-tests/resources
 export sts=$(aws sts assume-role --role-arn "$TEST_ASSUME_ROLE_ARN" --role-session-name "${AWS_ROLE_SESSION_NAME}" --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]')
 export profile=sdk-integ-test
 aws configure set aws_access_key_id $(echo "$sts" | jq -r '.[0]') --profile "$profile"

--- a/tools/scripts/run_integration_tests.py
+++ b/tools/scripts/run_integration_tests.py
@@ -45,7 +45,7 @@ def main():
         "aws-cpp-sdk-s3-unit-tests",
         "aws-cpp-sdk-s3-crt-integration-tests",
         #"aws-cpp-sdk-s3control-integration-tests",
-        # "aws-cpp-sdk-lambda-integration-tests",
+        "aws-cpp-sdk-lambda-integration-tests",
         "aws-cpp-sdk-cognitoidentity-integration-tests",
         #"aws-cpp-sdk-transfer-tests",
         #"aws-cpp-sdk-s3-encryption-integration-tests",


### PR DESCRIPTION
*Description of changes:*

Removes a hard check on exception in the event a service changes exception types. Enables lambda testing again. [that was accidentally disabled](https://github.com/aws/aws-sdk-cpp/commit/efbe7b2fae93fca939fa6166f580a8bbd5ec522d).

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
