### PR TITLE
Revert "add option to ignore content length in S3Crt"

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
@@ -7191,10 +7191,6 @@ namespace Aws
         Aws::Client::XmlOutcome GenerateXmlOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;
         Aws::Client::StreamOutcome GenerateStreamOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;
 
-    protected:
-        void AddContentLengthToRequest(const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest,
-            const std::shared_ptr<Aws::IOStream>& body,
-            bool isChunked) const override;
     private:
         friend class Aws::Client::ClientWithAsyncTemplateMethods<S3CrtClient>;
         void init(const S3Crt::ClientConfiguration& clientConfiguration,

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
@@ -160,16 +160,6 @@ namespace Aws
              * This setting maps to CRT's network_interface_names_array config.
              */
             Aws::Vector<Aws::String> networkInterfaceNames;
-
-            /**
-             * Configuration on how to handle missing content length. By default the SDK attempts to seek the stream
-             * to find the total length of the stream before streaming. CRT will fallback to multipart upload if there
-             * is no content length, creating multipart uploads of partSize before knowing the stream has ended.
-             */
-            enum class CONTENT_LENGTH_CONFIGURATION {
-              SEEK_STREAM,
-              SKIP_CONTENT_LENGTH,
-            } contentLenghtConfiguration {CONTENT_LENGTH_CONFIGURATION::SEEK_STREAM};
             /* End of S3 CRT specifics */
         private:
             void LoadS3CrtSpecificConfig(const Aws::String& profileName);

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -239,12 +239,10 @@ S3CrtClient::S3CrtClient(const S3Crt::ClientConfiguration& clientConfiguration, 
             signPayloads,
             false),
     Aws::MakeShared<S3CrtErrorMarshaller>(ALLOCATION_TAG)),
-    m_clientConfiguration(clientConfiguration),
+    m_clientConfiguration(clientConfiguration, signPayloads, useVirtualAddressing, USEast1RegionalEndPointOption),
     m_credProvider(Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, credentialsProvider)),
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
-  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
-  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration, m_credProvider);
 }
 
@@ -258,12 +256,10 @@ S3CrtClient::S3CrtClient(const AWSCredentials& credentials, const S3Crt::ClientC
             signPayloads,
             false),
     Aws::MakeShared<S3CrtErrorMarshaller>(ALLOCATION_TAG)),
-    m_clientConfiguration(clientConfiguration),
+    m_clientConfiguration(clientConfiguration, signPayloads, useVirtualAddressing, USEast1RegionalEndPointOption),
     m_credProvider(Aws::MakeShared<SimpleAWSCredentialsProvider>(ALLOCATION_TAG, credentials)),
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
-  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
-  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration, m_credProvider);
 }
 
@@ -278,12 +274,10 @@ S3CrtClient::S3CrtClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
             signPayloads,
             false),
     Aws::MakeShared<S3CrtErrorMarshaller>(ALLOCATION_TAG)),
-    m_clientConfiguration(clientConfiguration, signPayloads),
+    m_clientConfiguration(clientConfiguration, signPayloads, useVirtualAddressing, USEast1RegionalEndPointOption),
     m_credProvider(credentialsProvider),
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
-  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
-  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration, m_credProvider);
 }
 
@@ -5585,13 +5579,4 @@ Aws::String S3CrtClient::GeneratePresignedUrlWithSSEC(const Aws::String& bucket,
 bool S3CrtClient::MultipartUploadSupported() const
 {
     return true;
-}
-
-void S3CrtClient::AddContentLengthToRequest(const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest,
-    const std::shared_ptr<Aws::IOStream>& body,
-    bool isChunked) const
-{
-    if (m_clientConfiguration.contentLenghtConfiguration == S3CrtClientConfiguration::CONTENT_LENGTH_CONFIGURATION::SEEK_STREAM) {
-        BASECLASS::AddContentLengthToRequest(httpRequest, body, isChunked);
-    }
 }

--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
@@ -286,14 +286,6 @@ namespace Aws
                                           const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest) const;
 
             /**
-             * Adds content-length to the request if the request has a body by attempting to seek the end of
-             * the body.
-             */
-            virtual void AddContentLengthToRequest(const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest,
-                                                   const std::shared_ptr<Aws::IOStream>& body,
-                                                   bool isChunked) const;
-
-            /**
              *  Gets the underlying ErrorMarshaller for subclasses to use.
              */
             const std::shared_ptr<AWSErrorMarshaller>& GetErrorMarshaller() const
@@ -311,6 +303,7 @@ namespace Aws
             std::shared_ptr<Auth::AWSCredentialsProvider> GetCredentialsProvider() const {
                  return m_signerProvider->GetCredentialsProvider();
             }
+        protected:
 
             /**
               * Creates an HttpRequest instance with the given URI and sets the proper headers from the

--- a/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -820,7 +820,30 @@ void AWSClient::AddContentBodyToRequest(const std::shared_ptr<Aws::Http::HttpReq
             httpRequest->DeleteHeader(Http::CONTENT_LENGTH_HEADER);
         }
     }
-    AddContentLengthToRequest(httpRequest, body, isChunked);
+
+    //Add transfer-encoding:chunked to header
+    if (body && isChunked && !httpRequest->HasHeader(Http::CONTENT_LENGTH_HEADER))
+    {
+        httpRequest->SetTransferEncoding(CHUNKED_VALUE);
+    }
+    //in the scenario where we are adding a content body as a stream, the request object likely already
+    //has a content-length header set and we don't want to seek the stream just to find this information.
+    else if (body && !httpRequest->HasHeader(Http::CONTENT_LENGTH_HEADER))
+    {
+        if (!m_httpClient->SupportsChunkedTransferEncoding())
+        {
+            AWS_LOGSTREAM_WARN(AWS_CLIENT_LOG_TAG, "This http client doesn't support transfer-encoding:chunked. " <<
+                                                   "The request may fail if it's not a seekable stream.");
+        }
+        AWS_LOGSTREAM_TRACE(AWS_CLIENT_LOG_TAG, "Found body, but content-length has not been set, attempting to compute content-length");
+        body->seekg(0, body->end);
+        auto streamSize = body->tellg();
+        body->seekg(0, body->beg);
+        Aws::StringStream ss;
+        ss << streamSize;
+        httpRequest->SetContentLength(ss.str());
+    }
+
     if (needsContentMd5 && body && !httpRequest->HasHeader(Http::CONTENT_MD5_HEADER))
     {
         AWS_LOGSTREAM_TRACE(AWS_CLIENT_LOG_TAG, "Found body, and content-md5 needs to be set" <<
@@ -837,28 +860,6 @@ void AWSClient::AddContentBodyToRequest(const std::shared_ptr<Aws::Http::HttpReq
             httpRequest->SetHeaderValue(Http::CONTENT_MD5_HEADER, HashingUtils::Base64Encode(md5HashResult.GetResult()));
         }
     }
-}
-
-void AWSClient::AddContentLengthToRequest(
-  const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest,
-  const std::shared_ptr<Aws::IOStream>& body,
-  bool isChunked) const
-{
-  if (body && isChunked && !httpRequest->HasHeader(Http::CONTENT_LENGTH_HEADER)) {
-    httpRequest->SetTransferEncoding(CHUNKED_VALUE);
-  } else if (body && !httpRequest->HasHeader(Http::CONTENT_LENGTH_HEADER)) {
-    if (!m_httpClient->SupportsChunkedTransferEncoding()) {
-      AWS_LOGSTREAM_WARN(AWS_CLIENT_LOG_TAG, "This http client doesn't support transfer-encoding:chunked. " <<
-                                             "The request may fail if it's not a seekable stream.");
-    }
-    AWS_LOGSTREAM_TRACE(AWS_CLIENT_LOG_TAG, "Found body, but content-length has not been set, attempting to compute content-length");
-    body->seekg(0, body->end);
-    auto streamSize = body->tellg();
-    body->seekg(0, body->beg);
-    Aws::StringStream ss;
-    ss << streamSize;
-    httpRequest->SetContentLength(ss.str());
-  }
 }
 
 Aws::String Aws::Client::GetAuthorizationHeader(const Aws::Http::HttpRequest& httpRequest)

--- a/tests/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/tests/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp
@@ -1530,29 +1530,6 @@ namespace
         }
     }
 
-    TEST_F(BucketAndObjectOperationTest, ContentLengthMissingShouldWork) {
-        const Aws::String fullBucketName = CalculateBucketName(BASE_PUT_OBJECTS_BUCKET_NAME.c_str());
-        SCOPED_TRACE(Aws::String("FullBucketName ") + fullBucketName);
-        CreateBucketRequest createBucketRequest;
-        createBucketRequest.SetBucket(fullBucketName);
-        createBucketRequest.SetACL(BucketCannedACL::private_);
-
-        CreateBucketOutcome createBucketOutcome = Client->CreateBucket(createBucketRequest);
-        AWS_ASSERT_SUCCESS(createBucketOutcome);
-        const CreateBucketResult& createBucketResult = createBucketOutcome.GetResult();
-        ASSERT_TRUE(!createBucketResult.GetLocation().empty());
-        ASSERT_TRUE(WaitForBucketToPropagate(fullBucketName));
-        TagTestBucket(fullBucketName, Client);
-
-        S3CrtClientConfiguration configuration{};
-        configuration.contentLenghtConfiguration = S3CrtClientConfiguration::CONTENT_LENGTH_CONFIGURATION::SKIP_CONTENT_LENGTH;
-        const S3CrtClient client{configuration};
-        auto request = PutObjectRequest{}.WithBucket(fullBucketName).WithKey("sam");
-        request.SetBody(Aws::MakeShared<StringStream>(ALLOCATION_TAG, "bridges"));
-        const auto response = client.PutObject(request);
-        AWS_EXPECT_SUCCESS(response);
-    }
-
     class TestMonitoring: public Aws::Monitoring::MonitoringInterface
     {
         mutable std::shared_ptr<Aws::Vector<Aws::String>> m_sequence;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
@@ -212,10 +212,6 @@ namespace ${rootNamespace}
         Aws::Client::XmlOutcome GenerateXmlOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;
         Aws::Client::StreamOutcome GenerateStreamOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;
 
-    protected:
-        void AddContentLengthToRequest(const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest,
-            const std::shared_ptr<Aws::IOStream>& body,
-            bool isChunked) const override;
 #end
     private:
         friend class Aws::Client::ClientWithAsyncTemplateMethods<${className}>;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientSource.vm
@@ -356,15 +356,4 @@ bool ${className}::MultipartUploadSupported() const
 {
     return true;
 }
-#if($serviceNamespace == "S3Crt")
-
-void ${className}::AddContentLengthToRequest(const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest,
-    const std::shared_ptr<Aws::IOStream>& body,
-    bool isChunked) const
-{
-    if (m_clientConfiguration.contentLenghtConfiguration == ${className}Configuration::CONTENT_LENGTH_CONFIGURATION::SEEK_STREAM) {
-        BASECLASS::AddContentLengthToRequest(httpRequest, body, isChunked);
-    }
-}
-#end
 #end

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtClientConfigHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtClientConfigHeader.vm
@@ -93,14 +93,4 @@
              * This setting maps to CRT's network_interface_names_array config.
              */
             Aws::Vector<Aws::String> networkInterfaceNames;
-
-            /**
-             * Configuration on how to handle missing content length. By default the SDK attempts to seek the stream
-             * to find the total length of the stream before streaming. CRT will fallback to multipart upload if there
-             * is no content length, creating multipart uploads of partSize before knowing the stream has ended.
-             */
-            enum class CONTENT_LENGTH_CONFIGURATION {
-              SEEK_STREAM,
-              MULTIPART_UPLOAD,
-            } contentLenghtConfiguration {CONTENT_LENGTH_CONFIGURATION::SEEK_STREAM};
             /* End of S3 CRT specifics */

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -132,14 +132,12 @@ ${className}::${className}(const ${clientConfigurationNamespace}::ClientConfigur
             false),
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration),
+    m_clientConfiguration(clientConfiguration${signPayloadsParam}${virtualAddressingInit}${USEast1RegionalEndpointInitString}),
     ${defaultCredentialsProviderChainMember},
 #else${defaultCredentialsProviderChainMember}${virtualAddressingInit}${USEast1RegionalEndpointInitString},
 #end
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
-  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
-  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration${credentialsParam});
 }
 
@@ -154,14 +152,12 @@ ${className}::${className}(const AWSCredentials& credentials, const ${clientConf
             false),
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration),
+    m_clientConfiguration(clientConfiguration${signPayloadsParam}${virtualAddressingInit}${USEast1RegionalEndpointInitString}),
     ${simpleCredentialsProviderMember},
 #else${simpleCredentialsProviderMember}${virtualAddressingInit}${USEast1RegionalEndpointInitString},
 #end
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
-  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
-  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration${credentialsParam});
 }
 
@@ -177,15 +173,13 @@ ${className}::${className}(const std::shared_ptr<AWSCredentialsProvider>& creden
             false),
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration${signPayloadsParam}),
+    m_clientConfiguration(clientConfiguration${signPayloadsParam}${virtualAddressingInit}${USEast1RegionalEndpointInitString}),
     ${credentialsProviderMember},
 #else
     ${credentialsProviderMember}${virtualAddressingInit}${USEast1RegionalEndpointInitString},
 #end
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
-  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
-  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration${credentialsParam});
 }
 #else
@@ -195,15 +189,13 @@ ${className}::${className}(const ${clientConfigurationNamespace}::ClientConfigur
         SERVICE_NAME, Aws::Region::ComputeSignerRegion(clientConfiguration.region)${signPayloadsParam}${doubleEncodeValue}),
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration${signPayloadsParam}),
+    m_clientConfiguration(clientConfiguration${signPayloadsParam}${virtualAddressingInit}${USEast1RegionalEndpointInitString}),
     ${defaultCredentialsProviderChainMember},
 #else
     ${defaultCredentialsProviderChainMember}${virtualAddressingInit}${USEast1RegionalEndpointInitString},
 #end
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
-  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
-  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration${credentialsParam});
 }
 
@@ -213,15 +205,13 @@ ${className}::${className}(const AWSCredentials& credentials, const ${clientConf
          SERVICE_NAME, Aws::Region::ComputeSignerRegion(clientConfiguration.region)${signPayloadsParam}${doubleEncodeValue}),
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration),
+    m_clientConfiguration(clientConfiguration${signPayloadsParam}${virtualAddressingInit}${USEast1RegionalEndpointInitString}),
     ${simpleCredentialsProviderMember},
 #else
     ${simpleCredentialsProviderMember}${virtualAddressingInit}${USEast1RegionalEndpointInitString},
 #end
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
-  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
-  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration${credentialsParam});
 }
 
@@ -232,15 +222,13 @@ ${className}::${className}(const std::shared_ptr<AWSCredentialsProvider>& creden
          SERVICE_NAME, Aws::Region::ComputeSignerRegion(clientConfiguration.region)${signPayloadsParam}${doubleEncodeValue}),
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration),
+    m_clientConfiguration(clientConfiguration${signPayloadsParam}${virtualAddressingInit}${USEast1RegionalEndpointInitString}),
     ${virtualAddressingInit},
 #else
     ${virtualAddressingInit}${USEast1RegionalEndpointInitString}${credentialsProviderMember},
 #end
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
-  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
-  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration${credentialsParam});
 }
 #end
@@ -251,15 +239,13 @@ ${className}::${className}(const std::shared_ptr<Aws::Auth::AWSAuthSignerProvide
   BASECLASS(clientConfiguration, signerProvider,
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration),
+    m_clientConfiguration(clientConfiguration${signPayloadsParam}${virtualAddressingInit}${USEast1RegionalEndpointInitString}),
     ${virtualAddressingInit},
 #else
     ${virtualAddressingInit},
 #end
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
-  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
-  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(m_clientConfiguration);
 }
 


### PR DESCRIPTION
This reverts commit 22e831e00e084d140744b860b3ec0d3895d167fb.

*Description of changes:*

reverts changes as it breaks al2023 builds

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
