### PR TITLE
Fix codegen for eventstream boolean headers

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/CppViewHelper.java
@@ -10,6 +10,7 @@ import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.Shape;
 import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.ShapeMember;
 import com.amazonaws.util.awsclientgenerator.transform.CoreErrors;
 import com.google.common.base.CaseFormat;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.lang.RuntimeException;
@@ -122,6 +123,11 @@ public class CppViewHelper {
         C2J_TIMESTAMP_FORMAT_TO_CPP_DATE_TIME_FORMAT.put("rfc822", "RFC822");
         C2J_TIMESTAMP_FORMAT_TO_CPP_DATE_TIME_FORMAT.put("iso8601", "ISO_8601");
     }
+
+    private static final ImmutableMap<String, String> EVENT_STREAM_HEADER_ACCESSORS = ImmutableMap.of(
+            "string", "GetEventHeaderValueAsString()",
+            "boolean", "GetEventHeaderValueAsBoolean()"
+    );
 
     public static String computeExportValue(String classNamePrefix) {
         return String.format("AWS_%s_API", classNamePrefix.toUpperCase());
@@ -586,5 +592,12 @@ public class CppViewHelper {
     public static boolean hasListMemberUsedForHeader(final Shape shape) {
         return shape.getMembers().values().stream()
                 .anyMatch(shapeMember -> shapeMember.getShape().isList() && shapeMember.isUsedForHeader());
+    }
+
+    public static String getEventStreamHeaderAccessorName(final Shape shape) {
+        if (!EVENT_STREAM_HEADER_ACCESSORS.containsKey(shape.getType())) {
+            throw new RuntimeException("No event stream header accessor found for shape type: " + shape.getType());
+        }
+        return EVENT_STREAM_HEADER_ACCESSORS.get(shape.getType());
     }
 }

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/EventHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/EventHeader.vm
@@ -55,7 +55,12 @@ namespace Model
 #set($eventHeaderMemberNameWithFirstLetterCapitalized = $CppViewHelper.capitalizeFirstChar($eventHeader.getName()))
 #set($eventHeaderMemberHaseBeenSetName = $CppViewHelper.computeVariableHasBeenSetName($eventHeader.getName()))
 #set($eventHeaderMemberType = $CppViewHelper.computeCppType($eventHeader))
-    inline const $eventHeaderMemberType Get${eventHeaderMemberNameWithFirstLetterCapitalized}() const { return $eventHeaderMemberName; }
+#if($eventHeader.boolean)
+#set($constQualifer = "")
+#else
+#set($constQualifer = "const ")
+#end
+    inline $constQualifer$eventHeaderMemberType Get${eventHeaderMemberNameWithFirstLetterCapitalized}() const { return $eventHeaderMemberName; }
     inline bool ${eventHeaderMemberNameWithFirstLetterCapitalized}HasBeenSet() const { return $eventHeaderMemberHaseBeenSetName; }
     template<typename T = $eventHeaderMemberType>
     void Set${eventHeaderMemberNameWithFirstLetterCapitalized}(T&& value) { $eventHeaderMemberHaseBeenSetName = true; $eventHeaderMemberName = std::forward<T>(value); }

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonEventStreamHandlerSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonEventStreamHandlerSource.vm
@@ -142,7 +142,7 @@ namespace Model
 #set($headerVarName = $CppViewHelper.lowercasesFirstChar("${eventStreamHeader.getName()}Header"))
             const auto $headerVarName = headers.find("${eventStreamHeaderMapping.getKey()}");
             if ($headerVarName != headers.end()) {
-                event.Set$eventHeaderMemberNameWithFirstLetterCapitalized($headerVarName->second.GetEventHeaderValueAsString());
+                event.Set$eventHeaderMemberNameWithFirstLetterCapitalized($headerVarName->second.$CppViewHelper.getEventStreamHeaderAccessorName($eventStreamHeader));
             }
 #end
             m_on${eventShape.name}(event);


### PR DESCRIPTION
*Description of changes:*

Fixes codegen when there is a event stream  header that is a boolean type

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
