### PR TITLE
update version of smithy used in smoke tests

### DIFF
--- a/tools/code-generation/smithy/codegen/cpp-smoke-tests/build.gradle.kts
+++ b/tools/code-generation/smithy/codegen/cpp-smoke-tests/build.gradle.kts
@@ -9,7 +9,7 @@ val logger = Logging.getLogger("MyLogger")
 
 plugins {
     id("java-library")
-    id("software.amazon.smithy.gradle.smithy-base").version("1.2.0")
+    id("software.amazon.smithy.gradle.smithy-base").version("1.3.0")
 }
 
 repositories {

--- a/tools/code-generation/smithy/codegen/settings.gradle.kts
+++ b/tools/code-generation/smithy/codegen/settings.gradle.kts
@@ -14,7 +14,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         create("codegen") {
             // Smithy dependencies
-            version("smithy", "1.57.1")  // Centralize the version for Smithy-related dependencies
+            version("smithy", "1.61.0")  // Centralize the version for Smithy-related dependencies
             library("model", "software.amazon.smithy", "smithy-model").versionRef("smithy")
             library("aws-traits", "software.amazon.smithy", "smithy-aws-traits").versionRef("smithy")
             library("codegen-core", "software.amazon.smithy", "smithy-codegen-core").versionRef("smithy")


### PR DESCRIPTION
*Description of changes:*

updating smithy dependency used for generating smoke tests

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
