### PR TITLE
Update CRT to v0.34.1

### DIFF
--- a/prefetch_crt_dependency.sh
+++ b/prefetch_crt_dependency.sh
@@ -3,21 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 CRT_URI_PREFIX=https://codeload.github.com/awslabs
-CRT_URI=${CRT_URI_PREFIX}/aws-crt-cpp/zip/1b8903390cd4aa0c1fd94729c91e98b57f21b40f  # v0.33.4
+CRT_URI=${CRT_URI_PREFIX}/aws-crt-cpp/zip/d0afe7b0d179edbd5349b0429a1363ad52f36c56  # v0.34.1
 
-AWS_C_AUTH_URI=${CRT_URI_PREFIX}/aws-c-auth/zip/cd9d6afcd42035d49bb2d0d3bef24b9faed57773  # v0.9.0
+AWS_C_AUTH_URI=${CRT_URI_PREFIX}/aws-c-auth/zip/ab03bdd996437d9097953ebb9495de71b6adc537  # v0.9.1
 AWS_C_CAL_URI=${CRT_URI_PREFIX}/aws-c-cal/zip/8703b3e5930c9fd508025b268ab837fc9df3c4fd  # v0.9.2
-AWS_C_COMMON_URI=${CRT_URI_PREFIX}/aws-c-common/zip/aaa2f11ed609e3f888efd9bf745e810b45b13a38  # v0.12.3
+AWS_C_COMMON_URI=${CRT_URI_PREFIX}/aws-c-common/zip/2b67a658e461520f1de20d64342b91ddcedc7ebb  # v0.12.4
 AWS_C_COMPRESSION_URI=${CRT_URI_PREFIX}/aws-c-compression/zip/f951ab2b819fc6993b6e5e6cfef64b1a1554bfc8  # v0.3.1
-AWS_C_EVENT_STREAM_URI=${CRT_URI_PREFIX}/aws-c-event-stream/zip/8f8f599e78864188fe8547dafaa695a1d4855d6a  # v0.5.5
-AWS_C_HTTP_URI=${CRT_URI_PREFIX}/aws-c-http/zip/10961a708a4148c57db139232277573da2f6e99c  # v0.10.2
-AWS_C_IO_URI=${CRT_URI_PREFIX}/aws-c-io/zip/25faa8d6df108b0214345549c44ab6b75ad31e65  # v0.21.0
-AWS_C_MQTT_URI=${CRT_URI_PREFIX}/aws-c-mqtt/zip/00246525fc7128e93e4e4c7ed0a93809295a57b6  # v0.13.2
-AWS_C_S3_URI=${CRT_URI_PREFIX}/aws-c-s3/zip/1762f839fdca78ec4b30dc94fbbd88591d0b5b7c  # v0.8.3
+AWS_C_EVENT_STREAM_URI=${CRT_URI_PREFIX}/aws-c-event-stream/zip/2a0f7c9fe656c4789fa762a4ff04d06401abd282  # v0.5.6
+AWS_C_HTTP_URI=${CRT_URI_PREFIX}/aws-c-http/zip/ce0d65623bff28f03204756d9d1b3366bd0b387d  # v0.10.4
+AWS_C_IO_URI=${CRT_URI_PREFIX}/aws-c-io/zip/ba5cb6de2cf12bfb154f302f6dedddf81c0ce4cd  # v0.21.4
+AWS_C_MQTT_URI=${CRT_URI_PREFIX}/aws-c-mqtt/zip/1d512d92709f60b74e2cafa018e69a2e647f28e9  # v0.13.3
+AWS_C_S3_URI=${CRT_URI_PREFIX}/aws-c-s3/zip/3afa5d08be95e82199a153e3abbe59bbb42638d7  # v0.8.7
 AWS_C_SDKUTILS_URI=${CRT_URI_PREFIX}/aws-c-sdkutils/zip/f678bda9e21f7217e4bbf35e0d1ea59540687933  # v0.2.4
 AWS_CHECKSUMS_URI=${CRT_URI_PREFIX}/aws-checksums/zip/9978ba2c33a7a259c1a6bd0f62abe26827d03b85  # v0.2.6
-AWS_LC_URI=${CRT_URI_PREFIX}/aws-lc/zip/8b52781470d501fb94322ddfcadf06fcd3c19fa2  # v1.55.0
-S2N_URI=${CRT_URI_PREFIX}/s2n/zip/e33d7efac0336231a68663e17c779a6f523a838d  # v1.5.22
+AWS_LC_URI=${CRT_URI_PREFIX}/aws-lc/zip/98500e8bc7dc3e3e5871519abf12cdc781ebe4e1  # v1.60.0
+S2N_URI=${CRT_URI_PREFIX}/s2n/zip/a7862238a9d6703e0a3e2d7ea4341de8d57429bd  # v1.5.25
 
 
 echo "Removing CRT"


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/3531

*Description of changes:*

Picks up the latest CRT version that has changes to avoid a double free in the sts web identity provider.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
