### PR TITLE
fix memory leak in peformance tests

### DIFF
--- a/tests/performance-tests/include/performance-tests/reporting/JsonReportingMetrics.h
+++ b/tests/performance-tests/include/performance-tests/reporting/JsonReportingMetrics.h
@@ -38,6 +38,11 @@ struct PerformanceMetricRecord {
 };
 
 /**
+ * Context will be shared between monitor invocations.
+ */
+struct RequestContext;
+
+/**
  * An implementation of the MonitoringInterface that collects performance metrics
  * and reports them in a JSON format.
  */
@@ -150,6 +155,7 @@ class JsonReportingMetrics : public Aws::Monitoring::MonitoringInterface {
   void WriteJsonToFile(const Aws::Utils::Json::JsonValue& root) const;
 
   mutable Aws::Vector<PerformanceMetricRecord> m_performanceRecords;
+  mutable Aws::UnorderedMap<Aws::String, Aws::UniquePtr<RequestContext>> m_requestContexts;
   Aws::Set<Aws::String> m_monitoredOperations;
   Aws::String m_productId;
   Aws::String m_sdkVersion;


### PR DESCRIPTION
*Description of changes:*

Our CI jobs are failing infrequently with a ASAN check

```
==192==ERROR: LeakSanitizer: detected memory leaks
--
 
Direct leak of 2808 byte(s) in 27 object(s) allocated from:
#0 0x7fd90482657d in malloc (/lib64/libasan.so.4+0xd857d)
#1 0x7fd90395f1bf in Aws::Malloc(char const*, unsigned long) aws-sdk-cpp/src/aws-cpp-sdk-core/source/utils/memory/AWSMemory.cpp:146
#2 0x4e992a in RequestContext* Aws::New<RequestContext>(char const*) aws-sdk-cpp/src/aws-cpp-sdk-core/include/aws/core/utils/memory/AWSMemory.h:70
```

this tracks request contexts, storing them in a container, removing them from the map. If for any reason some get orphaned, they will be free-ed during object desctruction.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
