### PR TITLE
Fix incorrect signature with `SetPreservePathSeparators(true)` caused by stale `m_pathHasTrailingSlash`

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/URI.cpp
+++ b/src/aws-cpp-sdk-core/source/http/URI.cpp
@@ -254,6 +254,7 @@ Aws::String URI::GetURLEncodedPathRFC3986() const
 void URI::SetPath(const Aws::String& value)
 {
     m_pathSegments.clear();
+    m_pathHasTrailingSlash = false;
     AddPathSegments(value);
 }
 


### PR DESCRIPTION
This PR fixes an issue where pathless requests (e.g., STS or Athena) fail signature validation when `Aws::Http::SetPreservePathSeparators(true)` is enabled.

The root cause lies in the handling of `URI::SetPath(...)`:

- When an empty path is parsed, the SDK assigns `/` via `SetPath("/")`, which sets `m_pathHasTrailingSlash = true`.
- Later, the SDK internally re-applies the path via `uri.SetPath(uri.GetURLEncodedPathRFC3986());`, assuming it is idempotent.
- But in `AddPathSegments(...)`, this flag interferes with leading empty segment removal logic:

```cpp
if (s_preservePathSeparators && m_pathSegments.empty()
    && !split.empty() && split.front().empty()
    && !m_pathHasTrailingSlash)
{
    split.erase(split.begin());
}
```

We reset m_pathHasTrailingSlash to false in URI::SetPath() before calling AddPathSegments(...), ensuring consistent re-parsing.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
