### PR TITLE
check etag on both download branches

### DIFF
--- a/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -863,6 +863,10 @@ namespace Aws
                 TriggerDownloadProgressCallback(handle);
             });
 
+            if (handle->GetEtag().size() > 0) {
+              request.SetIfMatch(handle->GetEtag());
+            }
+
             auto getObjectOutcome = m_transferConfig.s3Client->GetObject(request);
             if (getObjectOutcome.IsSuccess())
             {


### PR DESCRIPTION
*Description of changes:*

https://github.com/aws/aws-sdk-cpp/pull/3375 added e-tag matching support for doing ranged gets, but this was only one half of the call path. If the size a of a object it small enough we will do a non ranged get. This adds that missing bit of logic.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
