### PR TITLE
ByteBuffer reference access implementation

### DIFF
--- a/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/model/AttributeValue.h
+++ b/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/model/AttributeValue.h
@@ -65,6 +65,8 @@ public:
 
     /// returns the ByteBuffer if the value is specialized to this type, otherwise an empty Buffer
     const Aws::Utils::ByteBuffer GetB() const;
+    /// returns a reference to the ByteBuffer if the value is specialized to this type, otherwise a reference to an empty Buffer
+    const Aws::Utils::ByteBuffer& AccessB() const;
     /// if already specialized to a ByteBuffer, sets the value to this value
     /// if uninitialized, specializes the type to a ByteBuffer with the specified value
     /// if already specialized to another type then the behavior is undefined

--- a/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/model/AttributeValueValue.h
+++ b/generated/src/aws-cpp-sdk-dynamodb/include/aws/dynamodb/model/AttributeValueValue.h
@@ -32,6 +32,11 @@ public:
 
     virtual const Aws::Utils::ByteBuffer GetB() const { return {}; }
 
+    virtual const Aws::Utils::ByteBuffer& AccessB() const {
+        static const Aws::Utils::ByteBuffer empty;
+        return empty;
+    }
+
     virtual const Aws::Vector<Aws::String> GetSS() const { return {}; }
 
     virtual void AddSItem(const Aws::String& ) { assert(false); }
@@ -104,6 +109,7 @@ public:
     explicit AttributeValueByteBuffer(const Aws::Utils::ByteBuffer& value) : m_b(value) {}
     explicit AttributeValueByteBuffer(Aws::Utils::Json::JsonView jsonValue);
     const Aws::Utils::ByteBuffer GetB() const override { return m_b; }
+    const Aws::Utils::ByteBuffer& AccessB() const override { return m_b; }
     bool IsDefault() const override { return m_b.GetLength() == 0; }
     bool operator == (const AttributeValueValue& other) const override { return GetType() == other.GetType() && m_b == other.GetB(); }
     Aws::Utils::Json::JsonValue Jsonize() const override;

--- a/generated/src/aws-cpp-sdk-dynamodb/source/model/AttributeValue.cpp
+++ b/generated/src/aws-cpp-sdk-dynamodb/source/model/AttributeValue.cpp
@@ -66,6 +66,19 @@ AttributeValue& AttributeValue::SetB(const ByteBuffer& b)
     return *this;
 }
 
+const ByteBuffer& AttributeValue::AccessB() const
+{
+    if (m_value)
+    {
+       return m_value->AccessB();
+    }
+    else
+    {
+        static const ByteBuffer empty;
+        return empty;
+    }
+}
+
 const Aws::Vector<Aws::String> AttributeValue::GetSS() const
 {
     if (m_value)

--- a/tests/aws-cpp-sdk-dynamodb-integration-tests/TableOperationTest.cpp
+++ b/tests/aws-cpp-sdk-dynamodb-integration-tests/TableOperationTest.cpp
@@ -1058,6 +1058,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         EXPECT_EQ("String Value", returnedItemCollection["String"].GetS());
         EXPECT_EQ("1001", returnedItemCollection["Number"].GetN());
         EXPECT_EQ(byteBuffer1, returnedItemCollection["ByteBuffer"].GetB()); // on the 3rd day of xmas...
+        EXPECT_EQ(byteBuffer1, returnedItemCollection["ByteBuffer"].AccessB());
     }
 
     // StringSet
@@ -1097,6 +1098,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         EXPECT_EQ("String Value", returnedItemCollection["String"].GetS());
         EXPECT_EQ("1001", returnedItemCollection["Number"].GetN());
         EXPECT_EQ(byteBuffer1, returnedItemCollection["ByteBuffer"].GetB());
+        EXPECT_EQ(byteBuffer1, returnedItemCollection["ByteBuffer"].AccessB());
         auto ss = returnedItemCollection["String Set"].GetSS();
         EXPECT_EQ(2u, ss.size());
         EXPECT_NE(ss.end(), std::find(ss.begin(), ss.end(), "test1"));
@@ -1140,6 +1142,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         EXPECT_EQ("String Value", returnedItemCollection["String"].GetS());
         EXPECT_EQ("1001", returnedItemCollection["Number"].GetN());
         EXPECT_EQ(byteBuffer1, returnedItemCollection["ByteBuffer"].GetB());
+        EXPECT_EQ(byteBuffer1, returnedItemCollection["ByteBuffer"].AccessB());
         auto ss = returnedItemCollection["String Set"].GetSS();
         EXPECT_EQ(2u, ss.size());
         EXPECT_NE(ss.end(), std::find(ss.begin(), ss.end(), "test1"));
@@ -1187,6 +1190,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         EXPECT_EQ("String Value", returnedItemCollection["String"].GetS());
         EXPECT_EQ("1001", returnedItemCollection["Number"].GetN());
         EXPECT_EQ(byteBuffer1, returnedItemCollection["ByteBuffer"].GetB());
+        EXPECT_EQ(byteBuffer1, returnedItemCollection["ByteBuffer"].AccessB());
         auto ss = returnedItemCollection["String Set"].GetSS();
         EXPECT_EQ(2u, ss.size());
         EXPECT_NE(ss.end(), std::find(ss.begin(), ss.end(), "test1"));
@@ -1240,6 +1244,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         EXPECT_EQ("String Value", returnedItemCollection["String"].GetS());
         EXPECT_EQ("1001", returnedItemCollection["Number"].GetN());
         EXPECT_EQ(byteBuffer1, returnedItemCollection["ByteBuffer"].GetB());
+        EXPECT_EQ(byteBuffer1, returnedItemCollection["ByteBuffer"].AccessB());
         auto ss = returnedItemCollection["String Set"].GetSS();
         EXPECT_EQ(2u, ss.size());
         EXPECT_NE(ss.end(), std::find(ss.begin(), ss.end(), "test1"));
@@ -1334,6 +1339,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
         EXPECT_EQ("String Value", returnedItemCollection["String"].GetS());
         EXPECT_EQ("1001", returnedItemCollection["Number"].GetN());
         EXPECT_EQ(byteBuffer1, returnedItemCollection["ByteBuffer"].GetB());
+        EXPECT_EQ(byteBuffer1, returnedItemCollection["ByteBuffer"].AccessB());
         auto ss = returnedItemCollection["String Set"].GetSS();
         EXPECT_EQ(2u, ss.size());
         EXPECT_NE(ss.end(), std::find(ss.begin(), ss.end(), "test1"));

--- a/tests/aws-cpp-sdk-dynamodb-integration-tests/TableOperationTest.cpp
+++ b/tests/aws-cpp-sdk-dynamodb-integration-tests/TableOperationTest.cpp
@@ -907,7 +907,7 @@ TEST_F(TableOperationTest, TestAttributeValues)
     const Aws::Utils::ByteBuffer byteBuffer1(buffer1, 6);
     unsigned char buffer2[6] = { 21, 35, 55, 68, 11, 6 };
     const Aws::Utils::ByteBuffer byteBuffer2(buffer2, 6);
-
+    const Aws::Utils::ByteBuffer emptyBuf;
     // create the Hash Key value
     AttributeValue hashKey("TestValue");
 
@@ -947,6 +947,9 @@ TEST_F(TableOperationTest, TestAttributeValues)
         //ReturnedItemCollection returnedItemCollection = result.GetItems();
         EXPECT_EQ("TestValue", returnedItemCollection[HASH_KEY_NAME].GetS());
         EXPECT_EQ("String Value", returnedItemCollection["String"].GetS());
+
+        EXPECT_EQ(emptyBuf, returnedItemCollection["ByteBuffer"].GetB());
+        EXPECT_EQ(emptyBuf, returnedItemCollection["ByteBuffer"].AccessB());
     }
 
     // Number Value

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/dynamodb/AttributeValueHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/dynamodb/AttributeValueHeader.vm
@@ -62,6 +62,8 @@ public:
 
     /// returns the ByteBuffer if the value is specialized to this type, otherwise an empty Buffer
     const Aws::Utils::ByteBuffer GetB() const;
+    /// returns a reference to the ByteBuffer if the value is specialized to this type, otherwise a reference to an empty Buffer
+    const Aws::Utils::ByteBuffer& AccessB() const;
     /// if already specialized to a ByteBuffer, sets the value to this value
     /// if uninitialized, specializes the type to a ByteBuffer with the specified value
     /// if already specialized to another type then the behavior is undefined

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/dynamodb/AttributeValueSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/dynamodb/AttributeValueSource.vm
@@ -63,6 +63,19 @@ AttributeValue& AttributeValue::SetB(const ByteBuffer& b)
     return *this;
 }
 
+const ByteBuffer& AttributeValue::AccessB() const
+{
+    if (m_value)
+    {
+       return m_value->AccessB();
+    }
+    else
+    {
+        static const ByteBuffer empty;
+        return empty;
+    }
+}
+
 const Aws::Vector<Aws::String> AttributeValue::GetSS() const
 {
     if (m_value)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/dynamodb/AttributeValueValueHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/dynamodb/AttributeValueValueHeader.vm
@@ -29,6 +29,11 @@ public:
 
     virtual const Aws::Utils::ByteBuffer GetB() const { return {}; }
 
+    virtual const Aws::Utils::ByteBuffer& AccessB() const {
+        static const Aws::Utils::ByteBuffer empty;
+        return empty;
+    }
+
     virtual const Aws::Vector<Aws::String> GetSS() const { return {}; }
 
     virtual void AddSItem(const Aws::String& ) { assert(false); }
@@ -101,6 +106,7 @@ public:
     explicit AttributeValueByteBuffer(const Aws::Utils::ByteBuffer& value) : m_b(value) {}
     explicit AttributeValueByteBuffer(Aws::Utils::Json::JsonView jsonValue);
     const Aws::Utils::ByteBuffer GetB() const override { return m_b; }
+    const Aws::Utils::ByteBuffer& AccessB() const override { return m_b; }
     bool IsDefault() const override { return m_b.GetLength() == 0; }
     bool operator == (const AttributeValueValue& other) const override { return GetType() == other.GetType() && m_b == other.GetB(); }
     Aws::Utils::Json::JsonValue Jsonize() const override;


### PR DESCRIPTION
*Issue #, if available:*
#3031 

*Description of changes:*

Implement a new function `AccessB()` that returns a reference to the byte buffer:

`const Aws::Utils::ByteBuffer& AccessB() const override { return m_b; }`

The changes are to the code generation velocity templates, and are only be scoped to the DynamoDB client.


*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
