### PR TITLE
use expired credentials from IMDS if none exist

### DIFF
--- a/src/aws-cpp-sdk-core/source/config/EC2InstanceProfileConfigLoader.cpp
+++ b/src/aws-cpp-sdk-core/source/config/EC2InstanceProfileConfigLoader.cpp
@@ -79,7 +79,7 @@ namespace Aws
             auto credentialsView = credentialsDoc.View();
             DateTime expirationTime(credentialsView.GetString(expiration), Aws::Utils::DateFormat::ISO_8601);
             // re-use old credentials and not block if the IMDS call failed or if the latest credential is in the past
-            if (expirationTime.WasParseSuccessful() && DateTime::Now() > expirationTime) {
+            if (expirationTime.WasParseSuccessful() && DateTime::Now() > expirationTime && m_profiles.find(INSTANCE_PROFILE_KEY) != m_profiles.end()) {
                 AWS_LOGSTREAM_ERROR(EC2_INSTANCE_PROFILE_LOG_TAG,
                                     "Expiration Time of Credentials in the past, refusing to update credentials");
                 this->credentialsValidUntilMillis = DateTime::Now().Millis() + calculateRetryTime();

--- a/tests/aws-cpp-sdk-core-tests/aws/auth/AWSCredentialsProviderTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/aws/auth/AWSCredentialsProviderTest.cpp
@@ -428,6 +428,17 @@ TEST_F(InstanceProfileCredentialsProviderTest, TestEC2MetadataClientReturnsBadDa
     ASSERT_EQ("", provider.GetAWSCredentials().GetAWSSecretKey());
 }
 
+TEST_F(InstanceProfileCredentialsProviderTest, TestUsesExpiredCredentialsIfNoneExist) {
+  auto mockClient = Aws::MakeShared<MockEC2MetadataClient>(AllocationTag);
+
+  const char* validCredentials = R"({ "AccessKeyId": "goodAccessKey", "SecretAccessKey": "goodSecretKey", "Token": "goodToken", "Code": "Success", "Expiration": "1991-04-19T06:12:00Z" })";
+  mockClient->SetMockedCredentialsValue(validCredentials);
+
+  InstanceProfileCredentialsProvider provider(Aws::MakeShared<Aws::Config::EC2InstanceProfileConfigLoader>(AllocationTag, mockClient), 10);
+  ASSERT_EQ("goodAccessKey", provider.GetAWSCredentials().GetAWSAccessKeyId());
+  ASSERT_EQ("goodSecretKey", provider.GetAWSCredentials().GetAWSSecretKey());
+}
+
 static Aws::String WrapEchoStringWithSingleQuoteForUnixShell(Aws::String str)
 {
 #ifndef _WIN32


### PR DESCRIPTION
*Description of changes:*

Currently for [AWS static stability](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/static-stability.html) we will continue to use a expired IMDS credential if IMDS provides a expired credential. However if a new client is instantiated, the credential provider will fail if it is given a credential with a expiry in the past.

This fixes it so that if there is no currently configured instance credential we will use a expired one if provided. however we will not update expired credentials with "new" expired credentials.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
