### PR TITLE
Integrate performance tests into the build, update docs, and add scripts to run tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ if (LEGACY_BUILD)
     option(ENABLE_ZLIB_REQUEST_COMPRESSION "For services that support it, request content will be compressed. On by default if dependency available" ON)
     option(DISABLE_INTERNAL_IMDSV1_CALLS "Disables IMDSv1 internal client calls" OFF)
     option(BUILD_BENCHMARKS "Enables building the benchmark executable" OFF)
+    option(BUILD_PERFORMANCE_TESTS "Enables building the performance test executables" OFF)
     option(BUILD_OPTEL "Enables building the open telemetry implementation of tracing" OFF)
     option(AWS_SDK_WARNINGS_ARE_ERRORS "Compiler warning is treated as an error. Try turning this off when observing errors on a new or uncommon compiler" ON)
     option(BUILD_OPTEL_OTLP_BENCHMARKS "Enables building the benchmark tests with open telemetry OTLP clients" OFF)
@@ -340,6 +341,11 @@ if (LEGACY_BUILD)
 
     add_sdks()
     include(tests)
+
+    # Performance tests for services
+    if (BUILD_PERFORMANCE_TESTS)
+        add_subdirectory(tests/performance-tests)
+    endif()
 
     # for user friendly cmake usage
     include(setup_cmake_find_module)

--- a/docs/CMake_Parameters.md
+++ b/docs/CMake_Parameters.md
@@ -128,6 +128,9 @@ You can also tell gcc or clang to pass these linker flags by specifying `-Wl,--g
 ### BUILD_BENCHMARKS
 (Defaults to OFF) Enables building the benchmark executable
 
+### BUILD_PERFORMANCE_TESTS
+(Defaults to OFF) Enables building the performance test executables for S3 and DynamoDB. These tests measure operation latencies and output results to JSON files. Requires S3 and DynamoDB clients to be built.
+
 ### BUILD_OPTEL
 (Defaults to OFF) Enables building the open telemetry implementation of tracing
 

--- a/tools/scripts/build-tests/build-al2-debug-default.sh
+++ b/tools/scripts/build-tests/build-al2-debug-default.sh
@@ -18,6 +18,6 @@ PREFIX_DIR="$1"
 mkdir "${PREFIX_DIR}/al2-build"
 mkdir "${PREFIX_DIR}/al2-install"
 cd "${PREFIX_DIR}/al2-build"
-cmake -GNinja ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-ggdb -fsanitize=address" -DMINIMIZE_SIZE=ON -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}/al2-install"
+cmake -GNinja ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-ggdb -fsanitize=address" -DMINIMIZE_SIZE=ON -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}/al2-install" -DBUILD_PERFORMANCE_TESTS=ON
 ninja-build -j $(grep -c ^processor /proc/cpuinfo)
 ninja-build install

--- a/tools/scripts/build-tests/run-al2-dynamodb-performance-tests.sh
+++ b/tools/scripts/build-tests/run-al2-dynamodb-performance-tests.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+# This script runs the pre-built DynamoDB performance test executable
+# Expects SDK build directory at ${PREFIX_DIR}/al2-build, source project at ${PREFIX_DIR}/aws-sdk-cpp,
+# and SDK installation directory at ${PREFIX_DIR}/al2-install
+# Platform: Amazon Linux 2
+
+set -e
+
+DEFAULT_REGION="us-east-1"
+DEFAULT_ITERATIONS=10
+
+if [ "$#" -lt 1 ]; then
+  echo "Error: Missing required argument. Usage: ${0} PREFIX_DIR [-r|--region REGION] [-i|--iterations NUM]"
+  exit 1
+fi
+
+PREFIX_DIR="$1"
+shift  
+
+REGION="$DEFAULT_REGION"
+ITERATIONS="$DEFAULT_ITERATIONS"
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -r|--region) REGION="$2"; shift 2 ;;
+    -i|--iterations) ITERATIONS="$2"; shift 2 ;;
+    *) echo "Unknown parameter: $1"; exit 1 ;;
+  esac
+done
+
+SDK_REPO_PATH="${PREFIX_DIR}/aws-sdk-cpp"
+if [ -d "$SDK_REPO_PATH" ]; then
+  COMMIT_ID=$(cd "$SDK_REPO_PATH" && git rev-parse HEAD)
+else
+  echo "Error: Git repository not found at $SDK_REPO_PATH"
+  exit 1
+fi
+
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${PREFIX_DIR}/al2-install/lib64/"
+
+cd "${PREFIX_DIR}/al2-build"
+if [ -f "${PREFIX_DIR}/aws-sdk-cpp/tools/scripts/suppressions.txt" ]; then export LSAN_OPTIONS=suppressions="${PREFIX_DIR}/aws-sdk-cpp/tools/scripts/suppressions.txt"; fi
+./tests/performance-tests/dynamodb-performance-test --region "$REGION" --iterations "$ITERATIONS" --commit-id "$COMMIT_ID"
+cat dynamodb-performance-test-results.json

--- a/tools/scripts/build-tests/run-al2-s3-performance-tests.sh
+++ b/tools/scripts/build-tests/run-al2-s3-performance-tests.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+# This script runs the pre-built S3 performance test executable
+# Expects SDK build directory at ${PREFIX_DIR}/al2-build, source project at ${PREFIX_DIR}/aws-sdk-cpp,
+# and SDK installation directory at ${PREFIX_DIR}/al2-install
+# Platform: Amazon Linux 2
+
+set -e
+
+DEFAULT_REGION="us-east-1"
+DEFAULT_AZ_ID="use1-az4"
+DEFAULT_ITERATIONS=10
+
+if [ "$#" -lt 1 ]; then
+  echo "Error: Missing required argument. Usage: ${0} PREFIX_DIR [-r|--region REGION] [-a|--az-id AZ_ID] [-i|--iterations NUM]"
+  exit 1
+fi
+
+PREFIX_DIR="$1"
+shift  
+
+REGION="$DEFAULT_REGION"
+AZ_ID="$DEFAULT_AZ_ID"
+ITERATIONS="$DEFAULT_ITERATIONS"
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -r|--region) REGION="$2"; shift 2 ;;
+    -a|--az-id) AZ_ID="$2"; shift 2 ;;
+    -i|--iterations) ITERATIONS="$2"; shift 2 ;;
+    *) echo "Unknown parameter: $1"; exit 1 ;;
+  esac
+done
+
+SDK_REPO_PATH="${PREFIX_DIR}/aws-sdk-cpp"
+if [ -d "$SDK_REPO_PATH" ]; then
+  COMMIT_ID=$(cd "$SDK_REPO_PATH" && git rev-parse HEAD)
+else
+  echo "Error: Git repository not found at $SDK_REPO_PATH"
+  exit 1
+fi
+
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${PREFIX_DIR}/al2-install/lib64/"
+
+cd "${PREFIX_DIR}/al2-build"
+if [ -f "${PREFIX_DIR}/aws-sdk-cpp/tools/scripts/suppressions.txt" ]; then export LSAN_OPTIONS=suppressions="${PREFIX_DIR}/aws-sdk-cpp/tools/scripts/suppressions.txt"; fi
+./tests/performance-tests/s3-performance-test --region "$REGION" --az-id "$AZ_ID" --iterations "$ITERATIONS" --commit-id "$COMMIT_ID"
+cat s3-performance-test-results.json


### PR DESCRIPTION
*Description of changes:*

This PR updates the root CMakeLists.txt to include the performance test module and adds corresponding documentation. It also includes build and run scripts for executing the performance tests on Amazon Linux 2.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [X] Windows
- [X] Android
- [X] MacOS
- [ ] IOS
- [ ] Other Platforms

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.