### PR TITLE
Reuse checksum on streaming retries + refactor ChecksumInterceptor

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceRequest.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceRequest.h
@@ -35,6 +35,10 @@ namespace Aws
     typedef std::function<void(const AmazonWebServiceRequest&)> RequestRetryHandler;
     typedef std::function<void(const Aws::Http::HttpRequest&)> RequestSignedHandler;
 
+    struct RetryContext {
+      std::pair<Aws::String, std::shared_ptr<Aws::Utils::Crypto::Hash>> m_requestHash;
+    };
+
     /**
      * Base level abstraction for all modeled AWS requests
      */
@@ -222,7 +226,9 @@ namespace Aws
          */
         Aws::Set<Aws::Client::UserAgentFeature> GetUserAgentFeatures() const { return m_userAgentFeatures; }
 
-      inline virtual bool RequestChecksumRequired() const { return false; }
+        inline virtual bool RequestChecksumRequired() const { return false; }
+
+        mutable Aws::RetryContext m_retryContext;
     protected:
         /**
          * Default does nothing. Override this to convert what would otherwise be the payload of the

--- a/src/aws-cpp-sdk-core/include/smithy/client/features/ChecksumInterceptor.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/features/ChecksumInterceptor.h
@@ -84,42 +84,49 @@ class ChecksumInterceptor : public smithy::interceptor::Interceptor {
         // AwsAuthSigner decide it.
         if (request.IsStreaming() && checksumValueAndAlgorithmProvided) {
           addChecksumFeatureForChecksumName(checksumAlgorithmName, request);
-          const auto hash = Aws::MakeShared<PrecalculatedHash>(AWS_SMITHY_CLIENT_CHECKSUM, checksumHeader->second);
-          httpRequest->SetRequestHash(checksumAlgorithmName, hash);
+          if (httpRequest->GetRequestHash().second == nullptr) {
+            const auto hash = Aws::MakeShared<PrecalculatedHash>(AWS_SMITHY_CLIENT_CHECKSUM, checksumHeader->second);
+            httpRequest->SetRequestHash(checksumAlgorithmName, hash);
+          }
         } else if (checksumValueAndAlgorithmProvided) {
           httpRequest->SetHeaderValue(checksumType, checksumHeader->second);
         } else if (checksumAlgorithmName == "crc64nvme") {
           request.AddUserAgentFeature(Aws::Client::UserAgentFeature::FLEXIBLE_CHECKSUMS_REQ_CRC64);
           if (request.IsStreaming()) {
-            httpRequest->SetRequestHash(checksumAlgorithmName, Aws::MakeShared<CRC64>(AWS_SMITHY_CLIENT_CHECKSUM));
+            if (httpRequest->GetRequestHash().second == nullptr)
+              httpRequest->SetRequestHash(checksumAlgorithmName, Aws::MakeShared<CRC64>(AWS_SMITHY_CLIENT_CHECKSUM));
           } else {
             httpRequest->SetHeaderValue(checksumType, HashingUtils::Base64Encode(HashingUtils::CalculateCRC64(*(GetBodyStream(request)))));
           }
         } else if (checksumAlgorithmName == "crc32") {
           request.AddUserAgentFeature(Aws::Client::UserAgentFeature::FLEXIBLE_CHECKSUMS_REQ_CRC32);
           if (request.IsStreaming()) {
-            httpRequest->SetRequestHash(checksumAlgorithmName, Aws::MakeShared<CRC32>(AWS_SMITHY_CLIENT_CHECKSUM));
+            if (httpRequest->GetRequestHash().second == nullptr)
+              httpRequest->SetRequestHash(checksumAlgorithmName, Aws::MakeShared<CRC32>(AWS_SMITHY_CLIENT_CHECKSUM));
           } else {
             httpRequest->SetHeaderValue(checksumType, HashingUtils::Base64Encode(HashingUtils::CalculateCRC32(*(GetBodyStream(request)))));
           }
         } else if (checksumAlgorithmName == "crc32c") {
           request.AddUserAgentFeature(Aws::Client::UserAgentFeature::FLEXIBLE_CHECKSUMS_REQ_CRC32C);
           if (request.IsStreaming()) {
-            httpRequest->SetRequestHash(checksumAlgorithmName, Aws::MakeShared<CRC32C>(AWS_SMITHY_CLIENT_CHECKSUM));
+            if (httpRequest->GetRequestHash().second == nullptr)
+              httpRequest->SetRequestHash(checksumAlgorithmName, Aws::MakeShared<CRC32C>(AWS_SMITHY_CLIENT_CHECKSUM));
           } else {
             httpRequest->SetHeaderValue(checksumType, HashingUtils::Base64Encode(HashingUtils::CalculateCRC32C(*(GetBodyStream(request)))));
           }
         } else if (checksumAlgorithmName == "sha256") {
           request.AddUserAgentFeature(Aws::Client::UserAgentFeature::FLEXIBLE_CHECKSUMS_REQ_SHA256);
           if (request.IsStreaming()) {
-            httpRequest->SetRequestHash(checksumAlgorithmName, Aws::MakeShared<Sha256>(AWS_SMITHY_CLIENT_CHECKSUM));
+            if (httpRequest->GetRequestHash().second == nullptr)
+              httpRequest->SetRequestHash(checksumAlgorithmName, Aws::MakeShared<Sha256>(AWS_SMITHY_CLIENT_CHECKSUM));
           } else {
             httpRequest->SetHeaderValue(checksumType, HashingUtils::Base64Encode(HashingUtils::CalculateSHA256(*(GetBodyStream(request)))));
           }
         } else if (checksumAlgorithmName == "sha1") {
           request.AddUserAgentFeature(Aws::Client::UserAgentFeature::FLEXIBLE_CHECKSUMS_REQ_SHA1);
           if (request.IsStreaming()) {
-            httpRequest->SetRequestHash(checksumAlgorithmName, Aws::MakeShared<Sha1>(AWS_SMITHY_CLIENT_CHECKSUM));
+            if (httpRequest->GetRequestHash().second == nullptr)
+              httpRequest->SetRequestHash(checksumAlgorithmName, Aws::MakeShared<Sha1>(AWS_SMITHY_CLIENT_CHECKSUM));
           } else {
             httpRequest->SetHeaderValue(checksumType, HashingUtils::Base64Encode(HashingUtils::CalculateSHA1(*(GetBodyStream(request)))));
           }

--- a/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -930,7 +930,7 @@ void AWSClient::BuildHttpRequest(const Aws::AmazonWebServiceRequest& request, co
 
     // check for retry context, if present use it
     if (request.m_retryContext.m_requestHash.second != nullptr) {
-      const auto hash = Aws::MakeShared<Aws::Utils::Crypto::PrecalculatedHash>(AWS_SMITHY_CLIENT_CHECKSUM, HashingUtils::Base64Encode(request.m_retryContext.m_requestHash.second->GetHash().GetResult()));
+      const auto hash = Aws::MakeShared<Aws::Utils::Crypto::PrecalculatedHash>(smithy::client::AWS_SMITHY_CLIENT_CHECKSUM, HashingUtils::Base64Encode(request.m_retryContext.m_requestHash.second->GetHash().GetResult()));
       httpRequest->SetRequestHash(request.m_retryContext.m_requestHash.first, hash);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- On streaming operations, if the request payload was fully consumed and request checksum calculation was complete we will save the request checksum algorithm and value in memory to be reused for retry.
- Refactored the ChecksumInterceptor logic for setting checksum headers/values to be split across separate functions to follow single responsibility and allow for easier addition of checksum algorithms in the future.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
  - Tests already exist to validate these changes.
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
