### PR TITLE
Feature/profile name credentials chain

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProviderChain.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProviderChain.h
@@ -59,11 +59,13 @@ namespace Aws
         class AWS_CORE_API DefaultAWSCredentialsProviderChain : public AWSCredentialsProviderChain
         {
         public:
-            /**
-             * Initializes the provider chain with EnvironmentAWSCredentialsProvider, ProfileConfigFileAWSCredentialsProvider,
-             * ProcessCredentialsProvider, STSAssumeRoleWebIdentityCredentialsProvider and SSOCredentialsProvider in that order.
-             */
-            DefaultAWSCredentialsProviderChain();
+          /**
+           * Initializes the provider chain using ClientConfiguration settings.
+           * If no configuration is provided, initializes with default providers in the following order:
+           * EnvironmentAWSCredentialsProvider, ProfileConfigFileAWSCredentialsProvider,
+           * ProcessCredentialsProvider, STSAssumeRoleWebIdentityCredentialsProvider and SSOCredentialsProvider.
+           */
+            DefaultAWSCredentialsProviderChain(const Aws::Client::CredentialProviderConfiguration& config = Aws::Client::CredentialProviderConfiguration());
 
             DefaultAWSCredentialsProviderChain(const DefaultAWSCredentialsProviderChain& chain);
         };

--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -89,6 +89,19 @@ namespace Aws
         };
 
         /**
+         * Configuration structure for credential providers in the AWS SDK.
+         * This structure allows passing configuration options to credential providers
+         * such as profile name and client configuration for HTTP requests made by
+         * credential providers that need to make network calls (e.g., InstanceProfileCredentialsProvider).
+         */
+        struct CredentialProviderConfiguration {
+          /**
+           * AWS profile name to use for credentials.
+           */
+          Aws::String profile;
+        };
+
+        /**
          * This mutable structure is used to configure any of the AWS clients.
          * Default values can only be overwritten prior to passing to the client constructors.
          */
@@ -496,6 +509,5 @@ namespace Aws
         AWS_CORE_API Aws::String ComputeUserAgentString(ClientConfiguration const * const pConfig = nullptr);
 
         AWS_CORE_API Aws::String FilterUserAgentToken(char const * const token);
-
     } // namespace Client
 } // namespace Aws

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm
@@ -63,7 +63,11 @@
 #set($AdditionalServiceSpecificConfigLoadString = "Load${metadata.classNamePrefix}SpecificConfig(config);")
 #end
 #set($clientConfigurationNamespace = "Client")
+#if($clientConfiguration.profileName && !$clientConfiguration.profileName.empty())
+#set($defaultCredentialsProviderChainParam = "Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, Aws::Client::CredentialProviderConfiguration{clientConfiguration.profileName})")
+#else
 #set($defaultCredentialsProviderChainParam = "Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG)")
+#end
 #set($s3ExpressIdentityProviderParam = "clientConfiguration.identityProviderSupplier(*this)")
 #set($simpleCredentialsProviderParam = "Aws::MakeShared<SimpleAWSCredentialsProvider>(ALLOCATION_TAG, credentials)")
 #set($hasEventStreamInputOperation = $serviceModel.hasStreamingRequestShapes())


### PR DESCRIPTION
*Issue #, if available:*  [#3395](https://github.com/aws/aws-sdk-cpp/issues/3395)

*Description of changes:* Added support for profile names in DefaultAWSCredentialsProviderChain by extending the constructor to accept a CredentialProviderConfiguration parameter. This addresses the feature request to allow specification of non-default profile names in the credentials chain.

*Check all that applies:*
- [ x] Did a review by yourself.
- [ x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ x] Checked if this PR is a breaking (APIs have been changed) change.
- [ x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ x] Linux
- [ x] Windows
- [ x] Android
- [ x] MacOS
- [ x] IOS
- [ x] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
