### PR TITLE
Add s3 service performance tests

### DIFF
--- a/tests/performance-tests/include/performance-tests/Utils.h
+++ b/tests/performance-tests/include/performance-tests/Utils.h
@@ -1,0 +1,71 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+#include <aws/core/Aws.h>
+#include <aws/core/utils/StringUtils.h>
+#include <aws/core/utils/UUID.h>
+#include <aws/core/utils/memory/stl/AWSString.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <random>
+#include <string>
+
+namespace PerformanceTest {
+namespace Utils {
+/**
+ * Generate a random string of specified length.
+ * @param length The desired length of the string
+ * @return A random string containing lowercase letters and digits
+ */
+static inline Aws::String RandomString(size_t length) {
+  auto randchar = []() -> char {
+    const char charset[] =
+        "0123456789"
+        "abcdefghijklmnopqrstuvwxyz";
+    const size_t max_index = (sizeof(charset) - 1);
+    return charset[rand() % max_index];
+  };
+  Aws::String str(length, 0);
+  std::generate_n(str.begin(), length, randchar);
+  return str;
+}
+
+/**
+ * Log error messages to stderr.
+ * @param service The name of the AWS service
+ * @param operation The name of the operation that failed
+ * @param message The error message to log
+ */
+static inline void LogError(const Aws::String& service, const Aws::String& operation, const Aws::String& message) {
+  std::cerr << "[ERROR] " << service << ":" << operation << " failed: " << message << '\n';
+}
+
+/**
+ * Generate a unique identifier using UUID.
+ * @return A 10-character lowercase UUID substring
+ */
+static inline Aws::String GenerateUniqueId() {
+  Aws::String const rawUUID = Aws::Utils::UUID::RandomUUID();
+  return Aws::Utils::StringUtils::ToLower(rawUUID.c_str()).substr(0, 10);
+}
+
+/**
+ * Get the current SDK version as a formatted string.
+ * @return SDK version in the format "major.minor.patch" (e.g., "1.11.0")
+ */
+static inline Aws::String GetSDKVersionString() {
+  Aws::SDKOptions::SDKVersion const version;
+  return Aws::Utils::StringUtils::to_string(static_cast<int>(version.major)) + "." +
+         Aws::Utils::StringUtils::to_string(static_cast<int>(version.minor)) + "." +
+         Aws::Utils::StringUtils::to_string(static_cast<int>(version.patch));
+}
+
+}  // namespace Utils
+}  // namespace PerformanceTest

--- a/tests/performance-tests/include/performance-tests/services/s3/S3PerformanceTest.h
+++ b/tests/performance-tests/include/performance-tests/services/s3/S3PerformanceTest.h
@@ -1,0 +1,62 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+#include <aws/core/utils/memory/stl/AWSString.h>
+#include <aws/s3/S3Client.h>
+
+#include <cstddef>
+
+namespace PerformanceTest {
+namespace Services {
+namespace S3 {
+/**
+ * Configuration for S3 performance test cases.
+ */
+struct TestCase {
+  Aws::String sizeLabel;
+  size_t sizeBytes;
+  Aws::String bucketTypeLabel;
+};
+
+/**
+ * Runs S3 performance test by creating a bucket, performing PutObject and GetObject operations,
+ * then cleaning up resources.
+ * @param s3 S3 client instance to use for operations
+ * @param config Test configuration containing object size and bucket type parameters
+ * @param availabilityZoneId Availability zone ID for S3 Express buckets
+ * @param iterations Number of put/get operations to perform
+ */
+void RunTest(Aws::S3::S3Client& s3, const TestCase& config, const Aws::String& availabilityZoneId, int iterations = 3);
+
+/**
+ * Create S3 bucket for testing.
+ * @param s3 S3 client instance
+ * @param config Test configuration
+ * @param availabilityZoneId Availability zone ID for S3 Express buckets
+ * @return Bucket name if successful, empty string if failed
+ */
+Aws::String SetupBucket(Aws::S3::S3Client& s3, const TestCase& config, const Aws::String& availabilityZoneId);
+
+/**
+ * Run PutObject and GetObject operations.
+ * @param s3 S3 client instance
+ * @param bucketName Name of the bucket to use
+ * @param config Test configuration
+ * @param iterations Number of operations to perform
+ */
+void RunOperations(Aws::S3::S3Client& s3, const Aws::String& bucketName, const TestCase& config, int iterations);
+
+/**
+ * Clean up S3 resources (objects and bucket).
+ * @param s3 S3 client instance
+ * @param bucketName Name of the bucket to clean up
+ * @param iterations Number of objects to delete
+ */
+void CleanupResources(Aws::S3::S3Client& s3, const Aws::String& bucketName, int iterations);
+}  // namespace S3
+}  // namespace Services
+}  // namespace PerformanceTest

--- a/tests/performance-tests/include/performance-tests/services/s3/S3TestConfig.h
+++ b/tests/performance-tests/include/performance-tests/services/s3/S3TestConfig.h
@@ -1,0 +1,26 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+#include <aws/core/utils/memory/stl/AWSSet.h>
+#include <aws/core/utils/memory/stl/AWSString.h>
+#include <aws/core/utils/memory/stl/AWSVector.h>
+
+namespace PerformanceTest {
+namespace Services {
+namespace S3 {
+namespace TestConfig {
+const Aws::Set<Aws::String> TestOperations = {"PutObject", "GetObject"};
+
+const Aws::Vector<TestCase> TestMatrix = {{"8KB", 8 * 1024, "s3-standard"},    {"64KB", 64 * 1024, "s3-standard"},
+                                          {"1MB", 1024 * 1024, "s3-standard"}, {"8KB", 8 * 1024, "s3-express"},
+                                          {"64KB", 64 * 1024, "s3-express"},   {"1MB", 1024 * 1024, "s3-express"}};
+
+const Aws::String OutputFilename = "s3-performance-test-results.json";
+}  // namespace TestConfig
+}  // namespace S3
+}  // namespace Services
+}  // namespace PerformanceTest

--- a/tests/performance-tests/src/services/s3/S3PerformanceTest.cpp
+++ b/tests/performance-tests/src/services/s3/S3PerformanceTest.cpp
@@ -1,0 +1,112 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/core/utils/StringUtils.h>
+#include <aws/core/utils/memory/stl/AWSAllocator.h>
+#include <aws/core/utils/memory/stl/AWSString.h>
+#include <aws/core/utils/memory/stl/AWSStringStream.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/BucketInfo.h>
+#include <aws/s3/model/BucketType.h>
+#include <aws/s3/model/CreateBucketConfiguration.h>
+#include <aws/s3/model/CreateBucketRequest.h>
+#include <aws/s3/model/DataRedundancy.h>
+#include <aws/s3/model/DeleteBucketRequest.h>
+#include <aws/s3/model/DeleteObjectRequest.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/LocationType.h>
+#include <aws/s3/model/PutObjectRequest.h>
+#include <performance-tests/Utils.h>
+#include <performance-tests/services/s3/S3PerformanceTest.h>
+
+void PerformanceTest::Services::S3::RunTest(Aws::S3::S3Client& s3, const TestCase& config, const Aws::String& availabilityZoneId,
+                                            int iterations) {
+  auto bucketName = SetupBucket(s3, config, availabilityZoneId);
+  if (bucketName.empty()) {
+    return;
+  }
+
+  RunOperations(s3, bucketName, config, iterations);
+  CleanupResources(s3, bucketName, iterations);
+}
+
+Aws::String PerformanceTest::Services::S3::SetupBucket(Aws::S3::S3Client& s3, const TestCase& config,
+                                                       const Aws::String& availabilityZoneId) {
+  Aws::String bucketName;
+  Aws::S3::Model::CreateBucketRequest cbr;
+  Aws::String const bucketId = PerformanceTest::Utils::GenerateUniqueId();
+
+  if (config.bucketTypeLabel == "s3-express") {
+    bucketName = "perf-express-" + bucketId + "--" + availabilityZoneId + "--x-s3";
+    cbr.SetBucket(bucketName);
+    Aws::S3::Model::CreateBucketConfiguration bucketConfig;
+    bucketConfig.SetLocation(
+        Aws::S3::Model::LocationInfo().WithType(Aws::S3::Model::LocationType::AvailabilityZone).WithName(availabilityZoneId));
+
+    bucketConfig.SetBucket(Aws::S3::Model::BucketInfo()
+                               .WithType(Aws::S3::Model::BucketType::Directory)
+                               .WithDataRedundancy(Aws::S3::Model::DataRedundancy::SingleAvailabilityZone));
+
+    cbr.SetCreateBucketConfiguration(bucketConfig);
+  } else {
+    bucketName = "perf-standard-" + bucketId;
+    cbr.SetBucket(bucketName);
+  }
+
+  auto createOutcome = s3.CreateBucket(cbr);
+  if (!createOutcome.IsSuccess()) {
+    PerformanceTest::Utils::LogError("S3", "CreateBucket", createOutcome.GetError().GetMessage());
+    return "";
+  }
+
+  return bucketName;
+}
+
+void PerformanceTest::Services::S3::RunOperations(Aws::S3::S3Client& s3, const Aws::String& bucketName, const TestCase& config,
+                                                  int iterations) {
+  const auto randomPayload = PerformanceTest::Utils::RandomString(config.sizeBytes);
+
+  // Run PutObject multiple times
+  for (int i = 0; i < iterations; i++) {
+    auto stream = Aws::MakeShared<Aws::StringStream>("PerfStream");
+    *stream << randomPayload;
+
+    Aws::S3::Model::PutObjectRequest por;
+    por.WithBucket(bucketName).WithKey("test-object-" + Aws::Utils::StringUtils::to_string(i)).SetBody(stream);
+    por.SetAdditionalCustomHeaderValue("test-dimension-size", config.sizeLabel);
+    por.SetAdditionalCustomHeaderValue("test-dimension-bucket-type", config.bucketTypeLabel);
+    auto putOutcome = s3.PutObject(por);
+    if (!putOutcome.IsSuccess()) {
+      PerformanceTest::Utils::LogError("S3", "PutObject", putOutcome.GetError().GetMessage());
+    }
+  }
+
+  // Run GetObject multiple times
+  for (int i = 0; i < iterations; i++) {
+    Aws::S3::Model::GetObjectRequest gor;
+    gor.WithBucket(bucketName).WithKey("test-object-" + Aws::Utils::StringUtils::to_string(i));
+    gor.SetAdditionalCustomHeaderValue("test-dimension-size", config.sizeLabel);
+    gor.SetAdditionalCustomHeaderValue("test-dimension-bucket-type", config.bucketTypeLabel);
+    auto getOutcome = s3.GetObject(gor);
+    if (!getOutcome.IsSuccess()) {
+      PerformanceTest::Utils::LogError("S3", "GetObject", getOutcome.GetError().GetMessage());
+    }
+  }
+}
+
+void PerformanceTest::Services::S3::CleanupResources(Aws::S3::S3Client& s3, const Aws::String& bucketName, int iterations) {
+  for (int i = 0; i < iterations; i++) {
+    auto deleteObjectOutcome = s3.DeleteObject(
+        Aws::S3::Model::DeleteObjectRequest().WithBucket(bucketName).WithKey("test-object-" + Aws::Utils::StringUtils::to_string(i)));
+    if (!deleteObjectOutcome.IsSuccess()) {
+      PerformanceTest::Utils::LogError("S3", "DeleteObject", deleteObjectOutcome.GetError().GetMessage());
+    }
+  }
+
+  auto deleteBucketOutcome = s3.DeleteBucket(Aws::S3::Model::DeleteBucketRequest().WithBucket(bucketName));
+  if (!deleteBucketOutcome.IsSuccess()) {
+    PerformanceTest::Utils::LogError("S3", "DeleteBucket", deleteBucketOutcome.GetError().GetMessage());
+  }
+}

--- a/tests/performance-tests/src/services/s3/main.cpp
+++ b/tests/performance-tests/src/services/s3/main.cpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/core/Aws.h>
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/monitoring/MonitoringFactory.h>
+#include <aws/core/utils/memory/AWSMemory.h>
+#include <aws/core/utils/memory/stl/AWSString.h>
+#include <aws/s3/S3Client.h>
+#include <performance-tests/Utils.h>
+#include <performance-tests/reporting/JsonReportingMetrics.h>
+#include <performance-tests/services/s3/S3PerformanceTest.h>
+#include <performance-tests/services/s3/S3TestConfig.h>
+
+#include <string>
+
+int main(int argc, char** argv) {
+  Aws::String region = "us-east-1";
+  Aws::String availabilityZoneId = "use1-az4";
+  Aws::String commitId = "unknown";
+  int iterations = 10;
+
+  for (int i = 1; i < argc; ++i) {
+    Aws::String const arg = argv[i];
+    if (arg == "--region" && i + 1 < argc) {
+      region = argv[++i];
+    } else if (arg == "--az-id" && i + 1 < argc) {
+      availabilityZoneId = argv[++i];
+    } else if (arg == "--iterations" && i + 1 < argc) {
+      iterations = std::stoi(argv[++i]);
+    } else if (arg == "--commit-id" && i + 1 < argc) {
+      commitId = argv[++i];
+    }
+  }
+
+  Aws::SDKOptions options;
+  Aws::String const versionStr = PerformanceTest::Utils::GetSDKVersionString();
+
+  options.monitoringOptions.customizedMonitoringFactory_create_fn = {[&]() -> Aws::UniquePtr<Aws::Monitoring::MonitoringFactory> {
+    return Aws::MakeUnique<PerformanceTest::Reporting::JsonReportingMetricsFactory>(
+        "JsonReportingMetricsFactory", PerformanceTest::Services::S3::TestConfig::TestOperations, "cpp1", versionStr, commitId,
+        PerformanceTest::Services::S3::TestConfig::OutputFilename);
+  }};
+
+  Aws::InitAPI(options);
+
+  {
+    Aws::Client::ClientConfiguration cfg;
+    cfg.region = region;
+
+    Aws::S3::S3Client s3(cfg);
+    for (const auto& config : PerformanceTest::Services::S3::TestConfig::TestMatrix) {
+      PerformanceTest::Services::S3::RunTest(s3, config, availabilityZoneId, iterations);
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}


### PR DESCRIPTION
*Description of changes:*

This PR adds performance tests for the s3 service. It tests operations including PutObject and GetObject with multiple test dimensions: bucket type and object size. 

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [X] Windows
- [X] Android
- [X] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
