### PR TITLE
Fix data received handler for winhttp

### DIFF
--- a/tests/aws-cpp-sdk-core-tests/utils/stream/StreamBufProtectedWriterTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/stream/StreamBufProtectedWriterTest.cpp
@@ -1,0 +1,68 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/core/utils/stream/StreamBufProtectedWriter.h>
+#include <aws/core/utils/memory/stl/AWSDeque.h>
+#include <aws/testing/AwsCppSdkGTestSuite.h>
+#include <sstream>
+#include <deque>
+
+using namespace Aws::Utils::Stream;
+
+class StreamBufProtectedWriterTest : public Aws::Testing::AwsCppSdkGTestSuite {};
+
+class MockedBuffer {
+public:
+    MockedBuffer(std::initializer_list<Aws::String> strings) : data_(strings) {}
+    
+    Aws::String read() {
+        if (data_.empty()) {
+          return {};
+        }
+        Aws::String result = data_.front();
+        data_.pop_front();
+        return result;
+    }
+    
+private:
+    Aws::Deque<Aws::String> data_;
+};
+
+TEST_F(StreamBufProtectedWriterTest, ShouldBeAbleToAccessStreamAfterWriteFunction) {
+  Aws::StringStream bufferedStream;
+  Aws::StringStream output;
+  MockedBuffer srcBuffer({ "joker",
+    "skull",
+    "panther",
+    "mona"});
+  Aws::String leftover{};
+  StreamBufProtectedWriter::WriteToBuffer(bufferedStream,
+    [&srcBuffer, &leftover](char* dst, uint64_t dstSz, uint64_t& read) -> bool {
+      Aws::String data{};
+      if (!leftover.empty()) {
+        data = leftover;
+        leftover.clear();
+      } else {
+        data = srcBuffer.read();
+        if (data.empty()) {
+          return false;
+        }
+      }
+      if (data.size() > dstSz) {
+        leftover = data.substr(static_cast<size_t>(dstSz));
+        read = dstSz;
+        memcpy(dst, data.c_str(), static_cast<size_t>(dstSz));
+      } else {
+        read = data.size();
+        memcpy(dst, data.c_str(), static_cast<size_t>(read));
+      }
+      return true;
+    },
+    [&bufferedStream, &output](uint64_t read) -> void {
+      AWS_UNREFERENCED_PARAM(read);
+      output << bufferedStream.rdbuf();
+    });
+  EXPECT_EQ(output.str(), "jokerskullpanthermona");
+}


### PR DESCRIPTION
*Description of changes:*

We accidentally changed the behavior of the `DataReceivedEventHandler` callback in https://github.com/aws/aws-sdk-cpp/pull/2954 for the windows http client. When we changed to buffer the input in `StreamBufProtectedWriter`, when we call the `DataReceivedEventHandler` in the writer function, the response body has not been updated yet, it is still in the temp buffer in the wrapper object. This causes the callback to see no data in the response stream.

This updates the code to work as it worked before by adding a `WriteCompleteCallback` in `StreamBufProtectedWriter` that can be called _after_ the response buffer has been written to.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
