### PR TITLE
SSO role URL encoding fix in SSOCredentialsClient

### DIFF
--- a/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
+++ b/src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp
@@ -661,8 +661,8 @@ namespace Aws
 
             httpRequest->SetUserAgent(m_userAgent);
 
-            httpRequest->AddQueryStringParameter("account_id", Aws::Utils::StringUtils::URLEncode(request.m_ssoAccountId.c_str()));
-            httpRequest->AddQueryStringParameter("role_name", Aws::Utils::StringUtils::URLEncode(request.m_ssoRoleName.c_str()));
+            httpRequest->AddQueryStringParameter("account_id", request.m_ssoAccountId);
+            httpRequest->AddQueryStringParameter("role_name", request.m_ssoRoleName);
 
             Aws::String credentialsStr = GetResourceWithAWSWebServiceResult(httpRequest).GetPayload();
 

--- a/tests/aws-cpp-sdk-core-tests/aws/auth/AWSCredentialsProviderTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/aws/auth/AWSCredentialsProviderTest.cpp
@@ -970,6 +970,75 @@ sso_start_url = https://d-92671207e4.awsapps.com/start
     ASSERT_EQ(DateTime((int64_t) 2303614800000), creds.GetExpiration());
 }
 
+TEST_F(SSOCredentialsProviderTest, TestParseCredentialsFromNonAsciiRole)
+{
+    AWS_LOGSTREAM_DEBUG("TEST_SSO", "Preparing Test Token file in: " << m_ssoTokenRefreshFileName);
+    Aws::OFStream tokenFile(m_ssoTokenRefreshFileName.c_str(), Aws::OFStream::out | Aws::OFStream::trunc);
+    tokenFile << R"({
+    "accessToken": "base64string",
+    "expiresAt": ")";
+    tokenFile << DateTime::Now().GetYear() + 1;
+    tokenFile << R"(-01-02T00:00:00Z",
+    "region": "us-west-2",
+    "startUrl": "https://d-92671207e4.awsapps.com/start"
+})";
+    tokenFile.close();
+    Aws::Environment::SetEnv("AWS_DEFAULT_PROFILE", "sso-profile", 1/*override*/);
+    Aws::Environment::SetEnv("AWS_PROFILE", "sso-profile", 1/*override*/);
+    Aws::OFStream configFile(m_configFileName.c_str(), Aws::OFStream::out | Aws::OFStream::trunc);
+    configFile << R"([profile sso-profile]
+sso_session = dev
+sso_account_id = 012345678901
+sso_role_name = Sample@@Role
+sso_region = us-east-1
+sso_start_url = https://d-92671207e4.awsapps.com/start
+
+[sso-session dev]
+sso_region = us-east-1
+sso_start_url = https://d-92671207e4.awsapps.com/start
+)";
+    configFile.close();
+
+    Aws::Config::ReloadCachedConfigFile();
+    SSOCredentialsProvider provider;
+
+    // No response is set to mockHttpClient, there will be no response
+    auto creds = provider.GetAWSCredentials();
+    ASSERT_TRUE(creds.IsEmpty());
+    auto request = mockHttpClient->GetMostRecentHttpRequest();
+
+    ASSERT_EQ("https://portal.sso.us-east-1.amazonaws.com/federation/credentials?account_id=012345678901&role_name=Sample%40%40Role", request.GetURIString());
+    ASSERT_EQ("base64string", request.GetHeaderValue("x-amz-sso_bearer_token"));
+    // No response is set to mockHttpClient, there will be no response
+    creds = provider.GetAWSCredentials();
+    ASSERT_TRUE(creds.IsEmpty());
+
+    // adding a valid response to the http request
+    std::shared_ptr<HttpRequest> requestTmp = CreateHttpRequest(URI(request.GetURIString(true /*include querystring*/)), HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+    //Made up credentials
+    Aws::String goodResult = R"({
+   "roleCredentials": {
+      "accessKeyId": "access",
+      "expiration": 2303614800000,
+      "secretAccessKey": "secret",
+      "sessionToken": "token"
+   }
+}
+)";
+
+    std::shared_ptr<StandardHttpResponse> goodResponse = Aws::MakeShared<StandardHttpResponse>(AllocationTag, requestTmp);
+    goodResponse->SetResponseCode(HttpResponseCode::OK);
+    goodResponse->GetResponseBody() << goodResult;
+    mockHttpClient->AddResponseToReturn(goodResponse);
+
+    creds = provider.GetAWSCredentials();
+    ASSERT_FALSE(creds.IsEmpty());
+    ASSERT_EQ("access", creds.GetAWSAccessKeyId());
+    ASSERT_EQ("secret", creds.GetAWSSecretKey());
+    ASSERT_EQ("token", creds.GetSessionToken());
+    ASSERT_EQ(DateTime((int64_t) 2303614800000), creds.GetExpiration());
+}
+
 TEST_F(SSOCredentialsProviderTest, TestParseCredentialsFromConfigFailsWithConflictingConfiguration)
 {
     AWS_LOGSTREAM_DEBUG("TEST_SSO", "Preparing Test Token file in: " << m_ssoTokenRefreshFileName);


### PR DESCRIPTION
*Issue #, if available:*
#3477

*Description of changes:*

Remove the `Aws::Utils::URLEncode` function call in the `SSOCredentialsClient` when adding QueryStringParameters to the `HTTPRequest` object. The URLEncode function is already called in the underlying `URI::AddQueryStringParameter` function, and as a result the parameters are being encoded twice. 

Included a test case for this scenario. 

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
