### PR TITLE
dont generate enum values for reserved core errors

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/ErrorFormatter.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/ErrorFormatter.java
@@ -7,21 +7,49 @@ package com.amazonaws.util.awsclientgenerator.generators.cpp;
 
 import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.Error;
 import com.google.common.base.CaseFormat;
+import com.google.common.collect.ImmutableSet;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ErrorFormatter {
 
+    static private final Set<String> CORE_ERROR_CONSTANTS = ImmutableSet.of(
+            "INCOMPLETE_SIGNATURE",
+            "INTERNAL_FAILURE",
+            "INVALID_ACTION",
+            "INVALID_CLIENT_TOKEN_ID",
+            "INVALID_PARAMETER_COMBINATION",
+            "INVALID_QUERY_PARAMETER",
+            "INVALID_PARAMETER_VALUE",
+            "MISSING_ACTION",
+            "MISSING_AUTHENTICATION_TOKEN",
+            "MISSING_PARAMETER",
+            "OPT_IN_REQUIRED",
+            "REQUEST_EXPIRED",
+            "SERVICE_UNAVAILABLE",
+            "THROTTLING",
+            "VALIDATION",
+            "ACCESS_DENIED",
+            "RESOURCE_NOT_FOUND",
+            "UNRECOGNIZED_CLIENT",
+            "MALFORMED_QUERY_STRING",
+            "SLOW_DOWN",
+            "REQUEST_TIME_TOO_SKEWED",
+            "INVALID_SIGNATURE",
+            "SIGNATURE_DOES_NOT_MATCH",
+            "INVALID_ACCESS_KEY_ID",
+            "REQUEST_TIMEOUT",
+            "NETWORK_CONNECTION"
+    );
+
     public List<String> formatErrorConstNames(Collection<Error> errors) {
-        List<String> formattedErrors = new ArrayList<>();
-        for (Error error : errors) {
-            formattedErrors.add(formatErrorConstName(error.getName()));
-        }
-        Collections.sort(formattedErrors);
-        return formattedErrors;
+        return errors.stream().map(error -> formatErrorConstName(error.getName()))
+                .filter(name -> !CORE_ERROR_CONSTANTS.contains(name))
+                .sorted()
+                .collect(Collectors.toList());
     }
 
     public static String formatErrorConstName(String errorName) {


### PR DESCRIPTION
*Description of changes:*

[The SDK assumes several existing enums](https://github.com/aws/aws-sdk-cpp/blob/main/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ErrorsHeader.vm#L21-L46) that exist in core. If a service models these enums, there will multiple definitions of the enum value leading to a compilation error. This fixes code gen to ignore the modeled error and use the reserved core error.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
