### PR TITLE
fix GetBool in Document

### DIFF
--- a/src/aws-cpp-sdk-core/source/utils/Document.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/Document.cpp
@@ -449,7 +449,7 @@ bool DocumentView::GetBool(const Aws::String& key) const
     assert(m_json);
     auto item = cJSON_AS4CPP_GetObjectItemCaseSensitive(m_json, key.c_str());
     assert(item);
-    return item->valueint != 0;
+    return item->type == cJSON_AS4CPP_True;
 }
 
 bool DocumentView::AsBool() const

--- a/tests/aws-cpp-sdk-core-tests/utils/DocumentTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/DocumentTest.cpp
@@ -637,3 +637,13 @@ TEST_F(DocumentTest, TestEquality)
     built.WithString("AWS", "Amazon Web Services");
     ASSERT_NE(parsed, built);
 }
+
+TEST_F(DocumentTest, TestBooleanTrue)
+{
+  const auto doc = Document{}
+    .WithBool("time_marches_on", true)
+    .WithBool("and_the_age_of_a_new_king_draws_near", false);
+
+  ASSERT_TRUE(doc.View().GetBool("time_marches_on"));
+  ASSERT_FALSE(doc.View().GetBool("and_the_age_of_a_new_king_draws_near"));
+}


### PR DESCRIPTION
*Description of changes:*

Right now there is a serialization issue on `Document` types that will cause `GetBool` to always return false.

root cause is in `GetBool` we look for the presence of a `1` in  the cjson node

```cpp
bool DocumentView::GetBool(const Aws::String& key) const
{
    assert(m_json);
    auto item = cJSON_AS4CPP_GetObjectItemCaseSensitive(m_json, key.c_str());
    assert(item);
    return item->valueint != 0;
}
```

when we set the bool using `WithBool` we call `cJSON_AS4CPP_CreateBool`

```cpp
Document& Document::WithBool(const char* key, bool value)
{
    if (!m_json)
    {
        m_json = cJSON_AS4CPP_CreateObject();
    }

    const auto val = cJSON_AS4CPP_CreateBool(value);
    AddOrReplace(m_json, key, val);
    return *this;
}
```

[which actually never sets the value, only the type](https://github.com/aws/aws-sdk-cpp/blob/main/src/aws-cpp-sdk-core/source/external/cjson/cJSON.cpp#L2168-L2178)
```cpp
CJSON_AS4CPP_PUBLIC(cJSON *) cJSON_AS4CPP_CreateBool(cJSON_AS4CPP_bool boolean)
{
    cJSON *item = cJSON_AS4CPP_New_Item(&global_hooks);
    if(item)
    {
        item->type = boolean ? cJSON_AS4CPP_True : cJSON_AS4CPP_False;
    }

    return item;
}
```

simply changing `GetBool` to 

```cpp
bool DocumentView::GetBool(const Aws::String& key) const
{
    assert(m_json);
    auto item = cJSON_AS4CPP_GetObjectItemCaseSensitive(m_json, key.c_str());
    assert(item);
    return item->type == cJSON_AS4CPP_True;
}
```

will fix this

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
