### PR TITLE
update to use regionalized STS credentials client

### DIFF
--- a/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClientConfiguration.cpp
+++ b/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClientConfiguration.cpp
@@ -45,6 +45,12 @@ void DynamoDBClientConfiguration::LoadDynamoDBSpecificConfig(const Aws::String& 
   if(!enableEndpointDiscovery) {
     enableEndpointDiscovery = IsEndpointDiscoveryEnabled(this->endpointOverride, inputProfileName);
   }
+  this->configFactories.retryStrategyCreateFn = []() -> std::shared_ptr<Client::RetryStrategy> {
+    // TODO: renable once default retries are evaluated
+    // Align with other SDKs to default retry to 10 times for dynamodb.
+    // return Client::InitRetryStrategy(10);
+    return Client::InitRetryStrategy();
+  };
 }
 
 DynamoDBClientConfiguration::DynamoDBClientConfiguration(const Client::ClientConfigurationInitValues &configuration)

--- a/src/aws-cpp-sdk-core/include/aws/core/auth/STSCredentialsProvider.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/auth/STSCredentialsProvider.h
@@ -26,6 +26,7 @@ namespace Aws
         {
         public:
             STSAssumeRoleWebIdentityCredentialsProvider();
+            STSAssumeRoleWebIdentityCredentialsProvider(Aws::Client::ClientConfiguration::CredentialProviderConfiguration config);
 
             /**
              * Retrieves the credentials if found, otherwise returns empty credential set.

--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -492,6 +492,11 @@ namespace Aws
             * AWS profile name to use for credentials.
             */
             Aws::String profile;
+
+            /**
+             * Region to use for calls
+             */
+            Aws::String region;
           }credentialProviderConfig;
         };
 
@@ -499,7 +504,8 @@ namespace Aws
          * A helper function to initialize a retry strategy.
          * Default is DefaultRetryStrategy (i.e. exponential backoff)
          */
-        std::shared_ptr<RetryStrategy> InitRetryStrategy(Aws::String retryMode = "");
+        AWS_CORE_API std::shared_ptr<RetryStrategy> InitRetryStrategy(Aws::String retryMode = "");
+        AWS_CORE_API std::shared_ptr<RetryStrategy> InitRetryStrategy(int maxRetries, Aws::String retryMode = "");
 
         /**
          * A helper function to compute a user agent

--- a/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProviderChain.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProviderChain.cpp
@@ -90,7 +90,7 @@ DefaultAWSCredentialsProviderChain::DefaultAWSCredentialsProviderChain(const Aws
     AddProvider(Aws::MakeShared<EnvironmentAWSCredentialsProvider>(DefaultCredentialsProviderChainTag));
     AddProvider(Aws::MakeShared<ProfileConfigFileAWSCredentialsProvider>(DefaultCredentialsProviderChainTag,config.profile.c_str()));
     AddProvider(Aws::MakeShared<ProcessCredentialsProvider>(DefaultCredentialsProviderChainTag,config.profile));
-    AddProvider(Aws::MakeShared<STSAssumeRoleWebIdentityCredentialsProvider>(DefaultCredentialsProviderChainTag));
+    AddProvider(Aws::MakeShared<STSAssumeRoleWebIdentityCredentialsProvider>(DefaultCredentialsProviderChainTag, config));
     AddProvider(Aws::MakeShared<SSOCredentialsProvider>(DefaultCredentialsProviderChainTag,config.profile));
 
     // General HTTP Credentials (prev. known as ECS TaskRole credentials) only available when ENVIRONMENT VARIABLE is set

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/ServiceClientConfigurationSource.vm
@@ -123,6 +123,15 @@ void ${metadata.classNamePrefix}ClientConfiguration::Load${serviceNamespace}Spec
     enableEndpointDiscovery = IsEndpointDiscoveryEnabled(this->endpointOverride, inputProfileName);
   }
 #end
+## DyanmoDB historically requires 10 retries for backwards compatibility
+#if($serviceModel.metadata.serviceId == "DynamoDB")
+  this->configFactories.retryStrategyCreateFn = []() -> std::shared_ptr<Client::RetryStrategy> {
+    // TODO: renable once default retries are evaluated
+    // Align with other SDKs to default retry to 10 times for dynamodb.
+    // return Client::InitRetryStrategy(10);
+    return Client::InitRetryStrategy();
+  };
+#end
 }
 
 ${metadata.classNamePrefix}ClientConfiguration::${metadata.classNamePrefix}ClientConfiguration(const Client::ClientConfigurationInitValues &configuration)


### PR DESCRIPTION
*Description of changes:*

Per [Updating AWS SDK defaults – AWS STS service endpoint and Retry Strategy](https://aws.amazon.com/blogs/developer/updating-aws-sdk-defaults-aws-sts-service-endpoint-and-retry-strategy/). Our STS credentials provider was already regionalized but did not use the region configured on client configuration. This moves to use that instead of a custom workflow.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
