### PR TITLE
fix tmpnam_s call error while using MinGW

### DIFF
--- a/src/aws-cpp-sdk-core/source/platform/windows/FileSystem.cpp
+++ b/src/aws-cpp-sdk-core/source/platform/windows/FileSystem.cpp
@@ -317,6 +317,11 @@ Aws::String CreateTempFilePath()
     // Definition from the MSVC stdio.h
     #define L_tmpnam_s (sizeof("\\") + 16)
 #endif
+
+#ifdef __MINGW64_VERSION_MAJOR < 12
+    #undef L_tmpnam_s
+    #define L_tmpnam_s 260
+#endif
     char s_tempName[L_tmpnam_s+1];
 
     /*
@@ -328,7 +333,7 @@ Aws::String CreateTempFilePath()
     for more details.
     */
 
-#if _MSC_VER >= 1900
+#if _MSC_VER >= 1900 || defined(_UCRT)
     tmpnam_s(s_tempName, L_tmpnam_s);
 #else
     s_tempName[0] = '.';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [x] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
