### PR TITLE
Legacy client constructor fix

### DIFF
--- a/generated/src/aws-cpp-sdk-AWSMigrationHub/source/MigrationHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-AWSMigrationHub/source/MigrationHubClient.cpp
@@ -115,7 +115,7 @@ MigrationHubClient::MigrationHubClient(const std::shared_ptr<AWSCredentialsProvi
   MigrationHubClient::MigrationHubClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-accessanalyzer/source/AccessAnalyzerClient.cpp
+++ b/generated/src/aws-cpp-sdk-accessanalyzer/source/AccessAnalyzerClient.cpp
@@ -131,7 +131,7 @@ AccessAnalyzerClient::AccessAnalyzerClient(const std::shared_ptr<AWSCredentialsP
   AccessAnalyzerClient::AccessAnalyzerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AccessAnalyzerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-account/source/AccountClient.cpp
+++ b/generated/src/aws-cpp-sdk-account/source/AccountClient.cpp
@@ -108,7 +108,7 @@ AccountClient::AccountClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   AccountClient::AccountClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AccountErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-acm-pca/source/ACMPCAClient.cpp
+++ b/generated/src/aws-cpp-sdk-acm-pca/source/ACMPCAClient.cpp
@@ -117,7 +117,7 @@ ACMPCAClient::ACMPCAClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   ACMPCAClient::ACMPCAClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ACMPCAErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-acm/source/ACMClient.cpp
+++ b/generated/src/aws-cpp-sdk-acm/source/ACMClient.cpp
@@ -110,7 +110,7 @@ ACMClient::ACMClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   ACMClient::ACMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ACMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-aiops/source/AIOpsClient.cpp
+++ b/generated/src/aws-cpp-sdk-aiops/source/AIOpsClient.cpp
@@ -105,7 +105,7 @@ AIOpsClient::AIOpsClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   AIOpsClient::AIOpsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AIOpsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-amp/source/PrometheusServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-amp/source/PrometheusServiceClient.cpp
@@ -133,7 +133,7 @@ PrometheusServiceClient::PrometheusServiceClient(const std::shared_ptr<AWSCreden
   PrometheusServiceClient::PrometheusServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PrometheusServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-amplify/source/AmplifyClient.cpp
+++ b/generated/src/aws-cpp-sdk-amplify/source/AmplifyClient.cpp
@@ -131,7 +131,7 @@ AmplifyClient::AmplifyClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   AmplifyClient::AmplifyClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AmplifyErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-amplifybackend/source/AmplifyBackendClient.cpp
+++ b/generated/src/aws-cpp-sdk-amplifybackend/source/AmplifyBackendClient.cpp
@@ -125,7 +125,7 @@ AmplifyBackendClient::AmplifyBackendClient(const std::shared_ptr<AWSCredentialsP
   AmplifyBackendClient::AmplifyBackendClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AmplifyBackendErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-amplifyuibuilder/source/AmplifyUIBuilderClient.cpp
+++ b/generated/src/aws-cpp-sdk-amplifyuibuilder/source/AmplifyUIBuilderClient.cpp
@@ -122,7 +122,7 @@ AmplifyUIBuilderClient::AmplifyUIBuilderClient(const std::shared_ptr<AWSCredenti
   AmplifyUIBuilderClient::AmplifyUIBuilderClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AmplifyUIBuilderErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-apigateway/source/APIGatewayClient.cpp
+++ b/generated/src/aws-cpp-sdk-apigateway/source/APIGatewayClient.cpp
@@ -218,7 +218,7 @@ APIGatewayClient::APIGatewayClient(const std::shared_ptr<AWSCredentialsProvider>
   APIGatewayClient::APIGatewayClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<APIGatewayErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-apigatewaymanagementapi/source/ApiGatewayManagementApiClient.cpp
+++ b/generated/src/aws-cpp-sdk-apigatewaymanagementapi/source/ApiGatewayManagementApiClient.cpp
@@ -97,7 +97,7 @@ ApiGatewayManagementApiClient::ApiGatewayManagementApiClient(const std::shared_p
   ApiGatewayManagementApiClient::ApiGatewayManagementApiClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApiGatewayManagementApiErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-apigatewayv2/source/ApiGatewayV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-apigatewayv2/source/ApiGatewayV2Client.cpp
@@ -171,7 +171,7 @@ ApiGatewayV2Client::ApiGatewayV2Client(const std::shared_ptr<AWSCredentialsProvi
   ApiGatewayV2Client::ApiGatewayV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApiGatewayV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appconfig/source/AppConfigClient.cpp
+++ b/generated/src/aws-cpp-sdk-appconfig/source/AppConfigClient.cpp
@@ -138,7 +138,7 @@ AppConfigClient::AppConfigClient(const std::shared_ptr<AWSCredentialsProvider>& 
   AppConfigClient::AppConfigClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppConfigErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appconfigdata/source/AppConfigDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-appconfigdata/source/AppConfigDataClient.cpp
@@ -96,7 +96,7 @@ AppConfigDataClient::AppConfigDataClient(const std::shared_ptr<AWSCredentialsPro
   AppConfigDataClient::AppConfigDataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppConfigDataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appfabric/source/AppFabricClient.cpp
+++ b/generated/src/aws-cpp-sdk-appfabric/source/AppFabricClient.cpp
@@ -120,7 +120,7 @@ AppFabricClient::AppFabricClient(const std::shared_ptr<AWSCredentialsProvider>& 
   AppFabricClient::AppFabricClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppFabricErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appflow/source/AppflowClient.cpp
+++ b/generated/src/aws-cpp-sdk-appflow/source/AppflowClient.cpp
@@ -119,7 +119,7 @@ AppflowClient::AppflowClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   AppflowClient::AppflowClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppflowErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appintegrations/source/AppIntegrationsServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-appintegrations/source/AppIntegrationsServiceClient.cpp
@@ -117,7 +117,7 @@ AppIntegrationsServiceClient::AppIntegrationsServiceClient(const std::shared_ptr
   AppIntegrationsServiceClient::AppIntegrationsServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppIntegrationsServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-application-autoscaling/source/ApplicationAutoScalingClient.cpp
+++ b/generated/src/aws-cpp-sdk-application-autoscaling/source/ApplicationAutoScalingClient.cpp
@@ -108,7 +108,7 @@ ApplicationAutoScalingClient::ApplicationAutoScalingClient(const std::shared_ptr
   ApplicationAutoScalingClient::ApplicationAutoScalingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApplicationAutoScalingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-application-insights/source/ApplicationInsightsClient.cpp
+++ b/generated/src/aws-cpp-sdk-application-insights/source/ApplicationInsightsClient.cpp
@@ -127,7 +127,7 @@ ApplicationInsightsClient::ApplicationInsightsClient(const std::shared_ptr<AWSCr
   ApplicationInsightsClient::ApplicationInsightsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApplicationInsightsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-application-signals/source/ApplicationSignalsClient.cpp
+++ b/generated/src/aws-cpp-sdk-application-signals/source/ApplicationSignalsClient.cpp
@@ -111,7 +111,7 @@ ApplicationSignalsClient::ApplicationSignalsClient(const std::shared_ptr<AWSCred
   ApplicationSignalsClient::ApplicationSignalsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApplicationSignalsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-applicationcostprofiler/source/ApplicationCostProfilerClient.cpp
+++ b/generated/src/aws-cpp-sdk-applicationcostprofiler/source/ApplicationCostProfilerClient.cpp
@@ -100,7 +100,7 @@ ApplicationCostProfilerClient::ApplicationCostProfilerClient(const std::shared_p
   ApplicationCostProfilerClient::ApplicationCostProfilerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApplicationCostProfilerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appmesh/source/AppMeshClient.cpp
+++ b/generated/src/aws-cpp-sdk-appmesh/source/AppMeshClient.cpp
@@ -132,7 +132,7 @@ AppMeshClient::AppMeshClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   AppMeshClient::AppMeshClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppMeshErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-apprunner/source/AppRunnerClient.cpp
+++ b/generated/src/aws-cpp-sdk-apprunner/source/AppRunnerClient.cpp
@@ -131,7 +131,7 @@ AppRunnerClient::AppRunnerClient(const std::shared_ptr<AWSCredentialsProvider>& 
   AppRunnerClient::AppRunnerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppRunnerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appstream/source/AppStreamClient.cpp
+++ b/generated/src/aws-cpp-sdk-appstream/source/AppStreamClient.cpp
@@ -173,7 +173,7 @@ AppStreamClient::AppStreamClient(const std::shared_ptr<AWSCredentialsProvider>& 
   AppStreamClient::AppStreamClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppStreamErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-appsync/source/AppSyncClient.cpp
+++ b/generated/src/aws-cpp-sdk-appsync/source/AppSyncClient.cpp
@@ -168,7 +168,7 @@ AppSyncClient::AppSyncClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   AppSyncClient::AppSyncClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppSyncErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-apptest/source/AppTestClient.cpp
+++ b/generated/src/aws-cpp-sdk-apptest/source/AppTestClient.cpp
@@ -118,7 +118,7 @@ AppTestClient::AppTestClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   AppTestClient::AppTestClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppTestErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-arc-region-switch/source/ARCRegionswitchClient.cpp
+++ b/generated/src/aws-cpp-sdk-arc-region-switch/source/ARCRegionswitchClient.cpp
@@ -114,7 +114,7 @@ ARCRegionswitchClient::ARCRegionswitchClient(const std::shared_ptr<AWSCredential
   ARCRegionswitchClient::ARCRegionswitchClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ARCRegionswitchErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-arc-zonal-shift/source/ARCZonalShiftClient.cpp
+++ b/generated/src/aws-cpp-sdk-arc-zonal-shift/source/ARCZonalShiftClient.cpp
@@ -109,7 +109,7 @@ ARCZonalShiftClient::ARCZonalShiftClient(const std::shared_ptr<AWSCredentialsPro
   ARCZonalShiftClient::ARCZonalShiftClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ARCZonalShiftErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-artifact/source/ArtifactClient.cpp
+++ b/generated/src/aws-cpp-sdk-artifact/source/ArtifactClient.cpp
@@ -101,7 +101,7 @@ ArtifactClient::ArtifactClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   ArtifactClient::ArtifactClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ArtifactErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-athena/source/AthenaClient.cpp
+++ b/generated/src/aws-cpp-sdk-athena/source/AthenaClient.cpp
@@ -162,7 +162,7 @@ AthenaClient::AthenaClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   AthenaClient::AthenaClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AthenaErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-auditmanager/source/AuditManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-auditmanager/source/AuditManagerClient.cpp
@@ -156,7 +156,7 @@ AuditManagerClient::AuditManagerClient(const std::shared_ptr<AWSCredentialsProvi
   AuditManagerClient::AuditManagerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AuditManagerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-autoscaling-plans/source/AutoScalingPlansClient.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling-plans/source/AutoScalingPlansClient.cpp
@@ -100,7 +100,7 @@ AutoScalingPlansClient::AutoScalingPlansClient(const std::shared_ptr<AWSCredenti
   AutoScalingPlansClient::AutoScalingPlansClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AutoScalingPlansErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-autoscaling/source/AutoScalingClient.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/AutoScalingClient.cpp
@@ -160,7 +160,7 @@ AutoScalingClient::AutoScalingClient(const std::shared_ptr<AWSCredentialsProvide
   AutoScalingClient::AutoScalingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AutoScalingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-awstransfer/source/TransferClient.cpp
+++ b/generated/src/aws-cpp-sdk-awstransfer/source/TransferClient.cpp
@@ -165,7 +165,7 @@ TransferClient::TransferClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   TransferClient::TransferClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TransferErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-b2bi/source/B2BIClient.cpp
+++ b/generated/src/aws-cpp-sdk-b2bi/source/B2BIClient.cpp
@@ -124,7 +124,7 @@ B2BIClient::B2BIClient(const std::shared_ptr<AWSCredentialsProvider>& credential
   B2BIClient::B2BIClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<B2BIErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-backup-gateway/source/BackupGatewayClient.cpp
+++ b/generated/src/aws-cpp-sdk-backup-gateway/source/BackupGatewayClient.cpp
@@ -119,7 +119,7 @@ BackupGatewayClient::BackupGatewayClient(const std::shared_ptr<AWSCredentialsPro
   BackupGatewayClient::BackupGatewayClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BackupGatewayErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-backup/source/BackupClient.cpp
+++ b/generated/src/aws-cpp-sdk-backup/source/BackupClient.cpp
@@ -193,7 +193,7 @@ BackupClient::BackupClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   BackupClient::BackupClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BackupErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-backupsearch/source/BackupSearchClient.cpp
+++ b/generated/src/aws-cpp-sdk-backupsearch/source/BackupSearchClient.cpp
@@ -106,7 +106,7 @@ BackupSearchClient::BackupSearchClient(const std::shared_ptr<AWSCredentialsProvi
   BackupSearchClient::BackupSearchClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BackupSearchErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-batch/source/BatchClient.cpp
+++ b/generated/src/aws-cpp-sdk-batch/source/BatchClient.cpp
@@ -133,7 +133,7 @@ BatchClient::BatchClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   BatchClient::BatchClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BatchErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bcm-dashboards/source/BCMDashboardsClient.cpp
+++ b/generated/src/aws-cpp-sdk-bcm-dashboards/source/BCMDashboardsClient.cpp
@@ -103,7 +103,7 @@ BCMDashboardsClient::BCMDashboardsClient(const std::shared_ptr<AWSCredentialsPro
   BCMDashboardsClient::BCMDashboardsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BCMDashboardsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bcm-data-exports/source/BCMDataExportsClient.cpp
+++ b/generated/src/aws-cpp-sdk-bcm-data-exports/source/BCMDataExportsClient.cpp
@@ -106,7 +106,7 @@ BCMDataExportsClient::BCMDataExportsClient(const std::shared_ptr<AWSCredentialsP
   BCMDataExportsClient::BCMDataExportsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BCMDataExportsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bcm-pricing-calculator/source/BCMPricingCalculatorClient.cpp
+++ b/generated/src/aws-cpp-sdk-bcm-pricing-calculator/source/BCMPricingCalculatorClient.cpp
@@ -130,7 +130,7 @@ BCMPricingCalculatorClient::BCMPricingCalculatorClient(const std::shared_ptr<AWS
   BCMPricingCalculatorClient::BCMPricingCalculatorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BCMPricingCalculatorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bcm-recommended-actions/source/BCMRecommendedActionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-bcm-recommended-actions/source/BCMRecommendedActionsClient.cpp
@@ -95,7 +95,7 @@ BCMRecommendedActionsClient::BCMRecommendedActionsClient(const std::shared_ptr<A
   BCMRecommendedActionsClient::BCMRecommendedActionsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BCMRecommendedActionsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bedrock-agent-runtime/source/BedrockAgentRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-agent-runtime/source/BedrockAgentRuntimeClient.cpp
@@ -126,7 +126,7 @@ BedrockAgentRuntimeClient::BedrockAgentRuntimeClient(const std::shared_ptr<AWSCr
   BedrockAgentRuntimeClient::BedrockAgentRuntimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockAgentRuntimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bedrock-agent/source/BedrockAgentClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-agent/source/BedrockAgentClient.cpp
@@ -166,7 +166,7 @@ BedrockAgentClient::BedrockAgentClient(const std::shared_ptr<AWSCredentialsProvi
   BedrockAgentClient::BedrockAgentClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockAgentErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bedrock-agentcore-control/source/BedrockAgentCoreControlClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-agentcore-control/source/BedrockAgentCoreControlClient.cpp
@@ -145,7 +145,7 @@ BedrockAgentCoreControlClient::BedrockAgentCoreControlClient(const std::shared_p
   BedrockAgentCoreControlClient::BedrockAgentCoreControlClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockAgentCoreControlErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bedrock-agentcore/source/BedrockAgentCoreClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-agentcore/source/BedrockAgentCoreClient.cpp
@@ -121,7 +121,7 @@ BedrockAgentCoreClient::BedrockAgentCoreClient(const std::shared_ptr<AWSCredenti
   BedrockAgentCoreClient::BedrockAgentCoreClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockAgentCoreErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bedrock-data-automation-runtime/source/BedrockDataAutomationRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-data-automation-runtime/source/BedrockDataAutomationRuntimeClient.cpp
@@ -99,7 +99,7 @@ BedrockDataAutomationRuntimeClient::BedrockDataAutomationRuntimeClient(const std
   BedrockDataAutomationRuntimeClient::BedrockDataAutomationRuntimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockDataAutomationRuntimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bedrock-data-automation/source/BedrockDataAutomationClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-data-automation/source/BedrockDataAutomationClient.cpp
@@ -108,7 +108,7 @@ BedrockDataAutomationClient::BedrockDataAutomationClient(const std::shared_ptr<A
   BedrockDataAutomationClient::BedrockDataAutomationClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockDataAutomationErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/source/BedrockRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/source/BedrockRuntimeClient.cpp
@@ -106,7 +106,7 @@ BedrockRuntimeClient::BedrockRuntimeClient(const std::shared_ptr<AWSCredentialsP
   BedrockRuntimeClient::BedrockRuntimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockRuntimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-bedrock/source/BedrockClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock/source/BedrockClient.cpp
@@ -188,7 +188,7 @@ BedrockClient::BedrockClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   BedrockClient::BedrockClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BedrockErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-billing/source/BillingClient.cpp
+++ b/generated/src/aws-cpp-sdk-billing/source/BillingClient.cpp
@@ -104,7 +104,7 @@ BillingClient::BillingClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   BillingClient::BillingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BillingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-billingconductor/source/BillingConductorClient.cpp
+++ b/generated/src/aws-cpp-sdk-billingconductor/source/BillingConductorClient.cpp
@@ -126,7 +126,7 @@ BillingConductorClient::BillingConductorClient(const std::shared_ptr<AWSCredenti
   BillingConductorClient::BillingConductorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BillingConductorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-braket/source/BraketClient.cpp
+++ b/generated/src/aws-cpp-sdk-braket/source/BraketClient.cpp
@@ -107,7 +107,7 @@ BraketClient::BraketClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   BraketClient::BraketClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BraketErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-budgets/source/BudgetsClient.cpp
+++ b/generated/src/aws-cpp-sdk-budgets/source/BudgetsClient.cpp
@@ -120,7 +120,7 @@ BudgetsClient::BudgetsClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   BudgetsClient::BudgetsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<BudgetsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ce/source/CostExplorerClient.cpp
+++ b/generated/src/aws-cpp-sdk-ce/source/CostExplorerClient.cpp
@@ -140,7 +140,7 @@ CostExplorerClient::CostExplorerClient(const std::shared_ptr<AWSCredentialsProvi
   CostExplorerClient::CostExplorerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CostExplorerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-chatbot/source/ChatbotClient.cpp
+++ b/generated/src/aws-cpp-sdk-chatbot/source/ChatbotClient.cpp
@@ -128,7 +128,7 @@ ChatbotClient::ChatbotClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   ChatbotClient::ChatbotClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChatbotErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-chime-sdk-identity/source/ChimeSDKIdentityClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-identity/source/ChimeSDKIdentityClient.cpp
@@ -124,7 +124,7 @@ ChimeSDKIdentityClient::ChimeSDKIdentityClient(const std::shared_ptr<AWSCredenti
   ChimeSDKIdentityClient::ChimeSDKIdentityClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKIdentityErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-chime-sdk-media-pipelines/source/ChimeSDKMediaPipelinesClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-media-pipelines/source/ChimeSDKMediaPipelinesClient.cpp
@@ -125,7 +125,7 @@ ChimeSDKMediaPipelinesClient::ChimeSDKMediaPipelinesClient(const std::shared_ptr
   ChimeSDKMediaPipelinesClient::ChimeSDKMediaPipelinesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKMediaPipelinesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-chime-sdk-meetings/source/ChimeSDKMeetingsClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-meetings/source/ChimeSDKMeetingsClient.cpp
@@ -110,7 +110,7 @@ ChimeSDKMeetingsClient::ChimeSDKMeetingsClient(const std::shared_ptr<AWSCredenti
   ChimeSDKMeetingsClient::ChimeSDKMeetingsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKMeetingsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-chime-sdk-messaging/source/ChimeSDKMessagingClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-messaging/source/ChimeSDKMessagingClient.cpp
@@ -145,7 +145,7 @@ ChimeSDKMessagingClient::ChimeSDKMessagingClient(const std::shared_ptr<AWSCreden
   ChimeSDKMessagingClient::ChimeSDKMessagingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKMessagingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-chime-sdk-voice/source/ChimeSDKVoiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-voice/source/ChimeSDKVoiceClient.cpp
@@ -188,7 +188,7 @@ ChimeSDKVoiceClient::ChimeSDKVoiceClient(const std::shared_ptr<AWSCredentialsPro
   ChimeSDKVoiceClient::ChimeSDKVoiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeSDKVoiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-chime/source/ChimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime/source/ChimeClient.cpp
@@ -156,7 +156,7 @@ ChimeClient::ChimeClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   ChimeClient::ChimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ChimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cleanrooms/source/CleanRoomsClient.cpp
+++ b/generated/src/aws-cpp-sdk-cleanrooms/source/CleanRoomsClient.cpp
@@ -181,7 +181,7 @@ CleanRoomsClient::CleanRoomsClient(const std::shared_ptr<AWSCredentialsProvider>
   CleanRoomsClient::CleanRoomsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CleanRoomsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cleanroomsml/source/CleanRoomsMLClient.cpp
+++ b/generated/src/aws-cpp-sdk-cleanroomsml/source/CleanRoomsMLClient.cpp
@@ -153,7 +153,7 @@ CleanRoomsMLClient::CleanRoomsMLClient(const std::shared_ptr<AWSCredentialsProvi
   CleanRoomsMLClient::CleanRoomsMLClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CleanRoomsMLErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloud9/source/Cloud9Client.cpp
+++ b/generated/src/aws-cpp-sdk-cloud9/source/Cloud9Client.cpp
@@ -107,7 +107,7 @@ Cloud9Client::Cloud9Client(const std::shared_ptr<AWSCredentialsProvider>& creden
   Cloud9Client::Cloud9Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Cloud9ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudcontrol/source/CloudControlApiClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudcontrol/source/CloudControlApiClient.cpp
@@ -102,7 +102,7 @@ CloudControlApiClient::CloudControlApiClient(const std::shared_ptr<AWSCredential
   CloudControlApiClient::CloudControlApiClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudControlApiErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-clouddirectory/source/CloudDirectoryClient.cpp
+++ b/generated/src/aws-cpp-sdk-clouddirectory/source/CloudDirectoryClient.cpp
@@ -160,7 +160,7 @@ CloudDirectoryClient::CloudDirectoryClient(const std::shared_ptr<AWSCredentialsP
   CloudDirectoryClient::CloudDirectoryClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudDirectoryErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudformation/source/CloudFormationClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/CloudFormationClient.cpp
@@ -183,7 +183,7 @@ CloudFormationClient::CloudFormationClient(const std::shared_ptr<AWSCredentialsP
   CloudFormationClient::CloudFormationClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudFormationErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudfront-keyvaluestore/source/CloudFrontKeyValueStoreClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront-keyvaluestore/source/CloudFrontKeyValueStoreClient.cpp
@@ -100,7 +100,7 @@ CloudFrontKeyValueStoreClient::CloudFrontKeyValueStoreClient(const std::shared_p
   CloudFrontKeyValueStoreClient::CloudFrontKeyValueStoreClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudFrontKeyValueStoreErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudfront/source/CloudFrontClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/CloudFrontClient.cpp
@@ -242,7 +242,7 @@ CloudFrontClient::CloudFrontClient(const std::shared_ptr<AWSCredentialsProvider>
   CloudFrontClient::CloudFrontClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudFrontErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudhsm/source/CloudHSMClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudhsm/source/CloudHSMClient.cpp
@@ -94,7 +94,7 @@ CloudHSMClient::CloudHSMClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   CloudHSMClient::CloudHSMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudHSMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudhsmv2/source/CloudHSMV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-cloudhsmv2/source/CloudHSMV2Client.cpp
@@ -112,7 +112,7 @@ CloudHSMV2Client::CloudHSMV2Client(const std::shared_ptr<AWSCredentialsProvider>
   CloudHSMV2Client::CloudHSMV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudHSMV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudsearch/source/CloudSearchClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudsearch/source/CloudSearchClient.cpp
@@ -121,7 +121,7 @@ CloudSearchClient::CloudSearchClient(const std::shared_ptr<AWSCredentialsProvide
   CloudSearchClient::CloudSearchClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudSearchErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudsearchdomain/source/CloudSearchDomainClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudsearchdomain/source/CloudSearchDomainClient.cpp
@@ -97,7 +97,7 @@ CloudSearchDomainClient::CloudSearchDomainClient(const std::shared_ptr<AWSCreden
   CloudSearchDomainClient::CloudSearchDomainClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudSearchDomainErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudtrail-data/source/CloudTrailDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudtrail-data/source/CloudTrailDataClient.cpp
@@ -95,7 +95,7 @@ CloudTrailDataClient::CloudTrailDataClient(const std::shared_ptr<AWSCredentialsP
   CloudTrailDataClient::CloudTrailDataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudTrailDataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cloudtrail/source/CloudTrailClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudtrail/source/CloudTrailClient.cpp
@@ -153,7 +153,7 @@ CloudTrailClient::CloudTrailClient(const std::shared_ptr<AWSCredentialsProvider>
   CloudTrailClient::CloudTrailClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudTrailErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codeartifact/source/CodeArtifactClient.cpp
+++ b/generated/src/aws-cpp-sdk-codeartifact/source/CodeArtifactClient.cpp
@@ -142,7 +142,7 @@ CodeArtifactClient::CodeArtifactClient(const std::shared_ptr<AWSCredentialsProvi
   CodeArtifactClient::CodeArtifactClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeArtifactErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codebuild/source/CodeBuildClient.cpp
+++ b/generated/src/aws-cpp-sdk-codebuild/source/CodeBuildClient.cpp
@@ -153,7 +153,7 @@ CodeBuildClient::CodeBuildClient(const std::shared_ptr<AWSCredentialsProvider>& 
   CodeBuildClient::CodeBuildClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeBuildErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codecommit/source/CodeCommitClient.cpp
+++ b/generated/src/aws-cpp-sdk-codecommit/source/CodeCommitClient.cpp
@@ -173,7 +173,7 @@ CodeCommitClient::CodeCommitClient(const std::shared_ptr<AWSCredentialsProvider>
   CodeCommitClient::CodeCommitClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeCommitErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codeconnections/source/CodeConnectionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-codeconnections/source/CodeConnectionsClient.cpp
@@ -121,7 +121,7 @@ CodeConnectionsClient::CodeConnectionsClient(const std::shared_ptr<AWSCredential
   CodeConnectionsClient::CodeConnectionsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeConnectionsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codedeploy/source/CodeDeployClient.cpp
+++ b/generated/src/aws-cpp-sdk-codedeploy/source/CodeDeployClient.cpp
@@ -137,7 +137,7 @@ CodeDeployClient::CodeDeployClient(const std::shared_ptr<AWSCredentialsProvider>
   CodeDeployClient::CodeDeployClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeDeployErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codeguru-reviewer/source/CodeGuruReviewerClient.cpp
+++ b/generated/src/aws-cpp-sdk-codeguru-reviewer/source/CodeGuruReviewerClient.cpp
@@ -108,7 +108,7 @@ CodeGuruReviewerClient::CodeGuruReviewerClient(const std::shared_ptr<AWSCredenti
   CodeGuruReviewerClient::CodeGuruReviewerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeGuruReviewerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codeguru-security/source/CodeGuruSecurityClient.cpp
+++ b/generated/src/aws-cpp-sdk-codeguru-security/source/CodeGuruSecurityClient.cpp
@@ -107,7 +107,7 @@ CodeGuruSecurityClient::CodeGuruSecurityClient(const std::shared_ptr<AWSCredenti
   CodeGuruSecurityClient::CodeGuruSecurityClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeGuruSecurityErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codeguruprofiler/source/CodeGuruProfilerClient.cpp
+++ b/generated/src/aws-cpp-sdk-codeguruprofiler/source/CodeGuruProfilerClient.cpp
@@ -117,7 +117,7 @@ CodeGuruProfilerClient::CodeGuruProfilerClient(const std::shared_ptr<AWSCredenti
   CodeGuruProfilerClient::CodeGuruProfilerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeGuruProfilerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codepipeline/source/CodePipelineClient.cpp
+++ b/generated/src/aws-cpp-sdk-codepipeline/source/CodePipelineClient.cpp
@@ -138,7 +138,7 @@ CodePipelineClient::CodePipelineClient(const std::shared_ptr<AWSCredentialsProvi
   CodePipelineClient::CodePipelineClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodePipelineErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codestar-connections/source/CodeStarconnectionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-codestar-connections/source/CodeStarconnectionsClient.cpp
@@ -121,7 +121,7 @@ CodeStarconnectionsClient::CodeStarconnectionsClient(const std::shared_ptr<AWSCr
   CodeStarconnectionsClient::CodeStarconnectionsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeStarconnectionsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-codestar-notifications/source/CodeStarNotificationsClient.cpp
+++ b/generated/src/aws-cpp-sdk-codestar-notifications/source/CodeStarNotificationsClient.cpp
@@ -107,7 +107,7 @@ CodeStarNotificationsClient::CodeStarNotificationsClient(const std::shared_ptr<A
   CodeStarNotificationsClient::CodeStarNotificationsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CodeStarNotificationsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cognito-identity/source/CognitoIdentityClient.cpp
+++ b/generated/src/aws-cpp-sdk-cognito-identity/source/CognitoIdentityClient.cpp
@@ -117,7 +117,7 @@ CognitoIdentityClient::CognitoIdentityClient(const std::shared_ptr<AWSCredential
   CognitoIdentityClient::CognitoIdentityClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CognitoIdentityErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cognito-idp/source/CognitoIdentityProviderClient.cpp
+++ b/generated/src/aws-cpp-sdk-cognito-idp/source/CognitoIdentityProviderClient.cpp
@@ -213,7 +213,7 @@ CognitoIdentityProviderClient::CognitoIdentityProviderClient(const std::shared_p
   CognitoIdentityProviderClient::CognitoIdentityProviderClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CognitoIdentityProviderErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cognito-sync/source/CognitoSyncClient.cpp
+++ b/generated/src/aws-cpp-sdk-cognito-sync/source/CognitoSyncClient.cpp
@@ -111,7 +111,7 @@ CognitoSyncClient::CognitoSyncClient(const std::shared_ptr<AWSCredentialsProvide
   CognitoSyncClient::CognitoSyncClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CognitoSyncErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-comprehend/source/ComprehendClient.cpp
+++ b/generated/src/aws-cpp-sdk-comprehend/source/ComprehendClient.cpp
@@ -179,7 +179,7 @@ ComprehendClient::ComprehendClient(const std::shared_ptr<AWSCredentialsProvider>
   ComprehendClient::ComprehendClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ComprehendErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-comprehendmedical/source/ComprehendMedicalClient.cpp
+++ b/generated/src/aws-cpp-sdk-comprehendmedical/source/ComprehendMedicalClient.cpp
@@ -119,7 +119,7 @@ ComprehendMedicalClient::ComprehendMedicalClient(const std::shared_ptr<AWSCreden
   ComprehendMedicalClient::ComprehendMedicalClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ComprehendMedicalErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-compute-optimizer/source/ComputeOptimizerClient.cpp
+++ b/generated/src/aws-cpp-sdk-compute-optimizer/source/ComputeOptimizerClient.cpp
@@ -122,7 +122,7 @@ ComputeOptimizerClient::ComputeOptimizerClient(const std::shared_ptr<AWSCredenti
   ComputeOptimizerClient::ComputeOptimizerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ComputeOptimizerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-config/source/ConfigServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-config/source/ConfigServiceClient.cpp
@@ -191,7 +191,7 @@ ConfigServiceClient::ConfigServiceClient(const std::shared_ptr<AWSCredentialsPro
   ConfigServiceClient::ConfigServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConfigServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-connect-contact-lens/source/ConnectContactLensClient.cpp
+++ b/generated/src/aws-cpp-sdk-connect-contact-lens/source/ConnectContactLensClient.cpp
@@ -95,7 +95,7 @@ ConnectContactLensClient::ConnectContactLensClient(const std::shared_ptr<AWSCred
   ConnectContactLensClient::ConnectContactLensClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectContactLensErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-connect/source/ConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-connect/source/ConnectClient.cpp
@@ -194,7 +194,7 @@ ConnectClient::ConnectClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   ConnectClient::ConnectClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-connectcampaigns/source/ConnectCampaignsClient.cpp
+++ b/generated/src/aws-cpp-sdk-connectcampaigns/source/ConnectCampaignsClient.cpp
@@ -116,7 +116,7 @@ ConnectCampaignsClient::ConnectCampaignsClient(const std::shared_ptr<AWSCredenti
   ConnectCampaignsClient::ConnectCampaignsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectCampaignsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-connectcampaignsv2/source/ConnectCampaignsV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-connectcampaignsv2/source/ConnectCampaignsV2Client.cpp
@@ -129,7 +129,7 @@ ConnectCampaignsV2Client::ConnectCampaignsV2Client(const std::shared_ptr<AWSCred
   ConnectCampaignsV2Client::ConnectCampaignsV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectCampaignsV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-connectcases/source/ConnectCasesClient.cpp
+++ b/generated/src/aws-cpp-sdk-connectcases/source/ConnectCasesClient.cpp
@@ -135,7 +135,7 @@ ConnectCasesClient::ConnectCasesClient(const std::shared_ptr<AWSCredentialsProvi
   ConnectCasesClient::ConnectCasesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectCasesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-connectparticipant/source/ConnectParticipantClient.cpp
+++ b/generated/src/aws-cpp-sdk-connectparticipant/source/ConnectParticipantClient.cpp
@@ -105,7 +105,7 @@ ConnectParticipantClient::ConnectParticipantClient(const std::shared_ptr<AWSCred
   ConnectParticipantClient::ConnectParticipantClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectParticipantErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-controlcatalog/source/ControlCatalogClient.cpp
+++ b/generated/src/aws-cpp-sdk-controlcatalog/source/ControlCatalogClient.cpp
@@ -100,7 +100,7 @@ ControlCatalogClient::ControlCatalogClient(const std::shared_ptr<AWSCredentialsP
   ControlCatalogClient::ControlCatalogClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ControlCatalogErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-controltower/source/ControlTowerClient.cpp
+++ b/generated/src/aws-cpp-sdk-controltower/source/ControlTowerClient.cpp
@@ -122,7 +122,7 @@ ControlTowerClient::ControlTowerClient(const std::shared_ptr<AWSCredentialsProvi
   ControlTowerClient::ControlTowerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ControlTowerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cost-optimization-hub/source/CostOptimizationHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-cost-optimization-hub/source/CostOptimizationHubClient.cpp
@@ -101,7 +101,7 @@ CostOptimizationHubClient::CostOptimizationHubClient(const std::shared_ptr<AWSCr
   CostOptimizationHubClient::CostOptimizationHubClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CostOptimizationHubErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-cur/source/CostandUsageReportServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-cur/source/CostandUsageReportServiceClient.cpp
@@ -101,7 +101,7 @@ CostandUsageReportServiceClient::CostandUsageReportServiceClient(const std::shar
   CostandUsageReportServiceClient::CostandUsageReportServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CostandUsageReportServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-customer-profiles/source/CustomerProfilesClient.cpp
+++ b/generated/src/aws-cpp-sdk-customer-profiles/source/CustomerProfilesClient.cpp
@@ -175,7 +175,7 @@ CustomerProfilesClient::CustomerProfilesClient(const std::shared_ptr<AWSCredenti
   CustomerProfilesClient::CustomerProfilesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CustomerProfilesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-databrew/source/GlueDataBrewClient.cpp
+++ b/generated/src/aws-cpp-sdk-databrew/source/GlueDataBrewClient.cpp
@@ -138,7 +138,7 @@ GlueDataBrewClient::GlueDataBrewClient(const std::shared_ptr<AWSCredentialsProvi
   GlueDataBrewClient::GlueDataBrewClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GlueDataBrewErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-dataexchange/source/DataExchangeClient.cpp
+++ b/generated/src/aws-cpp-sdk-dataexchange/source/DataExchangeClient.cpp
@@ -131,7 +131,7 @@ DataExchangeClient::DataExchangeClient(const std::shared_ptr<AWSCredentialsProvi
   DataExchangeClient::DataExchangeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DataExchangeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-datapipeline/source/DataPipelineClient.cpp
+++ b/generated/src/aws-cpp-sdk-datapipeline/source/DataPipelineClient.cpp
@@ -113,7 +113,7 @@ DataPipelineClient::DataPipelineClient(const std::shared_ptr<AWSCredentialsProvi
   DataPipelineClient::DataPipelineClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DataPipelineErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-datasync/source/DataSyncClient.cpp
+++ b/generated/src/aws-cpp-sdk-datasync/source/DataSyncClient.cpp
@@ -147,7 +147,7 @@ DataSyncClient::DataSyncClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   DataSyncClient::DataSyncClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DataSyncErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-datazone/source/DataZoneClient.cpp
+++ b/generated/src/aws-cpp-sdk-datazone/source/DataZoneClient.cpp
@@ -263,7 +263,7 @@ DataZoneClient::DataZoneClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   DataZoneClient::DataZoneClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DataZoneErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-dax/source/DAXClient.cpp
+++ b/generated/src/aws-cpp-sdk-dax/source/DAXClient.cpp
@@ -115,7 +115,7 @@ DAXClient::DAXClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   DAXClient::DAXClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DAXErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-deadline/source/DeadlineClient.cpp
+++ b/generated/src/aws-cpp-sdk-deadline/source/DeadlineClient.cpp
@@ -207,7 +207,7 @@ DeadlineClient::DeadlineClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   DeadlineClient::DeadlineClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DeadlineErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-detective/source/DetectiveClient.cpp
+++ b/generated/src/aws-cpp-sdk-detective/source/DetectiveClient.cpp
@@ -123,7 +123,7 @@ DetectiveClient::DetectiveClient(const std::shared_ptr<AWSCredentialsProvider>& 
   DetectiveClient::DetectiveClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DetectiveErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-devicefarm/source/DeviceFarmClient.cpp
+++ b/generated/src/aws-cpp-sdk-devicefarm/source/DeviceFarmClient.cpp
@@ -171,7 +171,7 @@ DeviceFarmClient::DeviceFarmClient(const std::shared_ptr<AWSCredentialsProvider>
   DeviceFarmClient::DeviceFarmClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DeviceFarmErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-devops-guru/source/DevOpsGuruClient.cpp
+++ b/generated/src/aws-cpp-sdk-devops-guru/source/DevOpsGuruClient.cpp
@@ -125,7 +125,7 @@ DevOpsGuruClient::DevOpsGuruClient(const std::shared_ptr<AWSCredentialsProvider>
   DevOpsGuruClient::DevOpsGuruClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DevOpsGuruErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-directconnect/source/DirectConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-directconnect/source/DirectConnectClient.cpp
@@ -153,7 +153,7 @@ DirectConnectClient::DirectConnectClient(const std::shared_ptr<AWSCredentialsPro
   DirectConnectClient::DirectConnectClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DirectConnectErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-directory-service-data/source/DirectoryServiceDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-directory-service-data/source/DirectoryServiceDataClient.cpp
@@ -111,7 +111,7 @@ DirectoryServiceDataClient::DirectoryServiceDataClient(const std::shared_ptr<AWS
   DirectoryServiceDataClient::DirectoryServiceDataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DirectoryServiceDataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-discovery/source/ApplicationDiscoveryServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-discovery/source/ApplicationDiscoveryServiceClient.cpp
@@ -120,7 +120,7 @@ ApplicationDiscoveryServiceClient::ApplicationDiscoveryServiceClient(const std::
   ApplicationDiscoveryServiceClient::ApplicationDiscoveryServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ApplicationDiscoveryServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-dlm/source/DLMClient.cpp
+++ b/generated/src/aws-cpp-sdk-dlm/source/DLMClient.cpp
@@ -102,7 +102,7 @@ DLMClient::DLMClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   DLMClient::DLMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DLMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-dms/source/DatabaseMigrationServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-dms/source/DatabaseMigrationServiceClient.cpp
@@ -206,7 +206,7 @@ DatabaseMigrationServiceClient::DatabaseMigrationServiceClient(const std::shared
   DatabaseMigrationServiceClient::DatabaseMigrationServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DatabaseMigrationServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-docdb-elastic/source/DocDBElasticClient.cpp
+++ b/generated/src/aws-cpp-sdk-docdb-elastic/source/DocDBElasticClient.cpp
@@ -113,7 +113,7 @@ DocDBElasticClient::DocDBElasticClient(const std::shared_ptr<AWSCredentialsProvi
   DocDBElasticClient::DocDBElasticClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DocDBElasticErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-docdb/source/DocDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/DocDBClient.cpp
@@ -150,7 +150,7 @@ DocDBClient::DocDBClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   DocDBClient::DocDBClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DocDBErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-drs/source/DrsClient.cpp
+++ b/generated/src/aws-cpp-sdk-drs/source/DrsClient.cpp
@@ -143,7 +143,7 @@ DrsClient::DrsClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   DrsClient::DrsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DrsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ds/source/DirectoryServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-ds/source/DirectoryServiceClient.cpp
@@ -174,7 +174,7 @@ DirectoryServiceClient::DirectoryServiceClient(const std::shared_ptr<AWSCredenti
   DirectoryServiceClient::DirectoryServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DirectoryServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-dsql/source/DSQLClient.cpp
+++ b/generated/src/aws-cpp-sdk-dsql/source/DSQLClient.cpp
@@ -103,7 +103,7 @@ DSQLClient::DSQLClient(const std::shared_ptr<AWSCredentialsProvider>& credential
   DSQLClient::DSQLClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DSQLErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-dynamodbstreams/source/DynamoDBStreamsClient.cpp
+++ b/generated/src/aws-cpp-sdk-dynamodbstreams/source/DynamoDBStreamsClient.cpp
@@ -98,7 +98,7 @@ DynamoDBStreamsClient::DynamoDBStreamsClient(const std::shared_ptr<AWSCredential
   DynamoDBStreamsClient::DynamoDBStreamsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<DynamoDBStreamsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ebs/source/EBSClient.cpp
+++ b/generated/src/aws-cpp-sdk-ebs/source/EBSClient.cpp
@@ -100,7 +100,7 @@ EBSClient::EBSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   EBSClient::EBSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EBSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ec2-instance-connect/source/EC2InstanceConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-ec2-instance-connect/source/EC2InstanceConnectClient.cpp
@@ -96,7 +96,7 @@ EC2InstanceConnectClient::EC2InstanceConnectClient(const std::shared_ptr<AWSCred
   EC2InstanceConnectClient::EC2InstanceConnectClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EC2InstanceConnectErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ec2/source/EC2Client.cpp
+++ b/generated/src/aws-cpp-sdk-ec2/source/EC2Client.cpp
@@ -195,7 +195,7 @@ EC2Client::EC2Client(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   EC2Client::EC2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EC2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ecr-public/source/ECRPublicClient.cpp
+++ b/generated/src/aws-cpp-sdk-ecr-public/source/ECRPublicClient.cpp
@@ -117,7 +117,7 @@ ECRPublicClient::ECRPublicClient(const std::shared_ptr<AWSCredentialsProvider>& 
   ECRPublicClient::ECRPublicClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ECRPublicErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ecr/source/ECRClient.cpp
+++ b/generated/src/aws-cpp-sdk-ecr/source/ECRClient.cpp
@@ -143,7 +143,7 @@ ECRClient::ECRClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   ECRClient::ECRClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ECRErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ecs/source/ECSClient.cpp
+++ b/generated/src/aws-cpp-sdk-ecs/source/ECSClient.cpp
@@ -154,7 +154,7 @@ ECSClient::ECSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   ECSClient::ECSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ECSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-eks-auth/source/EKSAuthClient.cpp
+++ b/generated/src/aws-cpp-sdk-eks-auth/source/EKSAuthClient.cpp
@@ -95,7 +95,7 @@ EKSAuthClient::EKSAuthClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   EKSAuthClient::EKSAuthClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EKSAuthErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-eks/source/EKSClient.cpp
+++ b/generated/src/aws-cpp-sdk-eks/source/EKSClient.cpp
@@ -153,7 +153,7 @@ EKSClient::EKSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   EKSClient::EKSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EKSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elasticache/source/ElastiCacheClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/ElastiCacheClient.cpp
@@ -170,7 +170,7 @@ ElastiCacheClient::ElastiCacheClient(const std::shared_ptr<AWSCredentialsProvide
   ElastiCacheClient::ElastiCacheClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElastiCacheErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/ElasticBeanstalkClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/ElasticBeanstalkClient.cpp
@@ -142,7 +142,7 @@ ElasticBeanstalkClient::ElasticBeanstalkClient(const std::shared_ptr<AWSCredenti
   ElasticBeanstalkClient::ElasticBeanstalkClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticBeanstalkErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elasticfilesystem/source/EFSClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticfilesystem/source/EFSClient.cpp
@@ -122,7 +122,7 @@ EFSClient::EFSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   EFSClient::EFSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EFSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/ElasticLoadBalancingClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/ElasticLoadBalancingClient.cpp
@@ -124,7 +124,7 @@ ElasticLoadBalancingClient::ElasticLoadBalancingClient(const std::shared_ptr<AWS
   ElasticLoadBalancingClient::ElasticLoadBalancingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticLoadBalancingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/ElasticLoadBalancingv2Client.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/ElasticLoadBalancingv2Client.cpp
@@ -146,7 +146,7 @@ ElasticLoadBalancingv2Client::ElasticLoadBalancingv2Client(const std::shared_ptr
   ElasticLoadBalancingv2Client::ElasticLoadBalancingv2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticLoadBalancingv2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elasticmapreduce/source/EMRClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticmapreduce/source/EMRClient.cpp
@@ -153,7 +153,7 @@ EMRClient::EMRClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   EMRClient::EMRClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EMRErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-elastictranscoder/source/ElasticTranscoderClient.cpp
+++ b/generated/src/aws-cpp-sdk-elastictranscoder/source/ElasticTranscoderClient.cpp
@@ -110,7 +110,7 @@ ElasticTranscoderClient::ElasticTranscoderClient(const std::shared_ptr<AWSCreden
   ElasticTranscoderClient::ElasticTranscoderClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticTranscoderErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-email/source/SESClient.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/SESClient.cpp
@@ -166,7 +166,7 @@ SESClient::SESClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SESClient::SESClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SESErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-emr-containers/source/EMRContainersClient.cpp
+++ b/generated/src/aws-cpp-sdk-emr-containers/source/EMRContainersClient.cpp
@@ -117,7 +117,7 @@ EMRContainersClient::EMRContainersClient(const std::shared_ptr<AWSCredentialsPro
   EMRContainersClient::EMRContainersClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EMRContainersErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-emr-serverless/source/EMRServerlessClient.cpp
+++ b/generated/src/aws-cpp-sdk-emr-serverless/source/EMRServerlessClient.cpp
@@ -110,7 +110,7 @@ EMRServerlessClient::EMRServerlessClient(const std::shared_ptr<AWSCredentialsPro
   EMRServerlessClient::EMRServerlessClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EMRServerlessErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-entityresolution/source/EntityResolutionClient.cpp
+++ b/generated/src/aws-cpp-sdk-entityresolution/source/EntityResolutionClient.cpp
@@ -132,7 +132,7 @@ EntityResolutionClient::EntityResolutionClient(const std::shared_ptr<AWSCredenti
   EntityResolutionClient::EntityResolutionClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EntityResolutionErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-es/source/ElasticsearchServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-es/source/ElasticsearchServiceClient.cpp
@@ -145,7 +145,7 @@ ElasticsearchServiceClient::ElasticsearchServiceClient(const std::shared_ptr<AWS
   ElasticsearchServiceClient::ElasticsearchServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ElasticsearchServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-eventbridge/source/EventBridgeClient.cpp
+++ b/generated/src/aws-cpp-sdk-eventbridge/source/EventBridgeClient.cpp
@@ -151,7 +151,7 @@ EventBridgeClient::EventBridgeClient(const std::shared_ptr<AWSCredentialsProvide
   EventBridgeClient::EventBridgeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EventBridgeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-events/source/CloudWatchEventsClient.cpp
+++ b/generated/src/aws-cpp-sdk-events/source/CloudWatchEventsClient.cpp
@@ -145,7 +145,7 @@ CloudWatchEventsClient::CloudWatchEventsClient(const std::shared_ptr<AWSCredenti
   CloudWatchEventsClient::CloudWatchEventsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchEventsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-evidently/source/CloudWatchEvidentlyClient.cpp
+++ b/generated/src/aws-cpp-sdk-evidently/source/CloudWatchEvidentlyClient.cpp
@@ -132,7 +132,7 @@ CloudWatchEvidentlyClient::CloudWatchEvidentlyClient(const std::shared_ptr<AWSCr
   CloudWatchEvidentlyClient::CloudWatchEvidentlyClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchEvidentlyErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-evs/source/EVSClient.cpp
+++ b/generated/src/aws-cpp-sdk-evs/source/EVSClient.cpp
@@ -107,7 +107,7 @@ EVSClient::EVSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   EVSClient::EVSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<EVSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-finspace-data/source/FinSpaceDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-finspace-data/source/FinSpaceDataClient.cpp
@@ -94,7 +94,7 @@ FinSpaceDataClient::FinSpaceDataClient(const std::shared_ptr<AWSCredentialsProvi
   FinSpaceDataClient::FinSpaceDataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FinSpaceDataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-finspace/source/FinspaceClient.cpp
+++ b/generated/src/aws-cpp-sdk-finspace/source/FinspaceClient.cpp
@@ -139,7 +139,7 @@ FinspaceClient::FinspaceClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   FinspaceClient::FinspaceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FinspaceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-firehose/source/FirehoseClient.cpp
+++ b/generated/src/aws-cpp-sdk-firehose/source/FirehoseClient.cpp
@@ -106,7 +106,7 @@ FirehoseClient::FirehoseClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   FirehoseClient::FirehoseClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FirehoseErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-fis/source/FISClient.cpp
+++ b/generated/src/aws-cpp-sdk-fis/source/FISClient.cpp
@@ -120,7 +120,7 @@ FISClient::FISClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   FISClient::FISClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FISErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-fms/source/FMSClient.cpp
+++ b/generated/src/aws-cpp-sdk-fms/source/FMSClient.cpp
@@ -136,7 +136,7 @@ FMSClient::FMSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   FMSClient::FMSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FMSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-forecast/source/ForecastServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-forecast/source/ForecastServiceClient.cpp
@@ -157,7 +157,7 @@ ForecastServiceClient::ForecastServiceClient(const std::shared_ptr<AWSCredential
   ForecastServiceClient::ForecastServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ForecastServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-forecastquery/source/ForecastQueryServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-forecastquery/source/ForecastQueryServiceClient.cpp
@@ -96,7 +96,7 @@ ForecastQueryServiceClient::ForecastQueryServiceClient(const std::shared_ptr<AWS
   ForecastQueryServiceClient::ForecastQueryServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ForecastQueryServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-frauddetector/source/FraudDetectorClient.cpp
+++ b/generated/src/aws-cpp-sdk-frauddetector/source/FraudDetectorClient.cpp
@@ -167,7 +167,7 @@ FraudDetectorClient::FraudDetectorClient(const std::shared_ptr<AWSCredentialsPro
   FraudDetectorClient::FraudDetectorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FraudDetectorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-freetier/source/FreeTierClient.cpp
+++ b/generated/src/aws-cpp-sdk-freetier/source/FreeTierClient.cpp
@@ -99,7 +99,7 @@ FreeTierClient::FreeTierClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   FreeTierClient::FreeTierClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FreeTierErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-fsx/source/FSxClient.cpp
+++ b/generated/src/aws-cpp-sdk-fsx/source/FSxClient.cpp
@@ -142,7 +142,7 @@ FSxClient::FSxClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   FSxClient::FSxClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<FSxErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-gamelift/source/GameLiftClient.cpp
+++ b/generated/src/aws-cpp-sdk-gamelift/source/GameLiftClient.cpp
@@ -212,7 +212,7 @@ GameLiftClient::GameLiftClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   GameLiftClient::GameLiftClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GameLiftErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-gameliftstreams/source/GameLiftStreamsClient.cpp
+++ b/generated/src/aws-cpp-sdk-gameliftstreams/source/GameLiftStreamsClient.cpp
@@ -118,7 +118,7 @@ GameLiftStreamsClient::GameLiftStreamsClient(const std::shared_ptr<AWSCredential
   GameLiftStreamsClient::GameLiftStreamsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GameLiftStreamsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-geo-maps/source/GeoMapsClient.cpp
+++ b/generated/src/aws-cpp-sdk-geo-maps/source/GeoMapsClient.cpp
@@ -99,7 +99,7 @@ GeoMapsClient::GeoMapsClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   GeoMapsClient::GeoMapsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GeoMapsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-geo-places/source/GeoPlacesClient.cpp
+++ b/generated/src/aws-cpp-sdk-geo-places/source/GeoPlacesClient.cpp
@@ -101,7 +101,7 @@ GeoPlacesClient::GeoPlacesClient(const std::shared_ptr<AWSCredentialsProvider>& 
   GeoPlacesClient::GeoPlacesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GeoPlacesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-geo-routes/source/GeoRoutesClient.cpp
+++ b/generated/src/aws-cpp-sdk-geo-routes/source/GeoRoutesClient.cpp
@@ -99,7 +99,7 @@ GeoRoutesClient::GeoRoutesClient(const std::shared_ptr<AWSCredentialsProvider>& 
   GeoRoutesClient::GeoRoutesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GeoRoutesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-glacier/source/GlacierClient.cpp
+++ b/generated/src/aws-cpp-sdk-glacier/source/GlacierClient.cpp
@@ -127,7 +127,7 @@ GlacierClient::GlacierClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   GlacierClient::GlacierClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GlacierErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-globalaccelerator/source/GlobalAcceleratorClient.cpp
+++ b/generated/src/aws-cpp-sdk-globalaccelerator/source/GlobalAcceleratorClient.cpp
@@ -150,7 +150,7 @@ GlobalAcceleratorClient::GlobalAcceleratorClient(const std::shared_ptr<AWSCreden
   GlobalAcceleratorClient::GlobalAcceleratorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GlobalAcceleratorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-glue/source/GlueClient.cpp
+++ b/generated/src/aws-cpp-sdk-glue/source/GlueClient.cpp
@@ -194,7 +194,7 @@ GlueClient::GlueClient(const std::shared_ptr<AWSCredentialsProvider>& credential
   GlueClient::GlueClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GlueErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-grafana/source/ManagedGrafanaClient.cpp
+++ b/generated/src/aws-cpp-sdk-grafana/source/ManagedGrafanaClient.cpp
@@ -119,7 +119,7 @@ ManagedGrafanaClient::ManagedGrafanaClient(const std::shared_ptr<AWSCredentialsP
   ManagedGrafanaClient::ManagedGrafanaClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ManagedGrafanaErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-greengrass/source/GreengrassClient.cpp
+++ b/generated/src/aws-cpp-sdk-greengrass/source/GreengrassClient.cpp
@@ -186,7 +186,7 @@ GreengrassClient::GreengrassClient(const std::shared_ptr<AWSCredentialsProvider>
   GreengrassClient::GreengrassClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GreengrassErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-greengrassv2/source/GreengrassV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-greengrassv2/source/GreengrassV2Client.cpp
@@ -123,7 +123,7 @@ GreengrassV2Client::GreengrassV2Client(const std::shared_ptr<AWSCredentialsProvi
   GreengrassV2Client::GreengrassV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GreengrassV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-groundstation/source/GroundStationClient.cpp
+++ b/generated/src/aws-cpp-sdk-groundstation/source/GroundStationClient.cpp
@@ -127,7 +127,7 @@ GroundStationClient::GroundStationClient(const std::shared_ptr<AWSCredentialsPro
   GroundStationClient::GroundStationClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GroundStationErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-guardduty/source/GuardDutyClient.cpp
+++ b/generated/src/aws-cpp-sdk-guardduty/source/GuardDutyClient.cpp
@@ -175,7 +175,7 @@ GuardDutyClient::GuardDutyClient(const std::shared_ptr<AWSCredentialsProvider>& 
   GuardDutyClient::GuardDutyClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<GuardDutyErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-health/source/HealthClient.cpp
+++ b/generated/src/aws-cpp-sdk-health/source/HealthClient.cpp
@@ -108,7 +108,7 @@ HealthClient::HealthClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   HealthClient::HealthClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<HealthErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-healthlake/source/HealthLakeClient.cpp
+++ b/generated/src/aws-cpp-sdk-healthlake/source/HealthLakeClient.cpp
@@ -107,7 +107,7 @@ HealthLakeClient::HealthLakeClient(const std::shared_ptr<AWSCredentialsProvider>
   HealthLakeClient::HealthLakeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<HealthLakeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iam/source/IAMClient.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/IAMClient.cpp
@@ -259,7 +259,7 @@ IAMClient::IAMClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   IAMClient::IAMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IAMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-identitystore/source/IdentityStoreClient.cpp
+++ b/generated/src/aws-cpp-sdk-identitystore/source/IdentityStoreClient.cpp
@@ -113,7 +113,7 @@ IdentityStoreClient::IdentityStoreClient(const std::shared_ptr<AWSCredentialsPro
   IdentityStoreClient::IdentityStoreClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IdentityStoreErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-imagebuilder/source/ImagebuilderClient.cpp
+++ b/generated/src/aws-cpp-sdk-imagebuilder/source/ImagebuilderClient.cpp
@@ -169,7 +169,7 @@ ImagebuilderClient::ImagebuilderClient(const std::shared_ptr<AWSCredentialsProvi
   ImagebuilderClient::ImagebuilderClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ImagebuilderErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-importexport/source/ImportExportClient.cpp
+++ b/generated/src/aws-cpp-sdk-importexport/source/ImportExportClient.cpp
@@ -101,7 +101,7 @@ ImportExportClient::ImportExportClient(const std::shared_ptr<AWSCredentialsProvi
   ImportExportClient::ImportExportClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ImportExportErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-inspector-scan/source/InspectorscanClient.cpp
+++ b/generated/src/aws-cpp-sdk-inspector-scan/source/InspectorscanClient.cpp
@@ -95,7 +95,7 @@ InspectorscanClient::InspectorscanClient(const std::shared_ptr<AWSCredentialsPro
   InspectorscanClient::InspectorscanClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<InspectorscanErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-inspector/source/InspectorClient.cpp
+++ b/generated/src/aws-cpp-sdk-inspector/source/InspectorClient.cpp
@@ -131,7 +131,7 @@ InspectorClient::InspectorClient(const std::shared_ptr<AWSCredentialsProvider>& 
   InspectorClient::InspectorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<InspectorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-inspector2/source/Inspector2Client.cpp
+++ b/generated/src/aws-cpp-sdk-inspector2/source/Inspector2Client.cpp
@@ -169,7 +169,7 @@ Inspector2Client::Inspector2Client(const std::shared_ptr<AWSCredentialsProvider>
   Inspector2Client::Inspector2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Inspector2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-internetmonitor/source/InternetMonitorClient.cpp
+++ b/generated/src/aws-cpp-sdk-internetmonitor/source/InternetMonitorClient.cpp
@@ -110,7 +110,7 @@ InternetMonitorClient::InternetMonitorClient(const std::shared_ptr<AWSCredential
   InternetMonitorClient::InternetMonitorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<InternetMonitorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-invoicing/source/InvoicingClient.cpp
+++ b/generated/src/aws-cpp-sdk-invoicing/source/InvoicingClient.cpp
@@ -104,7 +104,7 @@ InvoicingClient::InvoicingClient(const std::shared_ptr<AWSCredentialsProvider>& 
   InvoicingClient::InvoicingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<InvoicingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iot-data/source/IoTDataPlaneClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot-data/source/IoTDataPlaneClient.cpp
@@ -102,7 +102,7 @@ IoTDataPlaneClient::IoTDataPlaneClient(const std::shared_ptr<AWSCredentialsProvi
   IoTDataPlaneClient::IoTDataPlaneClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTDataPlaneErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iot-jobs-data/source/IoTJobsDataPlaneClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot-jobs-data/source/IoTJobsDataPlaneClient.cpp
@@ -99,7 +99,7 @@ IoTJobsDataPlaneClient::IoTJobsDataPlaneClient(const std::shared_ptr<AWSCredenti
   IoTJobsDataPlaneClient::IoTJobsDataPlaneClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTJobsDataPlaneErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iot-managed-integrations/source/IoTManagedIntegrationsClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot-managed-integrations/source/IoTManagedIntegrationsClient.cpp
@@ -176,7 +176,7 @@ IoTManagedIntegrationsClient::IoTManagedIntegrationsClient(const std::shared_ptr
   IoTManagedIntegrationsClient::IoTManagedIntegrationsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTManagedIntegrationsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iot/source/IoTClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot/source/IoTClient.cpp
@@ -194,7 +194,7 @@ IoTClient::IoTClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   IoTClient::IoTClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iot1click-devices/source/IoT1ClickDevicesServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot1click-devices/source/IoT1ClickDevicesServiceClient.cpp
@@ -107,7 +107,7 @@ IoT1ClickDevicesServiceClient::IoT1ClickDevicesServiceClient(const std::shared_p
   IoT1ClickDevicesServiceClient::IoT1ClickDevicesServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoT1ClickDevicesServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iot1click-projects/source/IoT1ClickProjectsClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot1click-projects/source/IoT1ClickProjectsClient.cpp
@@ -110,7 +110,7 @@ IoT1ClickProjectsClient::IoT1ClickProjectsClient(const std::shared_ptr<AWSCreden
   IoT1ClickProjectsClient::IoT1ClickProjectsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoT1ClickProjectsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotanalytics/source/IoTAnalyticsClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotanalytics/source/IoTAnalyticsClient.cpp
@@ -128,7 +128,7 @@ IoTAnalyticsClient::IoTAnalyticsClient(const std::shared_ptr<AWSCredentialsProvi
   IoTAnalyticsClient::IoTAnalyticsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTAnalyticsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotdeviceadvisor/source/IoTDeviceAdvisorClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotdeviceadvisor/source/IoTDeviceAdvisorClient.cpp
@@ -108,7 +108,7 @@ IoTDeviceAdvisorClient::IoTDeviceAdvisorClient(const std::shared_ptr<AWSCredenti
   IoTDeviceAdvisorClient::IoTDeviceAdvisorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTDeviceAdvisorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotevents-data/source/IoTEventsDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotevents-data/source/IoTEventsDataClient.cpp
@@ -106,7 +106,7 @@ IoTEventsDataClient::IoTEventsDataClient(const std::shared_ptr<AWSCredentialsPro
   IoTEventsDataClient::IoTEventsDataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTEventsDataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotevents/source/IoTEventsClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotevents/source/IoTEventsClient.cpp
@@ -120,7 +120,7 @@ IoTEventsClient::IoTEventsClient(const std::shared_ptr<AWSCredentialsProvider>& 
   IoTEventsClient::IoTEventsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTEventsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotfleethub/source/IoTFleetHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotfleethub/source/IoTFleetHubClient.cpp
@@ -102,7 +102,7 @@ IoTFleetHubClient::IoTFleetHubClient(const std::shared_ptr<AWSCredentialsProvide
   IoTFleetHubClient::IoTFleetHubClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTFleetHubErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotfleetwise/source/IoTFleetWiseClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotfleetwise/source/IoTFleetWiseClient.cpp
@@ -151,7 +151,7 @@ IoTFleetWiseClient::IoTFleetWiseClient(const std::shared_ptr<AWSCredentialsProvi
   IoTFleetWiseClient::IoTFleetWiseClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTFleetWiseErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotsecuretunneling/source/IoTSecureTunnelingClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotsecuretunneling/source/IoTSecureTunnelingClient.cpp
@@ -102,7 +102,7 @@ IoTSecureTunnelingClient::IoTSecureTunnelingClient(const std::shared_ptr<AWSCred
   IoTSecureTunnelingClient::IoTSecureTunnelingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTSecureTunnelingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotsitewise/source/IoTSiteWiseClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotsitewise/source/IoTSiteWiseClient.cpp
@@ -199,7 +199,7 @@ IoTSiteWiseClient::IoTSiteWiseClient(const std::shared_ptr<AWSCredentialsProvide
   IoTSiteWiseClient::IoTSiteWiseClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTSiteWiseErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotthingsgraph/source/IoTThingsGraphClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotthingsgraph/source/IoTThingsGraphClient.cpp
@@ -94,7 +94,7 @@ IoTThingsGraphClient::IoTThingsGraphClient(const std::shared_ptr<AWSCredentialsP
   IoTThingsGraphClient::IoTThingsGraphClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTThingsGraphErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iottwinmaker/source/IoTTwinMakerClient.cpp
+++ b/generated/src/aws-cpp-sdk-iottwinmaker/source/IoTTwinMakerClient.cpp
@@ -134,7 +134,7 @@ IoTTwinMakerClient::IoTTwinMakerClient(const std::shared_ptr<AWSCredentialsProvi
   IoTTwinMakerClient::IoTTwinMakerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTTwinMakerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-iotwireless/source/IoTWirelessClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotwireless/source/IoTWirelessClient.cpp
@@ -201,7 +201,7 @@ IoTWirelessClient::IoTWirelessClient(const std::shared_ptr<AWSCredentialsProvide
   IoTWirelessClient::IoTWirelessClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IoTWirelessErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ivs-realtime/source/IvsrealtimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-ivs-realtime/source/IvsrealtimeClient.cpp
@@ -133,7 +133,7 @@ IvsrealtimeClient::IvsrealtimeClient(const std::shared_ptr<AWSCredentialsProvide
   IvsrealtimeClient::IvsrealtimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IvsrealtimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ivs/source/IVSClient.cpp
+++ b/generated/src/aws-cpp-sdk-ivs/source/IVSClient.cpp
@@ -129,7 +129,7 @@ IVSClient::IVSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   IVSClient::IVSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IVSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ivschat/source/IvschatClient.cpp
+++ b/generated/src/aws-cpp-sdk-ivschat/source/IvschatClient.cpp
@@ -111,7 +111,7 @@ IvschatClient::IvschatClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   IvschatClient::IvschatClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<IvschatErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kafka/source/KafkaClient.cpp
+++ b/generated/src/aws-cpp-sdk-kafka/source/KafkaClient.cpp
@@ -146,7 +146,7 @@ KafkaClient::KafkaClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   KafkaClient::KafkaClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KafkaErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kafkaconnect/source/KafkaConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-kafkaconnect/source/KafkaConnectClient.cpp
@@ -112,7 +112,7 @@ KafkaConnectClient::KafkaConnectClient(const std::shared_ptr<AWSCredentialsProvi
   KafkaConnectClient::KafkaConnectClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KafkaConnectErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kendra-ranking/source/KendraRankingClient.cpp
+++ b/generated/src/aws-cpp-sdk-kendra-ranking/source/KendraRankingClient.cpp
@@ -103,7 +103,7 @@ KendraRankingClient::KendraRankingClient(const std::shared_ptr<AWSCredentialsPro
   KendraRankingClient::KendraRankingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KendraRankingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kendra/source/KendraClient.cpp
+++ b/generated/src/aws-cpp-sdk-kendra/source/KendraClient.cpp
@@ -160,7 +160,7 @@ KendraClient::KendraClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   KendraClient::KendraClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KendraErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-keyspaces/source/KeyspacesClient.cpp
+++ b/generated/src/aws-cpp-sdk-keyspaces/source/KeyspacesClient.cpp
@@ -113,7 +113,7 @@ KeyspacesClient::KeyspacesClient(const std::shared_ptr<AWSCredentialsProvider>& 
   KeyspacesClient::KeyspacesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KeyspacesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-keyspacesstreams/source/KeyspacesStreamsClient.cpp
+++ b/generated/src/aws-cpp-sdk-keyspacesstreams/source/KeyspacesStreamsClient.cpp
@@ -98,7 +98,7 @@ KeyspacesStreamsClient::KeyspacesStreamsClient(const std::shared_ptr<AWSCredenti
   KeyspacesStreamsClient::KeyspacesStreamsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KeyspacesStreamsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesis-video-archived-media/source/KinesisVideoArchivedMediaClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis-video-archived-media/source/KinesisVideoArchivedMediaClient.cpp
@@ -100,7 +100,7 @@ KinesisVideoArchivedMediaClient::KinesisVideoArchivedMediaClient(const std::shar
   KinesisVideoArchivedMediaClient::KinesisVideoArchivedMediaClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoArchivedMediaErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesis-video-media/source/KinesisVideoMediaClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis-video-media/source/KinesisVideoMediaClient.cpp
@@ -95,7 +95,7 @@ KinesisVideoMediaClient::KinesisVideoMediaClient(const std::shared_ptr<AWSCreden
   KinesisVideoMediaClient::KinesisVideoMediaClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoMediaErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesis-video-signaling/source/KinesisVideoSignalingChannelsClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis-video-signaling/source/KinesisVideoSignalingChannelsClient.cpp
@@ -96,7 +96,7 @@ KinesisVideoSignalingChannelsClient::KinesisVideoSignalingChannelsClient(const s
   KinesisVideoSignalingChannelsClient::KinesisVideoSignalingChannelsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoSignalingChannelsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesis-video-webrtc-storage/source/KinesisVideoWebRTCStorageClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis-video-webrtc-storage/source/KinesisVideoWebRTCStorageClient.cpp
@@ -96,7 +96,7 @@ KinesisVideoWebRTCStorageClient::KinesisVideoWebRTCStorageClient(const std::shar
   KinesisVideoWebRTCStorageClient::KinesisVideoWebRTCStorageClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoWebRTCStorageErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesis/source/KinesisClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis/source/KinesisClient.cpp
@@ -130,7 +130,7 @@ KinesisClient::KinesisClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   KinesisClient::KinesisClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesisanalytics/source/KinesisAnalyticsClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesisanalytics/source/KinesisAnalyticsClient.cpp
@@ -114,7 +114,7 @@ KinesisAnalyticsClient::KinesisAnalyticsClient(const std::shared_ptr<AWSCredenti
   KinesisAnalyticsClient::KinesisAnalyticsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisAnalyticsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesisanalyticsv2/source/KinesisAnalyticsV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-kinesisanalyticsv2/source/KinesisAnalyticsV2Client.cpp
@@ -127,7 +127,7 @@ KinesisAnalyticsV2Client::KinesisAnalyticsV2Client(const std::shared_ptr<AWSCred
   KinesisAnalyticsV2Client::KinesisAnalyticsV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisAnalyticsV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kinesisvideo/source/KinesisVideoClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesisvideo/source/KinesisVideoClient.cpp
@@ -124,7 +124,7 @@ KinesisVideoClient::KinesisVideoClient(const std::shared_ptr<AWSCredentialsProvi
   KinesisVideoClient::KinesisVideoClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KinesisVideoErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-kms/source/KMSClient.cpp
+++ b/generated/src/aws-cpp-sdk-kms/source/KMSClient.cpp
@@ -147,7 +147,7 @@ KMSClient::KMSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   KMSClient::KMSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<KMSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lakeformation/source/LakeFormationClient.cpp
+++ b/generated/src/aws-cpp-sdk-lakeformation/source/LakeFormationClient.cpp
@@ -154,7 +154,7 @@ LakeFormationClient::LakeFormationClient(const std::shared_ptr<AWSCredentialsPro
   LakeFormationClient::LakeFormationClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LakeFormationErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lambda/source/LambdaClient.cpp
+++ b/generated/src/aws-cpp-sdk-lambda/source/LambdaClient.cpp
@@ -162,7 +162,7 @@ LambdaClient::LambdaClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   LambdaClient::LambdaClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LambdaErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-launch-wizard/source/LaunchWizardClient.cpp
+++ b/generated/src/aws-cpp-sdk-launch-wizard/source/LaunchWizardClient.cpp
@@ -106,7 +106,7 @@ LaunchWizardClient::LaunchWizardClient(const std::shared_ptr<AWSCredentialsProvi
   LaunchWizardClient::LaunchWizardClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LaunchWizardErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lex-models/source/LexModelBuildingServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-lex-models/source/LexModelBuildingServiceClient.cpp
@@ -136,7 +136,7 @@ LexModelBuildingServiceClient::LexModelBuildingServiceClient(const std::shared_p
   LexModelBuildingServiceClient::LexModelBuildingServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LexModelBuildingServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lex/source/LexRuntimeServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-lex/source/LexRuntimeServiceClient.cpp
@@ -99,7 +99,7 @@ LexRuntimeServiceClient::LexRuntimeServiceClient(const std::shared_ptr<AWSCreden
   LexRuntimeServiceClient::LexRuntimeServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LexRuntimeServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lexv2-models/source/LexModelsV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-lexv2-models/source/LexModelsV2Client.cpp
@@ -196,7 +196,7 @@ LexModelsV2Client::LexModelsV2Client(const std::shared_ptr<AWSCredentialsProvide
   LexModelsV2Client::LexModelsV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LexModelsV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/source/LexRuntimeV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/source/LexRuntimeV2Client.cpp
@@ -102,7 +102,7 @@ LexRuntimeV2Client::LexRuntimeV2Client(const std::shared_ptr<AWSCredentialsProvi
   LexRuntimeV2Client::LexRuntimeV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LexRuntimeV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-license-manager-linux-subscriptions/source/LicenseManagerLinuxSubscriptionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-license-manager-linux-subscriptions/source/LicenseManagerLinuxSubscriptionsClient.cpp
@@ -105,7 +105,7 @@ LicenseManagerLinuxSubscriptionsClient::LicenseManagerLinuxSubscriptionsClient(c
   LicenseManagerLinuxSubscriptionsClient::LicenseManagerLinuxSubscriptionsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LicenseManagerLinuxSubscriptionsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-license-manager-user-subscriptions/source/LicenseManagerUserSubscriptionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-license-manager-user-subscriptions/source/LicenseManagerUserSubscriptionsClient.cpp
@@ -111,7 +111,7 @@ LicenseManagerUserSubscriptionsClient::LicenseManagerUserSubscriptionsClient(con
   LicenseManagerUserSubscriptionsClient::LicenseManagerUserSubscriptionsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LicenseManagerUserSubscriptionsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-license-manager/source/LicenseManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-license-manager/source/LicenseManagerClient.cpp
@@ -144,7 +144,7 @@ LicenseManagerClient::LicenseManagerClient(const std::shared_ptr<AWSCredentialsP
   LicenseManagerClient::LicenseManagerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LicenseManagerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lightsail/source/LightsailClient.cpp
+++ b/generated/src/aws-cpp-sdk-lightsail/source/LightsailClient.cpp
@@ -255,7 +255,7 @@ LightsailClient::LightsailClient(const std::shared_ptr<AWSCredentialsProvider>& 
   LightsailClient::LightsailClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LightsailErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-location/source/LocationServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-location/source/LocationServiceClient.cpp
@@ -154,7 +154,7 @@ LocationServiceClient::LocationServiceClient(const std::shared_ptr<AWSCredential
   LocationServiceClient::LocationServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LocationServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-logs/source/CloudWatchLogsClient.cpp
+++ b/generated/src/aws-cpp-sdk-logs/source/CloudWatchLogsClient.cpp
@@ -183,7 +183,7 @@ CloudWatchLogsClient::CloudWatchLogsClient(const std::shared_ptr<AWSCredentialsP
   CloudWatchLogsClient::CloudWatchLogsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchLogsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lookoutequipment/source/LookoutEquipmentClient.cpp
+++ b/generated/src/aws-cpp-sdk-lookoutequipment/source/LookoutEquipmentClient.cpp
@@ -143,7 +143,7 @@ LookoutEquipmentClient::LookoutEquipmentClient(const std::shared_ptr<AWSCredenti
   LookoutEquipmentClient::LookoutEquipmentClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LookoutEquipmentErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lookoutmetrics/source/LookoutMetricsClient.cpp
+++ b/generated/src/aws-cpp-sdk-lookoutmetrics/source/LookoutMetricsClient.cpp
@@ -124,7 +124,7 @@ LookoutMetricsClient::LookoutMetricsClient(const std::shared_ptr<AWSCredentialsP
   LookoutMetricsClient::LookoutMetricsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LookoutMetricsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-lookoutvision/source/LookoutforVisionClient.cpp
+++ b/generated/src/aws-cpp-sdk-lookoutvision/source/LookoutforVisionClient.cpp
@@ -116,7 +116,7 @@ LookoutforVisionClient::LookoutforVisionClient(const std::shared_ptr<AWSCredenti
   LookoutforVisionClient::LookoutforVisionClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<LookoutforVisionErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-m2/source/MainframeModernizationClient.cpp
+++ b/generated/src/aws-cpp-sdk-m2/source/MainframeModernizationClient.cpp
@@ -131,7 +131,7 @@ MainframeModernizationClient::MainframeModernizationClient(const std::shared_ptr
   MainframeModernizationClient::MainframeModernizationClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MainframeModernizationErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-machinelearning/source/MachineLearningClient.cpp
+++ b/generated/src/aws-cpp-sdk-machinelearning/source/MachineLearningClient.cpp
@@ -122,7 +122,7 @@ MachineLearningClient::MachineLearningClient(const std::shared_ptr<AWSCredential
   MachineLearningClient::MachineLearningClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MachineLearningErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-macie2/source/Macie2Client.cpp
+++ b/generated/src/aws-cpp-sdk-macie2/source/Macie2Client.cpp
@@ -175,7 +175,7 @@ Macie2Client::Macie2Client(const std::shared_ptr<AWSCredentialsProvider>& creden
   Macie2Client::Macie2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Macie2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mailmanager/source/MailManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-mailmanager/source/MailManagerClient.cpp
@@ -154,7 +154,7 @@ MailManagerClient::MailManagerClient(const std::shared_ptr<AWSCredentialsProvide
   MailManagerClient::MailManagerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MailManagerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-managedblockchain-query/source/ManagedBlockchainQueryClient.cpp
+++ b/generated/src/aws-cpp-sdk-managedblockchain-query/source/ManagedBlockchainQueryClient.cpp
@@ -103,7 +103,7 @@ ManagedBlockchainQueryClient::ManagedBlockchainQueryClient(const std::shared_ptr
   ManagedBlockchainQueryClient::ManagedBlockchainQueryClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ManagedBlockchainQueryErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-managedblockchain/source/ManagedBlockchainClient.cpp
+++ b/generated/src/aws-cpp-sdk-managedblockchain/source/ManagedBlockchainClient.cpp
@@ -121,7 +121,7 @@ ManagedBlockchainClient::ManagedBlockchainClient(const std::shared_ptr<AWSCreden
   ManagedBlockchainClient::ManagedBlockchainClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ManagedBlockchainErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-marketplace-agreement/source/AgreementServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplace-agreement/source/AgreementServiceClient.cpp
@@ -97,7 +97,7 @@ AgreementServiceClient::AgreementServiceClient(const std::shared_ptr<AWSCredenti
   AgreementServiceClient::AgreementServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AgreementServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-marketplace-catalog/source/MarketplaceCatalogClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplace-catalog/source/MarketplaceCatalogClient.cpp
@@ -107,7 +107,7 @@ MarketplaceCatalogClient::MarketplaceCatalogClient(const std::shared_ptr<AWSCred
   MarketplaceCatalogClient::MarketplaceCatalogClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceCatalogErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-marketplace-deployment/source/MarketplaceDeploymentClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplace-deployment/source/MarketplaceDeploymentClient.cpp
@@ -98,7 +98,7 @@ MarketplaceDeploymentClient::MarketplaceDeploymentClient(const std::shared_ptr<A
   MarketplaceDeploymentClient::MarketplaceDeploymentClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceDeploymentErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-marketplace-entitlement/source/MarketplaceEntitlementServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplace-entitlement/source/MarketplaceEntitlementServiceClient.cpp
@@ -95,7 +95,7 @@ MarketplaceEntitlementServiceClient::MarketplaceEntitlementServiceClient(const s
   MarketplaceEntitlementServiceClient::MarketplaceEntitlementServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceEntitlementServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-marketplace-reporting/source/MarketplaceReportingClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplace-reporting/source/MarketplaceReportingClient.cpp
@@ -95,7 +95,7 @@ MarketplaceReportingClient::MarketplaceReportingClient(const std::shared_ptr<AWS
   MarketplaceReportingClient::MarketplaceReportingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceReportingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-marketplacecommerceanalytics/source/MarketplaceCommerceAnalyticsClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplacecommerceanalytics/source/MarketplaceCommerceAnalyticsClient.cpp
@@ -95,7 +95,7 @@ MarketplaceCommerceAnalyticsClient::MarketplaceCommerceAnalyticsClient(const std
   MarketplaceCommerceAnalyticsClient::MarketplaceCommerceAnalyticsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceCommerceAnalyticsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediaconnect/source/MediaConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediaconnect/source/MediaConnectClient.cpp
@@ -146,7 +146,7 @@ MediaConnectClient::MediaConnectClient(const std::shared_ptr<AWSCredentialsProvi
   MediaConnectClient::MediaConnectClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaConnectErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediaconvert/source/MediaConvertClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediaconvert/source/MediaConvertClient.cpp
@@ -125,7 +125,7 @@ MediaConvertClient::MediaConvertClient(const std::shared_ptr<AWSCredentialsProvi
   MediaConvertClient::MediaConvertClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaConvertErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-medialive/source/MediaLiveClient.cpp
+++ b/generated/src/aws-cpp-sdk-medialive/source/MediaLiveClient.cpp
@@ -214,7 +214,7 @@ MediaLiveClient::MediaLiveClient(const std::shared_ptr<AWSCredentialsProvider>& 
   MediaLiveClient::MediaLiveClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaLiveErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediapackage-vod/source/MediaPackageVodClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediapackage-vod/source/MediaPackageVodClient.cpp
@@ -111,7 +111,7 @@ MediaPackageVodClient::MediaPackageVodClient(const std::shared_ptr<AWSCredential
   MediaPackageVodClient::MediaPackageVodClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaPackageVodErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediapackage/source/MediaPackageClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediapackage/source/MediaPackageClient.cpp
@@ -112,7 +112,7 @@ MediaPackageClient::MediaPackageClient(const std::shared_ptr<AWSCredentialsProvi
   MediaPackageClient::MediaPackageClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaPackageErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediapackagev2/source/Mediapackagev2Client.cpp
+++ b/generated/src/aws-cpp-sdk-mediapackagev2/source/Mediapackagev2Client.cpp
@@ -124,7 +124,7 @@ Mediapackagev2Client::Mediapackagev2Client(const std::shared_ptr<AWSCredentialsP
   Mediapackagev2Client::Mediapackagev2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Mediapackagev2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediastore-data/source/MediaStoreDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediastore-data/source/MediaStoreDataClient.cpp
@@ -99,7 +99,7 @@ MediaStoreDataClient::MediaStoreDataClient(const std::shared_ptr<AWSCredentialsP
   MediaStoreDataClient::MediaStoreDataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaStoreDataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediastore/source/MediaStoreClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediastore/source/MediaStoreClient.cpp
@@ -115,7 +115,7 @@ MediaStoreClient::MediaStoreClient(const std::shared_ptr<AWSCredentialsProvider>
   MediaStoreClient::MediaStoreClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaStoreErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mediatailor/source/MediaTailorClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediatailor/source/MediaTailorClient.cpp
@@ -138,7 +138,7 @@ MediaTailorClient::MediaTailorClient(const std::shared_ptr<AWSCredentialsProvide
   MediaTailorClient::MediaTailorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MediaTailorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-medical-imaging/source/MedicalImagingClient.cpp
+++ b/generated/src/aws-cpp-sdk-medical-imaging/source/MedicalImagingClient.cpp
@@ -112,7 +112,7 @@ MedicalImagingClient::MedicalImagingClient(const std::shared_ptr<AWSCredentialsP
   MedicalImagingClient::MedicalImagingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MedicalImagingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-memorydb/source/MemoryDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-memorydb/source/MemoryDBClient.cpp
@@ -137,7 +137,7 @@ MemoryDBClient::MemoryDBClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   MemoryDBClient::MemoryDBClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MemoryDBErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-meteringmarketplace/source/MarketplaceMeteringClient.cpp
+++ b/generated/src/aws-cpp-sdk-meteringmarketplace/source/MarketplaceMeteringClient.cpp
@@ -98,7 +98,7 @@ MarketplaceMeteringClient::MarketplaceMeteringClient(const std::shared_ptr<AWSCr
   MarketplaceMeteringClient::MarketplaceMeteringClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MarketplaceMeteringErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mgn/source/MgnClient.cpp
+++ b/generated/src/aws-cpp-sdk-mgn/source/MgnClient.cpp
@@ -164,7 +164,7 @@ MgnClient::MgnClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   MgnClient::MgnClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MgnErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-migration-hub-refactor-spaces/source/MigrationHubRefactorSpacesClient.cpp
+++ b/generated/src/aws-cpp-sdk-migration-hub-refactor-spaces/source/MigrationHubRefactorSpacesClient.cpp
@@ -118,7 +118,7 @@ MigrationHubRefactorSpacesClient::MigrationHubRefactorSpacesClient(const std::sh
   MigrationHubRefactorSpacesClient::MigrationHubRefactorSpacesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubRefactorSpacesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-migrationhub-config/source/MigrationHubConfigClient.cpp
+++ b/generated/src/aws-cpp-sdk-migrationhub-config/source/MigrationHubConfigClient.cpp
@@ -98,7 +98,7 @@ MigrationHubConfigClient::MigrationHubConfigClient(const std::shared_ptr<AWSCred
   MigrationHubConfigClient::MigrationHubConfigClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubConfigErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-migrationhuborchestrator/source/MigrationHubOrchestratorClient.cpp
+++ b/generated/src/aws-cpp-sdk-migrationhuborchestrator/source/MigrationHubOrchestratorClient.cpp
@@ -125,7 +125,7 @@ MigrationHubOrchestratorClient::MigrationHubOrchestratorClient(const std::shared
   MigrationHubOrchestratorClient::MigrationHubOrchestratorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubOrchestratorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-migrationhubstrategy/source/MigrationHubStrategyRecommendationsClient.cpp
+++ b/generated/src/aws-cpp-sdk-migrationhubstrategy/source/MigrationHubStrategyRecommendationsClient.cpp
@@ -116,7 +116,7 @@ MigrationHubStrategyRecommendationsClient::MigrationHubStrategyRecommendationsCl
   MigrationHubStrategyRecommendationsClient::MigrationHubStrategyRecommendationsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MigrationHubStrategyRecommendationsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-monitoring/source/CloudWatchClient.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/CloudWatchClient.cpp
@@ -134,7 +134,7 @@ CloudWatchClient::CloudWatchClient(const std::shared_ptr<AWSCredentialsProvider>
   CloudWatchClient::CloudWatchClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mpa/source/MPAClient.cpp
+++ b/generated/src/aws-cpp-sdk-mpa/source/MPAClient.cpp
@@ -115,7 +115,7 @@ MPAClient::MPAClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   MPAClient::MPAClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MPAErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mq/source/MQClient.cpp
+++ b/generated/src/aws-cpp-sdk-mq/source/MQClient.cpp
@@ -118,7 +118,7 @@ MQClient::MQClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsPro
   MQClient::MQClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MQErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mturk-requester/source/MTurkClient.cpp
+++ b/generated/src/aws-cpp-sdk-mturk-requester/source/MTurkClient.cpp
@@ -133,7 +133,7 @@ MTurkClient::MTurkClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   MTurkClient::MTurkClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MTurkErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-mwaa/source/MWAAClient.cpp
+++ b/generated/src/aws-cpp-sdk-mwaa/source/MWAAClient.cpp
@@ -105,7 +105,7 @@ MWAAClient::MWAAClient(const std::shared_ptr<AWSCredentialsProvider>& credential
   MWAAClient::MWAAClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<MWAAErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-neptune-graph/source/NeptuneGraphClient.cpp
+++ b/generated/src/aws-cpp-sdk-neptune-graph/source/NeptuneGraphClient.cpp
@@ -128,7 +128,7 @@ NeptuneGraphClient::NeptuneGraphClient(const std::shared_ptr<AWSCredentialsProvi
   NeptuneGraphClient::NeptuneGraphClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NeptuneGraphErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-neptune/source/NeptuneClient.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/NeptuneClient.cpp
@@ -165,7 +165,7 @@ NeptuneClient::NeptuneClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   NeptuneClient::NeptuneClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NeptuneErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-neptunedata/source/NeptunedataClient.cpp
+++ b/generated/src/aws-cpp-sdk-neptunedata/source/NeptunedataClient.cpp
@@ -137,7 +137,7 @@ NeptunedataClient::NeptunedataClient(const std::shared_ptr<AWSCredentialsProvide
   NeptunedataClient::NeptunedataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NeptunedataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-network-firewall/source/NetworkFirewallClient.cpp
+++ b/generated/src/aws-cpp-sdk-network-firewall/source/NetworkFirewallClient.cpp
@@ -151,7 +151,7 @@ NetworkFirewallClient::NetworkFirewallClient(const std::shared_ptr<AWSCredential
   NetworkFirewallClient::NetworkFirewallClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NetworkFirewallErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-networkflowmonitor/source/NetworkFlowMonitorClient.cpp
+++ b/generated/src/aws-cpp-sdk-networkflowmonitor/source/NetworkFlowMonitorClient.cpp
@@ -119,7 +119,7 @@ NetworkFlowMonitorClient::NetworkFlowMonitorClient(const std::shared_ptr<AWSCred
   NetworkFlowMonitorClient::NetworkFlowMonitorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NetworkFlowMonitorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-networkmanager/source/NetworkManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-networkmanager/source/NetworkManagerClient.cpp
@@ -182,7 +182,7 @@ NetworkManagerClient::NetworkManagerClient(const std::shared_ptr<AWSCredentialsP
   NetworkManagerClient::NetworkManagerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NetworkManagerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-networkmonitor/source/NetworkMonitorClient.cpp
+++ b/generated/src/aws-cpp-sdk-networkmonitor/source/NetworkMonitorClient.cpp
@@ -106,7 +106,7 @@ NetworkMonitorClient::NetworkMonitorClient(const std::shared_ptr<AWSCredentialsP
   NetworkMonitorClient::NetworkMonitorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NetworkMonitorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-notifications/source/NotificationsClient.cpp
+++ b/generated/src/aws-cpp-sdk-notifications/source/NotificationsClient.cpp
@@ -133,7 +133,7 @@ NotificationsClient::NotificationsClient(const std::shared_ptr<AWSCredentialsPro
   NotificationsClient::NotificationsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NotificationsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-notificationscontacts/source/NotificationsContactsClient.cpp
+++ b/generated/src/aws-cpp-sdk-notificationscontacts/source/NotificationsContactsClient.cpp
@@ -103,7 +103,7 @@ NotificationsContactsClient::NotificationsContactsClient(const std::shared_ptr<A
   NotificationsContactsClient::NotificationsContactsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<NotificationsContactsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-oam/source/OAMClient.cpp
+++ b/generated/src/aws-cpp-sdk-oam/source/OAMClient.cpp
@@ -109,7 +109,7 @@ OAMClient::OAMClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   OAMClient::OAMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OAMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-observabilityadmin/source/ObservabilityAdminClient.cpp
+++ b/generated/src/aws-cpp-sdk-observabilityadmin/source/ObservabilityAdminClient.cpp
@@ -120,7 +120,7 @@ ObservabilityAdminClient::ObservabilityAdminClient(const std::shared_ptr<AWSCred
   ObservabilityAdminClient::ObservabilityAdminClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ObservabilityAdminErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-odb/source/OdbClient.cpp
+++ b/generated/src/aws-cpp-sdk-odb/source/OdbClient.cpp
@@ -134,7 +134,7 @@ OdbClient::OdbClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   OdbClient::OdbClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OdbErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-omics/source/OmicsClient.cpp
+++ b/generated/src/aws-cpp-sdk-omics/source/OmicsClient.cpp
@@ -190,7 +190,7 @@ OmicsClient::OmicsClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   OmicsClient::OmicsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OmicsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-opensearch/source/OpenSearchServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-opensearch/source/OpenSearchServiceClient.cpp
@@ -170,7 +170,7 @@ OpenSearchServiceClient::OpenSearchServiceClient(const std::shared_ptr<AWSCreden
   OpenSearchServiceClient::OpenSearchServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OpenSearchServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-opensearchserverless/source/OpenSearchServerlessClient.cpp
+++ b/generated/src/aws-cpp-sdk-opensearchserverless/source/OpenSearchServerlessClient.cpp
@@ -135,7 +135,7 @@ OpenSearchServerlessClient::OpenSearchServerlessClient(const std::shared_ptr<AWS
   OpenSearchServerlessClient::OpenSearchServerlessClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OpenSearchServerlessErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-organizations/source/OrganizationsClient.cpp
+++ b/generated/src/aws-cpp-sdk-organizations/source/OrganizationsClient.cpp
@@ -151,7 +151,7 @@ OrganizationsClient::OrganizationsClient(const std::shared_ptr<AWSCredentialsPro
   OrganizationsClient::OrganizationsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OrganizationsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-osis/source/OSISClient.cpp
+++ b/generated/src/aws-cpp-sdk-osis/source/OSISClient.cpp
@@ -116,7 +116,7 @@ OSISClient::OSISClient(const std::shared_ptr<AWSCredentialsProvider>& credential
   OSISClient::OSISClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OSISErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-outposts/source/OutpostsClient.cpp
+++ b/generated/src/aws-cpp-sdk-outposts/source/OutpostsClient.cpp
@@ -128,7 +128,7 @@ OutpostsClient::OutpostsClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   OutpostsClient::OutpostsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<OutpostsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-panorama/source/PanoramaClient.cpp
+++ b/generated/src/aws-cpp-sdk-panorama/source/PanoramaClient.cpp
@@ -128,7 +128,7 @@ PanoramaClient::PanoramaClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   PanoramaClient::PanoramaClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PanoramaErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-partnercentral-selling/source/PartnerCentralSellingClient.cpp
+++ b/generated/src/aws-cpp-sdk-partnercentral-selling/source/PartnerCentralSellingClient.cpp
@@ -132,7 +132,7 @@ PartnerCentralSellingClient::PartnerCentralSellingClient(const std::shared_ptr<A
   PartnerCentralSellingClient::PartnerCentralSellingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PartnerCentralSellingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-payment-cryptography-data/source/PaymentCryptographyDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-payment-cryptography-data/source/PaymentCryptographyDataClient.cpp
@@ -106,7 +106,7 @@ PaymentCryptographyDataClient::PaymentCryptographyDataClient(const std::shared_p
   PaymentCryptographyDataClient::PaymentCryptographyDataClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PaymentCryptographyDataErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-payment-cryptography/source/PaymentCryptographyClient.cpp
+++ b/generated/src/aws-cpp-sdk-payment-cryptography/source/PaymentCryptographyClient.cpp
@@ -120,7 +120,7 @@ PaymentCryptographyClient::PaymentCryptographyClient(const std::shared_ptr<AWSCr
   PaymentCryptographyClient::PaymentCryptographyClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PaymentCryptographyErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pca-connector-ad/source/PcaConnectorAdClient.cpp
+++ b/generated/src/aws-cpp-sdk-pca-connector-ad/source/PcaConnectorAdClient.cpp
@@ -119,7 +119,7 @@ PcaConnectorAdClient::PcaConnectorAdClient(const std::shared_ptr<AWSCredentialsP
   PcaConnectorAdClient::PcaConnectorAdClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PcaConnectorAdErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pca-connector-scep/source/PcaConnectorScepClient.cpp
+++ b/generated/src/aws-cpp-sdk-pca-connector-scep/source/PcaConnectorScepClient.cpp
@@ -106,7 +106,7 @@ PcaConnectorScepClient::PcaConnectorScepClient(const std::shared_ptr<AWSCredenti
   PcaConnectorScepClient::PcaConnectorScepClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PcaConnectorScepErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pcs/source/PCSClient.cpp
+++ b/generated/src/aws-cpp-sdk-pcs/source/PCSClient.cpp
@@ -112,7 +112,7 @@ PCSClient::PCSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   PCSClient::PCSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PCSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-personalize-events/source/PersonalizeEventsClient.cpp
+++ b/generated/src/aws-cpp-sdk-personalize-events/source/PersonalizeEventsClient.cpp
@@ -99,7 +99,7 @@ PersonalizeEventsClient::PersonalizeEventsClient(const std::shared_ptr<AWSCreden
   PersonalizeEventsClient::PersonalizeEventsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PersonalizeEventsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-personalize-runtime/source/PersonalizeRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-personalize-runtime/source/PersonalizeRuntimeClient.cpp
@@ -97,7 +97,7 @@ PersonalizeRuntimeClient::PersonalizeRuntimeClient(const std::shared_ptr<AWSCred
   PersonalizeRuntimeClient::PersonalizeRuntimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PersonalizeRuntimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-personalize/source/PersonalizeClient.cpp
+++ b/generated/src/aws-cpp-sdk-personalize/source/PersonalizeClient.cpp
@@ -165,7 +165,7 @@ PersonalizeClient::PersonalizeClient(const std::shared_ptr<AWSCredentialsProvide
   PersonalizeClient::PersonalizeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PersonalizeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pi/source/PIClient.cpp
+++ b/generated/src/aws-cpp-sdk-pi/source/PIClient.cpp
@@ -107,7 +107,7 @@ PIClient::PIClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsPro
   PIClient::PIClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PIErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pinpoint-email/source/PinpointEmailClient.cpp
+++ b/generated/src/aws-cpp-sdk-pinpoint-email/source/PinpointEmailClient.cpp
@@ -136,7 +136,7 @@ PinpointEmailClient::PinpointEmailClient(const std::shared_ptr<AWSCredentialsPro
   PinpointEmailClient::PinpointEmailClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PinpointEmailErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pinpoint-sms-voice-v2/source/PinpointSMSVoiceV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-pinpoint-sms-voice-v2/source/PinpointSMSVoiceV2Client.cpp
@@ -184,7 +184,7 @@ PinpointSMSVoiceV2Client::PinpointSMSVoiceV2Client(const std::shared_ptr<AWSCred
   PinpointSMSVoiceV2Client::PinpointSMSVoiceV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PinpointSMSVoiceV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pinpoint/source/PinpointClient.cpp
+++ b/generated/src/aws-cpp-sdk-pinpoint/source/PinpointClient.cpp
@@ -216,7 +216,7 @@ PinpointClient::PinpointClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   PinpointClient::PinpointClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PinpointErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pipes/source/PipesClient.cpp
+++ b/generated/src/aws-cpp-sdk-pipes/source/PipesClient.cpp
@@ -104,7 +104,7 @@ PipesClient::PipesClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   PipesClient::PipesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PipesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-polly/source/PollyClient.cpp
+++ b/generated/src/aws-cpp-sdk-polly/source/PollyClient.cpp
@@ -103,7 +103,7 @@ PollyClient::PollyClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   PollyClient::PollyClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PollyErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-pricing/source/PricingClient.cpp
+++ b/generated/src/aws-cpp-sdk-pricing/source/PricingClient.cpp
@@ -99,7 +99,7 @@ PricingClient::PricingClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   PricingClient::PricingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PricingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-proton/source/ProtonClient.cpp
+++ b/generated/src/aws-cpp-sdk-proton/source/ProtonClient.cpp
@@ -181,7 +181,7 @@ ProtonClient::ProtonClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   ProtonClient::ProtonClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ProtonErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-qapps/source/QAppsClient.cpp
+++ b/generated/src/aws-cpp-sdk-qapps/source/QAppsClient.cpp
@@ -129,7 +129,7 @@ QAppsClient::QAppsClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
   QAppsClient::QAppsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QAppsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-qbusiness/source/QBusinessClient.cpp
+++ b/generated/src/aws-cpp-sdk-qbusiness/source/QBusinessClient.cpp
@@ -179,7 +179,7 @@ QBusinessClient::QBusinessClient(const std::shared_ptr<AWSCredentialsProvider>& 
   QBusinessClient::QBusinessClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QBusinessErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-qconnect/source/QConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-qconnect/source/QConnectClient.cpp
@@ -183,7 +183,7 @@ QConnectClient::QConnectClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   QConnectClient::QConnectClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QConnectErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-qldb-session/source/QLDBSessionClient.cpp
+++ b/generated/src/aws-cpp-sdk-qldb-session/source/QLDBSessionClient.cpp
@@ -95,7 +95,7 @@ QLDBSessionClient::QLDBSessionClient(const std::shared_ptr<AWSCredentialsProvide
   QLDBSessionClient::QLDBSessionClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QLDBSessionErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-qldb/source/QLDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-qldb/source/QLDBClient.cpp
@@ -114,7 +114,7 @@ QLDBClient::QLDBClient(const std::shared_ptr<AWSCredentialsProvider>& credential
   QLDBClient::QLDBClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QLDBErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-quicksight/source/QuickSightClient.cpp
+++ b/generated/src/aws-cpp-sdk-quicksight/source/QuickSightClient.cpp
@@ -194,7 +194,7 @@ QuickSightClient::QuickSightClient(const std::shared_ptr<AWSCredentialsProvider>
   QuickSightClient::QuickSightClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<QuickSightErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ram/source/RAMClient.cpp
+++ b/generated/src/aws-cpp-sdk-ram/source/RAMClient.cpp
@@ -128,7 +128,7 @@ RAMClient::RAMClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   RAMClient::RAMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RAMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-rbin/source/RecycleBinClient.cpp
+++ b/generated/src/aws-cpp-sdk-rbin/source/RecycleBinClient.cpp
@@ -104,7 +104,7 @@ RecycleBinClient::RecycleBinClient(const std::shared_ptr<AWSCredentialsProvider>
   RecycleBinClient::RecycleBinClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RecycleBinErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-rds-data/source/RDSDataServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-rds-data/source/RDSDataServiceClient.cpp
@@ -99,7 +99,7 @@ RDSDataServiceClient::RDSDataServiceClient(const std::shared_ptr<AWSCredentialsP
   RDSDataServiceClient::RDSDataServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RDSDataServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-rds/source/RDSClient.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/RDSClient.cpp
@@ -258,7 +258,7 @@ RDSClient::RDSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   RDSClient::RDSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RDSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-redshift-data/source/RedshiftDataAPIServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-redshift-data/source/RedshiftDataAPIServiceClient.cpp
@@ -105,7 +105,7 @@ RedshiftDataAPIServiceClient::RedshiftDataAPIServiceClient(const std::shared_ptr
   RedshiftDataAPIServiceClient::RedshiftDataAPIServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RedshiftDataAPIServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-redshift-serverless/source/RedshiftServerlessClient.cpp
+++ b/generated/src/aws-cpp-sdk-redshift-serverless/source/RedshiftServerlessClient.cpp
@@ -157,7 +157,7 @@ RedshiftServerlessClient::RedshiftServerlessClient(const std::shared_ptr<AWSCred
   RedshiftServerlessClient::RedshiftServerlessClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RedshiftServerlessErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-redshift/source/RedshiftClient.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/RedshiftClient.cpp
@@ -234,7 +234,7 @@ RedshiftClient::RedshiftClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   RedshiftClient::RedshiftClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RedshiftErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-rekognition/source/RekognitionClient.cpp
+++ b/generated/src/aws-cpp-sdk-rekognition/source/RekognitionClient.cpp
@@ -169,7 +169,7 @@ RekognitionClient::RekognitionClient(const std::shared_ptr<AWSCredentialsProvide
   RekognitionClient::RekognitionClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RekognitionErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-repostspace/source/RepostspaceClient.cpp
+++ b/generated/src/aws-cpp-sdk-repostspace/source/RepostspaceClient.cpp
@@ -113,7 +113,7 @@ RepostspaceClient::RepostspaceClient(const std::shared_ptr<AWSCredentialsProvide
   RepostspaceClient::RepostspaceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RepostspaceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-resiliencehub/source/ResilienceHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-resiliencehub/source/ResilienceHubClient.cpp
@@ -157,7 +157,7 @@ ResilienceHubClient::ResilienceHubClient(const std::shared_ptr<AWSCredentialsPro
   ResilienceHubClient::ResilienceHubClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ResilienceHubErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-resource-explorer-2/source/ResourceExplorer2Client.cpp
+++ b/generated/src/aws-cpp-sdk-resource-explorer-2/source/ResourceExplorer2Client.cpp
@@ -118,7 +118,7 @@ ResourceExplorer2Client::ResourceExplorer2Client(const std::shared_ptr<AWSCreden
   ResourceExplorer2Client::ResourceExplorer2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ResourceExplorer2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-resource-groups/source/ResourceGroupsClient.cpp
+++ b/generated/src/aws-cpp-sdk-resource-groups/source/ResourceGroupsClient.cpp
@@ -117,7 +117,7 @@ ResourceGroupsClient::ResourceGroupsClient(const std::shared_ptr<AWSCredentialsP
   ResourceGroupsClient::ResourceGroupsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ResourceGroupsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-resourcegroupstaggingapi/source/ResourceGroupsTaggingAPIClient.cpp
+++ b/generated/src/aws-cpp-sdk-resourcegroupstaggingapi/source/ResourceGroupsTaggingAPIClient.cpp
@@ -102,7 +102,7 @@ ResourceGroupsTaggingAPIClient::ResourceGroupsTaggingAPIClient(const std::shared
   ResourceGroupsTaggingAPIClient::ResourceGroupsTaggingAPIClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ResourceGroupsTaggingAPIErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-robomaker/source/RoboMakerClient.cpp
+++ b/generated/src/aws-cpp-sdk-robomaker/source/RoboMakerClient.cpp
@@ -136,7 +136,7 @@ RoboMakerClient::RoboMakerClient(const std::shared_ptr<AWSCredentialsProvider>& 
   RoboMakerClient::RoboMakerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RoboMakerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-rolesanywhere/source/RolesAnywhereClient.cpp
+++ b/generated/src/aws-cpp-sdk-rolesanywhere/source/RolesAnywhereClient.cpp
@@ -124,7 +124,7 @@ RolesAnywhereClient::RolesAnywhereClient(const std::shared_ptr<AWSCredentialsPro
   RolesAnywhereClient::RolesAnywhereClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<RolesAnywhereErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-route53-recovery-cluster/source/Route53RecoveryClusterClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53-recovery-cluster/source/Route53RecoveryClusterClient.cpp
@@ -98,7 +98,7 @@ Route53RecoveryClusterClient::Route53RecoveryClusterClient(const std::shared_ptr
   Route53RecoveryClusterClient::Route53RecoveryClusterClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53RecoveryClusterErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-route53-recovery-control-config/source/Route53RecoveryControlConfigClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53-recovery-control-config/source/Route53RecoveryControlConfigClient.cpp
@@ -119,7 +119,7 @@ Route53RecoveryControlConfigClient::Route53RecoveryControlConfigClient(const std
   Route53RecoveryControlConfigClient::Route53RecoveryControlConfigClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53RecoveryControlConfigErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-route53-recovery-readiness/source/Route53RecoveryReadinessClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53-recovery-readiness/source/Route53RecoveryReadinessClient.cpp
@@ -126,7 +126,7 @@ Route53RecoveryReadinessClient::Route53RecoveryReadinessClient(const std::shared
   Route53RecoveryReadinessClient::Route53RecoveryReadinessClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53RecoveryReadinessErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-route53/source/Route53Client.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/Route53Client.cpp
@@ -165,7 +165,7 @@ Route53Client::Route53Client(const std::shared_ptr<AWSCredentialsProvider>& cred
   Route53Client::Route53Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-route53domains/source/Route53DomainsClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53domains/source/Route53DomainsClient.cpp
@@ -128,7 +128,7 @@ Route53DomainsClient::Route53DomainsClient(const std::shared_ptr<AWSCredentialsP
   Route53DomainsClient::Route53DomainsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53DomainsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-route53profiles/source/Route53ProfilesClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53profiles/source/Route53ProfilesClient.cpp
@@ -110,7 +110,7 @@ Route53ProfilesClient::Route53ProfilesClient(const std::shared_ptr<AWSCredential
   Route53ProfilesClient::Route53ProfilesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53ProfilesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-route53resolver/source/Route53ResolverClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53resolver/source/Route53ResolverClient.cpp
@@ -162,7 +162,7 @@ Route53ResolverClient::Route53ResolverClient(const std::shared_ptr<AWSCredential
   Route53ResolverClient::Route53ResolverClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<Route53ResolverErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-rum/source/CloudWatchRUMClient.cpp
+++ b/generated/src/aws-cpp-sdk-rum/source/CloudWatchRUMClient.cpp
@@ -114,7 +114,7 @@ CloudWatchRUMClient::CloudWatchRUMClient(const std::shared_ptr<AWSCredentialsPro
   CloudWatchRUMClient::CloudWatchRUMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<CloudWatchRUMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp
@@ -279,7 +279,7 @@ S3Client::S3Client(const std::shared_ptr<AWSCredentialsProvider>& credentialsPro
                    Aws::S3::US_EAST_1_REGIONAL_ENDPOINT_OPTION USEast1RegionalEndPointOption) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,
-                                                                Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                 Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this),
                                                                 SERVICE_NAME,
                                                                 Aws::Region::ComputeSignerRegion(clientConfiguration.region),

--- a/generated/src/aws-cpp-sdk-s3control/source/S3ControlClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/S3ControlClient.cpp
@@ -199,7 +199,7 @@ S3ControlClient::S3ControlClient(const std::shared_ptr<AWSCredentialsProvider>& 
   S3ControlClient::S3ControlClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region),
                                              Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::RequestDependent,

--- a/generated/src/aws-cpp-sdk-s3outposts/source/S3OutpostsClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3outposts/source/S3OutpostsClient.cpp
@@ -99,7 +99,7 @@ S3OutpostsClient::S3OutpostsClient(const std::shared_ptr<AWSCredentialsProvider>
   S3OutpostsClient::S3OutpostsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<S3OutpostsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-s3tables/source/S3TablesClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3tables/source/S3TablesClient.cpp
@@ -124,7 +124,7 @@ S3TablesClient::S3TablesClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   S3TablesClient::S3TablesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<S3TablesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-s3vectors/source/S3VectorsClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3vectors/source/S3VectorsClient.cpp
@@ -110,7 +110,7 @@ S3VectorsClient::S3VectorsClient(const std::shared_ptr<AWSCredentialsProvider>& 
   S3VectorsClient::S3VectorsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<S3VectorsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sagemaker-a2i-runtime/source/AugmentedAIRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-a2i-runtime/source/AugmentedAIRuntimeClient.cpp
@@ -99,7 +99,7 @@ AugmentedAIRuntimeClient::AugmentedAIRuntimeClient(const std::shared_ptr<AWSCred
   AugmentedAIRuntimeClient::AugmentedAIRuntimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AugmentedAIRuntimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sagemaker-edge/source/SagemakerEdgeManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-edge/source/SagemakerEdgeManagerClient.cpp
@@ -97,7 +97,7 @@ SagemakerEdgeManagerClient::SagemakerEdgeManagerClient(const std::shared_ptr<AWS
   SagemakerEdgeManagerClient::SagemakerEdgeManagerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SagemakerEdgeManagerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sagemaker-featurestore-runtime/source/SageMakerFeatureStoreRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-featurestore-runtime/source/SageMakerFeatureStoreRuntimeClient.cpp
@@ -98,7 +98,7 @@ SageMakerFeatureStoreRuntimeClient::SageMakerFeatureStoreRuntimeClient(const std
   SageMakerFeatureStoreRuntimeClient::SageMakerFeatureStoreRuntimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerFeatureStoreRuntimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sagemaker-geospatial/source/SageMakerGeospatialClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-geospatial/source/SageMakerGeospatialClient.cpp
@@ -113,7 +113,7 @@ SageMakerGeospatialClient::SageMakerGeospatialClient(const std::shared_ptr<AWSCr
   SageMakerGeospatialClient::SageMakerGeospatialClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerGeospatialErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sagemaker-metrics/source/SageMakerMetricsClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-metrics/source/SageMakerMetricsClient.cpp
@@ -96,7 +96,7 @@ SageMakerMetricsClient::SageMakerMetricsClient(const std::shared_ptr<AWSCredenti
   SageMakerMetricsClient::SageMakerMetricsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerMetricsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sagemaker-runtime/source/SageMakerRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-runtime/source/SageMakerRuntimeClient.cpp
@@ -98,7 +98,7 @@ SageMakerRuntimeClient::SageMakerRuntimeClient(const std::shared_ptr<AWSCredenti
   SageMakerRuntimeClient::SageMakerRuntimeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerRuntimeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sagemaker/source/SageMakerClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker/source/SageMakerClient.cpp
@@ -194,7 +194,7 @@ SageMakerClient::SageMakerClient(const std::shared_ptr<AWSCredentialsProvider>& 
   SageMakerClient::SageMakerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SageMakerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-savingsplans/source/SavingsPlansClient.cpp
+++ b/generated/src/aws-cpp-sdk-savingsplans/source/SavingsPlansClient.cpp
@@ -104,7 +104,7 @@ SavingsPlansClient::SavingsPlansClient(const std::shared_ptr<AWSCredentialsProvi
   SavingsPlansClient::SavingsPlansClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SavingsPlansErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-scheduler/source/SchedulerClient.cpp
+++ b/generated/src/aws-cpp-sdk-scheduler/source/SchedulerClient.cpp
@@ -106,7 +106,7 @@ SchedulerClient::SchedulerClient(const std::shared_ptr<AWSCredentialsProvider>& 
   SchedulerClient::SchedulerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SchedulerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-schemas/source/SchemasClient.cpp
+++ b/generated/src/aws-cpp-sdk-schemas/source/SchemasClient.cpp
@@ -125,7 +125,7 @@ SchemasClient::SchemasClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   SchemasClient::SchemasClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SchemasErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sdb/source/SimpleDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-sdb/source/SimpleDBClient.cpp
@@ -105,7 +105,7 @@ SimpleDBClient::SimpleDBClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   SimpleDBClient::SimpleDBClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SimpleDBErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-secretsmanager/source/SecretsManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-secretsmanager/source/SecretsManagerClient.cpp
@@ -117,7 +117,7 @@ SecretsManagerClient::SecretsManagerClient(const std::shared_ptr<AWSCredentialsP
   SecretsManagerClient::SecretsManagerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SecretsManagerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-security-ir/source/SecurityIRClient.cpp
+++ b/generated/src/aws-cpp-sdk-security-ir/source/SecurityIRClient.cpp
@@ -116,7 +116,7 @@ SecurityIRClient::SecurityIRClient(const std::shared_ptr<AWSCredentialsProvider>
   SecurityIRClient::SecurityIRClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SecurityIRErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-securityhub/source/SecurityHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-securityhub/source/SecurityHubClient.cpp
@@ -196,7 +196,7 @@ SecurityHubClient::SecurityHubClient(const std::shared_ptr<AWSCredentialsProvide
   SecurityHubClient::SecurityHubClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SecurityHubErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-securitylake/source/SecurityLakeClient.cpp
+++ b/generated/src/aws-cpp-sdk-securitylake/source/SecurityLakeClient.cpp
@@ -125,7 +125,7 @@ SecurityLakeClient::SecurityLakeClient(const std::shared_ptr<AWSCredentialsProvi
   SecurityLakeClient::SecurityLakeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SecurityLakeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-serverlessrepo/source/ServerlessApplicationRepositoryClient.cpp
+++ b/generated/src/aws-cpp-sdk-serverlessrepo/source/ServerlessApplicationRepositoryClient.cpp
@@ -108,7 +108,7 @@ ServerlessApplicationRepositoryClient::ServerlessApplicationRepositoryClient(con
   ServerlessApplicationRepositoryClient::ServerlessApplicationRepositoryClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ServerlessApplicationRepositoryErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-service-quotas/source/ServiceQuotasClient.cpp
+++ b/generated/src/aws-cpp-sdk-service-quotas/source/ServiceQuotasClient.cpp
@@ -114,7 +114,7 @@ ServiceQuotasClient::ServiceQuotasClient(const std::shared_ptr<AWSCredentialsPro
   ServiceQuotasClient::ServiceQuotasClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ServiceQuotasErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-servicecatalog-appregistry/source/AppRegistryClient.cpp
+++ b/generated/src/aws-cpp-sdk-servicecatalog-appregistry/source/AppRegistryClient.cpp
@@ -118,7 +118,7 @@ AppRegistryClient::AppRegistryClient(const std::shared_ptr<AWSCredentialsProvide
   AppRegistryClient::AppRegistryClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<AppRegistryErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-servicecatalog/source/ServiceCatalogClient.cpp
+++ b/generated/src/aws-cpp-sdk-servicecatalog/source/ServiceCatalogClient.cpp
@@ -184,7 +184,7 @@ ServiceCatalogClient::ServiceCatalogClient(const std::shared_ptr<AWSCredentialsP
   ServiceCatalogClient::ServiceCatalogClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ServiceCatalogErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-servicediscovery/source/ServiceDiscoveryClient.cpp
+++ b/generated/src/aws-cpp-sdk-servicediscovery/source/ServiceDiscoveryClient.cpp
@@ -124,7 +124,7 @@ ServiceDiscoveryClient::ServiceDiscoveryClient(const std::shared_ptr<AWSCredenti
   ServiceDiscoveryClient::ServiceDiscoveryClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ServiceDiscoveryErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sesv2/source/SESV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-sesv2/source/SESV2Client.cpp
@@ -203,7 +203,7 @@ SESV2Client::SESV2Client(const std::shared_ptr<AWSCredentialsProvider>& credenti
   SESV2Client::SESV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SESV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-shield/source/ShieldClient.cpp
+++ b/generated/src/aws-cpp-sdk-shield/source/ShieldClient.cpp
@@ -129,7 +129,7 @@ ShieldClient::ShieldClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   ShieldClient::ShieldClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ShieldErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-signer/source/SignerClient.cpp
+++ b/generated/src/aws-cpp-sdk-signer/source/SignerClient.cpp
@@ -113,7 +113,7 @@ SignerClient::SignerClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   SignerClient::SignerClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SignerErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-simspaceweaver/source/SimSpaceWeaverClient.cpp
+++ b/generated/src/aws-cpp-sdk-simspaceweaver/source/SimSpaceWeaverClient.cpp
@@ -110,7 +110,7 @@ SimSpaceWeaverClient::SimSpaceWeaverClient(const std::shared_ptr<AWSCredentialsP
   SimSpaceWeaverClient::SimSpaceWeaverClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SimSpaceWeaverErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sms-voice/source/PinpointSMSVoiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-sms-voice/source/PinpointSMSVoiceClient.cpp
@@ -102,7 +102,7 @@ PinpointSMSVoiceClient::PinpointSMSVoiceClient(const std::shared_ptr<AWSCredenti
   PinpointSMSVoiceClient::PinpointSMSVoiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<PinpointSMSVoiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-snow-device-management/source/SnowDeviceManagementClient.cpp
+++ b/generated/src/aws-cpp-sdk-snow-device-management/source/SnowDeviceManagementClient.cpp
@@ -107,7 +107,7 @@ SnowDeviceManagementClient::SnowDeviceManagementClient(const std::shared_ptr<AWS
   SnowDeviceManagementClient::SnowDeviceManagementClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SnowDeviceManagementErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-snowball/source/SnowballClient.cpp
+++ b/generated/src/aws-cpp-sdk-snowball/source/SnowballClient.cpp
@@ -121,7 +121,7 @@ SnowballClient::SnowballClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   SnowballClient::SnowballClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SnowballErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sns/source/SNSClient.cpp
+++ b/generated/src/aws-cpp-sdk-sns/source/SNSClient.cpp
@@ -137,7 +137,7 @@ SNSClient::SNSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SNSClient::SNSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SNSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-socialmessaging/source/SocialMessagingClient.cpp
+++ b/generated/src/aws-cpp-sdk-socialmessaging/source/SocialMessagingClient.cpp
@@ -115,7 +115,7 @@ SocialMessagingClient::SocialMessagingClient(const std::shared_ptr<AWSCredential
   SocialMessagingClient::SocialMessagingClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SocialMessagingErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sqs/source/SQSClient.cpp
+++ b/generated/src/aws-cpp-sdk-sqs/source/SQSClient.cpp
@@ -117,7 +117,7 @@ SQSClient::SQSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SQSClient::SQSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SQSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ssm-contacts/source/SSMContactsClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm-contacts/source/SSMContactsClient.cpp
@@ -133,7 +133,7 @@ SSMContactsClient::SSMContactsClient(const std::shared_ptr<AWSCredentialsProvide
   SSMContactsClient::SSMContactsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSMContactsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ssm-guiconnect/source/SSMGuiConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm-guiconnect/source/SSMGuiConnectClient.cpp
@@ -97,7 +97,7 @@ SSMGuiConnectClient::SSMGuiConnectClient(const std::shared_ptr<AWSCredentialsPro
   SSMGuiConnectClient::SSMGuiConnectClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSMGuiConnectErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ssm-incidents/source/SSMIncidentsClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm-incidents/source/SSMIncidentsClient.cpp
@@ -125,7 +125,7 @@ SSMIncidentsClient::SSMIncidentsClient(const std::shared_ptr<AWSCredentialsProvi
   SSMIncidentsClient::SSMIncidentsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSMIncidentsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ssm-quicksetup/source/SSMQuickSetupClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm-quicksetup/source/SSMQuickSetupClient.cpp
@@ -108,7 +108,7 @@ SSMQuickSetupClient::SSMQuickSetupClient(const std::shared_ptr<AWSCredentialsPro
   SSMQuickSetupClient::SSMQuickSetupClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSMQuickSetupErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ssm-sap/source/SsmSapClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm-sap/source/SsmSapClient.cpp
@@ -121,7 +121,7 @@ SsmSapClient::SsmSapClient(const std::shared_ptr<AWSCredentialsProvider>& creden
   SsmSapClient::SsmSapClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SsmSapErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-ssm/source/SSMClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm/source/SSMClient.cpp
@@ -240,7 +240,7 @@ SSMClient::SSMClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SSMClient::SSMClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSMErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sso-admin/source/SSOAdminClient.cpp
+++ b/generated/src/aws-cpp-sdk-sso-admin/source/SSOAdminClient.cpp
@@ -169,7 +169,7 @@ SSOAdminClient::SSOAdminClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   SSOAdminClient::SSOAdminClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSOAdminErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sso-oidc/source/SSOOIDCClient.cpp
+++ b/generated/src/aws-cpp-sdk-sso-oidc/source/SSOOIDCClient.cpp
@@ -98,7 +98,7 @@ SSOOIDCClient::SSOOIDCClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   SSOOIDCClient::SSOOIDCClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSOOIDCErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sso/source/SSOClient.cpp
+++ b/generated/src/aws-cpp-sdk-sso/source/SSOClient.cpp
@@ -98,7 +98,7 @@ SSOClient::SSOClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SSOClient::SSOClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SSOErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-states/source/SFNClient.cpp
+++ b/generated/src/aws-cpp-sdk-states/source/SFNClient.cpp
@@ -131,7 +131,7 @@ SFNClient::SFNClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SFNClient::SFNClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SFNErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-storagegateway/source/StorageGatewayClient.cpp
+++ b/generated/src/aws-cpp-sdk-storagegateway/source/StorageGatewayClient.cpp
@@ -190,7 +190,7 @@ StorageGatewayClient::StorageGatewayClient(const std::shared_ptr<AWSCredentialsP
   StorageGatewayClient::StorageGatewayClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<StorageGatewayErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-sts/source/STSClient.cpp
+++ b/generated/src/aws-cpp-sdk-sts/source/STSClient.cpp
@@ -104,7 +104,7 @@ STSClient::STSClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   STSClient::STSClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<STSErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-supplychain/source/SupplyChainClient.cpp
+++ b/generated/src/aws-cpp-sdk-supplychain/source/SupplyChainClient.cpp
@@ -124,7 +124,7 @@ SupplyChainClient::SupplyChainClient(const std::shared_ptr<AWSCredentialsProvide
   SupplyChainClient::SupplyChainClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SupplyChainErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-support-app/source/SupportAppClient.cpp
+++ b/generated/src/aws-cpp-sdk-support-app/source/SupportAppClient.cpp
@@ -104,7 +104,7 @@ SupportAppClient::SupportAppClient(const std::shared_ptr<AWSCredentialsProvider>
   SupportAppClient::SupportAppClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SupportAppErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-support/source/SupportClient.cpp
+++ b/generated/src/aws-cpp-sdk-support/source/SupportClient.cpp
@@ -110,7 +110,7 @@ SupportClient::SupportClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   SupportClient::SupportClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SupportErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-swf/source/SWFClient.cpp
+++ b/generated/src/aws-cpp-sdk-swf/source/SWFClient.cpp
@@ -133,7 +133,7 @@ SWFClient::SWFClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   SWFClient::SWFClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SWFErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-synthetics/source/SyntheticsClient.cpp
+++ b/generated/src/aws-cpp-sdk-synthetics/source/SyntheticsClient.cpp
@@ -116,7 +116,7 @@ SyntheticsClient::SyntheticsClient(const std::shared_ptr<AWSCredentialsProvider>
   SyntheticsClient::SyntheticsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<SyntheticsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-taxsettings/source/TaxSettingsClient.cpp
+++ b/generated/src/aws-cpp-sdk-taxsettings/source/TaxSettingsClient.cpp
@@ -110,7 +110,7 @@ TaxSettingsClient::TaxSettingsClient(const std::shared_ptr<AWSCredentialsProvide
   TaxSettingsClient::TaxSettingsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TaxSettingsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-textract/source/TextractClient.cpp
+++ b/generated/src/aws-cpp-sdk-textract/source/TextractClient.cpp
@@ -119,7 +119,7 @@ TextractClient::TextractClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   TextractClient::TextractClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TextractErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-timestream-influxdb/source/TimestreamInfluxDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-timestream-influxdb/source/TimestreamInfluxDBClient.cpp
@@ -111,7 +111,7 @@ TimestreamInfluxDBClient::TimestreamInfluxDBClient(const std::shared_ptr<AWSCred
   TimestreamInfluxDBClient::TimestreamInfluxDBClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TimestreamInfluxDBErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-timestream-query/source/TimestreamQueryClient.cpp
+++ b/generated/src/aws-cpp-sdk-timestream-query/source/TimestreamQueryClient.cpp
@@ -110,7 +110,7 @@ TimestreamQueryClient::TimestreamQueryClient(const std::shared_ptr<AWSCredential
   TimestreamQueryClient::TimestreamQueryClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TimestreamQueryErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-timestream-write/source/TimestreamWriteClient.cpp
+++ b/generated/src/aws-cpp-sdk-timestream-write/source/TimestreamWriteClient.cpp
@@ -114,7 +114,7 @@ TimestreamWriteClient::TimestreamWriteClient(const std::shared_ptr<AWSCredential
   TimestreamWriteClient::TimestreamWriteClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TimestreamWriteErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-tnb/source/TnbClient.cpp
+++ b/generated/src/aws-cpp-sdk-tnb/source/TnbClient.cpp
@@ -127,7 +127,7 @@ TnbClient::TnbClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   TnbClient::TnbClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TnbErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-transcribe/source/TranscribeServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-transcribe/source/TranscribeServiceClient.cpp
@@ -137,7 +137,7 @@ TranscribeServiceClient::TranscribeServiceClient(const std::shared_ptr<AWSCreden
   TranscribeServiceClient::TranscribeServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TranscribeServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
@@ -101,7 +101,7 @@ TranscribeStreamingServiceClient::TranscribeStreamingServiceClient(const std::sh
   TranscribeStreamingServiceClient::TranscribeStreamingServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<Aws::Auth::DefaultAuthSignerProvider>(ALLOCATION_TAG,
-                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                                                  Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                                   SERVICE_NAME,
                                                                   Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TranscribeStreamingServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-translate/source/TranslateClient.cpp
+++ b/generated/src/aws-cpp-sdk-translate/source/TranslateClient.cpp
@@ -113,7 +113,7 @@ TranslateClient::TranslateClient(const std::shared_ptr<AWSCredentialsProvider>& 
   TranslateClient::TranslateClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TranslateErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-trustedadvisor/source/TrustedAdvisorClient.cpp
+++ b/generated/src/aws-cpp-sdk-trustedadvisor/source/TrustedAdvisorClient.cpp
@@ -105,7 +105,7 @@ TrustedAdvisorClient::TrustedAdvisorClient(const std::shared_ptr<AWSCredentialsP
   TrustedAdvisorClient::TrustedAdvisorClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<TrustedAdvisorErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-verifiedpermissions/source/VerifiedPermissionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-verifiedpermissions/source/VerifiedPermissionsClient.cpp
@@ -124,7 +124,7 @@ VerifiedPermissionsClient::VerifiedPermissionsClient(const std::shared_ptr<AWSCr
   VerifiedPermissionsClient::VerifiedPermissionsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<VerifiedPermissionsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-voice-id/source/VoiceIDClient.cpp
+++ b/generated/src/aws-cpp-sdk-voice-id/source/VoiceIDClient.cpp
@@ -123,7 +123,7 @@ VoiceIDClient::VoiceIDClient(const std::shared_ptr<AWSCredentialsProvider>& cred
   VoiceIDClient::VoiceIDClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<VoiceIDErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-vpc-lattice/source/VPCLatticeClient.cpp
+++ b/generated/src/aws-cpp-sdk-vpc-lattice/source/VPCLatticeClient.cpp
@@ -163,7 +163,7 @@ VPCLatticeClient::VPCLatticeClient(const std::shared_ptr<AWSCredentialsProvider>
   VPCLatticeClient::VPCLatticeClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<VPCLatticeErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-waf-regional/source/WAFRegionalClient.cpp
+++ b/generated/src/aws-cpp-sdk-waf-regional/source/WAFRegionalClient.cpp
@@ -175,7 +175,7 @@ WAFRegionalClient::WAFRegionalClient(const std::shared_ptr<AWSCredentialsProvide
   WAFRegionalClient::WAFRegionalClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WAFRegionalErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-waf/source/WAFClient.cpp
+++ b/generated/src/aws-cpp-sdk-waf/source/WAFClient.cpp
@@ -171,7 +171,7 @@ WAFClient::WAFClient(const std::shared_ptr<AWSCredentialsProvider>& credentialsP
   WAFClient::WAFClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WAFErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-wafv2/source/WAFV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-wafv2/source/WAFV2Client.cpp
@@ -148,7 +148,7 @@ WAFV2Client::WAFV2Client(const std::shared_ptr<AWSCredentialsProvider>& credenti
   WAFV2Client::WAFV2Client(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WAFV2ErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-wellarchitected/source/WellArchitectedClient.cpp
+++ b/generated/src/aws-cpp-sdk-wellarchitected/source/WellArchitectedClient.cpp
@@ -166,7 +166,7 @@ WellArchitectedClient::WellArchitectedClient(const std::shared_ptr<AWSCredential
   WellArchitectedClient::WellArchitectedClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WellArchitectedErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-wisdom/source/ConnectWisdomServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-wisdom/source/ConnectWisdomServiceClient.cpp
@@ -133,7 +133,7 @@ ConnectWisdomServiceClient::ConnectWisdomServiceClient(const std::shared_ptr<AWS
   ConnectWisdomServiceClient::ConnectWisdomServiceClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<ConnectWisdomServiceErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-workdocs/source/WorkDocsClient.cpp
+++ b/generated/src/aws-cpp-sdk-workdocs/source/WorkDocsClient.cpp
@@ -138,7 +138,7 @@ WorkDocsClient::WorkDocsClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   WorkDocsClient::WorkDocsClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkDocsErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-worklink/source/WorkLinkClient.cpp
+++ b/generated/src/aws-cpp-sdk-worklink/source/WorkLinkClient.cpp
@@ -94,7 +94,7 @@ WorkLinkClient::WorkLinkClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   WorkLinkClient::WorkLinkClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkLinkErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-workmail/source/WorkMailClient.cpp
+++ b/generated/src/aws-cpp-sdk-workmail/source/WorkMailClient.cpp
@@ -186,7 +186,7 @@ WorkMailClient::WorkMailClient(const std::shared_ptr<AWSCredentialsProvider>& cr
   WorkMailClient::WorkMailClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkMailErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-workmailmessageflow/source/WorkMailMessageFlowClient.cpp
+++ b/generated/src/aws-cpp-sdk-workmailmessageflow/source/WorkMailMessageFlowClient.cpp
@@ -96,7 +96,7 @@ WorkMailMessageFlowClient::WorkMailMessageFlowClient(const std::shared_ptr<AWSCr
   WorkMailMessageFlowClient::WorkMailMessageFlowClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkMailMessageFlowErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-workspaces-instances/source/WorkspacesInstancesClient.cpp
+++ b/generated/src/aws-cpp-sdk-workspaces-instances/source/WorkspacesInstancesClient.cpp
@@ -107,7 +107,7 @@ WorkspacesInstancesClient::WorkspacesInstancesClient(const std::shared_ptr<AWSCr
   WorkspacesInstancesClient::WorkspacesInstancesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkspacesInstancesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-workspaces-thin-client/source/WorkSpacesThinClientClient.cpp
+++ b/generated/src/aws-cpp-sdk-workspaces-thin-client/source/WorkSpacesThinClientClient.cpp
@@ -110,7 +110,7 @@ WorkSpacesThinClientClient::WorkSpacesThinClientClient(const std::shared_ptr<AWS
   WorkSpacesThinClientClient::WorkSpacesThinClientClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkSpacesThinClientErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-workspaces-web/source/WorkSpacesWebClient.cpp
+++ b/generated/src/aws-cpp-sdk-workspaces-web/source/WorkSpacesWebClient.cpp
@@ -169,7 +169,7 @@ WorkSpacesWebClient::WorkSpacesWebClient(const std::shared_ptr<AWSCredentialsPro
   WorkSpacesWebClient::WorkSpacesWebClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkSpacesWebErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-workspaces/source/WorkSpacesClient.cpp
+++ b/generated/src/aws-cpp-sdk-workspaces/source/WorkSpacesClient.cpp
@@ -185,7 +185,7 @@ WorkSpacesClient::WorkSpacesClient(const std::shared_ptr<AWSCredentialsProvider>
   WorkSpacesClient::WorkSpacesClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<WorkSpacesErrorMarshaller>(ALLOCATION_TAG)),

--- a/generated/src/aws-cpp-sdk-xray/source/XRayClient.cpp
+++ b/generated/src/aws-cpp-sdk-xray/source/XRayClient.cpp
@@ -132,7 +132,7 @@ XRayClient::XRayClient(const std::shared_ptr<AWSCredentialsProvider>& credential
   XRayClient::XRayClient(const Client::ClientConfiguration& clientConfiguration) :
   BASECLASS(clientConfiguration,
             Aws::MakeShared<AWSAuthV4Signer>(ALLOCATION_TAG,
-                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG),
+                                             Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                              SERVICE_NAME,
                                              Aws::Region::ComputeSignerRegion(clientConfiguration.region)),
             Aws::MakeShared<XRayErrorMarshaller>(ALLOCATION_TAG)),

--- a/tests/aws-cpp-sdk-ec2-integration-tests/EC2TestsDualStack.cpp
+++ b/tests/aws-cpp-sdk-ec2-integration-tests/EC2TestsDualStack.cpp
@@ -43,7 +43,10 @@ TEST_F(EC2DualStackTests, TestDualStackMocked)
     goodResponse->GetResponseBody() << goodReply;
     mockHttpClient->AddResponseToReturn(goodResponse);
 
-    Aws::Client::ClientConfiguration clientConfig("default", true);
+    Aws::Client::ClientConfigurationInitValues initValues;
+    initValues.shouldDisableIMDS = true;
+    Aws::Client::ClientConfiguration clientConfig(initValues);
+
     clientConfig.region = "us-east-1";
     clientConfig.useDualStack = true;
 
@@ -69,7 +72,10 @@ TEST_F(EC2DualStackTests, TestDualStackMocked)
 
 TEST_F(EC2DualStackTests, TestDualStackEndpoint)
 {
-    Aws::Client::ClientConfiguration clientConfig("default", true);
+    Aws::Client::ClientConfigurationInitValues initValues;
+    initValues.shouldDisableIMDS = true;
+    Aws::Client::ClientConfiguration clientConfig(initValues);
+
     clientConfig.region = "us-east-1";
     clientConfig.useDualStack = true;
 

--- a/tests/aws-cpp-sdk-transfer-tests/TransferTests.cpp
+++ b/tests/aws-cpp-sdk-transfer-tests/TransferTests.cpp
@@ -649,7 +649,7 @@ protected:
     static void SetUpTestCase()
     {
         // Create a client
-        ClientConfiguration config("default");
+        ClientConfiguration config(ClientConfigurationInitValues{});
         config.scheme = Scheme::HTTP;
         config.connectTimeoutMs = 3000;
         config.requestTimeoutMs = 60000;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceLegacyConstructors.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceLegacyConstructors.vm
@@ -57,7 +57,7 @@
 #set($AdditionalServiceSpecificConfigLoadString = "Load${metadata.classNamePrefix}SpecificConfig(config);")
 #end
 #set($clientConfigurationNamespace = "Client")
-#set($defaultCredentialsProviderChainParam = "Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG)")
+#set($defaultCredentialsProviderChainParam = "Aws::MakeShared<DefaultAWSCredentialsProviderChain>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig)")
 #set($simpleCredentialsProviderParam = "Aws::MakeShared<SimpleAWSCredentialsProvider>(ALLOCATION_TAG, credentials)")
 #set($hasEventStreamInputOperation = $serviceModel.hasStreamingRequestShapes())
 #set($signerToMake = "AWSAuthV4Signer")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update legacy client constructors to use the CredentialProviderConfiguration struct
- Update tests that explicitly declare profile name to not do that since profile name actually works now 

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
