### PR TITLE
Fix query compatible for JSON services

### DIFF
--- a/tests/aws-cpp-sdk-monitoring-integration-tests/CloudWatchMonitoringTests.cpp
+++ b/tests/aws-cpp-sdk-monitoring-integration-tests/CloudWatchMonitoringTests.cpp
@@ -10,6 +10,7 @@
 #include <aws/core/utils/memory/AWSMemory.h>
 #include <aws/monitoring/CloudWatchClient.h>
 #include <aws/monitoring/model/PutMetricDataRequest.h>
+#include <aws/monitoring/model/GetDashboardRequest.h>
 #include <aws/testing/AwsTestHelpers.h>
 #include <aws/testing/TestingEnvironment.h>
 #include <gtest/gtest.h>
@@ -90,5 +91,13 @@ TEST_F(CloudWatchMonitoringOperationTest, PutLargeMetricDataTest) {
   Aws::CloudWatch::Model::PutMetricDataOutcome outcome =
       m_client->PutMetricData(request);
   AWS_ASSERT_SUCCESS(outcome);
+}
+
+TEST_F(CloudWatchMonitoringOperationTest, DashboardNotFoundShouldParseCorrectly) {
+  const auto response = m_client->GetDashboard(GetDashboardRequest().WithDashboardName("foo"));
+  EXPECT_FALSE(response.IsSuccess());
+  EXPECT_EQ(CloudWatchErrors::DASHBOARD_NOT_FOUND, response.GetError().GetErrorType());
+  EXPECT_EQ("ResourceNotFound", response.GetError().GetExceptionName());
+  EXPECT_EQ("Dashboard foo does not exist", response.GetError().GetMessage());
 }
 } // namespace

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/config/ServiceGeneratorConfig.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/config/ServiceGeneratorConfig.java
@@ -20,6 +20,7 @@ import com.amazonaws.util.awsclientgenerator.generators.cpp.eventbridge.EventBri
 import com.amazonaws.util.awsclientgenerator.generators.cpp.glacier.GlacierRestJsonCppClientGenerator;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.lambda.LambdaRestJsonCppClientGenerator;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.machinelearning.MachineLearningJsonCppClientGenerator;
+import com.amazonaws.util.awsclientgenerator.generators.cpp.monitoring.CloudwatchMonitoringJsonCppClientGenerator;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.neptune.NeptuneCppClientGenerator;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.polly.PollyCppClientGenerator;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.rds.RDSCppClientGenerator;
@@ -68,6 +69,7 @@ public class ServiceGeneratorConfig {
             SPEC_OVERRIDE_MAPPING.put("cpp-neptune-query", new NeptuneCppClientGenerator());
             SPEC_OVERRIDE_MAPPING.put("cpp-eventbridge-json", new EventBridgeCppClientGenerator());
             SPEC_OVERRIDE_MAPPING.put("cpp-dsql-rest-json", new DsqlCppClientGenerator());
+            SPEC_OVERRIDE_MAPPING.put("cpp-monitoring-json", new CloudwatchMonitoringJsonCppClientGenerator());
 
             // protocol tests clients
             SPEC_OVERRIDE_MAPPING.put("cpp-ec2-protocol-ec2", new Ec2CppClientGenerator());

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/ServiceModel.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/ServiceModel.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -32,6 +33,7 @@ public class ServiceModel {
     boolean enableVirtualOperations;
     Collection<Error> serviceErrors;
     Collection<CustomPresignedUtility> presigners;
+    Map<String, String> queryCompatibleErrorMappings;
 
     public boolean hasStreamingRequestShapes() {
         return shapes.values().parallelStream().anyMatch(shape -> shape.isRequest() && (shape.hasStreamMembers() || shape.hasEventStreamMembers()));

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/monitoring/CloudwatchMonitoringJsonCppClientGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/monitoring/CloudwatchMonitoringJsonCppClientGenerator.java
@@ -1,0 +1,21 @@
+package com.amazonaws.util.awsclientgenerator.generators.cpp.monitoring;
+
+import com.amazonaws.util.awsclientgenerator.domainmodels.SdkFileEntry;
+import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.ServiceModel;
+import com.amazonaws.util.awsclientgenerator.generators.cpp.JsonCppClientGenerator;
+import com.google.common.collect.ImmutableMap;
+
+public class CloudwatchMonitoringJsonCppClientGenerator extends JsonCppClientGenerator {
+    public CloudwatchMonitoringJsonCppClientGenerator() throws Exception {
+        super();
+    }
+
+    @Override
+    protected SdkFileEntry generateErrorSourceFile(ServiceModel serviceModel) throws Exception {
+        serviceModel.setQueryCompatibleErrorMappings(ImmutableMap.of(
+                "DASHBOARD_NOT_FOUND", "DashboardNotFoundError"
+        ));
+
+        return super.generateErrorSourceFile(serviceModel);
+    }
+}

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceErrorsSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceErrorsSource.vm
@@ -5,6 +5,7 @@
 #set($serviceNamespace = $metadata.namespace)
 #set($payloadType = ${CppViewHelper.computeServicePayloadType($metadata.findFirstSupportedProtocol())})
 #set($nonCoreServiceErrors = $serviceModel.getNonCoreServiceErrors())
+#set($queryCompatibleMappings = $serviceModel.getQueryCompatibleErrorMappings())
 \#include <aws/core/client/AWSError.h>
 \#include <aws/core/utils/HashingUtils.h>
 \#include <aws/${metadata.projectName}/${metadata.classNamePrefix}Errors.h>
@@ -54,6 +55,9 @@ namespace ${metadata.classNamePrefix}ErrorMapper
 #foreach($error in $nonCoreServiceErrors)
 #set($constName = ${ErrorFormatter.formatErrorConstName($error.name)})
 static const int ${constName}_HASH = HashingUtils::HashString("${error.text}");
+#end
+#foreach($mapping in $queryCompatibleMappings.entrySet())
+static const int ${mapping.getKey()}_HASH_COMPATIBLE = HashingUtils::HashString("${mapping.getValue()}");
 #end
 
 #if ($nonCoreServiceErrors.size() > 121)
@@ -129,6 +133,12 @@ AWSError<CoreErrors> GetErrorForName(const char* errorName)
 #end
 #else
   AWS_UNREFERENCED_PARAM(errorName);
+#end
+#foreach($mapping in $queryCompatibleMappings.entrySet())
+  ${elseText}if (hashCode == ${mapping.getKey()}_HASH_COMPATIBLE)
+  {
+    return AWSError<CoreErrors>(static_cast<CoreErrors>(${metadata.classNamePrefix}Errors::${mapping.getKey()}), RetryableType::NOT_RETRYABLE);
+  }
 #end
   return AWSError<CoreErrors>(CoreErrors::UNKNOWN, false);
 }


### PR DESCRIPTION
*Description of changes:*

* Adds a test for `GetDashboard` in cloudwatch monitoring integration tests to make sure the correct error is being returned.
* Adds a customization point for cloudwatch monitoring to add additional error mappings for querycompatible errors that may differ in error code.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
