### PR TITLE
Add build-mode as a new test dimension into performance tests

### DIFF
--- a/tests/performance-tests/include/performance-tests/reporting/JsonReportingMetrics.h
+++ b/tests/performance-tests/include/performance-tests/reporting/JsonReportingMetrics.h
@@ -55,25 +55,26 @@ class JsonReportingMetrics : public Aws::Monitoring::MonitoringInterface {
    * @param sdkVersion SDK version string
    * @param commitId Git commit identifier
    * @param outputFilename Path to output file (e.g., "s3-perf-results.json")
+   * @param buildMode Build mode (e.g., "debug" or "release")
    */
   JsonReportingMetrics(const Aws::Set<Aws::String>& monitoredOperations = Aws::Set<Aws::String>(), const Aws::String& productId = "unknown",
                        const Aws::String& sdkVersion = "unknown", const Aws::String& commitId = "unknown",
-                       const Aws::String& outputFilename = "performance-test-results.json");
+                       const Aws::String& outputFilename = "performance-test-results.json", const Aws::String& buildMode = "unknown");
 
   ~JsonReportingMetrics() override;
 
   /**
-   * Called when an AWS request is started. Returns context for tracking.
+   * Called when an AWS request is started. Creates and returns context for tracking.
    * @param serviceName Name of the AWS service
    * @param requestName Name of the operation
    * @param request HTTP request object
-   * @return Context pointer (always returns nullptr)
+   * @return Context pointer to newly created RequestContext
    */
   void* OnRequestStarted(const Aws::String& serviceName, const Aws::String& requestName,
                          const std::shared_ptr<const Aws::Http::HttpRequest>& request) const override;
 
   /**
-   * Called when an AWS request succeeds. Records performance metrics.
+   * Called when an AWS request succeeds. Stores latency metrics in context.
    * @param serviceName Name of the AWS service
    * @param requestName Name of the operation
    * @param request HTTP request object
@@ -86,7 +87,7 @@ class JsonReportingMetrics : public Aws::Monitoring::MonitoringInterface {
                           const Aws::Monitoring::CoreMetricsCollection& metrics, void* context) const override;
 
   /**
-   * Called when an AWS request fails. Records performance metrics.
+   * Called when an AWS request fails. Stores latency metrics in context.
    * @param serviceName Name of the AWS service
    * @param requestName Name of the operation
    * @param request HTTP request object
@@ -109,7 +110,7 @@ class JsonReportingMetrics : public Aws::Monitoring::MonitoringInterface {
                       const std::shared_ptr<const Aws::Http::HttpRequest>& request, void* context) const override;
 
   /**
-   * Called when an AWS request finishes. No action taken.
+   * Called when an AWS request finishes. Processes stored metrics and cleans up context.
    * @param serviceName Name of the AWS service
    * @param requestName Name of the operation
    * @param request HTTP request object
@@ -161,6 +162,7 @@ class JsonReportingMetrics : public Aws::Monitoring::MonitoringInterface {
   Aws::String m_sdkVersion;
   Aws::String m_commitId;
   Aws::String m_outputFilename;
+  Aws::String m_buildMode;
 };
 
 /**
@@ -176,10 +178,12 @@ class JsonReportingMetricsFactory : public Aws::Monitoring::MonitoringFactory {
    * @param sdkVersion SDK version string
    * @param commitId Git commit identifier
    * @param outputFilename Path to output file (e.g., "s3-perf-results.json")
+   * @param buildMode Build mode (e.g., "debug" or "release")
    */
   JsonReportingMetricsFactory(const Aws::Set<Aws::String>& monitoredOperations = Aws::Set<Aws::String>(),
                               const Aws::String& productId = "unknown", const Aws::String& sdkVersion = "unknown",
-                              const Aws::String& commitId = "unknown", const Aws::String& outputFilename = "performance-test-results.json");
+                              const Aws::String& commitId = "unknown", const Aws::String& outputFilename = "performance-test-results.json",
+                              const Aws::String& buildMode = "unknown");
 
   ~JsonReportingMetricsFactory() override = default;
 
@@ -195,6 +199,7 @@ class JsonReportingMetricsFactory : public Aws::Monitoring::MonitoringFactory {
   Aws::String m_sdkVersion;
   Aws::String m_commitId;
   Aws::String m_outputFilename;
+  Aws::String m_buildMode;
 };
 }  // namespace Reporting
 }  // namespace PerformanceTest

--- a/tests/performance-tests/src/services/dynamodb/main.cpp
+++ b/tests/performance-tests/src/services/dynamodb/main.cpp
@@ -23,12 +23,14 @@ int main(int argc, char** argv) {
   cxxopts::Options options("dynamodb-perf-test", "DynamoDB Performance Test");
   options.add_options()("r,region", "AWS region", cxxopts::value<std::string>()->default_value("us-east-1"))(
       "i,iterations", "Number of iterations", cxxopts::value<int>()->default_value("10"))(
-      "c,commit-id", "Commit ID", cxxopts::value<std::string>()->default_value("unknown"));
+      "c,commit-id", "Commit ID", cxxopts::value<std::string>()->default_value("unknown"))(
+      "b,build-mode", "Build mode", cxxopts::value<std::string>()->default_value("unknown"));
 
   auto const result = options.parse(argc, argv);
 
   Aws::String const region = Aws::Utils::StringUtils::to_string(result["region"].as<std::string>());
   Aws::String const commitId = Aws::Utils::StringUtils::to_string(result["commit-id"].as<std::string>());
+  Aws::String const buildMode = Aws::Utils::StringUtils::to_string(result["build-mode"].as<std::string>());
   int const iterations = result["iterations"].as<int>();
 
   Aws::SDKOptions sdkOptions;
@@ -41,7 +43,7 @@ int main(int argc, char** argv) {
     }
     return Aws::MakeUnique<PerformanceTest::Reporting::JsonReportingMetricsFactory>(
         "JsonReportingMetricsFactory", operations, "cpp1", versionStr, commitId,
-        PerformanceTest::Services::DynamoDB::TestConfig::OutputFilename);
+        PerformanceTest::Services::DynamoDB::TestConfig::OutputFilename, buildMode);
   }};
 
   Aws::InitAPI(sdkOptions);

--- a/tests/performance-tests/src/services/s3/main.cpp
+++ b/tests/performance-tests/src/services/s3/main.cpp
@@ -24,13 +24,15 @@ int main(int argc, char** argv) {
   options.add_options()("r,region", "AWS region", cxxopts::value<std::string>()->default_value("us-east-1"))(
       "a,az-id", "Availability zone ID", cxxopts::value<std::string>()->default_value("use1-az4"))(
       "i,iterations", "Number of iterations", cxxopts::value<int>()->default_value("10"))(
-      "c,commit-id", "Commit ID", cxxopts::value<std::string>()->default_value("unknown"));
+      "c,commit-id", "Commit ID", cxxopts::value<std::string>()->default_value("unknown"))(
+      "b,build-mode", "Build mode", cxxopts::value<std::string>()->default_value("unknown"));
 
   auto const result = options.parse(argc, argv);
 
   Aws::String const region = Aws::Utils::StringUtils::to_string(result["region"].as<std::string>());
   Aws::String const availabilityZoneId = Aws::Utils::StringUtils::to_string(result["az-id"].as<std::string>());
   Aws::String const commitId = Aws::Utils::StringUtils::to_string(result["commit-id"].as<std::string>());
+  Aws::String const buildMode = Aws::Utils::StringUtils::to_string(result["build-mode"].as<std::string>());
   int const iterations = result["iterations"].as<int>();
 
   Aws::SDKOptions sdkOptions;
@@ -42,7 +44,8 @@ int main(int argc, char** argv) {
       operations.insert(operation);
     }
     return Aws::MakeUnique<PerformanceTest::Reporting::JsonReportingMetricsFactory>(
-        "JsonReportingMetricsFactory", operations, "cpp1", versionStr, commitId, PerformanceTest::Services::S3::TestConfig::OutputFilename);
+        "JsonReportingMetricsFactory", operations, "cpp1", versionStr, commitId, PerformanceTest::Services::S3::TestConfig::OutputFilename,
+        buildMode);
   }};
 
   Aws::InitAPI(sdkOptions);

--- a/tools/scripts/build-tests/run-al2-dynamodb-performance-tests.sh
+++ b/tools/scripts/build-tests/run-al2-dynamodb-performance-tests.sh
@@ -11,22 +11,25 @@ set -e
 
 DEFAULT_REGION="us-east-1"
 DEFAULT_ITERATIONS=10
+DEFAULT_BUILD_MODE="unknown"
 
 if [ "$#" -lt 1 ]; then
-  echo "Error: Missing required argument. Usage: ${0} PREFIX_DIR [-r|--region REGION] [-i|--iterations NUM]"
+  echo "Error: Missing required argument. Usage: ${0} PREFIX_DIR [-r|--region REGION] [-i|--iterations NUM] [-b|--build-mode BUILD_MODE]"
   exit 1
 fi
 
 PREFIX_DIR="$1"
-shift  
+shift
 
 REGION="$DEFAULT_REGION"
 ITERATIONS="$DEFAULT_ITERATIONS"
+BUILD_MODE="$DEFAULT_BUILD_MODE"
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     -r|--region) REGION="$2"; shift 2 ;;
     -i|--iterations) ITERATIONS="$2"; shift 2 ;;
+    -b|--build-mode) BUILD_MODE="$2"; shift 2 ;;
     *) echo "Unknown parameter: $1"; exit 1 ;;
   esac
 done
@@ -42,6 +45,8 @@ fi
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${PREFIX_DIR}/al2-install/lib64/"
 
 cd "${PREFIX_DIR}/al2-build"
-if [ -f "${PREFIX_DIR}/aws-sdk-cpp/tools/scripts/suppressions.txt" ]; then export LSAN_OPTIONS=suppressions="${PREFIX_DIR}/aws-sdk-cpp/tools/scripts/suppressions.txt"; fi
-./tests/performance-tests/dynamodb-performance-test --region "$REGION" --iterations "$ITERATIONS" --commit-id "$COMMIT_ID"
+if [ "$BUILD_MODE" != "release" ] && [ -f "${PREFIX_DIR}/aws-sdk-cpp/tools/scripts/suppressions.txt" ]; then
+  export LSAN_OPTIONS=suppressions="${PREFIX_DIR}/aws-sdk-cpp/tools/scripts/suppressions.txt"
+fi
+./tests/performance-tests/dynamodb-performance-test --region "$REGION" --iterations "$ITERATIONS" --commit-id "$COMMIT_ID" --build-mode "$BUILD_MODE"
 cat dynamodb-performance-test-results.json

--- a/tools/scripts/build-tests/run-al2-s3-performance-tests.sh
+++ b/tools/scripts/build-tests/run-al2-s3-performance-tests.sh
@@ -12,24 +12,27 @@ set -e
 DEFAULT_REGION="us-east-1"
 DEFAULT_AZ_ID="use1-az4"
 DEFAULT_ITERATIONS=10
+DEFAULT_BUILD_MODE="unknown"
 
 if [ "$#" -lt 1 ]; then
-  echo "Error: Missing required argument. Usage: ${0} PREFIX_DIR [-r|--region REGION] [-a|--az-id AZ_ID] [-i|--iterations NUM]"
+  echo "Error: Missing required argument. Usage: ${0} PREFIX_DIR [-r|--region REGION] [-a|--az-id AZ_ID] [-i|--iterations NUM] [-b|--build-mode BUILD_MODE]"
   exit 1
 fi
 
 PREFIX_DIR="$1"
-shift  
+shift
 
 REGION="$DEFAULT_REGION"
 AZ_ID="$DEFAULT_AZ_ID"
 ITERATIONS="$DEFAULT_ITERATIONS"
+BUILD_MODE="$DEFAULT_BUILD_MODE"
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     -r|--region) REGION="$2"; shift 2 ;;
     -a|--az-id) AZ_ID="$2"; shift 2 ;;
     -i|--iterations) ITERATIONS="$2"; shift 2 ;;
+    -b|--build-mode) BUILD_MODE="$2"; shift 2 ;;
     *) echo "Unknown parameter: $1"; exit 1 ;;
   esac
 done
@@ -45,6 +48,8 @@ fi
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${PREFIX_DIR}/al2-install/lib64/"
 
 cd "${PREFIX_DIR}/al2-build"
-if [ -f "${PREFIX_DIR}/aws-sdk-cpp/tools/scripts/suppressions.txt" ]; then export LSAN_OPTIONS=suppressions="${PREFIX_DIR}/aws-sdk-cpp/tools/scripts/suppressions.txt"; fi
-./tests/performance-tests/s3-performance-test --region "$REGION" --az-id "$AZ_ID" --iterations "$ITERATIONS" --commit-id "$COMMIT_ID"
+if [ "$BUILD_MODE" != "release" ] && [ -f "${PREFIX_DIR}/aws-sdk-cpp/tools/scripts/suppressions.txt" ]; then
+  export LSAN_OPTIONS=suppressions="${PREFIX_DIR}/aws-sdk-cpp/tools/scripts/suppressions.txt"
+fi
+./tests/performance-tests/s3-performance-test --region "$REGION" --az-id "$AZ_ID" --iterations "$ITERATIONS" --commit-id "$COMMIT_ID" --build-mode "$BUILD_MODE"
 cat s3-performance-test-results.json


### PR DESCRIPTION
*Description of changes:*

This PR adds build-mode as a new test dimension into performance tests. When it is specified via command line arguments with a value that is not "unknown", the build-mode will be included in the test dimensions of each test record. Backward compatibility is supported, and dry-run has passed.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [X] Windows
- [X] Android
- [X] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
