### PR TITLE
fix codegen for eventstream operations with no input

### DIFF
--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassMembersAndInlines.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassMembersAndInlines.vm
@@ -138,7 +138,7 @@
     ///@}
 #end##if(!($CppViewHelper.isStreamingPayloadMember($shape, $member.key) && $shape.request))
 #end##foreach($member in $shape.members.entrySet())
-#if($shape.members.size() > 0)##next contains private only
+#if($shape.members.size() > 0 || $operation.result.shape.hasEventStreamMembers())##next contains private only
   private:
 #foreach($member in $shape.members.entrySet())
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderOperations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientHeaderOperations.vm
@@ -12,7 +12,7 @@
 #if(!$operation.documentation)
 #set($operation.documentation = '')
 #end
-#if($operation.isRequestlessDefault())
+#if($operation.isRequestlessDefault() && !$operation.result.shape.hasEventStreamMembers())
 #set($defaultOp = " = {}")
 #else
 #set($defaultOp = "")
@@ -61,7 +61,7 @@
 #if($serviceModel.metadata.serviceId == "S3" && $operation.s3CrtEnabled)
 ##S3 CRT-backed Operations are primarly based on Async implementation not sync blocking calls
         $virtual void ${operation.name}Async(${constText}Model::${operation.request.shape.name}& request, const ${operation.name}ResponseReceivedHandler& handler, const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context = nullptr) const;
-#elseif($operation.isRequestlessDefault())
+#elseif($operation.isRequestlessDefault() && !$operation.result.shape.hasEventStreamMembers())
         template<typename ${operation.name}RequestT = Model::${operation.request.shape.name}>
         void ${operation.name}Async(const ${operation.name}ResponseReceivedHandler& handler, const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context = nullptr, ${constText}${operation.name}RequestT& request${defaultOp}) const
         {


### PR DESCRIPTION
*Description of changes:*

Right now event stream operations that have a empty request structure will break codgen as we have some logic around "requestless" operations. this fixes those assumptions to make sure the correct member variables are created..

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
