### PR TITLE
Update pdb file install to only for MSVC & BUILD_SHARED_LIBS

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -147,7 +147,7 @@ macro(do_packaging)
             COMPONENT
             Devel)
     endif()
-    if (MSVC)
+    if (MSVC AND BUILD_SHARED_LIBS)
         install (FILES $<TARGET_PDB_FILE:${PROJECT_NAME}> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)
     endif()
 endmacro()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix cmake error when BUILD_SHARED_LIBS is off. 

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
