### PR TITLE
C++ support AWS_METADATA_SERVICE_TIMEOUT

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProvider.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProvider.h
@@ -22,6 +22,10 @@
 
 namespace Aws
 {
+    namespace Client
+    {
+        struct ClientConfiguration;
+    }
     namespace Auth
     {
         constexpr int REFRESH_THRESHOLD = 1000 * 60 * 5;
@@ -211,6 +215,11 @@ namespace Aws
              * uses a supplied EC2MetadataClient.
              */
             InstanceProfileCredentialsProvider(const std::shared_ptr<Aws::Config::EC2InstanceProfileConfigLoader>&, long refreshRateMs = REFRESH_THRESHOLD);
+
+            /**
+             * Initializes the provider using ClientConfiguration for IMDS settings.
+             */
+            InstanceProfileCredentialsProvider(const Aws::Client::ClientConfiguration::CredentialProviderConfiguration& credentialProviderConfig, long refreshRateMs = REFRESH_THRESHOLD);
 
             /**
             * Retrieves the credentials if found, otherwise returns empty credential set.

--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -497,6 +497,28 @@ namespace Aws
              * Region to use for calls
              */
             Aws::String region;
+
+            /**
+             * IMDS configuration settings
+             */
+            struct {
+              /**
+               * Number of total attempts to make when retrieving data from IMDS. Default 1.
+               */
+              long metadataServiceNumAttempts = 1;
+              
+              /**
+               * Timeout in seconds when retrieving data from IMDS. Default 1.
+               */
+              long metadataServiceTimeout = 1;
+
+              /**
+               * Retry Strategy for IMDS
+               */
+              std::shared_ptr<RetryStrategy> imdsRetryStrategy;
+              bool disableImdsV1;
+              bool disableImds;
+            } imdsConfig;
           }credentialProviderConfig;
         };
 

--- a/src/aws-cpp-sdk-core/include/aws/core/config/EC2InstanceProfileConfigLoader.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/config/EC2InstanceProfileConfigLoader.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <aws/core/config/AWSProfileConfigLoaderBase.h>
-
+#include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/utils/memory/stl/AWSMap.h>
 #include <aws/core/utils/DateTime.h>
@@ -33,6 +33,11 @@ namespace Aws
              * If client is nullptr, the default EC2MetadataClient will be created.
              */
             EC2InstanceProfileConfigLoader(const std::shared_ptr<Aws::Internal::EC2MetadataClient>& = nullptr);
+
+            /**
+             * Creates EC2MetadataClient using the provided CredentialProviderConfiguration.
+             */
+            EC2InstanceProfileConfigLoader(const Aws::Client::ClientConfiguration::CredentialProviderConfiguration& credentialConfig);
 
             virtual ~EC2InstanceProfileConfigLoader() = default;
 

--- a/src/aws-cpp-sdk-core/include/aws/core/internal/AWSHttpResourceClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/internal/AWSHttpResourceClient.h
@@ -103,6 +103,7 @@ namespace Aws
              */
             EC2MetadataClient(const char* endpoint = "http://169.254.169.254");
             EC2MetadataClient(const Client::ClientConfiguration& clientConfiguration, const char* endpoint = "http://169.254.169.254");
+            EC2MetadataClient(const Client::ClientConfiguration::CredentialProviderConfiguration& credentialConfig, const char* endpoint = "http://169.254.169.254");
 
             EC2MetadataClient& operator =(const EC2MetadataClient& rhs) = delete;
             EC2MetadataClient(const EC2MetadataClient& rhs) = delete;

--- a/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
@@ -7,6 +7,7 @@
 #include <aws/core/auth/AWSCredentialsProvider.h>
 
 #include <aws/core/config/AWSProfileConfigLoader.h>
+#include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/platform/Environment.h>
 #include <aws/core/platform/FileSystem.h>
 #include <aws/core/platform/OSVersionInfo.h>
@@ -242,6 +243,12 @@ InstanceProfileCredentialsProvider::InstanceProfileCredentialsProvider(const std
     AWS_LOGSTREAM_INFO(INSTANCE_LOG_TAG, "Creating Instance with injected EC2MetadataClient and refresh rate " << refreshRateMs);
 }
 
+InstanceProfileCredentialsProvider::InstanceProfileCredentialsProvider(const Aws::Client::ClientConfiguration::CredentialProviderConfiguration& credentialConfig, long refreshRateMs) :
+    m_ec2MetadataConfigLoader(Aws::MakeShared<Aws::Config::EC2InstanceProfileConfigLoader>(INSTANCE_LOG_TAG, credentialConfig)),
+    m_loadFrequencyMs(refreshRateMs)
+{
+    AWS_LOGSTREAM_INFO(INSTANCE_LOG_TAG, "Creating Instance with IMDS timeout: " << credentialConfig.imdsConfig.metadataServiceTimeout << "s, attempts: " << credentialConfig.imdsConfig.metadataServiceNumAttempts);
+}
 
 AWSCredentials InstanceProfileCredentialsProvider::GetAWSCredentials()
 {

--- a/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProviderChain.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProviderChain.cpp
@@ -6,6 +6,7 @@
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
 #include <aws/core/auth/STSCredentialsProvider.h>
 #include <aws/core/auth/SSOCredentialsProvider.h>
+#include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/platform/Environment.h>
 #include <aws/core/utils/memory/AWSMemory.h>
 #include <aws/core/utils/StringUtils.h>
@@ -125,7 +126,7 @@ DefaultAWSCredentialsProviderChain::DefaultAWSCredentialsProviderChain(const Aws
     }
     else if (Aws::Utils::StringUtils::ToLower(ec2MetadataDisabled.c_str()) != "true")
     {
-        AddProvider(Aws::MakeShared<InstanceProfileCredentialsProvider>(DefaultCredentialsProviderChainTag));
+        AddProvider(Aws::MakeShared<InstanceProfileCredentialsProvider>(DefaultCredentialsProviderChainTag, config));
         AWS_LOGSTREAM_INFO(DefaultCredentialsProviderChainTag, "Added EC2 metadata service credentials provider to the provider chain.");
     }
 }

--- a/src/aws-cpp-sdk-core/source/auth/STSCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/STSCredentialsProvider.cpp
@@ -107,7 +107,7 @@ Aws::String LegacyGetRegion() {
 
 STSAssumeRoleWebIdentityCredentialsProvider::STSAssumeRoleWebIdentityCredentialsProvider()
     : STSAssumeRoleWebIdentityCredentialsProvider(
-          Aws::Client::ClientConfiguration::CredentialProviderConfiguration{Aws::Auth::GetConfigProfileName(), LegacyGetRegion()}) {}
+          Aws::Client::ClientConfiguration::CredentialProviderConfiguration{Aws::Auth::GetConfigProfileName(), LegacyGetRegion(), {}}) {}
 
 AWSCredentials STSAssumeRoleWebIdentityCredentialsProvider::GetAWSCredentials()
 {

--- a/src/aws-cpp-sdk-core/source/config/EC2InstanceProfileConfigLoader.cpp
+++ b/src/aws-cpp-sdk-core/source/config/EC2InstanceProfileConfigLoader.cpp
@@ -6,6 +6,7 @@
 #include <aws/core/config/AWSProfileConfigLoader.h>
 #include <aws/core/internal/AWSHttpResourceClient.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/utils/memory/stl/AWSList.h>
 #include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/json/JsonSerializer.h>
@@ -37,6 +38,10 @@ namespace Aws
                 m_ec2metadataClient = client;
             }
         }
+        
+        EC2InstanceProfileConfigLoader::EC2InstanceProfileConfigLoader(const Aws::Client::ClientConfiguration::CredentialProviderConfiguration& credentialConfig)
+            : m_ec2metadataClient(Aws::MakeShared<Aws::Internal::EC2MetadataClient>(EC2_INSTANCE_PROFILE_LOG_TAG, credentialConfig))
+        {}
 
         bool EC2InstanceProfileConfigLoader::LoadInternal()
         {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Implement a new configuration support for  IMDS (Instance Metadata Service), specifically support for environment variable AWS_METADATA_SERVICE_TIMEOUT and AWS_METADATA_SERVICE_NUM_ATTEMPTS . [Reference](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ec2-instance-metadata.html) for Amazon EC2 instance metadata.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
