### PR TITLE
fix cache and threading concerns with STS Webidentity provider

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -131,6 +131,7 @@
     "DENABLED",
     "DENFORCE",
     "APPSTORE",
+    "UCRT",
     // Compiler and linker
     "Wpedantic",
     "Wextra",

--- a/.github/workflows/cspell.yml
+++ b/.github/workflows/cspell.yml
@@ -17,5 +17,5 @@ jobs:
     - name: cspell
       run: |
         cd aws-sdk-cpp
-        sudo cspell --fail-fast "src/**/*.txt" "*.txt" "src/aws-cpp-sdk-core/**/*.h" "src/aws-cpp-sdk-core/**/*.cpp"
+        sudo cspell "src/**/*.txt" "*.txt" "src/aws-cpp-sdk-core/**/*.h" "src/aws-cpp-sdk-core/**/*.cpp"
         if [ $? -ne 0  ]; then sudo cspell "src/**/*.txt" "*.txt" "src/aws-cpp-sdk-core/**/*.h" "src/aws-cpp-sdk-core/**/*.cpp"; exit 1; fi;

--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -544,6 +544,11 @@ namespace Aws
                * Time out for the credentials future call.
                */
               std::chrono::milliseconds retrieveCredentialsFutureTimeout = std::chrono::seconds(10);
+
+              /**
+               * How long a cached credential set will be used for
+               */
+              std::chrono::milliseconds credentialCacheCacheTTL = std::chrono::minutes(50);
             } stsCredentialsProviderConfig;
           } credentialProviderConfig;
         };

--- a/src/aws-cpp-sdk-core/source/auth/STSCredentialsProvider.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/STSCredentialsProvider.cpp
@@ -37,11 +37,26 @@ STSAssumeRoleWebIdentityCredentialsProvider::STSAssumeRoleWebIdentityCredentials
     }
     return UUID::RandomUUID();
   }().c_str();
-  m_credentialsProvider = Aws::Crt::Auth::CredentialsProvider::CreateCredentialsProviderSTSWebIdentity(stsConfig);
+
+  // Create underlying STS provider
+  auto stsProvider = Aws::Crt::Auth::CredentialsProvider::CreateCredentialsProviderSTSWebIdentity(stsConfig);
+  if (!stsProvider || !stsProvider->IsValid()) {
+    AWS_LOGSTREAM_WARN(STS_LOG_TAG, "Failed to create underlying STS credentials provider");
+    return;
+  }
+
+  // Wrap with caching provider
+  Aws::Crt::Auth::CredentialsProviderCachedConfig cachedConfig;
+  cachedConfig.Provider = stsProvider;
+  cachedConfig.CachedCredentialTTL = credentialsConfig.stsCredentialsProviderConfig.credentialCacheCacheTTL;
+
+  m_credentialsProvider = Aws::Crt::Auth::CredentialsProvider::CreateCredentialsProviderCached(cachedConfig);
   if (m_credentialsProvider && m_credentialsProvider->IsValid()) {
     m_state = STATE::INITIALIZED;
+    AWS_LOGSTREAM_INFO(STS_LOG_TAG,
+                       "STS credentials provider initialized with cache TTL " << cachedConfig.CachedCredentialTTL.count() << " ms");
   } else {
-    AWS_LOGSTREAM_WARN(STS_LOG_TAG, "Failed to create STS credentials provider");
+    AWS_LOGSTREAM_WARN(STS_LOG_TAG, "Failed to create cached STS credentials provider");
   }
 }
 
@@ -80,31 +95,15 @@ AWSCredentials STSAssumeRoleWebIdentityCredentialsProvider::GetAWSCredentials() 
     AWS_LOGSTREAM_DEBUG(STS_LOG_TAG, "STSCredentialsProvider is not initialized, returning empty credentials");
     return AWSCredentials{};
   }
-  AWSCredentials credentials{};
-  auto refreshDone = false;
-  m_credentialsProvider->GetCredentials(
-      [this, &credentials, &refreshDone](std::shared_ptr<Aws::Crt::Auth::Credentials> crtCredentials, int errorCode) -> void {
-        {
-          const std::unique_lock<std::mutex> lock{m_refreshMutex};
-          if (errorCode != AWS_ERROR_SUCCESS) {
-            AWS_LOGSTREAM_ERROR(STS_LOG_TAG, "Failed to get credentials from STS: " << errorCode);
-          } else {
-            const auto accountIdCursor = crtCredentials->GetAccessKeyId();
-            credentials.SetAWSAccessKeyId({reinterpret_cast<char*>(accountIdCursor.ptr), accountIdCursor.len});
-            const auto secretKeuCursor = crtCredentials->GetSecretAccessKey();
-            credentials.SetAWSSecretKey({reinterpret_cast<char*>(secretKeuCursor.ptr), secretKeuCursor.len});
-            const auto expiration = crtCredentials->GetExpirationTimepointInSeconds();
-            credentials.SetExpiration(DateTime{static_cast<double>(expiration)});
-            const auto sessionTokenCursor = crtCredentials->GetSessionToken();
-            credentials.SetSessionToken({reinterpret_cast<char*>(sessionTokenCursor.ptr), sessionTokenCursor.len});
-          }
-          refreshDone = true;
-        }
-        m_refreshSignal.notify_one();
-      });
 
-  std::unique_lock<std::mutex> lock{m_refreshMutex};
-  m_refreshSignal.wait_for(lock, m_providerFuturesTimeoutMs, [&refreshDone]() -> bool { return refreshDone; });
+  // Thread-safe check: If another thread is already fetching, wait for its result
+  auto expected = false;
+  if (!m_refreshInProgress.compare_exchange_strong(expected, true)) {
+    return waitForSharedCredentials();
+  }
+
+  // This thread will fetch the credentials
+  auto credentials = fetchCredentialsAsync();
 
   if (!credentials.IsEmpty()) {
     credentials.AddUserAgentFeature(Aws::Client::UserAgentFeature::CREDENTIALS_STS_WEB_IDENTITY_TOKEN);
@@ -115,4 +114,66 @@ AWSCredentials STSAssumeRoleWebIdentityCredentialsProvider::GetAWSCredentials() 
 
 void STSAssumeRoleWebIdentityCredentialsProvider::Reload() {
   AWS_LOGSTREAM_DEBUG(STS_LOG_TAG, "Calling reload on STSCredentialsProvider is a no-op and no longer in the call path");
+}
+
+AWSCredentials STSAssumeRoleWebIdentityCredentialsProvider::waitForSharedCredentials() const {
+  AWS_LOGSTREAM_DEBUG(STS_LOG_TAG, "Another thread is fetching credentials, waiting for result");
+  std::unique_lock<std::mutex> lock{m_refreshMutex};
+  m_refreshSignal.wait_for(lock, m_providerFuturesTimeoutMs, [this]() -> bool { return !m_refreshInProgress.load(); });
+
+  if (m_pendingCredentials) {
+    return *m_pendingCredentials;
+  }
+
+  AWS_LOGSTREAM_WARN(STS_LOG_TAG, "Failed to get shared credentials after timeout");
+  return AWSCredentials{};
+}
+
+AWSCredentials STSAssumeRoleWebIdentityCredentialsProvider::extractCredentialsFromCrt(
+    const Aws::Crt::Auth::Credentials& crtCredentials) const {
+  AWSCredentials credentials{};
+  const auto accountIdCursor = crtCredentials.GetAccessKeyId();
+  credentials.SetAWSAccessKeyId({reinterpret_cast<char*>(accountIdCursor.ptr), accountIdCursor.len});
+  const auto secretKeyCursor = crtCredentials.GetSecretAccessKey();
+  credentials.SetAWSSecretKey({reinterpret_cast<char*>(secretKeyCursor.ptr), secretKeyCursor.len});
+  const auto expiration = crtCredentials.GetExpirationTimepointInSeconds();
+  credentials.SetExpiration(DateTime{static_cast<double>(expiration)});
+  const auto sessionTokenCursor = crtCredentials.GetSessionToken();
+  credentials.SetSessionToken({reinterpret_cast<char*>(sessionTokenCursor.ptr), sessionTokenCursor.len});
+  return credentials;
+}
+
+AWSCredentials STSAssumeRoleWebIdentityCredentialsProvider::fetchCredentialsAsync() {
+  AWS_LOGSTREAM_DEBUG(STS_LOG_TAG, "Initiating credential fetch from STS/cache");
+
+  AWSCredentials credentials{};
+  std::atomic<bool> refreshDone{false};
+
+  m_credentialsProvider->GetCredentials(
+      [this, &credentials, &refreshDone](std::shared_ptr<Aws::Crt::Auth::Credentials> crtCredentials, int errorCode) -> void {
+        std::unique_lock<std::mutex> lock{m_refreshMutex};
+        if (errorCode != AWS_ERROR_SUCCESS) {
+          m_pendingCredentials.reset();
+        } else {
+          credentials = extractCredentialsFromCrt(*crtCredentials);
+
+          // Store for other waiting threads
+          m_pendingCredentials = Aws::MakeShared<AWSCredentials>(STS_LOG_TAG, credentials);
+        }
+        refreshDone.store(true);
+        m_refreshInProgress.store(false);
+        m_refreshSignal.notify_all();
+      });
+
+  // Wait for completion
+  std::unique_lock<std::mutex> lock{m_refreshMutex};
+  auto completed = m_refreshSignal.wait_for(lock, m_providerFuturesTimeoutMs, [&refreshDone]() -> bool { return refreshDone.load(); });
+
+  if (!completed) {
+    AWS_LOGSTREAM_ERROR(STS_LOG_TAG, "Credential fetch timed out after " << m_providerFuturesTimeoutMs.count() << "ms");
+    m_refreshInProgress.store(false);
+    m_refreshSignal.notify_all();
+  }
+
+  return credentials;
 }

--- a/src/aws-cpp-sdk-core/source/client/AWSErrorMarshaller.cpp
+++ b/src/aws-cpp-sdk-core/source/client/AWSErrorMarshaller.cpp
@@ -301,7 +301,8 @@ void JsonErrorMarshallerQueryCompatible::MarshallError(AWSError<CoreErrors>& err
 }
 
 AWSError<CoreErrors> RpcV2ErrorMarshaller::Marshall(const Aws::Http::HttpResponse& httpResponse) const {
-  return AWSError<CoreErrors>(CoreErrors::UNKNOWN, "Not implemented yet", "RpcV2ErrorMarshaller::Marshall not implemeneted yet: " + httpResponse.GetClientErrorMessage(), false);
+  return AWSError<CoreErrors>(CoreErrors::UNKNOWN, "Not implemented yet",
+                              "RpcV2ErrorMarshaller::Marshall not implemented yet: " + httpResponse.GetClientErrorMessage(), false);
 }
 
 AWSError<CoreErrors> RpcV2ErrorMarshaller::BuildAWSError(const std::shared_ptr<Http::HttpResponse>& httpResponse) const {


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/3558

*Description of changes:*

There was a fundamental misunderstanding when we swapped to [use the CRT implementation of the STSWebidentityProvider](https://github.com/aws/aws-sdk-cpp/commit/c6ed3e3c6c965a088ab7fb09e429e045134ffaa6) and that was that CRT would cache the credentials from STS using their expiration. This is incorrect, it is up to us to cache and expire the credentials.

This change moves the implementation back to using a reader/writer lock to cache the credentials between invocations, making a network call only when expiration is close.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
