### PR TITLE
Add support for eventheader trait

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/Shape.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/Shape.java
@@ -54,6 +54,7 @@ public class Shape {
     private String eventPayloadMemberName;
     private String eventPayloadType;
     private boolean isOutgoingEventStream;
+    private Map<String, Shape> eventStreamHeaders;
     private boolean exception;
     private boolean sensitive;
     private boolean hasPreSignedUrl;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/EventHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/EventHeader.vm
@@ -49,10 +49,32 @@ namespace Model
     inline ${classNameRef} With${memberKeyWithFirstLetterCapitalized}(${moveType} value) { Set${memberKeyWithFirstLetterCapitalized}(std::move(value)); return *this;}
     ///@}
 
+#foreach($eventHeaderMapping in $shape.getEventStreamHeaders().entrySet())
+#set($eventHeader = $eventHeaderMapping.getValue())
+#set($eventHeaderMemberName = $CppViewHelper.computeMemberVariableName($eventHeader.getName()))
+#set($eventHeaderMemberNameWithFirstLetterCapitalized = $CppViewHelper.capitalizeFirstChar($eventHeader.getName()))
+#set($eventHeaderMemberHaseBeenSetName = $CppViewHelper.computeVariableHasBeenSetName($eventHeader.getName()))
+#set($eventHeaderMemberType = $CppViewHelper.computeCppType($eventHeader))
+    inline const $eventHeaderMemberType Get${eventHeaderMemberNameWithFirstLetterCapitalized}() const { return $eventHeaderMemberName; }
+    inline bool ${eventHeaderMemberNameWithFirstLetterCapitalized}HasBeenSet() const { return $eventHeaderMemberHaseBeenSetName; }
+    template<typename T = $eventHeaderMemberType>
+    void Set${eventHeaderMemberNameWithFirstLetterCapitalized}(T&& value) { $eventHeaderMemberHaseBeenSetName = true; $eventHeaderMemberName = std::forward<T>(value); }
+    template<typename T = $eventHeaderMemberType>
+    ${classNameRef} With${eventHeaderMemberNameWithFirstLetterCapitalized}(T&& value) { Set${eventHeaderMemberNameWithFirstLetterCapitalized}(value); return *this; }
+
+#end
   private:
 
     Aws::Vector<unsigned char> $memberVariableName;
     bool ${CppViewHelper.computeVariableHasBeenSetName($blobMember.key)} = false;
+#foreach($eventHeaderMapping in $shape.getEventStreamHeaders().entrySet())
+#set($eventHeader = $eventHeaderMapping.getValue())
+#set($eventHeaderMemberName = $CppViewHelper.computeMemberVariableName($eventHeader.getName()))
+#set($eventHeaderMemberHaseBeenSetName = $CppViewHelper.computeVariableHasBeenSetName($eventHeader.getName()))
+#set($eventHeaderMemberType = $CppViewHelper.computeCppType($eventHeader))
+    $eventHeaderMemberType $eventHeaderMemberName;
+    bool $eventHeaderMemberHaseBeenSetName;
+#end
   };
 
 } // namespace Model

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonEventStreamHandlerSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonEventStreamHandlerSource.vm
@@ -134,6 +134,19 @@ namespace Model
             ${eventShape.name} event(GetEventPayloadWithOwnership());
             m_on${eventShape.name}(event);
             break;
+#elseif($eventShape.getEventStreamHeaders().size() > 0)
+            ${eventShape.name} event(GetEventPayloadWithOwnership());
+#foreach($eventStreamHeaderMapping in $eventShape.getEventStreamHeaders().entrySet())
+#set($eventStreamHeader = $eventStreamHeaderMapping.getValue())
+#set($eventHeaderMemberNameWithFirstLetterCapitalized = $CppViewHelper.capitalizeFirstChar($eventStreamHeader.getName()))
+#set($headerVarName = $CppViewHelper.lowercasesFirstChar("${eventStreamHeader.getName()}Header"))
+            const auto $headerVarName = headers.find("${eventStreamHeaderMapping.getKey()}");
+            if ($headerVarName != headers.end()) {
+                event.Set$eventHeaderMemberNameWithFirstLetterCapitalized($headerVarName->second.GetEventHeaderValueAsString());
+            }
+#end
+            m_on${eventShape.name}(event);
+            break;
 ##multiple members or the only one member is structure
 #elseif(!$eventShape.members.isEmpty())
             JsonValue json(GetEventPayloadAsString());


### PR DESCRIPTION
*Description of changes:*

Adds support for the [event header trait](https://smithy.io/2.0/spec/streaming.html#eventheader-trait)

> Binds a member of a structure to be serialized as an event header when sent through an event stream.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms

> If tests are not applicable, explain.

no tests exist in the PR as the correct place would be protocol tests, and adding one there will come upstream from smithy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
