### PR TITLE
Fix CRT constructor

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -283,7 +283,7 @@ S3CrtClient::S3CrtClient(const std::shared_ptr<AWSCredentialsProvider>& credenti
             signPayloads,
             false),
     Aws::MakeShared<S3CrtErrorMarshaller>(ALLOCATION_TAG)),
-    m_clientConfiguration(clientConfiguration, signPayloads),
+    m_clientConfiguration(clientConfiguration),
     m_credProvider(credentialsProvider),
     m_identityProvider(Aws::MakeShared<DefaultS3ExpressIdentityProvider>(ALLOCATION_TAG, *this))
 {

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -177,7 +177,7 @@ ${className}::${className}(const std::shared_ptr<AWSCredentialsProvider>& creden
             false),
     Aws::MakeShared<${metadata.classNamePrefix}ErrorMarshaller>(ALLOCATION_TAG)),
 #if($serviceModel.endpointRules)
-    m_clientConfiguration(clientConfiguration${signPayloadsParam}),
+    m_clientConfiguration(clientConfiguration),
     ${credentialsProviderMember},
 #else
     ${credentialsProviderMember}${virtualAddressingInit}${USEast1RegionalEndpointInitString},


### PR DESCRIPTION
*Description of changes:*

Fixes a bug where client configuration was not getting created correctly in the `S3CrtClient` causing inconsistencies between different constructors.

Specifically that on the constructor where a credentials provider was being provided, the incorrect call was being made, causing S3Crt specific config to be lost

i.e.
```c++
#include <aws/core/Aws.h>
#include <aws/core/utils/logging/LogLevel.h>
#include <aws/s3-crt/S3CrtClient.h>

int main() {
  Aws::SDKOptions sdk_options;
  sdk_options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Off;
  Aws::InitAPI(sdk_options);

  Aws::S3Crt::S3CrtClientConfiguration configuration{};
  configuration.contentLengthConfiguration = Aws::S3Crt::S3CrtClientConfiguration::CONTENT_LENGTH_CONFIGURATION::SKIP_CONTENT_LENGTH;
  Aws::S3Crt::S3CrtClientConfiguration copied{configuration, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never};
  if (copied.contentLengthConfiguration != Aws::S3Crt::S3CrtClientConfiguration::CONTENT_LENGTH_CONFIGURATION::SKIP_CONTENT_LENGTH) {
    std::cout << "copied incorrectly!\n";
  }

  Aws::ShutdownAPI(sdk_options);
  return 0;
}
```

The impact of this was customers that set `SKIP_CONTENT_LENGTH` would not have it honored if they provided their own credentials provider.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
