### PR TITLE
Fix OverrideEndpoint API for services with endpoint discovery

### DIFF
--- a/generated/src/aws-cpp-sdk-AWSMigrationHub/source/MigrationHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-AWSMigrationHub/source/MigrationHubClient.cpp
@@ -182,6 +182,7 @@ void MigrationHubClient::init(const MigrationHub::MigrationHubClientConfiguratio
 void MigrationHubClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-accessanalyzer/source/AccessAnalyzerClient.cpp
+++ b/generated/src/aws-cpp-sdk-accessanalyzer/source/AccessAnalyzerClient.cpp
@@ -198,6 +198,7 @@ void AccessAnalyzerClient::init(const AccessAnalyzer::AccessAnalyzerClientConfig
 void AccessAnalyzerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-account/source/AccountClient.cpp
+++ b/generated/src/aws-cpp-sdk-account/source/AccountClient.cpp
@@ -175,6 +175,7 @@ void AccountClient::init(const Account::AccountClientConfiguration& config)
 void AccountClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-acm-pca/source/ACMPCAClient.cpp
+++ b/generated/src/aws-cpp-sdk-acm-pca/source/ACMPCAClient.cpp
@@ -184,6 +184,7 @@ void ACMPCAClient::init(const ACMPCA::ACMPCAClientConfiguration& config)
 void ACMPCAClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-acm/source/ACMClient.cpp
+++ b/generated/src/aws-cpp-sdk-acm/source/ACMClient.cpp
@@ -177,6 +177,7 @@ void ACMClient::init(const ACM::ACMClientConfiguration& config)
 void ACMClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-aiops/source/AIOpsClient.cpp
+++ b/generated/src/aws-cpp-sdk-aiops/source/AIOpsClient.cpp
@@ -172,6 +172,7 @@ void AIOpsClient::init(const AIOps::AIOpsClientConfiguration& config)
 void AIOpsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-amp/source/PrometheusServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-amp/source/PrometheusServiceClient.cpp
@@ -200,6 +200,7 @@ void PrometheusServiceClient::init(const PrometheusService::PrometheusServiceCli
 void PrometheusServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-amplify/source/AmplifyClient.cpp
+++ b/generated/src/aws-cpp-sdk-amplify/source/AmplifyClient.cpp
@@ -198,6 +198,7 @@ void AmplifyClient::init(const Amplify::AmplifyClientConfiguration& config)
 void AmplifyClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-amplifybackend/source/AmplifyBackendClient.cpp
+++ b/generated/src/aws-cpp-sdk-amplifybackend/source/AmplifyBackendClient.cpp
@@ -192,6 +192,7 @@ void AmplifyBackendClient::init(const AmplifyBackend::AmplifyBackendClientConfig
 void AmplifyBackendClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-amplifyuibuilder/source/AmplifyUIBuilderClient.cpp
+++ b/generated/src/aws-cpp-sdk-amplifyuibuilder/source/AmplifyUIBuilderClient.cpp
@@ -189,6 +189,7 @@ void AmplifyUIBuilderClient::init(const AmplifyUIBuilder::AmplifyUIBuilderClient
 void AmplifyUIBuilderClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-apigateway/source/APIGatewayClient.cpp
+++ b/generated/src/aws-cpp-sdk-apigateway/source/APIGatewayClient.cpp
@@ -285,6 +285,7 @@ void APIGatewayClient::init(const APIGateway::APIGatewayClientConfiguration& con
 void APIGatewayClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-apigatewaymanagementapi/source/ApiGatewayManagementApiClient.cpp
+++ b/generated/src/aws-cpp-sdk-apigatewaymanagementapi/source/ApiGatewayManagementApiClient.cpp
@@ -164,6 +164,7 @@ void ApiGatewayManagementApiClient::init(const ApiGatewayManagementApi::ApiGatew
 void ApiGatewayManagementApiClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-apigatewayv2/source/ApiGatewayV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-apigatewayv2/source/ApiGatewayV2Client.cpp
@@ -238,6 +238,7 @@ void ApiGatewayV2Client::init(const ApiGatewayV2::ApiGatewayV2ClientConfiguratio
 void ApiGatewayV2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-appconfig/source/AppConfigClient.cpp
+++ b/generated/src/aws-cpp-sdk-appconfig/source/AppConfigClient.cpp
@@ -205,6 +205,7 @@ void AppConfigClient::init(const AppConfig::AppConfigClientConfiguration& config
 void AppConfigClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-appconfigdata/source/AppConfigDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-appconfigdata/source/AppConfigDataClient.cpp
@@ -163,6 +163,7 @@ void AppConfigDataClient::init(const AppConfigData::AppConfigDataClientConfigura
 void AppConfigDataClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-appfabric/source/AppFabricClient.cpp
+++ b/generated/src/aws-cpp-sdk-appfabric/source/AppFabricClient.cpp
@@ -187,6 +187,7 @@ void AppFabricClient::init(const AppFabric::AppFabricClientConfiguration& config
 void AppFabricClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-appflow/source/AppflowClient.cpp
+++ b/generated/src/aws-cpp-sdk-appflow/source/AppflowClient.cpp
@@ -186,6 +186,7 @@ void AppflowClient::init(const Appflow::AppflowClientConfiguration& config)
 void AppflowClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-appintegrations/source/AppIntegrationsServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-appintegrations/source/AppIntegrationsServiceClient.cpp
@@ -184,6 +184,7 @@ void AppIntegrationsServiceClient::init(const AppIntegrationsService::AppIntegra
 void AppIntegrationsServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-application-autoscaling/source/ApplicationAutoScalingClient.cpp
+++ b/generated/src/aws-cpp-sdk-application-autoscaling/source/ApplicationAutoScalingClient.cpp
@@ -175,6 +175,7 @@ void ApplicationAutoScalingClient::init(const ApplicationAutoScaling::Applicatio
 void ApplicationAutoScalingClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-application-insights/source/ApplicationInsightsClient.cpp
+++ b/generated/src/aws-cpp-sdk-application-insights/source/ApplicationInsightsClient.cpp
@@ -194,6 +194,7 @@ void ApplicationInsightsClient::init(const ApplicationInsights::ApplicationInsig
 void ApplicationInsightsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-application-signals/source/ApplicationSignalsClient.cpp
+++ b/generated/src/aws-cpp-sdk-application-signals/source/ApplicationSignalsClient.cpp
@@ -183,6 +183,7 @@ void ApplicationSignalsClient::init(const ApplicationSignals::ApplicationSignals
 void ApplicationSignalsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-applicationcostprofiler/source/ApplicationCostProfilerClient.cpp
+++ b/generated/src/aws-cpp-sdk-applicationcostprofiler/source/ApplicationCostProfilerClient.cpp
@@ -167,6 +167,7 @@ void ApplicationCostProfilerClient::init(const ApplicationCostProfiler::Applicat
 void ApplicationCostProfilerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-appmesh/source/AppMeshClient.cpp
+++ b/generated/src/aws-cpp-sdk-appmesh/source/AppMeshClient.cpp
@@ -199,6 +199,7 @@ void AppMeshClient::init(const AppMesh::AppMeshClientConfiguration& config)
 void AppMeshClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-apprunner/source/AppRunnerClient.cpp
+++ b/generated/src/aws-cpp-sdk-apprunner/source/AppRunnerClient.cpp
@@ -198,6 +198,7 @@ void AppRunnerClient::init(const AppRunner::AppRunnerClientConfiguration& config
 void AppRunnerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-appstream/source/AppStreamClient.cpp
+++ b/generated/src/aws-cpp-sdk-appstream/source/AppStreamClient.cpp
@@ -240,6 +240,7 @@ void AppStreamClient::init(const AppStream::AppStreamClientConfiguration& config
 void AppStreamClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-appsync/source/AppSyncClient.cpp
+++ b/generated/src/aws-cpp-sdk-appsync/source/AppSyncClient.cpp
@@ -235,6 +235,7 @@ void AppSyncClient::init(const AppSync::AppSyncClientConfiguration& config)
 void AppSyncClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-apptest/source/AppTestClient.cpp
+++ b/generated/src/aws-cpp-sdk-apptest/source/AppTestClient.cpp
@@ -185,6 +185,7 @@ void AppTestClient::init(const AppTest::AppTestClientConfiguration& config)
 void AppTestClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-arc-region-switch/source/ARCRegionswitchClient.cpp
+++ b/generated/src/aws-cpp-sdk-arc-region-switch/source/ARCRegionswitchClient.cpp
@@ -181,6 +181,7 @@ void ARCRegionswitchClient::init(const ARCRegionswitch::ARCRegionswitchClientCon
 void ARCRegionswitchClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-arc-zonal-shift/source/ARCZonalShiftClient.cpp
+++ b/generated/src/aws-cpp-sdk-arc-zonal-shift/source/ARCZonalShiftClient.cpp
@@ -176,6 +176,7 @@ void ARCZonalShiftClient::init(const ARCZonalShift::ARCZonalShiftClientConfigura
 void ARCZonalShiftClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-artifact/source/ArtifactClient.cpp
+++ b/generated/src/aws-cpp-sdk-artifact/source/ArtifactClient.cpp
@@ -168,6 +168,7 @@ void ArtifactClient::init(const Artifact::ArtifactClientConfiguration& config)
 void ArtifactClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-athena/source/AthenaClient.cpp
+++ b/generated/src/aws-cpp-sdk-athena/source/AthenaClient.cpp
@@ -229,6 +229,7 @@ void AthenaClient::init(const Athena::AthenaClientConfiguration& config)
 void AthenaClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-auditmanager/source/AuditManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-auditmanager/source/AuditManagerClient.cpp
@@ -223,6 +223,7 @@ void AuditManagerClient::init(const AuditManager::AuditManagerClientConfiguratio
 void AuditManagerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-autoscaling-plans/source/AutoScalingPlansClient.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling-plans/source/AutoScalingPlansClient.cpp
@@ -167,6 +167,7 @@ void AutoScalingPlansClient::init(const AutoScalingPlans::AutoScalingPlansClient
 void AutoScalingPlansClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-autoscaling/source/AutoScalingClient.cpp
+++ b/generated/src/aws-cpp-sdk-autoscaling/source/AutoScalingClient.cpp
@@ -227,6 +227,7 @@ void AutoScalingClient::init(const AutoScaling::AutoScalingClientConfiguration& 
 void AutoScalingClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-awstransfer/source/TransferClient.cpp
+++ b/generated/src/aws-cpp-sdk-awstransfer/source/TransferClient.cpp
@@ -232,6 +232,7 @@ void TransferClient::init(const Transfer::TransferClientConfiguration& config)
 void TransferClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-b2bi/source/B2BIClient.cpp
+++ b/generated/src/aws-cpp-sdk-b2bi/source/B2BIClient.cpp
@@ -191,6 +191,7 @@ void B2BIClient::init(const B2BI::B2BIClientConfiguration& config)
 void B2BIClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-backup-gateway/source/BackupGatewayClient.cpp
+++ b/generated/src/aws-cpp-sdk-backup-gateway/source/BackupGatewayClient.cpp
@@ -186,6 +186,7 @@ void BackupGatewayClient::init(const BackupGateway::BackupGatewayClientConfigura
 void BackupGatewayClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-backup/source/BackupClient.cpp
+++ b/generated/src/aws-cpp-sdk-backup/source/BackupClient.cpp
@@ -260,6 +260,7 @@ void BackupClient::init(const Backup::BackupClientConfiguration& config)
 void BackupClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-backupsearch/source/BackupSearchClient.cpp
+++ b/generated/src/aws-cpp-sdk-backupsearch/source/BackupSearchClient.cpp
@@ -173,6 +173,7 @@ void BackupSearchClient::init(const BackupSearch::BackupSearchClientConfiguratio
 void BackupSearchClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-batch/source/BatchClient.cpp
+++ b/generated/src/aws-cpp-sdk-batch/source/BatchClient.cpp
@@ -200,6 +200,7 @@ void BatchClient::init(const Batch::BatchClientConfiguration& config)
 void BatchClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-bcm-dashboards/source/BCMDashboardsClient.cpp
+++ b/generated/src/aws-cpp-sdk-bcm-dashboards/source/BCMDashboardsClient.cpp
@@ -170,6 +170,7 @@ void BCMDashboardsClient::init(const BCMDashboards::BCMDashboardsClientConfigura
 void BCMDashboardsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-bcm-data-exports/source/BCMDataExportsClient.cpp
+++ b/generated/src/aws-cpp-sdk-bcm-data-exports/source/BCMDataExportsClient.cpp
@@ -173,6 +173,7 @@ void BCMDataExportsClient::init(const BCMDataExports::BCMDataExportsClientConfig
 void BCMDataExportsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-bcm-pricing-calculator/source/BCMPricingCalculatorClient.cpp
+++ b/generated/src/aws-cpp-sdk-bcm-pricing-calculator/source/BCMPricingCalculatorClient.cpp
@@ -197,6 +197,7 @@ void BCMPricingCalculatorClient::init(const BCMPricingCalculator::BCMPricingCalc
 void BCMPricingCalculatorClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-bcm-recommended-actions/source/BCMRecommendedActionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-bcm-recommended-actions/source/BCMRecommendedActionsClient.cpp
@@ -162,6 +162,7 @@ void BCMRecommendedActionsClient::init(const BCMRecommendedActions::BCMRecommend
 void BCMRecommendedActionsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-bedrock-agent-runtime/source/BedrockAgentRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-agent-runtime/source/BedrockAgentRuntimeClient.cpp
@@ -193,6 +193,7 @@ void BedrockAgentRuntimeClient::init(const BedrockAgentRuntime::BedrockAgentRunt
 void BedrockAgentRuntimeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-bedrock-agent/source/BedrockAgentClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-agent/source/BedrockAgentClient.cpp
@@ -233,6 +233,7 @@ void BedrockAgentClient::init(const BedrockAgent::BedrockAgentClientConfiguratio
 void BedrockAgentClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-bedrock-agentcore-control/source/BedrockAgentCoreControlClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-agentcore-control/source/BedrockAgentCoreControlClient.cpp
@@ -215,6 +215,7 @@ void BedrockAgentCoreControlClient::init(const BedrockAgentCoreControl::BedrockA
 void BedrockAgentCoreControlClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-bedrock-agentcore/source/BedrockAgentCoreClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-agentcore/source/BedrockAgentCoreClient.cpp
@@ -188,6 +188,7 @@ void BedrockAgentCoreClient::init(const BedrockAgentCore::BedrockAgentCoreClient
 void BedrockAgentCoreClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-bedrock-data-automation-runtime/source/BedrockDataAutomationRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-data-automation-runtime/source/BedrockDataAutomationRuntimeClient.cpp
@@ -166,6 +166,7 @@ void BedrockDataAutomationRuntimeClient::init(const BedrockDataAutomationRuntime
 void BedrockDataAutomationRuntimeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-bedrock-data-automation/source/BedrockDataAutomationClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-data-automation/source/BedrockDataAutomationClient.cpp
@@ -175,6 +175,7 @@ void BedrockDataAutomationClient::init(const BedrockDataAutomation::BedrockDataA
 void BedrockDataAutomationClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/source/BedrockRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/source/BedrockRuntimeClient.cpp
@@ -173,6 +173,7 @@ void BedrockRuntimeClient::init(const BedrockRuntime::BedrockRuntimeClientConfig
 void BedrockRuntimeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-bedrock/source/BedrockClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock/source/BedrockClient.cpp
@@ -255,6 +255,7 @@ void BedrockClient::init(const Bedrock::BedrockClientConfiguration& config)
 void BedrockClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-billing/source/BillingClient.cpp
+++ b/generated/src/aws-cpp-sdk-billing/source/BillingClient.cpp
@@ -173,6 +173,7 @@ void BillingClient::init(const Billing::BillingClientConfiguration& config)
 void BillingClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-billingconductor/source/BillingConductorClient.cpp
+++ b/generated/src/aws-cpp-sdk-billingconductor/source/BillingConductorClient.cpp
@@ -193,6 +193,7 @@ void BillingConductorClient::init(const BillingConductor::BillingConductorClient
 void BillingConductorClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-braket/source/BraketClient.cpp
+++ b/generated/src/aws-cpp-sdk-braket/source/BraketClient.cpp
@@ -174,6 +174,7 @@ void BraketClient::init(const Braket::BraketClientConfiguration& config)
 void BraketClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-budgets/source/BudgetsClient.cpp
+++ b/generated/src/aws-cpp-sdk-budgets/source/BudgetsClient.cpp
@@ -187,6 +187,7 @@ void BudgetsClient::init(const Budgets::BudgetsClientConfiguration& config)
 void BudgetsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ce/source/CostExplorerClient.cpp
+++ b/generated/src/aws-cpp-sdk-ce/source/CostExplorerClient.cpp
@@ -207,6 +207,7 @@ void CostExplorerClient::init(const CostExplorer::CostExplorerClientConfiguratio
 void CostExplorerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-chatbot/source/ChatbotClient.cpp
+++ b/generated/src/aws-cpp-sdk-chatbot/source/ChatbotClient.cpp
@@ -195,6 +195,7 @@ void ChatbotClient::init(const chatbot::ChatbotClientConfiguration& config)
 void ChatbotClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-chime-sdk-identity/source/ChimeSDKIdentityClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-identity/source/ChimeSDKIdentityClient.cpp
@@ -191,6 +191,7 @@ void ChimeSDKIdentityClient::init(const ChimeSDKIdentity::ChimeSDKIdentityClient
 void ChimeSDKIdentityClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-chime-sdk-media-pipelines/source/ChimeSDKMediaPipelinesClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-media-pipelines/source/ChimeSDKMediaPipelinesClient.cpp
@@ -192,6 +192,7 @@ void ChimeSDKMediaPipelinesClient::init(const ChimeSDKMediaPipelines::ChimeSDKMe
 void ChimeSDKMediaPipelinesClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-chime-sdk-meetings/source/ChimeSDKMeetingsClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-meetings/source/ChimeSDKMeetingsClient.cpp
@@ -177,6 +177,7 @@ void ChimeSDKMeetingsClient::init(const ChimeSDKMeetings::ChimeSDKMeetingsClient
 void ChimeSDKMeetingsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-chime-sdk-messaging/source/ChimeSDKMessagingClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-messaging/source/ChimeSDKMessagingClient.cpp
@@ -212,6 +212,7 @@ void ChimeSDKMessagingClient::init(const ChimeSDKMessaging::ChimeSDKMessagingCli
 void ChimeSDKMessagingClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-chime-sdk-voice/source/ChimeSDKVoiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime-sdk-voice/source/ChimeSDKVoiceClient.cpp
@@ -255,6 +255,7 @@ void ChimeSDKVoiceClient::init(const ChimeSDKVoice::ChimeSDKVoiceClientConfigura
 void ChimeSDKVoiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-chime/source/ChimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-chime/source/ChimeClient.cpp
@@ -223,6 +223,7 @@ void ChimeClient::init(const Chime::ChimeClientConfiguration& config)
 void ChimeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cleanrooms/source/CleanRoomsClient.cpp
+++ b/generated/src/aws-cpp-sdk-cleanrooms/source/CleanRoomsClient.cpp
@@ -248,6 +248,7 @@ void CleanRoomsClient::init(const CleanRooms::CleanRoomsClientConfiguration& con
 void CleanRoomsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cleanroomsml/source/CleanRoomsMLClient.cpp
+++ b/generated/src/aws-cpp-sdk-cleanroomsml/source/CleanRoomsMLClient.cpp
@@ -220,6 +220,7 @@ void CleanRoomsMLClient::init(const CleanRoomsML::CleanRoomsMLClientConfiguratio
 void CleanRoomsMLClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cloud9/source/Cloud9Client.cpp
+++ b/generated/src/aws-cpp-sdk-cloud9/source/Cloud9Client.cpp
@@ -174,6 +174,7 @@ void Cloud9Client::init(const Cloud9::Cloud9ClientConfiguration& config)
 void Cloud9Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cloudcontrol/source/CloudControlApiClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudcontrol/source/CloudControlApiClient.cpp
@@ -169,6 +169,7 @@ void CloudControlApiClient::init(const CloudControlApi::CloudControlApiClientCon
 void CloudControlApiClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-clouddirectory/source/CloudDirectoryClient.cpp
+++ b/generated/src/aws-cpp-sdk-clouddirectory/source/CloudDirectoryClient.cpp
@@ -227,6 +227,7 @@ void CloudDirectoryClient::init(const CloudDirectory::CloudDirectoryClientConfig
 void CloudDirectoryClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cloudformation/source/CloudFormationClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudformation/source/CloudFormationClient.cpp
@@ -250,6 +250,7 @@ void CloudFormationClient::init(const CloudFormation::CloudFormationClientConfig
 void CloudFormationClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cloudfront-keyvaluestore/source/CloudFrontKeyValueStoreClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront-keyvaluestore/source/CloudFrontKeyValueStoreClient.cpp
@@ -167,6 +167,7 @@ void CloudFrontKeyValueStoreClient::init(const CloudFrontKeyValueStore::CloudFro
 void CloudFrontKeyValueStoreClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cloudfront/source/CloudFrontClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/CloudFrontClient.cpp
@@ -309,6 +309,7 @@ void CloudFrontClient::init(const CloudFront::CloudFrontClientConfiguration& con
 void CloudFrontClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cloudhsm/source/CloudHSMClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudhsm/source/CloudHSMClient.cpp
@@ -161,6 +161,7 @@ void CloudHSMClient::init(const CloudHSM::CloudHSMClientConfiguration& config)
 void CloudHSMClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cloudhsmv2/source/CloudHSMV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-cloudhsmv2/source/CloudHSMV2Client.cpp
@@ -179,6 +179,7 @@ void CloudHSMV2Client::init(const CloudHSMV2::CloudHSMV2ClientConfiguration& con
 void CloudHSMV2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cloudsearch/source/CloudSearchClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudsearch/source/CloudSearchClient.cpp
@@ -188,6 +188,7 @@ void CloudSearchClient::init(const CloudSearch::CloudSearchClientConfiguration& 
 void CloudSearchClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cloudsearchdomain/source/CloudSearchDomainClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudsearchdomain/source/CloudSearchDomainClient.cpp
@@ -164,6 +164,7 @@ void CloudSearchDomainClient::init(const CloudSearchDomain::CloudSearchDomainCli
 void CloudSearchDomainClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cloudtrail-data/source/CloudTrailDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudtrail-data/source/CloudTrailDataClient.cpp
@@ -162,6 +162,7 @@ void CloudTrailDataClient::init(const CloudTrailData::CloudTrailDataClientConfig
 void CloudTrailDataClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cloudtrail/source/CloudTrailClient.cpp
+++ b/generated/src/aws-cpp-sdk-cloudtrail/source/CloudTrailClient.cpp
@@ -220,6 +220,7 @@ void CloudTrailClient::init(const CloudTrail::CloudTrailClientConfiguration& con
 void CloudTrailClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-codeartifact/source/CodeArtifactClient.cpp
+++ b/generated/src/aws-cpp-sdk-codeartifact/source/CodeArtifactClient.cpp
@@ -209,6 +209,7 @@ void CodeArtifactClient::init(const CodeArtifact::CodeArtifactClientConfiguratio
 void CodeArtifactClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-codebuild/source/CodeBuildClient.cpp
+++ b/generated/src/aws-cpp-sdk-codebuild/source/CodeBuildClient.cpp
@@ -220,6 +220,7 @@ void CodeBuildClient::init(const CodeBuild::CodeBuildClientConfiguration& config
 void CodeBuildClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-codecatalyst/source/CodeCatalystClient.cpp
+++ b/generated/src/aws-cpp-sdk-codecatalyst/source/CodeCatalystClient.cpp
@@ -136,6 +136,7 @@ void CodeCatalystClient::init(const CodeCatalyst::CodeCatalystClientConfiguratio
 void CodeCatalystClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-codecommit/source/CodeCommitClient.cpp
+++ b/generated/src/aws-cpp-sdk-codecommit/source/CodeCommitClient.cpp
@@ -240,6 +240,7 @@ void CodeCommitClient::init(const CodeCommit::CodeCommitClientConfiguration& con
 void CodeCommitClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-codeconnections/source/CodeConnectionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-codeconnections/source/CodeConnectionsClient.cpp
@@ -188,6 +188,7 @@ void CodeConnectionsClient::init(const CodeConnections::CodeConnectionsClientCon
 void CodeConnectionsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-codedeploy/source/CodeDeployClient.cpp
+++ b/generated/src/aws-cpp-sdk-codedeploy/source/CodeDeployClient.cpp
@@ -204,6 +204,7 @@ void CodeDeployClient::init(const CodeDeploy::CodeDeployClientConfiguration& con
 void CodeDeployClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-codeguru-reviewer/source/CodeGuruReviewerClient.cpp
+++ b/generated/src/aws-cpp-sdk-codeguru-reviewer/source/CodeGuruReviewerClient.cpp
@@ -175,6 +175,7 @@ void CodeGuruReviewerClient::init(const CodeGuruReviewer::CodeGuruReviewerClient
 void CodeGuruReviewerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-codeguru-security/source/CodeGuruSecurityClient.cpp
+++ b/generated/src/aws-cpp-sdk-codeguru-security/source/CodeGuruSecurityClient.cpp
@@ -174,6 +174,7 @@ void CodeGuruSecurityClient::init(const CodeGuruSecurity::CodeGuruSecurityClient
 void CodeGuruSecurityClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-codeguruprofiler/source/CodeGuruProfilerClient.cpp
+++ b/generated/src/aws-cpp-sdk-codeguruprofiler/source/CodeGuruProfilerClient.cpp
@@ -184,6 +184,7 @@ void CodeGuruProfilerClient::init(const CodeGuruProfiler::CodeGuruProfilerClient
 void CodeGuruProfilerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-codepipeline/source/CodePipelineClient.cpp
+++ b/generated/src/aws-cpp-sdk-codepipeline/source/CodePipelineClient.cpp
@@ -205,6 +205,7 @@ void CodePipelineClient::init(const CodePipeline::CodePipelineClientConfiguratio
 void CodePipelineClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-codestar-connections/source/CodeStarconnectionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-codestar-connections/source/CodeStarconnectionsClient.cpp
@@ -188,6 +188,7 @@ void CodeStarconnectionsClient::init(const CodeStarconnections::CodeStarconnecti
 void CodeStarconnectionsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-codestar-notifications/source/CodeStarNotificationsClient.cpp
+++ b/generated/src/aws-cpp-sdk-codestar-notifications/source/CodeStarNotificationsClient.cpp
@@ -174,6 +174,7 @@ void CodeStarNotificationsClient::init(const CodeStarNotifications::CodeStarNoti
 void CodeStarNotificationsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cognito-identity/source/CognitoIdentityClient.cpp
+++ b/generated/src/aws-cpp-sdk-cognito-identity/source/CognitoIdentityClient.cpp
@@ -184,6 +184,7 @@ void CognitoIdentityClient::init(const CognitoIdentity::CognitoIdentityClientCon
 void CognitoIdentityClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cognito-idp/source/CognitoIdentityProviderClient.cpp
+++ b/generated/src/aws-cpp-sdk-cognito-idp/source/CognitoIdentityProviderClient.cpp
@@ -280,6 +280,7 @@ void CognitoIdentityProviderClient::init(const CognitoIdentityProvider::CognitoI
 void CognitoIdentityProviderClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cognito-sync/source/CognitoSyncClient.cpp
+++ b/generated/src/aws-cpp-sdk-cognito-sync/source/CognitoSyncClient.cpp
@@ -178,6 +178,7 @@ void CognitoSyncClient::init(const CognitoSync::CognitoSyncClientConfiguration& 
 void CognitoSyncClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-comprehend/source/ComprehendClient.cpp
+++ b/generated/src/aws-cpp-sdk-comprehend/source/ComprehendClient.cpp
@@ -246,6 +246,7 @@ void ComprehendClient::init(const Comprehend::ComprehendClientConfiguration& con
 void ComprehendClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-comprehendmedical/source/ComprehendMedicalClient.cpp
+++ b/generated/src/aws-cpp-sdk-comprehendmedical/source/ComprehendMedicalClient.cpp
@@ -186,6 +186,7 @@ void ComprehendMedicalClient::init(const ComprehendMedical::ComprehendMedicalCli
 void ComprehendMedicalClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-compute-optimizer/source/ComputeOptimizerClient.cpp
+++ b/generated/src/aws-cpp-sdk-compute-optimizer/source/ComputeOptimizerClient.cpp
@@ -189,6 +189,7 @@ void ComputeOptimizerClient::init(const ComputeOptimizer::ComputeOptimizerClient
 void ComputeOptimizerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-config/source/ConfigServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-config/source/ConfigServiceClient.cpp
@@ -258,6 +258,7 @@ void ConfigServiceClient::init(const ConfigService::ConfigServiceClientConfigura
 void ConfigServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-connect-contact-lens/source/ConnectContactLensClient.cpp
+++ b/generated/src/aws-cpp-sdk-connect-contact-lens/source/ConnectContactLensClient.cpp
@@ -162,6 +162,7 @@ void ConnectContactLensClient::init(const ConnectContactLens::ConnectContactLens
 void ConnectContactLensClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-connect/source/ConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-connect/source/ConnectClient.cpp
@@ -261,6 +261,7 @@ void ConnectClient::init(const Connect::ConnectClientConfiguration& config)
 void ConnectClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-connectcampaigns/source/ConnectCampaignsClient.cpp
+++ b/generated/src/aws-cpp-sdk-connectcampaigns/source/ConnectCampaignsClient.cpp
@@ -183,6 +183,7 @@ void ConnectCampaignsClient::init(const ConnectCampaigns::ConnectCampaignsClient
 void ConnectCampaignsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-connectcampaignsv2/source/ConnectCampaignsV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-connectcampaignsv2/source/ConnectCampaignsV2Client.cpp
@@ -196,6 +196,7 @@ void ConnectCampaignsV2Client::init(const ConnectCampaignsV2::ConnectCampaignsV2
 void ConnectCampaignsV2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-connectcases/source/ConnectCasesClient.cpp
+++ b/generated/src/aws-cpp-sdk-connectcases/source/ConnectCasesClient.cpp
@@ -203,6 +203,7 @@ void ConnectCasesClient::init(const ConnectCases::ConnectCasesClientConfiguratio
 void ConnectCasesClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-connectparticipant/source/ConnectParticipantClient.cpp
+++ b/generated/src/aws-cpp-sdk-connectparticipant/source/ConnectParticipantClient.cpp
@@ -172,6 +172,7 @@ void ConnectParticipantClient::init(const ConnectParticipant::ConnectParticipant
 void ConnectParticipantClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-controlcatalog/source/ControlCatalogClient.cpp
+++ b/generated/src/aws-cpp-sdk-controlcatalog/source/ControlCatalogClient.cpp
@@ -167,6 +167,7 @@ void ControlCatalogClient::init(const ControlCatalog::ControlCatalogClientConfig
 void ControlCatalogClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-controltower/source/ControlTowerClient.cpp
+++ b/generated/src/aws-cpp-sdk-controltower/source/ControlTowerClient.cpp
@@ -189,6 +189,7 @@ void ControlTowerClient::init(const ControlTower::ControlTowerClientConfiguratio
 void ControlTowerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cost-optimization-hub/source/CostOptimizationHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-cost-optimization-hub/source/CostOptimizationHubClient.cpp
@@ -168,6 +168,7 @@ void CostOptimizationHubClient::init(const CostOptimizationHub::CostOptimization
 void CostOptimizationHubClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-cur/source/CostandUsageReportServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-cur/source/CostandUsageReportServiceClient.cpp
@@ -168,6 +168,7 @@ void CostandUsageReportServiceClient::init(const CostandUsageReportService::Cost
 void CostandUsageReportServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-customer-profiles/source/CustomerProfilesClient.cpp
+++ b/generated/src/aws-cpp-sdk-customer-profiles/source/CustomerProfilesClient.cpp
@@ -244,6 +244,7 @@ void CustomerProfilesClient::init(const CustomerProfiles::CustomerProfilesClient
 void CustomerProfilesClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-databrew/source/GlueDataBrewClient.cpp
+++ b/generated/src/aws-cpp-sdk-databrew/source/GlueDataBrewClient.cpp
@@ -205,6 +205,7 @@ void GlueDataBrewClient::init(const GlueDataBrew::GlueDataBrewClientConfiguratio
 void GlueDataBrewClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-dataexchange/source/DataExchangeClient.cpp
+++ b/generated/src/aws-cpp-sdk-dataexchange/source/DataExchangeClient.cpp
@@ -198,6 +198,7 @@ void DataExchangeClient::init(const DataExchange::DataExchangeClientConfiguratio
 void DataExchangeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-datapipeline/source/DataPipelineClient.cpp
+++ b/generated/src/aws-cpp-sdk-datapipeline/source/DataPipelineClient.cpp
@@ -180,6 +180,7 @@ void DataPipelineClient::init(const DataPipeline::DataPipelineClientConfiguratio
 void DataPipelineClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-datasync/source/DataSyncClient.cpp
+++ b/generated/src/aws-cpp-sdk-datasync/source/DataSyncClient.cpp
@@ -214,6 +214,7 @@ void DataSyncClient::init(const DataSync::DataSyncClientConfiguration& config)
 void DataSyncClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-datazone/source/DataZoneClient.cpp
+++ b/generated/src/aws-cpp-sdk-datazone/source/DataZoneClient.cpp
@@ -330,6 +330,7 @@ void DataZoneClient::init(const DataZone::DataZoneClientConfiguration& config)
 void DataZoneClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-dax/source/DAXClient.cpp
+++ b/generated/src/aws-cpp-sdk-dax/source/DAXClient.cpp
@@ -182,6 +182,7 @@ void DAXClient::init(const DAX::DAXClientConfiguration& config)
 void DAXClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-deadline/source/DeadlineClient.cpp
+++ b/generated/src/aws-cpp-sdk-deadline/source/DeadlineClient.cpp
@@ -274,6 +274,7 @@ void DeadlineClient::init(const deadline::DeadlineClientConfiguration& config)
 void DeadlineClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-detective/source/DetectiveClient.cpp
+++ b/generated/src/aws-cpp-sdk-detective/source/DetectiveClient.cpp
@@ -190,6 +190,7 @@ void DetectiveClient::init(const Detective::DetectiveClientConfiguration& config
 void DetectiveClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-devicefarm/source/DeviceFarmClient.cpp
+++ b/generated/src/aws-cpp-sdk-devicefarm/source/DeviceFarmClient.cpp
@@ -238,6 +238,7 @@ void DeviceFarmClient::init(const DeviceFarm::DeviceFarmClientConfiguration& con
 void DeviceFarmClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-devops-guru/source/DevOpsGuruClient.cpp
+++ b/generated/src/aws-cpp-sdk-devops-guru/source/DevOpsGuruClient.cpp
@@ -192,6 +192,7 @@ void DevOpsGuruClient::init(const DevOpsGuru::DevOpsGuruClientConfiguration& con
 void DevOpsGuruClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-directconnect/source/DirectConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-directconnect/source/DirectConnectClient.cpp
@@ -220,6 +220,7 @@ void DirectConnectClient::init(const DirectConnect::DirectConnectClientConfigura
 void DirectConnectClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-directory-service-data/source/DirectoryServiceDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-directory-service-data/source/DirectoryServiceDataClient.cpp
@@ -178,6 +178,7 @@ void DirectoryServiceDataClient::init(const DirectoryServiceData::DirectoryServi
 void DirectoryServiceDataClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-discovery/source/ApplicationDiscoveryServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-discovery/source/ApplicationDiscoveryServiceClient.cpp
@@ -187,6 +187,7 @@ void ApplicationDiscoveryServiceClient::init(const ApplicationDiscoveryService::
 void ApplicationDiscoveryServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-dlm/source/DLMClient.cpp
+++ b/generated/src/aws-cpp-sdk-dlm/source/DLMClient.cpp
@@ -169,6 +169,7 @@ void DLMClient::init(const DLM::DLMClientConfiguration& config)
 void DLMClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-dms/source/DatabaseMigrationServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-dms/source/DatabaseMigrationServiceClient.cpp
@@ -273,6 +273,7 @@ void DatabaseMigrationServiceClient::init(const DatabaseMigrationService::Databa
 void DatabaseMigrationServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-docdb-elastic/source/DocDBElasticClient.cpp
+++ b/generated/src/aws-cpp-sdk-docdb-elastic/source/DocDBElasticClient.cpp
@@ -180,6 +180,7 @@ void DocDBElasticClient::init(const DocDBElastic::DocDBElasticClientConfiguratio
 void DocDBElasticClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-docdb/source/DocDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-docdb/source/DocDBClient.cpp
@@ -217,6 +217,7 @@ void DocDBClient::init(const DocDB::DocDBClientConfiguration& config)
 void DocDBClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-drs/source/DrsClient.cpp
+++ b/generated/src/aws-cpp-sdk-drs/source/DrsClient.cpp
@@ -210,6 +210,7 @@ void DrsClient::init(const drs::DrsClientConfiguration& config)
 void DrsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ds/source/DirectoryServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-ds/source/DirectoryServiceClient.cpp
@@ -241,6 +241,7 @@ void DirectoryServiceClient::init(const DirectoryService::DirectoryServiceClient
 void DirectoryServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-dsql/source/DSQLClient.cpp
+++ b/generated/src/aws-cpp-sdk-dsql/source/DSQLClient.cpp
@@ -170,6 +170,7 @@ void DSQLClient::init(const DSQL::DSQLClientConfiguration& config)
 void DSQLClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClient.cpp
@@ -205,6 +205,7 @@ std::shared_ptr<DynamoDBEndpointProviderBase>& DynamoDBClient::accessEndpointPro
 void DynamoDBClient::OverrideEndpoint(const Aws::String& endpoint)
 {
     AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+    m_clientConfiguration.endpointOverride = endpoint;
     m_endpointProvider->OverrideEndpoint(endpoint);
 }
 BatchExecuteStatementOutcome DynamoDBClient::BatchExecuteStatement(const BatchExecuteStatementRequest& request) const

--- a/generated/src/aws-cpp-sdk-dynamodbstreams/source/DynamoDBStreamsClient.cpp
+++ b/generated/src/aws-cpp-sdk-dynamodbstreams/source/DynamoDBStreamsClient.cpp
@@ -165,6 +165,7 @@ void DynamoDBStreamsClient::init(const DynamoDBStreams::DynamoDBStreamsClientCon
 void DynamoDBStreamsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ebs/source/EBSClient.cpp
+++ b/generated/src/aws-cpp-sdk-ebs/source/EBSClient.cpp
@@ -167,6 +167,7 @@ void EBSClient::init(const EBS::EBSClientConfiguration& config)
 void EBSClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ec2-instance-connect/source/EC2InstanceConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-ec2-instance-connect/source/EC2InstanceConnectClient.cpp
@@ -163,6 +163,7 @@ void EC2InstanceConnectClient::init(const EC2InstanceConnect::EC2InstanceConnect
 void EC2InstanceConnectClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ec2/source/EC2Client.cpp
+++ b/generated/src/aws-cpp-sdk-ec2/source/EC2Client.cpp
@@ -262,6 +262,7 @@ void EC2Client::init(const EC2::EC2ClientConfiguration& config)
 void EC2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ecr-public/source/ECRPublicClient.cpp
+++ b/generated/src/aws-cpp-sdk-ecr-public/source/ECRPublicClient.cpp
@@ -184,6 +184,7 @@ void ECRPublicClient::init(const ECRPublic::ECRPublicClientConfiguration& config
 void ECRPublicClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ecr/source/ECRClient.cpp
+++ b/generated/src/aws-cpp-sdk-ecr/source/ECRClient.cpp
@@ -210,6 +210,7 @@ void ECRClient::init(const ECR::ECRClientConfiguration& config)
 void ECRClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ecs/source/ECSClient.cpp
+++ b/generated/src/aws-cpp-sdk-ecs/source/ECSClient.cpp
@@ -221,6 +221,7 @@ void ECSClient::init(const ECS::ECSClientConfiguration& config)
 void ECSClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-eks-auth/source/EKSAuthClient.cpp
+++ b/generated/src/aws-cpp-sdk-eks-auth/source/EKSAuthClient.cpp
@@ -162,6 +162,7 @@ void EKSAuthClient::init(const EKSAuth::EKSAuthClientConfiguration& config)
 void EKSAuthClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-eks/source/EKSClient.cpp
+++ b/generated/src/aws-cpp-sdk-eks/source/EKSClient.cpp
@@ -220,6 +220,7 @@ void EKSClient::init(const EKS::EKSClientConfiguration& config)
 void EKSClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-elasticache/source/ElastiCacheClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticache/source/ElastiCacheClient.cpp
@@ -237,6 +237,7 @@ void ElastiCacheClient::init(const ElastiCache::ElastiCacheClientConfiguration& 
 void ElastiCacheClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-elasticbeanstalk/source/ElasticBeanstalkClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticbeanstalk/source/ElasticBeanstalkClient.cpp
@@ -209,6 +209,7 @@ void ElasticBeanstalkClient::init(const ElasticBeanstalk::ElasticBeanstalkClient
 void ElasticBeanstalkClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-elasticfilesystem/source/EFSClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticfilesystem/source/EFSClient.cpp
@@ -189,6 +189,7 @@ void EFSClient::init(const EFS::EFSClientConfiguration& config)
 void EFSClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancing/source/ElasticLoadBalancingClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancing/source/ElasticLoadBalancingClient.cpp
@@ -191,6 +191,7 @@ void ElasticLoadBalancingClient::init(const ElasticLoadBalancing::ElasticLoadBal
 void ElasticLoadBalancingClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/ElasticLoadBalancingv2Client.cpp
+++ b/generated/src/aws-cpp-sdk-elasticloadbalancingv2/source/ElasticLoadBalancingv2Client.cpp
@@ -213,6 +213,7 @@ void ElasticLoadBalancingv2Client::init(const ElasticLoadBalancingv2::ElasticLoa
 void ElasticLoadBalancingv2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-elasticmapreduce/source/EMRClient.cpp
+++ b/generated/src/aws-cpp-sdk-elasticmapreduce/source/EMRClient.cpp
@@ -220,6 +220,7 @@ void EMRClient::init(const EMR::EMRClientConfiguration& config)
 void EMRClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-elastictranscoder/source/ElasticTranscoderClient.cpp
+++ b/generated/src/aws-cpp-sdk-elastictranscoder/source/ElasticTranscoderClient.cpp
@@ -177,6 +177,7 @@ void ElasticTranscoderClient::init(const ElasticTranscoder::ElasticTranscoderCli
 void ElasticTranscoderClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-email/source/SESClient.cpp
+++ b/generated/src/aws-cpp-sdk-email/source/SESClient.cpp
@@ -233,6 +233,7 @@ void SESClient::init(const SES::SESClientConfiguration& config)
 void SESClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-emr-containers/source/EMRContainersClient.cpp
+++ b/generated/src/aws-cpp-sdk-emr-containers/source/EMRContainersClient.cpp
@@ -184,6 +184,7 @@ void EMRContainersClient::init(const EMRContainers::EMRContainersClientConfigura
 void EMRContainersClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-emr-serverless/source/EMRServerlessClient.cpp
+++ b/generated/src/aws-cpp-sdk-emr-serverless/source/EMRServerlessClient.cpp
@@ -177,6 +177,7 @@ void EMRServerlessClient::init(const EMRServerless::EMRServerlessClientConfigura
 void EMRServerlessClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-entityresolution/source/EntityResolutionClient.cpp
+++ b/generated/src/aws-cpp-sdk-entityresolution/source/EntityResolutionClient.cpp
@@ -199,6 +199,7 @@ void EntityResolutionClient::init(const EntityResolution::EntityResolutionClient
 void EntityResolutionClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-es/source/ElasticsearchServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-es/source/ElasticsearchServiceClient.cpp
@@ -212,6 +212,7 @@ void ElasticsearchServiceClient::init(const ElasticsearchService::ElasticsearchS
 void ElasticsearchServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-eventbridge/source/EventBridgeClient.cpp
+++ b/generated/src/aws-cpp-sdk-eventbridge/source/EventBridgeClient.cpp
@@ -218,6 +218,7 @@ void EventBridgeClient::init(const EventBridge::EventBridgeClientConfiguration& 
 void EventBridgeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-events/source/CloudWatchEventsClient.cpp
+++ b/generated/src/aws-cpp-sdk-events/source/CloudWatchEventsClient.cpp
@@ -212,6 +212,7 @@ void CloudWatchEventsClient::init(const CloudWatchEvents::CloudWatchEventsClient
 void CloudWatchEventsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-evidently/source/CloudWatchEvidentlyClient.cpp
+++ b/generated/src/aws-cpp-sdk-evidently/source/CloudWatchEvidentlyClient.cpp
@@ -199,6 +199,7 @@ void CloudWatchEvidentlyClient::init(const CloudWatchEvidently::CloudWatchEviden
 void CloudWatchEvidentlyClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-evs/source/EVSClient.cpp
+++ b/generated/src/aws-cpp-sdk-evs/source/EVSClient.cpp
@@ -174,6 +174,7 @@ void EVSClient::init(const EVS::EVSClientConfiguration& config)
 void EVSClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-finspace-data/source/FinSpaceDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-finspace-data/source/FinSpaceDataClient.cpp
@@ -161,6 +161,7 @@ void FinSpaceDataClient::init(const FinSpaceData::FinSpaceDataClientConfiguratio
 void FinSpaceDataClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-finspace/source/FinspaceClient.cpp
+++ b/generated/src/aws-cpp-sdk-finspace/source/FinspaceClient.cpp
@@ -206,6 +206,7 @@ void FinspaceClient::init(const finspace::FinspaceClientConfiguration& config)
 void FinspaceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-firehose/source/FirehoseClient.cpp
+++ b/generated/src/aws-cpp-sdk-firehose/source/FirehoseClient.cpp
@@ -173,6 +173,7 @@ void FirehoseClient::init(const Firehose::FirehoseClientConfiguration& config)
 void FirehoseClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-fis/source/FISClient.cpp
+++ b/generated/src/aws-cpp-sdk-fis/source/FISClient.cpp
@@ -187,6 +187,7 @@ void FISClient::init(const FIS::FISClientConfiguration& config)
 void FISClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-fms/source/FMSClient.cpp
+++ b/generated/src/aws-cpp-sdk-fms/source/FMSClient.cpp
@@ -203,6 +203,7 @@ void FMSClient::init(const FMS::FMSClientConfiguration& config)
 void FMSClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-forecast/source/ForecastServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-forecast/source/ForecastServiceClient.cpp
@@ -224,6 +224,7 @@ void ForecastServiceClient::init(const ForecastService::ForecastServiceClientCon
 void ForecastServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-forecastquery/source/ForecastQueryServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-forecastquery/source/ForecastQueryServiceClient.cpp
@@ -163,6 +163,7 @@ void ForecastQueryServiceClient::init(const ForecastQueryService::ForecastQueryS
 void ForecastQueryServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-frauddetector/source/FraudDetectorClient.cpp
+++ b/generated/src/aws-cpp-sdk-frauddetector/source/FraudDetectorClient.cpp
@@ -234,6 +234,7 @@ void FraudDetectorClient::init(const FraudDetector::FraudDetectorClientConfigura
 void FraudDetectorClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-freetier/source/FreeTierClient.cpp
+++ b/generated/src/aws-cpp-sdk-freetier/source/FreeTierClient.cpp
@@ -166,6 +166,7 @@ void FreeTierClient::init(const FreeTier::FreeTierClientConfiguration& config)
 void FreeTierClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-fsx/source/FSxClient.cpp
+++ b/generated/src/aws-cpp-sdk-fsx/source/FSxClient.cpp
@@ -209,6 +209,7 @@ void FSxClient::init(const FSx::FSxClientConfiguration& config)
 void FSxClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-gamelift/source/GameLiftClient.cpp
+++ b/generated/src/aws-cpp-sdk-gamelift/source/GameLiftClient.cpp
@@ -279,6 +279,7 @@ void GameLiftClient::init(const GameLift::GameLiftClientConfiguration& config)
 void GameLiftClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-gameliftstreams/source/GameLiftStreamsClient.cpp
+++ b/generated/src/aws-cpp-sdk-gameliftstreams/source/GameLiftStreamsClient.cpp
@@ -185,6 +185,7 @@ void GameLiftStreamsClient::init(const GameLiftStreams::GameLiftStreamsClientCon
 void GameLiftStreamsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-geo-maps/source/GeoMapsClient.cpp
+++ b/generated/src/aws-cpp-sdk-geo-maps/source/GeoMapsClient.cpp
@@ -166,6 +166,7 @@ void GeoMapsClient::init(const GeoMaps::GeoMapsClientConfiguration& config)
 void GeoMapsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-geo-places/source/GeoPlacesClient.cpp
+++ b/generated/src/aws-cpp-sdk-geo-places/source/GeoPlacesClient.cpp
@@ -168,6 +168,7 @@ void GeoPlacesClient::init(const GeoPlaces::GeoPlacesClientConfiguration& config
 void GeoPlacesClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-geo-routes/source/GeoRoutesClient.cpp
+++ b/generated/src/aws-cpp-sdk-geo-routes/source/GeoRoutesClient.cpp
@@ -166,6 +166,7 @@ void GeoRoutesClient::init(const GeoRoutes::GeoRoutesClientConfiguration& config
 void GeoRoutesClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-glacier/source/GlacierClient.cpp
+++ b/generated/src/aws-cpp-sdk-glacier/source/GlacierClient.cpp
@@ -194,6 +194,7 @@ void GlacierClient::init(const Glacier::GlacierClientConfiguration& config)
 void GlacierClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-globalaccelerator/source/GlobalAcceleratorClient.cpp
+++ b/generated/src/aws-cpp-sdk-globalaccelerator/source/GlobalAcceleratorClient.cpp
@@ -217,6 +217,7 @@ void GlobalAcceleratorClient::init(const GlobalAccelerator::GlobalAcceleratorCli
 void GlobalAcceleratorClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-glue/source/GlueClient.cpp
+++ b/generated/src/aws-cpp-sdk-glue/source/GlueClient.cpp
@@ -261,6 +261,7 @@ void GlueClient::init(const Glue::GlueClientConfiguration& config)
 void GlueClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-grafana/source/ManagedGrafanaClient.cpp
+++ b/generated/src/aws-cpp-sdk-grafana/source/ManagedGrafanaClient.cpp
@@ -186,6 +186,7 @@ void ManagedGrafanaClient::init(const ManagedGrafana::ManagedGrafanaClientConfig
 void ManagedGrafanaClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-greengrass/source/GreengrassClient.cpp
+++ b/generated/src/aws-cpp-sdk-greengrass/source/GreengrassClient.cpp
@@ -253,6 +253,7 @@ void GreengrassClient::init(const Greengrass::GreengrassClientConfiguration& con
 void GreengrassClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-greengrassv2/source/GreengrassV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-greengrassv2/source/GreengrassV2Client.cpp
@@ -190,6 +190,7 @@ void GreengrassV2Client::init(const GreengrassV2::GreengrassV2ClientConfiguratio
 void GreengrassV2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-groundstation/source/GroundStationClient.cpp
+++ b/generated/src/aws-cpp-sdk-groundstation/source/GroundStationClient.cpp
@@ -194,6 +194,7 @@ void GroundStationClient::init(const GroundStation::GroundStationClientConfigura
 void GroundStationClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-guardduty/source/GuardDutyClient.cpp
+++ b/generated/src/aws-cpp-sdk-guardduty/source/GuardDutyClient.cpp
@@ -242,6 +242,7 @@ void GuardDutyClient::init(const GuardDuty::GuardDutyClientConfiguration& config
 void GuardDutyClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-health/source/HealthClient.cpp
+++ b/generated/src/aws-cpp-sdk-health/source/HealthClient.cpp
@@ -175,6 +175,7 @@ void HealthClient::init(const Health::HealthClientConfiguration& config)
 void HealthClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-healthlake/source/HealthLakeClient.cpp
+++ b/generated/src/aws-cpp-sdk-healthlake/source/HealthLakeClient.cpp
@@ -174,6 +174,7 @@ void HealthLakeClient::init(const HealthLake::HealthLakeClientConfiguration& con
 void HealthLakeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iam/source/IAMClient.cpp
+++ b/generated/src/aws-cpp-sdk-iam/source/IAMClient.cpp
@@ -326,6 +326,7 @@ void IAMClient::init(const IAM::IAMClientConfiguration& config)
 void IAMClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-identitystore/source/IdentityStoreClient.cpp
+++ b/generated/src/aws-cpp-sdk-identitystore/source/IdentityStoreClient.cpp
@@ -180,6 +180,7 @@ void IdentityStoreClient::init(const IdentityStore::IdentityStoreClientConfigura
 void IdentityStoreClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-imagebuilder/source/ImagebuilderClient.cpp
+++ b/generated/src/aws-cpp-sdk-imagebuilder/source/ImagebuilderClient.cpp
@@ -236,6 +236,7 @@ void ImagebuilderClient::init(const imagebuilder::ImagebuilderClientConfiguratio
 void ImagebuilderClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-importexport/source/ImportExportClient.cpp
+++ b/generated/src/aws-cpp-sdk-importexport/source/ImportExportClient.cpp
@@ -168,6 +168,7 @@ void ImportExportClient::init(const ImportExport::ImportExportClientConfiguratio
 void ImportExportClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-inspector-scan/source/InspectorscanClient.cpp
+++ b/generated/src/aws-cpp-sdk-inspector-scan/source/InspectorscanClient.cpp
@@ -162,6 +162,7 @@ void InspectorscanClient::init(const inspectorscan::InspectorscanClientConfigura
 void InspectorscanClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-inspector/source/InspectorClient.cpp
+++ b/generated/src/aws-cpp-sdk-inspector/source/InspectorClient.cpp
@@ -198,6 +198,7 @@ void InspectorClient::init(const Inspector::InspectorClientConfiguration& config
 void InspectorClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-inspector2/source/Inspector2Client.cpp
+++ b/generated/src/aws-cpp-sdk-inspector2/source/Inspector2Client.cpp
@@ -236,6 +236,7 @@ void Inspector2Client::init(const Inspector2::Inspector2ClientConfiguration& con
 void Inspector2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-internetmonitor/source/InternetMonitorClient.cpp
+++ b/generated/src/aws-cpp-sdk-internetmonitor/source/InternetMonitorClient.cpp
@@ -177,6 +177,7 @@ void InternetMonitorClient::init(const InternetMonitor::InternetMonitorClientCon
 void InternetMonitorClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-invoicing/source/InvoicingClient.cpp
+++ b/generated/src/aws-cpp-sdk-invoicing/source/InvoicingClient.cpp
@@ -171,6 +171,7 @@ void InvoicingClient::init(const Invoicing::InvoicingClientConfiguration& config
 void InvoicingClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iot-data/source/IoTDataPlaneClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot-data/source/IoTDataPlaneClient.cpp
@@ -169,6 +169,7 @@ void IoTDataPlaneClient::init(const IoTDataPlane::IoTDataPlaneClientConfiguratio
 void IoTDataPlaneClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iot-jobs-data/source/IoTJobsDataPlaneClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot-jobs-data/source/IoTJobsDataPlaneClient.cpp
@@ -166,6 +166,7 @@ void IoTJobsDataPlaneClient::init(const IoTJobsDataPlane::IoTJobsDataPlaneClient
 void IoTJobsDataPlaneClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iot-managed-integrations/source/IoTManagedIntegrationsClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot-managed-integrations/source/IoTManagedIntegrationsClient.cpp
@@ -243,6 +243,7 @@ void IoTManagedIntegrationsClient::init(const IoTManagedIntegrations::IoTManaged
 void IoTManagedIntegrationsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iot/source/IoTClient.cpp
+++ b/generated/src/aws-cpp-sdk-iot/source/IoTClient.cpp
@@ -261,6 +261,7 @@ void IoTClient::init(const IoT::IoTClientConfiguration& config)
 void IoTClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iotanalytics/source/IoTAnalyticsClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotanalytics/source/IoTAnalyticsClient.cpp
@@ -195,6 +195,7 @@ void IoTAnalyticsClient::init(const IoTAnalytics::IoTAnalyticsClientConfiguratio
 void IoTAnalyticsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iotdeviceadvisor/source/IoTDeviceAdvisorClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotdeviceadvisor/source/IoTDeviceAdvisorClient.cpp
@@ -175,6 +175,7 @@ void IoTDeviceAdvisorClient::init(const IoTDeviceAdvisor::IoTDeviceAdvisorClient
 void IoTDeviceAdvisorClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iotevents-data/source/IoTEventsDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotevents-data/source/IoTEventsDataClient.cpp
@@ -173,6 +173,7 @@ void IoTEventsDataClient::init(const IoTEventsData::IoTEventsDataClientConfigura
 void IoTEventsDataClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iotevents/source/IoTEventsClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotevents/source/IoTEventsClient.cpp
@@ -187,6 +187,7 @@ void IoTEventsClient::init(const IoTEvents::IoTEventsClientConfiguration& config
 void IoTEventsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iotfleethub/source/IoTFleetHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotfleethub/source/IoTFleetHubClient.cpp
@@ -169,6 +169,7 @@ void IoTFleetHubClient::init(const IoTFleetHub::IoTFleetHubClientConfiguration& 
 void IoTFleetHubClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iotfleetwise/source/IoTFleetWiseClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotfleetwise/source/IoTFleetWiseClient.cpp
@@ -218,6 +218,7 @@ void IoTFleetWiseClient::init(const IoTFleetWise::IoTFleetWiseClientConfiguratio
 void IoTFleetWiseClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iotsecuretunneling/source/IoTSecureTunnelingClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotsecuretunneling/source/IoTSecureTunnelingClient.cpp
@@ -169,6 +169,7 @@ void IoTSecureTunnelingClient::init(const IoTSecureTunneling::IoTSecureTunneling
 void IoTSecureTunnelingClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iotsitewise/source/IoTSiteWiseClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotsitewise/source/IoTSiteWiseClient.cpp
@@ -266,6 +266,7 @@ void IoTSiteWiseClient::init(const IoTSiteWise::IoTSiteWiseClientConfiguration& 
 void IoTSiteWiseClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iotthingsgraph/source/IoTThingsGraphClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotthingsgraph/source/IoTThingsGraphClient.cpp
@@ -161,6 +161,7 @@ void IoTThingsGraphClient::init(const IoTThingsGraph::IoTThingsGraphClientConfig
 void IoTThingsGraphClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iottwinmaker/source/IoTTwinMakerClient.cpp
+++ b/generated/src/aws-cpp-sdk-iottwinmaker/source/IoTTwinMakerClient.cpp
@@ -201,6 +201,7 @@ void IoTTwinMakerClient::init(const IoTTwinMaker::IoTTwinMakerClientConfiguratio
 void IoTTwinMakerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-iotwireless/source/IoTWirelessClient.cpp
+++ b/generated/src/aws-cpp-sdk-iotwireless/source/IoTWirelessClient.cpp
@@ -268,6 +268,7 @@ void IoTWirelessClient::init(const IoTWireless::IoTWirelessClientConfiguration& 
 void IoTWirelessClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ivs-realtime/source/IvsrealtimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-ivs-realtime/source/IvsrealtimeClient.cpp
@@ -200,6 +200,7 @@ void IvsrealtimeClient::init(const ivsrealtime::IvsrealtimeClientConfiguration& 
 void IvsrealtimeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ivs/source/IVSClient.cpp
+++ b/generated/src/aws-cpp-sdk-ivs/source/IVSClient.cpp
@@ -196,6 +196,7 @@ void IVSClient::init(const IVS::IVSClientConfiguration& config)
 void IVSClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ivschat/source/IvschatClient.cpp
+++ b/generated/src/aws-cpp-sdk-ivschat/source/IvschatClient.cpp
@@ -178,6 +178,7 @@ void IvschatClient::init(const ivschat::IvschatClientConfiguration& config)
 void IvschatClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-kafka/source/KafkaClient.cpp
+++ b/generated/src/aws-cpp-sdk-kafka/source/KafkaClient.cpp
@@ -213,6 +213,7 @@ void KafkaClient::init(const Kafka::KafkaClientConfiguration& config)
 void KafkaClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-kafkaconnect/source/KafkaConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-kafkaconnect/source/KafkaConnectClient.cpp
@@ -179,6 +179,7 @@ void KafkaConnectClient::init(const KafkaConnect::KafkaConnectClientConfiguratio
 void KafkaConnectClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-kendra-ranking/source/KendraRankingClient.cpp
+++ b/generated/src/aws-cpp-sdk-kendra-ranking/source/KendraRankingClient.cpp
@@ -170,6 +170,7 @@ void KendraRankingClient::init(const KendraRanking::KendraRankingClientConfigura
 void KendraRankingClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-kendra/source/KendraClient.cpp
+++ b/generated/src/aws-cpp-sdk-kendra/source/KendraClient.cpp
@@ -227,6 +227,7 @@ void KendraClient::init(const kendra::KendraClientConfiguration& config)
 void KendraClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-keyspaces/source/KeyspacesClient.cpp
+++ b/generated/src/aws-cpp-sdk-keyspaces/source/KeyspacesClient.cpp
@@ -180,6 +180,7 @@ void KeyspacesClient::init(const Keyspaces::KeyspacesClientConfiguration& config
 void KeyspacesClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-keyspacesstreams/source/KeyspacesStreamsClient.cpp
+++ b/generated/src/aws-cpp-sdk-keyspacesstreams/source/KeyspacesStreamsClient.cpp
@@ -165,6 +165,7 @@ void KeyspacesStreamsClient::init(const KeyspacesStreams::KeyspacesStreamsClient
 void KeyspacesStreamsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-kinesis-video-archived-media/source/KinesisVideoArchivedMediaClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis-video-archived-media/source/KinesisVideoArchivedMediaClient.cpp
@@ -167,6 +167,7 @@ void KinesisVideoArchivedMediaClient::init(const KinesisVideoArchivedMedia::Kine
 void KinesisVideoArchivedMediaClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-kinesis-video-media/source/KinesisVideoMediaClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis-video-media/source/KinesisVideoMediaClient.cpp
@@ -162,6 +162,7 @@ void KinesisVideoMediaClient::init(const KinesisVideoMedia::KinesisVideoMediaCli
 void KinesisVideoMediaClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-kinesis-video-signaling/source/KinesisVideoSignalingChannelsClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis-video-signaling/source/KinesisVideoSignalingChannelsClient.cpp
@@ -163,6 +163,7 @@ void KinesisVideoSignalingChannelsClient::init(const KinesisVideoSignalingChanne
 void KinesisVideoSignalingChannelsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-kinesis-video-webrtc-storage/source/KinesisVideoWebRTCStorageClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis-video-webrtc-storage/source/KinesisVideoWebRTCStorageClient.cpp
@@ -163,6 +163,7 @@ void KinesisVideoWebRTCStorageClient::init(const KinesisVideoWebRTCStorage::Kine
 void KinesisVideoWebRTCStorageClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-kinesis/source/KinesisClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesis/source/KinesisClient.cpp
@@ -197,6 +197,7 @@ void KinesisClient::init(const Kinesis::KinesisClientConfiguration& config)
 void KinesisClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-kinesisanalytics/source/KinesisAnalyticsClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesisanalytics/source/KinesisAnalyticsClient.cpp
@@ -181,6 +181,7 @@ void KinesisAnalyticsClient::init(const KinesisAnalytics::KinesisAnalyticsClient
 void KinesisAnalyticsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-kinesisanalyticsv2/source/KinesisAnalyticsV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-kinesisanalyticsv2/source/KinesisAnalyticsV2Client.cpp
@@ -194,6 +194,7 @@ void KinesisAnalyticsV2Client::init(const KinesisAnalyticsV2::KinesisAnalyticsV2
 void KinesisAnalyticsV2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-kinesisvideo/source/KinesisVideoClient.cpp
+++ b/generated/src/aws-cpp-sdk-kinesisvideo/source/KinesisVideoClient.cpp
@@ -191,6 +191,7 @@ void KinesisVideoClient::init(const KinesisVideo::KinesisVideoClientConfiguratio
 void KinesisVideoClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-kms/source/KMSClient.cpp
+++ b/generated/src/aws-cpp-sdk-kms/source/KMSClient.cpp
@@ -214,6 +214,7 @@ void KMSClient::init(const KMS::KMSClientConfiguration& config)
 void KMSClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-lakeformation/source/LakeFormationClient.cpp
+++ b/generated/src/aws-cpp-sdk-lakeformation/source/LakeFormationClient.cpp
@@ -221,6 +221,7 @@ void LakeFormationClient::init(const LakeFormation::LakeFormationClientConfigura
 void LakeFormationClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-lambda/source/LambdaClient.cpp
+++ b/generated/src/aws-cpp-sdk-lambda/source/LambdaClient.cpp
@@ -229,6 +229,7 @@ void LambdaClient::init(const Lambda::LambdaClientConfiguration& config)
 void LambdaClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-launch-wizard/source/LaunchWizardClient.cpp
+++ b/generated/src/aws-cpp-sdk-launch-wizard/source/LaunchWizardClient.cpp
@@ -173,6 +173,7 @@ void LaunchWizardClient::init(const LaunchWizard::LaunchWizardClientConfiguratio
 void LaunchWizardClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-lex-models/source/LexModelBuildingServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-lex-models/source/LexModelBuildingServiceClient.cpp
@@ -203,6 +203,7 @@ void LexModelBuildingServiceClient::init(const LexModelBuildingService::LexModel
 void LexModelBuildingServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-lex/source/LexRuntimeServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-lex/source/LexRuntimeServiceClient.cpp
@@ -166,6 +166,7 @@ void LexRuntimeServiceClient::init(const LexRuntimeService::LexRuntimeServiceCli
 void LexRuntimeServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-lexv2-models/source/LexModelsV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-lexv2-models/source/LexModelsV2Client.cpp
@@ -263,6 +263,7 @@ void LexModelsV2Client::init(const LexModelsV2::LexModelsV2ClientConfiguration& 
 void LexModelsV2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/source/LexRuntimeV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/source/LexRuntimeV2Client.cpp
@@ -169,6 +169,7 @@ void LexRuntimeV2Client::init(const LexRuntimeV2::LexRuntimeV2ClientConfiguratio
 void LexRuntimeV2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-license-manager-linux-subscriptions/source/LicenseManagerLinuxSubscriptionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-license-manager-linux-subscriptions/source/LicenseManagerLinuxSubscriptionsClient.cpp
@@ -172,6 +172,7 @@ void LicenseManagerLinuxSubscriptionsClient::init(const LicenseManagerLinuxSubsc
 void LicenseManagerLinuxSubscriptionsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-license-manager-user-subscriptions/source/LicenseManagerUserSubscriptionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-license-manager-user-subscriptions/source/LicenseManagerUserSubscriptionsClient.cpp
@@ -178,6 +178,7 @@ void LicenseManagerUserSubscriptionsClient::init(const LicenseManagerUserSubscri
 void LicenseManagerUserSubscriptionsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-license-manager/source/LicenseManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-license-manager/source/LicenseManagerClient.cpp
@@ -211,6 +211,7 @@ void LicenseManagerClient::init(const LicenseManager::LicenseManagerClientConfig
 void LicenseManagerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-lightsail/source/LightsailClient.cpp
+++ b/generated/src/aws-cpp-sdk-lightsail/source/LightsailClient.cpp
@@ -322,6 +322,7 @@ void LightsailClient::init(const Lightsail::LightsailClientConfiguration& config
 void LightsailClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-location/source/LocationServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-location/source/LocationServiceClient.cpp
@@ -221,6 +221,7 @@ void LocationServiceClient::init(const LocationService::LocationServiceClientCon
 void LocationServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-logs/source/CloudWatchLogsClient.cpp
+++ b/generated/src/aws-cpp-sdk-logs/source/CloudWatchLogsClient.cpp
@@ -250,6 +250,7 @@ void CloudWatchLogsClient::init(const CloudWatchLogs::CloudWatchLogsClientConfig
 void CloudWatchLogsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-lookoutequipment/source/LookoutEquipmentClient.cpp
+++ b/generated/src/aws-cpp-sdk-lookoutequipment/source/LookoutEquipmentClient.cpp
@@ -210,6 +210,7 @@ void LookoutEquipmentClient::init(const LookoutEquipment::LookoutEquipmentClient
 void LookoutEquipmentClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-lookoutmetrics/source/LookoutMetricsClient.cpp
+++ b/generated/src/aws-cpp-sdk-lookoutmetrics/source/LookoutMetricsClient.cpp
@@ -191,6 +191,7 @@ void LookoutMetricsClient::init(const LookoutMetrics::LookoutMetricsClientConfig
 void LookoutMetricsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-lookoutvision/source/LookoutforVisionClient.cpp
+++ b/generated/src/aws-cpp-sdk-lookoutvision/source/LookoutforVisionClient.cpp
@@ -183,6 +183,7 @@ void LookoutforVisionClient::init(const LookoutforVision::LookoutforVisionClient
 void LookoutforVisionClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-m2/source/MainframeModernizationClient.cpp
+++ b/generated/src/aws-cpp-sdk-m2/source/MainframeModernizationClient.cpp
@@ -198,6 +198,7 @@ void MainframeModernizationClient::init(const MainframeModernization::MainframeM
 void MainframeModernizationClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-machinelearning/source/MachineLearningClient.cpp
+++ b/generated/src/aws-cpp-sdk-machinelearning/source/MachineLearningClient.cpp
@@ -189,6 +189,7 @@ void MachineLearningClient::init(const MachineLearning::MachineLearningClientCon
 void MachineLearningClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-macie2/source/Macie2Client.cpp
+++ b/generated/src/aws-cpp-sdk-macie2/source/Macie2Client.cpp
@@ -242,6 +242,7 @@ void Macie2Client::init(const Macie2::Macie2ClientConfiguration& config)
 void Macie2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-mailmanager/source/MailManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-mailmanager/source/MailManagerClient.cpp
@@ -221,6 +221,7 @@ void MailManagerClient::init(const MailManager::MailManagerClientConfiguration& 
 void MailManagerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-managedblockchain-query/source/ManagedBlockchainQueryClient.cpp
+++ b/generated/src/aws-cpp-sdk-managedblockchain-query/source/ManagedBlockchainQueryClient.cpp
@@ -170,6 +170,7 @@ void ManagedBlockchainQueryClient::init(const ManagedBlockchainQuery::ManagedBlo
 void ManagedBlockchainQueryClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-managedblockchain/source/ManagedBlockchainClient.cpp
+++ b/generated/src/aws-cpp-sdk-managedblockchain/source/ManagedBlockchainClient.cpp
@@ -188,6 +188,7 @@ void ManagedBlockchainClient::init(const ManagedBlockchain::ManagedBlockchainCli
 void ManagedBlockchainClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-marketplace-agreement/source/AgreementServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplace-agreement/source/AgreementServiceClient.cpp
@@ -164,6 +164,7 @@ void AgreementServiceClient::init(const AgreementService::AgreementServiceClient
 void AgreementServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-marketplace-catalog/source/MarketplaceCatalogClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplace-catalog/source/MarketplaceCatalogClient.cpp
@@ -174,6 +174,7 @@ void MarketplaceCatalogClient::init(const MarketplaceCatalog::MarketplaceCatalog
 void MarketplaceCatalogClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-marketplace-deployment/source/MarketplaceDeploymentClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplace-deployment/source/MarketplaceDeploymentClient.cpp
@@ -165,6 +165,7 @@ void MarketplaceDeploymentClient::init(const MarketplaceDeployment::MarketplaceD
 void MarketplaceDeploymentClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-marketplace-entitlement/source/MarketplaceEntitlementServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplace-entitlement/source/MarketplaceEntitlementServiceClient.cpp
@@ -162,6 +162,7 @@ void MarketplaceEntitlementServiceClient::init(const MarketplaceEntitlementServi
 void MarketplaceEntitlementServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-marketplace-reporting/source/MarketplaceReportingClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplace-reporting/source/MarketplaceReportingClient.cpp
@@ -162,6 +162,7 @@ void MarketplaceReportingClient::init(const MarketplaceReporting::MarketplaceRep
 void MarketplaceReportingClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-marketplacecommerceanalytics/source/MarketplaceCommerceAnalyticsClient.cpp
+++ b/generated/src/aws-cpp-sdk-marketplacecommerceanalytics/source/MarketplaceCommerceAnalyticsClient.cpp
@@ -162,6 +162,7 @@ void MarketplaceCommerceAnalyticsClient::init(const MarketplaceCommerceAnalytics
 void MarketplaceCommerceAnalyticsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-mediaconnect/source/MediaConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediaconnect/source/MediaConnectClient.cpp
@@ -213,6 +213,7 @@ void MediaConnectClient::init(const MediaConnect::MediaConnectClientConfiguratio
 void MediaConnectClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-mediaconvert/source/MediaConvertClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediaconvert/source/MediaConvertClient.cpp
@@ -192,6 +192,7 @@ void MediaConvertClient::init(const MediaConvert::MediaConvertClientConfiguratio
 void MediaConvertClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-medialive/source/MediaLiveClient.cpp
+++ b/generated/src/aws-cpp-sdk-medialive/source/MediaLiveClient.cpp
@@ -281,6 +281,7 @@ void MediaLiveClient::init(const MediaLive::MediaLiveClientConfiguration& config
 void MediaLiveClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-mediapackage-vod/source/MediaPackageVodClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediapackage-vod/source/MediaPackageVodClient.cpp
@@ -178,6 +178,7 @@ void MediaPackageVodClient::init(const MediaPackageVod::MediaPackageVodClientCon
 void MediaPackageVodClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-mediapackage/source/MediaPackageClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediapackage/source/MediaPackageClient.cpp
@@ -179,6 +179,7 @@ void MediaPackageClient::init(const MediaPackage::MediaPackageClientConfiguratio
 void MediaPackageClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-mediapackagev2/source/Mediapackagev2Client.cpp
+++ b/generated/src/aws-cpp-sdk-mediapackagev2/source/Mediapackagev2Client.cpp
@@ -191,6 +191,7 @@ void Mediapackagev2Client::init(const mediapackagev2::Mediapackagev2ClientConfig
 void Mediapackagev2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-mediastore-data/source/MediaStoreDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediastore-data/source/MediaStoreDataClient.cpp
@@ -166,6 +166,7 @@ void MediaStoreDataClient::init(const MediaStoreData::MediaStoreDataClientConfig
 void MediaStoreDataClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-mediastore/source/MediaStoreClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediastore/source/MediaStoreClient.cpp
@@ -182,6 +182,7 @@ void MediaStoreClient::init(const MediaStore::MediaStoreClientConfiguration& con
 void MediaStoreClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-mediatailor/source/MediaTailorClient.cpp
+++ b/generated/src/aws-cpp-sdk-mediatailor/source/MediaTailorClient.cpp
@@ -205,6 +205,7 @@ void MediaTailorClient::init(const MediaTailor::MediaTailorClientConfiguration& 
 void MediaTailorClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-medical-imaging/source/MedicalImagingClient.cpp
+++ b/generated/src/aws-cpp-sdk-medical-imaging/source/MedicalImagingClient.cpp
@@ -179,6 +179,7 @@ void MedicalImagingClient::init(const MedicalImaging::MedicalImagingClientConfig
 void MedicalImagingClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-memorydb/source/MemoryDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-memorydb/source/MemoryDBClient.cpp
@@ -204,6 +204,7 @@ void MemoryDBClient::init(const MemoryDB::MemoryDBClientConfiguration& config)
 void MemoryDBClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-meteringmarketplace/source/MarketplaceMeteringClient.cpp
+++ b/generated/src/aws-cpp-sdk-meteringmarketplace/source/MarketplaceMeteringClient.cpp
@@ -165,6 +165,7 @@ void MarketplaceMeteringClient::init(const MarketplaceMetering::MarketplaceMeter
 void MarketplaceMeteringClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-mgn/source/MgnClient.cpp
+++ b/generated/src/aws-cpp-sdk-mgn/source/MgnClient.cpp
@@ -231,6 +231,7 @@ void MgnClient::init(const mgn::MgnClientConfiguration& config)
 void MgnClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-migration-hub-refactor-spaces/source/MigrationHubRefactorSpacesClient.cpp
+++ b/generated/src/aws-cpp-sdk-migration-hub-refactor-spaces/source/MigrationHubRefactorSpacesClient.cpp
@@ -185,6 +185,7 @@ void MigrationHubRefactorSpacesClient::init(const MigrationHubRefactorSpaces::Mi
 void MigrationHubRefactorSpacesClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-migrationhub-config/source/MigrationHubConfigClient.cpp
+++ b/generated/src/aws-cpp-sdk-migrationhub-config/source/MigrationHubConfigClient.cpp
@@ -165,6 +165,7 @@ void MigrationHubConfigClient::init(const MigrationHubConfig::MigrationHubConfig
 void MigrationHubConfigClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-migrationhuborchestrator/source/MigrationHubOrchestratorClient.cpp
+++ b/generated/src/aws-cpp-sdk-migrationhuborchestrator/source/MigrationHubOrchestratorClient.cpp
@@ -192,6 +192,7 @@ void MigrationHubOrchestratorClient::init(const MigrationHubOrchestrator::Migrat
 void MigrationHubOrchestratorClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-migrationhubstrategy/source/MigrationHubStrategyRecommendationsClient.cpp
+++ b/generated/src/aws-cpp-sdk-migrationhubstrategy/source/MigrationHubStrategyRecommendationsClient.cpp
@@ -183,6 +183,7 @@ void MigrationHubStrategyRecommendationsClient::init(const MigrationHubStrategyR
 void MigrationHubStrategyRecommendationsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-monitoring/source/CloudWatchClient.cpp
+++ b/generated/src/aws-cpp-sdk-monitoring/source/CloudWatchClient.cpp
@@ -201,6 +201,7 @@ void CloudWatchClient::init(const CloudWatch::CloudWatchClientConfiguration& con
 void CloudWatchClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-mpa/source/MPAClient.cpp
+++ b/generated/src/aws-cpp-sdk-mpa/source/MPAClient.cpp
@@ -182,6 +182,7 @@ void MPAClient::init(const MPA::MPAClientConfiguration& config)
 void MPAClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-mq/source/MQClient.cpp
+++ b/generated/src/aws-cpp-sdk-mq/source/MQClient.cpp
@@ -185,6 +185,7 @@ void MQClient::init(const MQ::MQClientConfiguration& config)
 void MQClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-mturk-requester/source/MTurkClient.cpp
+++ b/generated/src/aws-cpp-sdk-mturk-requester/source/MTurkClient.cpp
@@ -200,6 +200,7 @@ void MTurkClient::init(const MTurk::MTurkClientConfiguration& config)
 void MTurkClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-mwaa/source/MWAAClient.cpp
+++ b/generated/src/aws-cpp-sdk-mwaa/source/MWAAClient.cpp
@@ -172,6 +172,7 @@ void MWAAClient::init(const MWAA::MWAAClientConfiguration& config)
 void MWAAClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-neptune-graph/source/NeptuneGraphClient.cpp
+++ b/generated/src/aws-cpp-sdk-neptune-graph/source/NeptuneGraphClient.cpp
@@ -195,6 +195,7 @@ void NeptuneGraphClient::init(const NeptuneGraph::NeptuneGraphClientConfiguratio
 void NeptuneGraphClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-neptune/source/NeptuneClient.cpp
+++ b/generated/src/aws-cpp-sdk-neptune/source/NeptuneClient.cpp
@@ -232,6 +232,7 @@ void NeptuneClient::init(const Neptune::NeptuneClientConfiguration& config)
 void NeptuneClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-neptunedata/source/NeptunedataClient.cpp
+++ b/generated/src/aws-cpp-sdk-neptunedata/source/NeptunedataClient.cpp
@@ -204,6 +204,7 @@ void NeptunedataClient::init(const neptunedata::NeptunedataClientConfiguration& 
 void NeptunedataClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-network-firewall/source/NetworkFirewallClient.cpp
+++ b/generated/src/aws-cpp-sdk-network-firewall/source/NetworkFirewallClient.cpp
@@ -218,6 +218,7 @@ void NetworkFirewallClient::init(const NetworkFirewall::NetworkFirewallClientCon
 void NetworkFirewallClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-networkflowmonitor/source/NetworkFlowMonitorClient.cpp
+++ b/generated/src/aws-cpp-sdk-networkflowmonitor/source/NetworkFlowMonitorClient.cpp
@@ -186,6 +186,7 @@ void NetworkFlowMonitorClient::init(const NetworkFlowMonitor::NetworkFlowMonitor
 void NetworkFlowMonitorClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-networkmanager/source/NetworkManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-networkmanager/source/NetworkManagerClient.cpp
@@ -249,6 +249,7 @@ void NetworkManagerClient::init(const NetworkManager::NetworkManagerClientConfig
 void NetworkManagerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-networkmonitor/source/NetworkMonitorClient.cpp
+++ b/generated/src/aws-cpp-sdk-networkmonitor/source/NetworkMonitorClient.cpp
@@ -173,6 +173,7 @@ void NetworkMonitorClient::init(const NetworkMonitor::NetworkMonitorClientConfig
 void NetworkMonitorClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-notifications/source/NotificationsClient.cpp
+++ b/generated/src/aws-cpp-sdk-notifications/source/NotificationsClient.cpp
@@ -200,6 +200,7 @@ void NotificationsClient::init(const Notifications::NotificationsClientConfigura
 void NotificationsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-notificationscontacts/source/NotificationsContactsClient.cpp
+++ b/generated/src/aws-cpp-sdk-notificationscontacts/source/NotificationsContactsClient.cpp
@@ -170,6 +170,7 @@ void NotificationsContactsClient::init(const NotificationsContacts::Notification
 void NotificationsContactsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-oam/source/OAMClient.cpp
+++ b/generated/src/aws-cpp-sdk-oam/source/OAMClient.cpp
@@ -176,6 +176,7 @@ void OAMClient::init(const OAM::OAMClientConfiguration& config)
 void OAMClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-observabilityadmin/source/ObservabilityAdminClient.cpp
+++ b/generated/src/aws-cpp-sdk-observabilityadmin/source/ObservabilityAdminClient.cpp
@@ -187,6 +187,7 @@ void ObservabilityAdminClient::init(const ObservabilityAdmin::ObservabilityAdmin
 void ObservabilityAdminClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-odb/source/OdbClient.cpp
+++ b/generated/src/aws-cpp-sdk-odb/source/OdbClient.cpp
@@ -201,6 +201,7 @@ void OdbClient::init(const odb::OdbClientConfiguration& config)
 void OdbClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-omics/source/OmicsClient.cpp
+++ b/generated/src/aws-cpp-sdk-omics/source/OmicsClient.cpp
@@ -257,6 +257,7 @@ void OmicsClient::init(const Omics::OmicsClientConfiguration& config)
 void OmicsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-opensearch/source/OpenSearchServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-opensearch/source/OpenSearchServiceClient.cpp
@@ -237,6 +237,7 @@ void OpenSearchServiceClient::init(const OpenSearchService::OpenSearchServiceCli
 void OpenSearchServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-opensearchserverless/source/OpenSearchServerlessClient.cpp
+++ b/generated/src/aws-cpp-sdk-opensearchserverless/source/OpenSearchServerlessClient.cpp
@@ -202,6 +202,7 @@ void OpenSearchServerlessClient::init(const OpenSearchServerless::OpenSearchServ
 void OpenSearchServerlessClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-organizations/source/OrganizationsClient.cpp
+++ b/generated/src/aws-cpp-sdk-organizations/source/OrganizationsClient.cpp
@@ -218,6 +218,7 @@ void OrganizationsClient::init(const Organizations::OrganizationsClientConfigura
 void OrganizationsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-osis/source/OSISClient.cpp
+++ b/generated/src/aws-cpp-sdk-osis/source/OSISClient.cpp
@@ -183,6 +183,7 @@ void OSISClient::init(const OSIS::OSISClientConfiguration& config)
 void OSISClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-outposts/source/OutpostsClient.cpp
+++ b/generated/src/aws-cpp-sdk-outposts/source/OutpostsClient.cpp
@@ -195,6 +195,7 @@ void OutpostsClient::init(const Outposts::OutpostsClientConfiguration& config)
 void OutpostsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-panorama/source/PanoramaClient.cpp
+++ b/generated/src/aws-cpp-sdk-panorama/source/PanoramaClient.cpp
@@ -195,6 +195,7 @@ void PanoramaClient::init(const Panorama::PanoramaClientConfiguration& config)
 void PanoramaClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-partnercentral-selling/source/PartnerCentralSellingClient.cpp
+++ b/generated/src/aws-cpp-sdk-partnercentral-selling/source/PartnerCentralSellingClient.cpp
@@ -199,6 +199,7 @@ void PartnerCentralSellingClient::init(const PartnerCentralSelling::PartnerCentr
 void PartnerCentralSellingClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-payment-cryptography-data/source/PaymentCryptographyDataClient.cpp
+++ b/generated/src/aws-cpp-sdk-payment-cryptography-data/source/PaymentCryptographyDataClient.cpp
@@ -174,6 +174,7 @@ void PaymentCryptographyDataClient::init(const PaymentCryptographyData::PaymentC
 void PaymentCryptographyDataClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-payment-cryptography/source/PaymentCryptographyClient.cpp
+++ b/generated/src/aws-cpp-sdk-payment-cryptography/source/PaymentCryptographyClient.cpp
@@ -187,6 +187,7 @@ void PaymentCryptographyClient::init(const PaymentCryptography::PaymentCryptogra
 void PaymentCryptographyClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-pca-connector-ad/source/PcaConnectorAdClient.cpp
+++ b/generated/src/aws-cpp-sdk-pca-connector-ad/source/PcaConnectorAdClient.cpp
@@ -186,6 +186,7 @@ void PcaConnectorAdClient::init(const PcaConnectorAd::PcaConnectorAdClientConfig
 void PcaConnectorAdClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-pca-connector-scep/source/PcaConnectorScepClient.cpp
+++ b/generated/src/aws-cpp-sdk-pca-connector-scep/source/PcaConnectorScepClient.cpp
@@ -173,6 +173,7 @@ void PcaConnectorScepClient::init(const PcaConnectorScep::PcaConnectorScepClient
 void PcaConnectorScepClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-pcs/source/PCSClient.cpp
+++ b/generated/src/aws-cpp-sdk-pcs/source/PCSClient.cpp
@@ -180,6 +180,7 @@ void PCSClient::init(const PCS::PCSClientConfiguration& config)
 void PCSClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-personalize-events/source/PersonalizeEventsClient.cpp
+++ b/generated/src/aws-cpp-sdk-personalize-events/source/PersonalizeEventsClient.cpp
@@ -166,6 +166,7 @@ void PersonalizeEventsClient::init(const PersonalizeEvents::PersonalizeEventsCli
 void PersonalizeEventsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-personalize-runtime/source/PersonalizeRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-personalize-runtime/source/PersonalizeRuntimeClient.cpp
@@ -164,6 +164,7 @@ void PersonalizeRuntimeClient::init(const PersonalizeRuntime::PersonalizeRuntime
 void PersonalizeRuntimeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-personalize/source/PersonalizeClient.cpp
+++ b/generated/src/aws-cpp-sdk-personalize/source/PersonalizeClient.cpp
@@ -232,6 +232,7 @@ void PersonalizeClient::init(const Personalize::PersonalizeClientConfiguration& 
 void PersonalizeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-pi/source/PIClient.cpp
+++ b/generated/src/aws-cpp-sdk-pi/source/PIClient.cpp
@@ -174,6 +174,7 @@ void PIClient::init(const PI::PIClientConfiguration& config)
 void PIClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-pinpoint-email/source/PinpointEmailClient.cpp
+++ b/generated/src/aws-cpp-sdk-pinpoint-email/source/PinpointEmailClient.cpp
@@ -203,6 +203,7 @@ void PinpointEmailClient::init(const PinpointEmail::PinpointEmailClientConfigura
 void PinpointEmailClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-pinpoint-sms-voice-v2/source/PinpointSMSVoiceV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-pinpoint-sms-voice-v2/source/PinpointSMSVoiceV2Client.cpp
@@ -251,6 +251,7 @@ void PinpointSMSVoiceV2Client::init(const PinpointSMSVoiceV2::PinpointSMSVoiceV2
 void PinpointSMSVoiceV2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-pinpoint/source/PinpointClient.cpp
+++ b/generated/src/aws-cpp-sdk-pinpoint/source/PinpointClient.cpp
@@ -283,6 +283,7 @@ void PinpointClient::init(const Pinpoint::PinpointClientConfiguration& config)
 void PinpointClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-pipes/source/PipesClient.cpp
+++ b/generated/src/aws-cpp-sdk-pipes/source/PipesClient.cpp
@@ -171,6 +171,7 @@ void PipesClient::init(const Pipes::PipesClientConfiguration& config)
 void PipesClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-polly/source/PollyClient.cpp
+++ b/generated/src/aws-cpp-sdk-polly/source/PollyClient.cpp
@@ -170,6 +170,7 @@ void PollyClient::init(const Polly::PollyClientConfiguration& config)
 void PollyClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-pricing/source/PricingClient.cpp
+++ b/generated/src/aws-cpp-sdk-pricing/source/PricingClient.cpp
@@ -166,6 +166,7 @@ void PricingClient::init(const Pricing::PricingClientConfiguration& config)
 void PricingClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-proton/source/ProtonClient.cpp
+++ b/generated/src/aws-cpp-sdk-proton/source/ProtonClient.cpp
@@ -248,6 +248,7 @@ void ProtonClient::init(const Proton::ProtonClientConfiguration& config)
 void ProtonClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-qapps/source/QAppsClient.cpp
+++ b/generated/src/aws-cpp-sdk-qapps/source/QAppsClient.cpp
@@ -196,6 +196,7 @@ void QAppsClient::init(const QApps::QAppsClientConfiguration& config)
 void QAppsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-qbusiness/source/QBusinessClient.cpp
+++ b/generated/src/aws-cpp-sdk-qbusiness/source/QBusinessClient.cpp
@@ -246,6 +246,7 @@ void QBusinessClient::init(const QBusiness::QBusinessClientConfiguration& config
 void QBusinessClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-qconnect/source/QConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-qconnect/source/QConnectClient.cpp
@@ -250,6 +250,7 @@ void QConnectClient::init(const QConnect::QConnectClientConfiguration& config)
 void QConnectClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-qldb-session/source/QLDBSessionClient.cpp
+++ b/generated/src/aws-cpp-sdk-qldb-session/source/QLDBSessionClient.cpp
@@ -162,6 +162,7 @@ void QLDBSessionClient::init(const QLDBSession::QLDBSessionClientConfiguration& 
 void QLDBSessionClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-qldb/source/QLDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-qldb/source/QLDBClient.cpp
@@ -181,6 +181,7 @@ void QLDBClient::init(const QLDB::QLDBClientConfiguration& config)
 void QLDBClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-quicksight/source/QuickSightClient.cpp
+++ b/generated/src/aws-cpp-sdk-quicksight/source/QuickSightClient.cpp
@@ -261,6 +261,7 @@ void QuickSightClient::init(const QuickSight::QuickSightClientConfiguration& con
 void QuickSightClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ram/source/RAMClient.cpp
+++ b/generated/src/aws-cpp-sdk-ram/source/RAMClient.cpp
@@ -195,6 +195,7 @@ void RAMClient::init(const RAM::RAMClientConfiguration& config)
 void RAMClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-rbin/source/RecycleBinClient.cpp
+++ b/generated/src/aws-cpp-sdk-rbin/source/RecycleBinClient.cpp
@@ -171,6 +171,7 @@ void RecycleBinClient::init(const RecycleBin::RecycleBinClientConfiguration& con
 void RecycleBinClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-rds-data/source/RDSDataServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-rds-data/source/RDSDataServiceClient.cpp
@@ -166,6 +166,7 @@ void RDSDataServiceClient::init(const RDSDataService::RDSDataServiceClientConfig
 void RDSDataServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-rds/source/RDSClient.cpp
+++ b/generated/src/aws-cpp-sdk-rds/source/RDSClient.cpp
@@ -325,6 +325,7 @@ void RDSClient::init(const RDS::RDSClientConfiguration& config)
 void RDSClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-redshift-data/source/RedshiftDataAPIServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-redshift-data/source/RedshiftDataAPIServiceClient.cpp
@@ -172,6 +172,7 @@ void RedshiftDataAPIServiceClient::init(const RedshiftDataAPIService::RedshiftDa
 void RedshiftDataAPIServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-redshift-serverless/source/RedshiftServerlessClient.cpp
+++ b/generated/src/aws-cpp-sdk-redshift-serverless/source/RedshiftServerlessClient.cpp
@@ -224,6 +224,7 @@ void RedshiftServerlessClient::init(const RedshiftServerless::RedshiftServerless
 void RedshiftServerlessClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-redshift/source/RedshiftClient.cpp
+++ b/generated/src/aws-cpp-sdk-redshift/source/RedshiftClient.cpp
@@ -301,6 +301,7 @@ void RedshiftClient::init(const Redshift::RedshiftClientConfiguration& config)
 void RedshiftClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-rekognition/source/RekognitionClient.cpp
+++ b/generated/src/aws-cpp-sdk-rekognition/source/RekognitionClient.cpp
@@ -236,6 +236,7 @@ void RekognitionClient::init(const Rekognition::RekognitionClientConfiguration& 
 void RekognitionClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-repostspace/source/RepostspaceClient.cpp
+++ b/generated/src/aws-cpp-sdk-repostspace/source/RepostspaceClient.cpp
@@ -180,6 +180,7 @@ void RepostspaceClient::init(const repostspace::RepostspaceClientConfiguration& 
 void RepostspaceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-resiliencehub/source/ResilienceHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-resiliencehub/source/ResilienceHubClient.cpp
@@ -224,6 +224,7 @@ void ResilienceHubClient::init(const ResilienceHub::ResilienceHubClientConfigura
 void ResilienceHubClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-resource-explorer-2/source/ResourceExplorer2Client.cpp
+++ b/generated/src/aws-cpp-sdk-resource-explorer-2/source/ResourceExplorer2Client.cpp
@@ -185,6 +185,7 @@ void ResourceExplorer2Client::init(const ResourceExplorer2::ResourceExplorer2Cli
 void ResourceExplorer2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-resource-groups/source/ResourceGroupsClient.cpp
+++ b/generated/src/aws-cpp-sdk-resource-groups/source/ResourceGroupsClient.cpp
@@ -184,6 +184,7 @@ void ResourceGroupsClient::init(const ResourceGroups::ResourceGroupsClientConfig
 void ResourceGroupsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-resourcegroupstaggingapi/source/ResourceGroupsTaggingAPIClient.cpp
+++ b/generated/src/aws-cpp-sdk-resourcegroupstaggingapi/source/ResourceGroupsTaggingAPIClient.cpp
@@ -169,6 +169,7 @@ void ResourceGroupsTaggingAPIClient::init(const ResourceGroupsTaggingAPI::Resour
 void ResourceGroupsTaggingAPIClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-robomaker/source/RoboMakerClient.cpp
+++ b/generated/src/aws-cpp-sdk-robomaker/source/RoboMakerClient.cpp
@@ -203,6 +203,7 @@ void RoboMakerClient::init(const RoboMaker::RoboMakerClientConfiguration& config
 void RoboMakerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-rolesanywhere/source/RolesAnywhereClient.cpp
+++ b/generated/src/aws-cpp-sdk-rolesanywhere/source/RolesAnywhereClient.cpp
@@ -191,6 +191,7 @@ void RolesAnywhereClient::init(const RolesAnywhere::RolesAnywhereClientConfigura
 void RolesAnywhereClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-route53-recovery-cluster/source/Route53RecoveryClusterClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53-recovery-cluster/source/Route53RecoveryClusterClient.cpp
@@ -165,6 +165,7 @@ void Route53RecoveryClusterClient::init(const Route53RecoveryCluster::Route53Rec
 void Route53RecoveryClusterClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-route53-recovery-control-config/source/Route53RecoveryControlConfigClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53-recovery-control-config/source/Route53RecoveryControlConfigClient.cpp
@@ -186,6 +186,7 @@ void Route53RecoveryControlConfigClient::init(const Route53RecoveryControlConfig
 void Route53RecoveryControlConfigClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-route53-recovery-readiness/source/Route53RecoveryReadinessClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53-recovery-readiness/source/Route53RecoveryReadinessClient.cpp
@@ -193,6 +193,7 @@ void Route53RecoveryReadinessClient::init(const Route53RecoveryReadiness::Route5
 void Route53RecoveryReadinessClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-route53/source/Route53Client.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/Route53Client.cpp
@@ -232,6 +232,7 @@ void Route53Client::init(const Route53::Route53ClientConfiguration& config)
 void Route53Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-route53domains/source/Route53DomainsClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53domains/source/Route53DomainsClient.cpp
@@ -195,6 +195,7 @@ void Route53DomainsClient::init(const Route53Domains::Route53DomainsClientConfig
 void Route53DomainsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-route53profiles/source/Route53ProfilesClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53profiles/source/Route53ProfilesClient.cpp
@@ -177,6 +177,7 @@ void Route53ProfilesClient::init(const Route53Profiles::Route53ProfilesClientCon
 void Route53ProfilesClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-route53resolver/source/Route53ResolverClient.cpp
+++ b/generated/src/aws-cpp-sdk-route53resolver/source/Route53ResolverClient.cpp
@@ -229,6 +229,7 @@ void Route53ResolverClient::init(const Route53Resolver::Route53ResolverClientCon
 void Route53ResolverClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-rum/source/CloudWatchRUMClient.cpp
+++ b/generated/src/aws-cpp-sdk-rum/source/CloudWatchRUMClient.cpp
@@ -181,6 +181,7 @@ void CloudWatchRUMClient::init(const CloudWatchRUM::CloudWatchRUMClientConfigura
 void CloudWatchRUMClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -526,6 +526,7 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config,
 void S3CrtClient::OverrideEndpoint(const Aws::String& endpoint)
 {
     AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+    m_clientConfiguration.endpointOverride = endpoint;
     m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp
@@ -361,6 +361,7 @@ void S3Client::init(const S3::S3ClientConfiguration& config)
 void S3Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-s3control/source/S3ControlClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/S3ControlClient.cpp
@@ -272,6 +272,7 @@ void S3ControlClient::init(const S3Control::S3ControlClientConfiguration& config
 void S3ControlClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-s3outposts/source/S3OutpostsClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3outposts/source/S3OutpostsClient.cpp
@@ -166,6 +166,7 @@ void S3OutpostsClient::init(const S3Outposts::S3OutpostsClientConfiguration& con
 void S3OutpostsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-s3tables/source/S3TablesClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3tables/source/S3TablesClient.cpp
@@ -191,6 +191,7 @@ void S3TablesClient::init(const S3Tables::S3TablesClientConfiguration& config)
 void S3TablesClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-s3vectors/source/S3VectorsClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3vectors/source/S3VectorsClient.cpp
@@ -177,6 +177,7 @@ void S3VectorsClient::init(const S3Vectors::S3VectorsClientConfiguration& config
 void S3VectorsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sagemaker-a2i-runtime/source/AugmentedAIRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-a2i-runtime/source/AugmentedAIRuntimeClient.cpp
@@ -166,6 +166,7 @@ void AugmentedAIRuntimeClient::init(const AugmentedAIRuntime::AugmentedAIRuntime
 void AugmentedAIRuntimeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sagemaker-edge/source/SagemakerEdgeManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-edge/source/SagemakerEdgeManagerClient.cpp
@@ -164,6 +164,7 @@ void SagemakerEdgeManagerClient::init(const SagemakerEdgeManager::SagemakerEdgeM
 void SagemakerEdgeManagerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sagemaker-featurestore-runtime/source/SageMakerFeatureStoreRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-featurestore-runtime/source/SageMakerFeatureStoreRuntimeClient.cpp
@@ -165,6 +165,7 @@ void SageMakerFeatureStoreRuntimeClient::init(const SageMakerFeatureStoreRuntime
 void SageMakerFeatureStoreRuntimeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sagemaker-geospatial/source/SageMakerGeospatialClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-geospatial/source/SageMakerGeospatialClient.cpp
@@ -180,6 +180,7 @@ void SageMakerGeospatialClient::init(const SageMakerGeospatial::SageMakerGeospat
 void SageMakerGeospatialClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sagemaker-metrics/source/SageMakerMetricsClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-metrics/source/SageMakerMetricsClient.cpp
@@ -163,6 +163,7 @@ void SageMakerMetricsClient::init(const SageMakerMetrics::SageMakerMetricsClient
 void SageMakerMetricsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sagemaker-runtime/source/SageMakerRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-runtime/source/SageMakerRuntimeClient.cpp
@@ -165,6 +165,7 @@ void SageMakerRuntimeClient::init(const SageMakerRuntime::SageMakerRuntimeClient
 void SageMakerRuntimeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sagemaker/source/SageMakerClient.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker/source/SageMakerClient.cpp
@@ -261,6 +261,7 @@ void SageMakerClient::init(const SageMaker::SageMakerClientConfiguration& config
 void SageMakerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-savingsplans/source/SavingsPlansClient.cpp
+++ b/generated/src/aws-cpp-sdk-savingsplans/source/SavingsPlansClient.cpp
@@ -171,6 +171,7 @@ void SavingsPlansClient::init(const SavingsPlans::SavingsPlansClientConfiguratio
 void SavingsPlansClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-scheduler/source/SchedulerClient.cpp
+++ b/generated/src/aws-cpp-sdk-scheduler/source/SchedulerClient.cpp
@@ -173,6 +173,7 @@ void SchedulerClient::init(const Scheduler::SchedulerClientConfiguration& config
 void SchedulerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-schemas/source/SchemasClient.cpp
+++ b/generated/src/aws-cpp-sdk-schemas/source/SchemasClient.cpp
@@ -192,6 +192,7 @@ void SchemasClient::init(const Schemas::SchemasClientConfiguration& config)
 void SchemasClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sdb/source/SimpleDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-sdb/source/SimpleDBClient.cpp
@@ -172,6 +172,7 @@ void SimpleDBClient::init(const SimpleDB::SimpleDBClientConfiguration& config)
 void SimpleDBClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-secretsmanager/source/SecretsManagerClient.cpp
+++ b/generated/src/aws-cpp-sdk-secretsmanager/source/SecretsManagerClient.cpp
@@ -184,6 +184,7 @@ void SecretsManagerClient::init(const SecretsManager::SecretsManagerClientConfig
 void SecretsManagerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-security-ir/source/SecurityIRClient.cpp
+++ b/generated/src/aws-cpp-sdk-security-ir/source/SecurityIRClient.cpp
@@ -183,6 +183,7 @@ void SecurityIRClient::init(const SecurityIR::SecurityIRClientConfiguration& con
 void SecurityIRClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-securityhub/source/SecurityHubClient.cpp
+++ b/generated/src/aws-cpp-sdk-securityhub/source/SecurityHubClient.cpp
@@ -263,6 +263,7 @@ void SecurityHubClient::init(const SecurityHub::SecurityHubClientConfiguration& 
 void SecurityHubClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-securitylake/source/SecurityLakeClient.cpp
+++ b/generated/src/aws-cpp-sdk-securitylake/source/SecurityLakeClient.cpp
@@ -192,6 +192,7 @@ void SecurityLakeClient::init(const SecurityLake::SecurityLakeClientConfiguratio
 void SecurityLakeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-serverlessrepo/source/ServerlessApplicationRepositoryClient.cpp
+++ b/generated/src/aws-cpp-sdk-serverlessrepo/source/ServerlessApplicationRepositoryClient.cpp
@@ -175,6 +175,7 @@ void ServerlessApplicationRepositoryClient::init(const ServerlessApplicationRepo
 void ServerlessApplicationRepositoryClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-service-quotas/source/ServiceQuotasClient.cpp
+++ b/generated/src/aws-cpp-sdk-service-quotas/source/ServiceQuotasClient.cpp
@@ -181,6 +181,7 @@ void ServiceQuotasClient::init(const ServiceQuotas::ServiceQuotasClientConfigura
 void ServiceQuotasClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-servicecatalog-appregistry/source/AppRegistryClient.cpp
+++ b/generated/src/aws-cpp-sdk-servicecatalog-appregistry/source/AppRegistryClient.cpp
@@ -185,6 +185,7 @@ void AppRegistryClient::init(const AppRegistry::AppRegistryClientConfiguration& 
 void AppRegistryClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-servicecatalog/source/ServiceCatalogClient.cpp
+++ b/generated/src/aws-cpp-sdk-servicecatalog/source/ServiceCatalogClient.cpp
@@ -251,6 +251,7 @@ void ServiceCatalogClient::init(const ServiceCatalog::ServiceCatalogClientConfig
 void ServiceCatalogClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-servicediscovery/source/ServiceDiscoveryClient.cpp
+++ b/generated/src/aws-cpp-sdk-servicediscovery/source/ServiceDiscoveryClient.cpp
@@ -191,6 +191,7 @@ void ServiceDiscoveryClient::init(const ServiceDiscovery::ServiceDiscoveryClient
 void ServiceDiscoveryClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sesv2/source/SESV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-sesv2/source/SESV2Client.cpp
@@ -270,6 +270,7 @@ void SESV2Client::init(const SESV2::SESV2ClientConfiguration& config)
 void SESV2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-shield/source/ShieldClient.cpp
+++ b/generated/src/aws-cpp-sdk-shield/source/ShieldClient.cpp
@@ -196,6 +196,7 @@ void ShieldClient::init(const Shield::ShieldClientConfiguration& config)
 void ShieldClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-signer/source/SignerClient.cpp
+++ b/generated/src/aws-cpp-sdk-signer/source/SignerClient.cpp
@@ -180,6 +180,7 @@ void SignerClient::init(const signer::SignerClientConfiguration& config)
 void SignerClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-simspaceweaver/source/SimSpaceWeaverClient.cpp
+++ b/generated/src/aws-cpp-sdk-simspaceweaver/source/SimSpaceWeaverClient.cpp
@@ -177,6 +177,7 @@ void SimSpaceWeaverClient::init(const SimSpaceWeaver::SimSpaceWeaverClientConfig
 void SimSpaceWeaverClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sms-voice/source/PinpointSMSVoiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-sms-voice/source/PinpointSMSVoiceClient.cpp
@@ -169,6 +169,7 @@ void PinpointSMSVoiceClient::init(const PinpointSMSVoice::PinpointSMSVoiceClient
 void PinpointSMSVoiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-snow-device-management/source/SnowDeviceManagementClient.cpp
+++ b/generated/src/aws-cpp-sdk-snow-device-management/source/SnowDeviceManagementClient.cpp
@@ -174,6 +174,7 @@ void SnowDeviceManagementClient::init(const SnowDeviceManagement::SnowDeviceMana
 void SnowDeviceManagementClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-snowball/source/SnowballClient.cpp
+++ b/generated/src/aws-cpp-sdk-snowball/source/SnowballClient.cpp
@@ -188,6 +188,7 @@ void SnowballClient::init(const Snowball::SnowballClientConfiguration& config)
 void SnowballClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sns/source/SNSClient.cpp
+++ b/generated/src/aws-cpp-sdk-sns/source/SNSClient.cpp
@@ -204,6 +204,7 @@ void SNSClient::init(const SNS::SNSClientConfiguration& config)
 void SNSClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-socialmessaging/source/SocialMessagingClient.cpp
+++ b/generated/src/aws-cpp-sdk-socialmessaging/source/SocialMessagingClient.cpp
@@ -182,6 +182,7 @@ void SocialMessagingClient::init(const SocialMessaging::SocialMessagingClientCon
 void SocialMessagingClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sqs/source/SQSClient.cpp
+++ b/generated/src/aws-cpp-sdk-sqs/source/SQSClient.cpp
@@ -184,6 +184,7 @@ void SQSClient::init(const SQS::SQSClientConfiguration& config)
 void SQSClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ssm-contacts/source/SSMContactsClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm-contacts/source/SSMContactsClient.cpp
@@ -200,6 +200,7 @@ void SSMContactsClient::init(const SSMContacts::SSMContactsClientConfiguration& 
 void SSMContactsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ssm-guiconnect/source/SSMGuiConnectClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm-guiconnect/source/SSMGuiConnectClient.cpp
@@ -164,6 +164,7 @@ void SSMGuiConnectClient::init(const SSMGuiConnect::SSMGuiConnectClientConfigura
 void SSMGuiConnectClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ssm-incidents/source/SSMIncidentsClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm-incidents/source/SSMIncidentsClient.cpp
@@ -192,6 +192,7 @@ void SSMIncidentsClient::init(const SSMIncidents::SSMIncidentsClientConfiguratio
 void SSMIncidentsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ssm-quicksetup/source/SSMQuickSetupClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm-quicksetup/source/SSMQuickSetupClient.cpp
@@ -175,6 +175,7 @@ void SSMQuickSetupClient::init(const SSMQuickSetup::SSMQuickSetupClientConfigura
 void SSMQuickSetupClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ssm-sap/source/SsmSapClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm-sap/source/SsmSapClient.cpp
@@ -188,6 +188,7 @@ void SsmSapClient::init(const SsmSap::SsmSapClientConfiguration& config)
 void SsmSapClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-ssm/source/SSMClient.cpp
+++ b/generated/src/aws-cpp-sdk-ssm/source/SSMClient.cpp
@@ -307,6 +307,7 @@ void SSMClient::init(const SSM::SSMClientConfiguration& config)
 void SSMClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sso-admin/source/SSOAdminClient.cpp
+++ b/generated/src/aws-cpp-sdk-sso-admin/source/SSOAdminClient.cpp
@@ -236,6 +236,7 @@ void SSOAdminClient::init(const SSOAdmin::SSOAdminClientConfiguration& config)
 void SSOAdminClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sso-oidc/source/SSOOIDCClient.cpp
+++ b/generated/src/aws-cpp-sdk-sso-oidc/source/SSOOIDCClient.cpp
@@ -165,6 +165,7 @@ void SSOOIDCClient::init(const SSOOIDC::SSOOIDCClientConfiguration& config)
 void SSOOIDCClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sso/source/SSOClient.cpp
+++ b/generated/src/aws-cpp-sdk-sso/source/SSOClient.cpp
@@ -165,6 +165,7 @@ void SSOClient::init(const SSO::SSOClientConfiguration& config)
 void SSOClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-states/source/SFNClient.cpp
+++ b/generated/src/aws-cpp-sdk-states/source/SFNClient.cpp
@@ -198,6 +198,7 @@ void SFNClient::init(const SFN::SFNClientConfiguration& config)
 void SFNClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-storagegateway/source/StorageGatewayClient.cpp
+++ b/generated/src/aws-cpp-sdk-storagegateway/source/StorageGatewayClient.cpp
@@ -257,6 +257,7 @@ void StorageGatewayClient::init(const StorageGateway::StorageGatewayClientConfig
 void StorageGatewayClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-sts/source/STSClient.cpp
+++ b/generated/src/aws-cpp-sdk-sts/source/STSClient.cpp
@@ -171,6 +171,7 @@ void STSClient::init(const STS::STSClientConfiguration& config)
 void STSClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-supplychain/source/SupplyChainClient.cpp
+++ b/generated/src/aws-cpp-sdk-supplychain/source/SupplyChainClient.cpp
@@ -191,6 +191,7 @@ void SupplyChainClient::init(const SupplyChain::SupplyChainClientConfiguration& 
 void SupplyChainClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-support-app/source/SupportAppClient.cpp
+++ b/generated/src/aws-cpp-sdk-support-app/source/SupportAppClient.cpp
@@ -171,6 +171,7 @@ void SupportAppClient::init(const SupportApp::SupportAppClientConfiguration& con
 void SupportAppClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-support/source/SupportClient.cpp
+++ b/generated/src/aws-cpp-sdk-support/source/SupportClient.cpp
@@ -177,6 +177,7 @@ void SupportClient::init(const Support::SupportClientConfiguration& config)
 void SupportClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-swf/source/SWFClient.cpp
+++ b/generated/src/aws-cpp-sdk-swf/source/SWFClient.cpp
@@ -200,6 +200,7 @@ void SWFClient::init(const SWF::SWFClientConfiguration& config)
 void SWFClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-synthetics/source/SyntheticsClient.cpp
+++ b/generated/src/aws-cpp-sdk-synthetics/source/SyntheticsClient.cpp
@@ -183,6 +183,7 @@ void SyntheticsClient::init(const Synthetics::SyntheticsClientConfiguration& con
 void SyntheticsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-taxsettings/source/TaxSettingsClient.cpp
+++ b/generated/src/aws-cpp-sdk-taxsettings/source/TaxSettingsClient.cpp
@@ -177,6 +177,7 @@ void TaxSettingsClient::init(const TaxSettings::TaxSettingsClientConfiguration& 
 void TaxSettingsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-textract/source/TextractClient.cpp
+++ b/generated/src/aws-cpp-sdk-textract/source/TextractClient.cpp
@@ -186,6 +186,7 @@ void TextractClient::init(const Textract::TextractClientConfiguration& config)
 void TextractClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-timestream-influxdb/source/TimestreamInfluxDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-timestream-influxdb/source/TimestreamInfluxDBClient.cpp
@@ -178,6 +178,7 @@ void TimestreamInfluxDBClient::init(const TimestreamInfluxDB::TimestreamInfluxDB
 void TimestreamInfluxDBClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-timestream-query/source/TimestreamQueryClient.cpp
+++ b/generated/src/aws-cpp-sdk-timestream-query/source/TimestreamQueryClient.cpp
@@ -177,6 +177,7 @@ void TimestreamQueryClient::init(const TimestreamQuery::TimestreamQueryClientCon
 void TimestreamQueryClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-timestream-write/source/TimestreamWriteClient.cpp
+++ b/generated/src/aws-cpp-sdk-timestream-write/source/TimestreamWriteClient.cpp
@@ -181,6 +181,7 @@ void TimestreamWriteClient::init(const TimestreamWrite::TimestreamWriteClientCon
 void TimestreamWriteClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-tnb/source/TnbClient.cpp
+++ b/generated/src/aws-cpp-sdk-tnb/source/TnbClient.cpp
@@ -194,6 +194,7 @@ void TnbClient::init(const tnb::TnbClientConfiguration& config)
 void TnbClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-transcribe/source/TranscribeServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-transcribe/source/TranscribeServiceClient.cpp
@@ -204,6 +204,7 @@ void TranscribeServiceClient::init(const TranscribeService::TranscribeServiceCli
 void TranscribeServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
@@ -168,6 +168,7 @@ void TranscribeStreamingServiceClient::init(const TranscribeStreamingService::Tr
 void TranscribeStreamingServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-translate/source/TranslateClient.cpp
+++ b/generated/src/aws-cpp-sdk-translate/source/TranslateClient.cpp
@@ -180,6 +180,7 @@ void TranslateClient::init(const Translate::TranslateClientConfiguration& config
 void TranslateClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-trustedadvisor/source/TrustedAdvisorClient.cpp
+++ b/generated/src/aws-cpp-sdk-trustedadvisor/source/TrustedAdvisorClient.cpp
@@ -172,6 +172,7 @@ void TrustedAdvisorClient::init(const TrustedAdvisor::TrustedAdvisorClientConfig
 void TrustedAdvisorClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-verifiedpermissions/source/VerifiedPermissionsClient.cpp
+++ b/generated/src/aws-cpp-sdk-verifiedpermissions/source/VerifiedPermissionsClient.cpp
@@ -191,6 +191,7 @@ void VerifiedPermissionsClient::init(const VerifiedPermissions::VerifiedPermissi
 void VerifiedPermissionsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-voice-id/source/VoiceIDClient.cpp
+++ b/generated/src/aws-cpp-sdk-voice-id/source/VoiceIDClient.cpp
@@ -190,6 +190,7 @@ void VoiceIDClient::init(const VoiceID::VoiceIDClientConfiguration& config)
 void VoiceIDClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-vpc-lattice/source/VPCLatticeClient.cpp
+++ b/generated/src/aws-cpp-sdk-vpc-lattice/source/VPCLatticeClient.cpp
@@ -230,6 +230,7 @@ void VPCLatticeClient::init(const VPCLattice::VPCLatticeClientConfiguration& con
 void VPCLatticeClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-waf-regional/source/WAFRegionalClient.cpp
+++ b/generated/src/aws-cpp-sdk-waf-regional/source/WAFRegionalClient.cpp
@@ -242,6 +242,7 @@ void WAFRegionalClient::init(const WAFRegional::WAFRegionalClientConfiguration& 
 void WAFRegionalClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-waf/source/WAFClient.cpp
+++ b/generated/src/aws-cpp-sdk-waf/source/WAFClient.cpp
@@ -238,6 +238,7 @@ void WAFClient::init(const WAF::WAFClientConfiguration& config)
 void WAFClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-wafv2/source/WAFV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-wafv2/source/WAFV2Client.cpp
@@ -215,6 +215,7 @@ void WAFV2Client::init(const WAFV2::WAFV2ClientConfiguration& config)
 void WAFV2Client::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-wellarchitected/source/WellArchitectedClient.cpp
+++ b/generated/src/aws-cpp-sdk-wellarchitected/source/WellArchitectedClient.cpp
@@ -233,6 +233,7 @@ void WellArchitectedClient::init(const WellArchitected::WellArchitectedClientCon
 void WellArchitectedClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-wisdom/source/ConnectWisdomServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-wisdom/source/ConnectWisdomServiceClient.cpp
@@ -200,6 +200,7 @@ void ConnectWisdomServiceClient::init(const ConnectWisdomService::ConnectWisdomS
 void ConnectWisdomServiceClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-workdocs/source/WorkDocsClient.cpp
+++ b/generated/src/aws-cpp-sdk-workdocs/source/WorkDocsClient.cpp
@@ -205,6 +205,7 @@ void WorkDocsClient::init(const WorkDocs::WorkDocsClientConfiguration& config)
 void WorkDocsClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-workmail/source/WorkMailClient.cpp
+++ b/generated/src/aws-cpp-sdk-workmail/source/WorkMailClient.cpp
@@ -253,6 +253,7 @@ void WorkMailClient::init(const WorkMail::WorkMailClientConfiguration& config)
 void WorkMailClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-workmailmessageflow/source/WorkMailMessageFlowClient.cpp
+++ b/generated/src/aws-cpp-sdk-workmailmessageflow/source/WorkMailMessageFlowClient.cpp
@@ -163,6 +163,7 @@ void WorkMailMessageFlowClient::init(const WorkMailMessageFlow::WorkMailMessageF
 void WorkMailMessageFlowClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-workspaces-instances/source/WorkspacesInstancesClient.cpp
+++ b/generated/src/aws-cpp-sdk-workspaces-instances/source/WorkspacesInstancesClient.cpp
@@ -174,6 +174,7 @@ void WorkspacesInstancesClient::init(const WorkspacesInstances::WorkspacesInstan
 void WorkspacesInstancesClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-workspaces-thin-client/source/WorkSpacesThinClientClient.cpp
+++ b/generated/src/aws-cpp-sdk-workspaces-thin-client/source/WorkSpacesThinClientClient.cpp
@@ -177,6 +177,7 @@ void WorkSpacesThinClientClient::init(const WorkSpacesThinClient::WorkSpacesThin
 void WorkSpacesThinClientClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-workspaces-web/source/WorkSpacesWebClient.cpp
+++ b/generated/src/aws-cpp-sdk-workspaces-web/source/WorkSpacesWebClient.cpp
@@ -236,6 +236,7 @@ void WorkSpacesWebClient::init(const WorkSpacesWeb::WorkSpacesWebClientConfigura
 void WorkSpacesWebClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-workspaces/source/WorkSpacesClient.cpp
+++ b/generated/src/aws-cpp-sdk-workspaces/source/WorkSpacesClient.cpp
@@ -252,6 +252,7 @@ void WorkSpacesClient::init(const WorkSpaces::WorkSpacesClientConfiguration& con
 void WorkSpacesClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/generated/src/aws-cpp-sdk-xray/source/XRayClient.cpp
+++ b/generated/src/aws-cpp-sdk-xray/source/XRayClient.cpp
@@ -199,6 +199,7 @@ void XRayClient::init(const XRay::XRayClientConfiguration& config)
 void XRayClient::OverrideEndpoint(const Aws::String& endpoint)
 {
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 }
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceInit.vm
@@ -449,6 +449,7 @@ void ${className}::OverrideEndpoint(const Aws::String& endpoint)
 {
 #if($serviceModel.endpointRules)
   AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+  m_clientConfiguration.endpointOverride = endpoint;
   m_endpointProvider->OverrideEndpoint(endpoint);
 #else##-#if($serviceModel.endpointRules)
 #if($virtualAddressingSupported || $arnEndpointSupported || $metadata.hasEndpointTrait)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -597,6 +597,7 @@ void ${className}::OverrideEndpoint(const Aws::String& endpoint)
 {
 #if($serviceModel.endpointRules)
     AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+    m_clientConfiguration.endpointOverride = endpoint;
     m_endpointProvider->OverrideEndpoint(endpoint);
 #else##-#if($serviceModel.endpointRules)
 #if($virtualAddressingSupported || $arnEndpointSupported || $metadata.hasEndpointTrait)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/SmithyS3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/SmithyS3CrtServiceClientSourceInit.vm
@@ -540,6 +540,7 @@ void ${className}::OverrideEndpoint(const Aws::String& endpoint)
 {
 #if($serviceModel.endpointRules)
     AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+    m_clientConfiguration.endpointOverride = endpoint;
     m_endpointProvider->OverrideEndpoint(endpoint);
 #else##-#if($serviceModel.endpointRules)
 #if($virtualAddressingSupported || $arnEndpointSupported || $metadata.hasEndpointTrait)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyClientSourceInit.vm
@@ -348,5 +348,6 @@ std::shared_ptr<${metadata.classNamePrefix}EndpointProviderBase>& ${className}::
 void ${className}::OverrideEndpoint(const Aws::String& endpoint)
 {
     AWS_CHECK_PTR(SERVICE_NAME, m_endpointProvider);
+    m_clientConfiguration.endpointOverride = endpoint;
     m_endpointProvider->OverrideEndpoint(endpoint);
 }


### PR DESCRIPTION
*Description of changes:*

Our clients provide a `OverrideEndpoint` API that exists for backwards compatibility. This API sets the override on the endpoint provider. However it does not set the override on the client configuration object which is used to compute override logic for services with endpoint discovery i.e. `timestream-query`. When this API is used, [like in the ODBC driver](https://github.com/awslabs/amazon-timestream-odbc-driver/blob/b6326e0964550b0d7fd5e44175c53151c2870798/src/odbc/src/connection.cpp#L724) this results in the overriden endpoint not being used, and endpoint discovery taking place.

This change fixes setting the endpoint override on the client configuration when this API is invoked. It should be noted that overriding the endpoint via client configuration is the preferred method of doing this.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
