### PR TITLE
fixes sts creds provider env var resolution

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -6,14 +6,16 @@
 #pragma once
 
 #include <aws/core/Core_EXPORTS.h>
+#include <aws/core/Region.h>
+#include <aws/core/http/HttpTypes.h>
 #include <aws/core/http/Scheme.h>
 #include <aws/core/http/Version.h>
-#include <aws/core/Region.h>
-#include <aws/core/utils/memory/stl/AWSString.h>
-#include <aws/core/http/HttpTypes.h>
 #include <aws/core/utils/Array.h>
+#include <aws/core/utils/StringUtils.h>
+#include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/crt/Optional.h>
 #include <smithy/tracing/TelemetryProvider.h>
+
 #include <memory>
 
 namespace Aws
@@ -447,6 +449,16 @@ namespace Aws
             static Aws::String LoadConfigFromEnvOrProfile(const Aws::String& envKey, const Aws::String& profile,
                                                           const Aws::String& profileProperty, const Aws::Vector<Aws::String>& allowedValues,
                                                           const Aws::String& defaultValue);
+            /**
+             * A helper function to read config value from env variable or aws profile config. Addresses a problem in
+             * LoadConfigFromEnvOrProfile where env variables values are always mapped to their lower case equivalent.
+             * This fails for cases where ENV vars need to be case sensitive in instances like AWS_ROLE_ARN can have
+             * camel case values.
+             */
+            static Aws::String LoadConfigFromEnvOrProfileCaseSensitive(
+                const Aws::String& envKey, const Aws::String& profile, const Aws::String& profileProperty,
+                const Aws::Vector<Aws::String>& allowedValues, const Aws::String& defaultValue,
+                const std::function<Aws::String(const char*)>& envValueMapping = Utils::StringUtils::ToLower);
 
             /**
              * A wrapper for interfacing with telemetry functionality. Defaults to Noop provider.


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/discussions/3600

*Description of changes:*

Fixes two problems:
* The `STSWebIdentityCredentialsProvider` used a typo-ed version of two env vars, `AWS_IAM_ROLE_ARN` and `AWS_IAM_ROLE_SESSION_NAME`. this changes the provider to use the correct `AWS_ROLE_ARN ` and `AWS_ROLE_SESSION_NAME `. In addition it provides backwards compatibility to the old typo-ed names.
* The function `LoadConfigFromEnvOrProfile` will call `ToLower` on any environment variable loaded, which is incorrect for the env var `AWS_IAM_ROLE_ARN` as arns can contain case sensitive values. This is likely a greater issue across other configurations, but fixing for the STS web identity provider for now.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
