### PR TITLE
add option to ignore content length in S3Crt

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
@@ -7191,6 +7191,10 @@ namespace Aws
         Aws::Client::XmlOutcome GenerateXmlOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;
         Aws::Client::StreamOutcome GenerateStreamOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;
 
+    protected:
+        void AddContentLengthToRequest(const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest,
+            const std::shared_ptr<Aws::IOStream>& body,
+            bool isChunked) const override;
     private:
         friend class Aws::Client::ClientWithAsyncTemplateMethods<S3CrtClient>;
         void init(const S3Crt::ClientConfiguration& clientConfiguration,

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClientConfiguration.h
@@ -160,6 +160,16 @@ namespace Aws
              * This setting maps to CRT's network_interface_names_array config.
              */
             Aws::Vector<Aws::String> networkInterfaceNames;
+
+            /**
+             * Configuration on how to handle missing content length. By default the SDK attempts to seek the stream
+             * to find the total length of the stream before streaming. CRT will fallback to multipart upload if there
+             * is no content length, creating multipart uploads of partSize before knowing the stream has ended.
+             */
+            enum class CONTENT_LENGTH_CONFIGURATION {
+              SEEK_STREAM,
+              SKIP_CONTENT_LENGTH,
+            } contentLengthConfiguration {CONTENT_LENGTH_CONFIGURATION::SEEK_STREAM};
             /* End of S3 CRT specifics */
         private:
             void LoadS3CrtSpecificConfig(const Aws::String& profileName);

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -239,10 +239,12 @@ S3CrtClient::S3CrtClient(const S3Crt::ClientConfiguration& clientConfiguration, 
             signPayloads,
             false),
     Aws::MakeShared<S3CrtErrorMarshaller>(ALLOCATION_TAG)),
-    m_clientConfiguration(clientConfiguration, signPayloads, useVirtualAddressing, USEast1RegionalEndPointOption),
+    m_clientConfiguration(clientConfiguration),
     m_credProvider(Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, credentialsProvider)),
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
+  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
+  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration, m_credProvider);
 }
 
@@ -256,10 +258,12 @@ S3CrtClient::S3CrtClient(const AWSCredentials& credentials, const S3Crt::ClientC
             signPayloads,
             false),
     Aws::MakeShared<S3CrtErrorMarshaller>(ALLOCATION_TAG)),
-    m_clientConfiguration(clientConfiguration, signPayloads, useVirtualAddressing, USEast1RegionalEndPointOption),
+    m_clientConfiguration(clientConfiguration),
     m_credProvider(Aws::MakeShared<SimpleAWSCredentialsProvider>(ALLOCATION_TAG, credentials)),
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
+  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
+  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration, m_credProvider);
 }
 
@@ -274,10 +278,12 @@ S3CrtClient::S3CrtClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
             signPayloads,
             false),
     Aws::MakeShared<S3CrtErrorMarshaller>(ALLOCATION_TAG)),
-    m_clientConfiguration(clientConfiguration, signPayloads, useVirtualAddressing, USEast1RegionalEndPointOption),
+    m_clientConfiguration(clientConfiguration, signPayloads),
     m_credProvider(credentialsProvider),
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
+  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
+  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration, m_credProvider);
 }
 
@@ -5579,4 +5585,13 @@ Aws::String S3CrtClient::GeneratePresignedUrlWithSSEC(const Aws::String& bucket,
 bool S3CrtClient::MultipartUploadSupported() const
 {
     return true;
+}
+
+void S3CrtClient::AddContentLengthToRequest(const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest,
+    const std::shared_ptr<Aws::IOStream>& body,
+    bool isChunked) const
+{
+    if (m_clientConfiguration.contentLengthConfiguration == S3CrtClientConfiguration::CONTENT_LENGTH_CONFIGURATION::SEEK_STREAM) {
+        BASECLASS::AddContentLengthToRequest(httpRequest, body, isChunked);
+    }
 }

--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
@@ -286,6 +286,14 @@ namespace Aws
                                           const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest) const;
 
             /**
+             * Adds content-length to the request if the request has a body by attempting to seek the end of
+             * the body.
+             */
+            virtual void AddContentLengthToRequest(const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest,
+                                                   const std::shared_ptr<Aws::IOStream>& body,
+                                                   bool isChunked) const;
+
+            /**
              *  Gets the underlying ErrorMarshaller for subclasses to use.
              */
             const std::shared_ptr<AWSErrorMarshaller>& GetErrorMarshaller() const
@@ -303,7 +311,6 @@ namespace Aws
             std::shared_ptr<Auth::AWSCredentialsProvider> GetCredentialsProvider() const {
                  return m_signerProvider->GetCredentialsProvider();
             }
-        protected:
 
             /**
               * Creates an HttpRequest instance with the given URI and sets the proper headers from the

--- a/tests/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/tests/aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp
@@ -1530,6 +1530,30 @@ namespace
         }
     }
 
+    TEST_F(BucketAndObjectOperationTest, ContentLengthMissingShouldWork) {
+        const Aws::String fullBucketName = CalculateBucketName(BASE_PUT_OBJECTS_BUCKET_NAME.c_str());
+        SCOPED_TRACE(Aws::String("FullBucketName ") + fullBucketName);
+        CreateBucketRequest createBucketRequest;
+        createBucketRequest.SetBucket(fullBucketName);
+        createBucketRequest.SetACL(BucketCannedACL::private_);
+
+        CreateBucketOutcome createBucketOutcome = Client->CreateBucket(createBucketRequest);
+        AWS_ASSERT_SUCCESS(createBucketOutcome);
+        const CreateBucketResult& createBucketResult = createBucketOutcome.GetResult();
+        ASSERT_TRUE(!createBucketResult.GetLocation().empty());
+        ASSERT_TRUE(WaitForBucketToPropagate(fullBucketName));
+        TagTestBucket(fullBucketName, Client);
+
+        S3CrtClientConfiguration configuration{};
+        configuration.region = "us-east-1";
+        configuration.contentLengthConfiguration = Aws::S3Crt::S3CrtClientConfiguration::CONTENT_LENGTH_CONFIGURATION::SKIP_CONTENT_LENGTH;
+        const S3CrtClient client{configuration};
+        auto request = PutObjectRequest{}.WithBucket(fullBucketName).WithKey("sam");
+        request.SetBody(Aws::MakeShared<StringStream>(ALLOCATION_TAG, "bridges"));
+        const auto response = client.PutObject(request);
+        AWS_EXPECT_SUCCESS(response);
+    }
+
     class TestMonitoring: public Aws::Monitoring::MonitoringInterface
     {
         mutable std::shared_ptr<Aws::Vector<Aws::String>> m_sequence;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
@@ -212,6 +212,10 @@ namespace ${rootNamespace}
         Aws::Client::XmlOutcome GenerateXmlOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;
         Aws::Client::StreamOutcome GenerateStreamOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;
 
+    protected:
+        void AddContentLengthToRequest(const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest,
+            const std::shared_ptr<Aws::IOStream>& body,
+            bool isChunked) const override;
 #end
     private:
         friend class Aws::Client::ClientWithAsyncTemplateMethods<${className}>;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientSource.vm
@@ -356,4 +356,15 @@ bool ${className}::MultipartUploadSupported() const
 {
     return true;
 }
+#if($serviceNamespace == "S3Crt")
+
+void ${className}::AddContentLengthToRequest(const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest,
+    const std::shared_ptr<Aws::IOStream>& body,
+    bool isChunked) const
+{
+    if (m_clientConfiguration.contentLengthConfiguration == ${className}Configuration::CONTENT_LENGTH_CONFIGURATION::SEEK_STREAM) {
+        BASECLASS::AddContentLengthToRequest(httpRequest, body, isChunked);
+    }
+}
+#end
 #end

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtClientConfigHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtClientConfigHeader.vm
@@ -93,4 +93,14 @@
              * This setting maps to CRT's network_interface_names_array config.
              */
             Aws::Vector<Aws::String> networkInterfaceNames;
+
+            /**
+             * Configuration on how to handle missing content length. By default the SDK attempts to seek the stream
+             * to find the total length of the stream before streaming. CRT will fallback to multipart upload if there
+             * is no content length, creating multipart uploads of partSize before knowing the stream has ended.
+             */
+            enum class CONTENT_LENGTH_CONFIGURATION {
+              SEEK_STREAM,
+              SKIP_CONTENT_LENGTH,
+            } contentLengthConfiguration {CONTENT_LENGTH_CONFIGURATION::SEEK_STREAM};
             /* End of S3 CRT specifics */

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -132,12 +132,14 @@ ${className}::${className}(const ${clientConfigurationNamespace}::ClientConfigur
             false),
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration${signPayloadsParam}${virtualAddressingInit}${USEast1RegionalEndpointInitString}),
+    m_clientConfiguration(clientConfiguration),
     ${defaultCredentialsProviderChainMember},
 #else${defaultCredentialsProviderChainMember}${virtualAddressingInit}${USEast1RegionalEndpointInitString},
 #end
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
+  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
+  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration${credentialsParam});
 }
 
@@ -152,12 +154,14 @@ ${className}::${className}(const AWSCredentials& credentials, const ${clientConf
             false),
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration${signPayloadsParam}${virtualAddressingInit}${USEast1RegionalEndpointInitString}),
+    m_clientConfiguration(clientConfiguration),
     ${simpleCredentialsProviderMember},
 #else${simpleCredentialsProviderMember}${virtualAddressingInit}${USEast1RegionalEndpointInitString},
 #end
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
+  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
+  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration${credentialsParam});
 }
 
@@ -173,13 +177,15 @@ ${className}::${className}(const std::shared_ptr<AWSCredentialsProvider>& creden
             false),
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration${signPayloadsParam}${virtualAddressingInit}${USEast1RegionalEndpointInitString}),
+    m_clientConfiguration(clientConfiguration${signPayloadsParam}),
     ${credentialsProviderMember},
 #else
     ${credentialsProviderMember}${virtualAddressingInit}${USEast1RegionalEndpointInitString},
 #end
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
+  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
+  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration${credentialsParam});
 }
 #else
@@ -189,13 +195,15 @@ ${className}::${className}(const ${clientConfigurationNamespace}::ClientConfigur
         SERVICE_NAME, Aws::Region::ComputeSignerRegion(clientConfiguration.region)${signPayloadsParam}${doubleEncodeValue}),
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration${signPayloadsParam}${virtualAddressingInit}${USEast1RegionalEndpointInitString}),
+    m_clientConfiguration(clientConfiguration${signPayloadsParam}),
     ${defaultCredentialsProviderChainMember},
 #else
     ${defaultCredentialsProviderChainMember}${virtualAddressingInit}${USEast1RegionalEndpointInitString},
 #end
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
+  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
+  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration${credentialsParam});
 }
 
@@ -205,13 +213,15 @@ ${className}::${className}(const AWSCredentials& credentials, const ${clientConf
          SERVICE_NAME, Aws::Region::ComputeSignerRegion(clientConfiguration.region)${signPayloadsParam}${doubleEncodeValue}),
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration${signPayloadsParam}${virtualAddressingInit}${USEast1RegionalEndpointInitString}),
+    m_clientConfiguration(clientConfiguration),
     ${simpleCredentialsProviderMember},
 #else
     ${simpleCredentialsProviderMember}${virtualAddressingInit}${USEast1RegionalEndpointInitString},
 #end
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
+  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
+  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration${credentialsParam});
 }
 
@@ -222,13 +232,15 @@ ${className}::${className}(const std::shared_ptr<AWSCredentialsProvider>& creden
          SERVICE_NAME, Aws::Region::ComputeSignerRegion(clientConfiguration.region)${signPayloadsParam}${doubleEncodeValue}),
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration${signPayloadsParam}${virtualAddressingInit}${USEast1RegionalEndpointInitString}),
+    m_clientConfiguration(clientConfiguration),
     ${virtualAddressingInit},
 #else
     ${virtualAddressingInit}${USEast1RegionalEndpointInitString}${credentialsProviderMember},
 #end
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
+  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
+  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(clientConfiguration${credentialsParam});
 }
 #end
@@ -239,13 +251,15 @@ ${className}::${className}(const std::shared_ptr<Aws::Auth::AWSAuthSignerProvide
   BASECLASS(clientConfiguration, signerProvider,
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration${signPayloadsParam}${virtualAddressingInit}${USEast1RegionalEndpointInitString}),
+    m_clientConfiguration(clientConfiguration),
     ${virtualAddressingInit},
 #else
     ${virtualAddressingInit},
 #end
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {
+  AWS_UNREFERENCED_PARAM(useVirtualAddressing);
+  AWS_UNREFERENCED_PARAM(USEast1RegionalEndPointOption);
   init(m_clientConfiguration);
 }
 


### PR DESCRIPTION
*Description of changes:*

the S3CrtClient has the ability to alias a PutObject call to a underlying multipart upload call if content-length is not present optimizing uploads, and more importantly, functioning as a "transfer manager" to allow the easy upload of streams where seeking for content lengths is unreasonable.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
