### PR TITLE
refactor crosslink_redirect to align with new docs website

### DIFF
--- a/docs/doxygen/static/crosslink_redirect.html
+++ b/docs/doxygen/static/crosslink_redirect.html
@@ -8,7 +8,7 @@
             
             var uidToServiceName = JSON.parse(uidServiceData);            
             
-            var baseUri = "LATEST/";
+            var defaultUrl = "root/html/index.html";
             
             function getQueryStringParameter(name, url) {
                 
@@ -46,7 +46,7 @@
                 var serviceName = uidToServiceName[uid];
                 
                 if(serviceName == null) {
-                    return baseUri;
+                    return defaultUrl;
                 }
                 
                 var dirtyName = "class_aws_1_1_";
@@ -69,7 +69,7 @@
                 }
                 
                 dirtyName += ".html";
-                return baseUri + "aws-cpp-sdk-" + serviceName.toLowerCase() + "/html/" + escapeCharacters(dirtyName);
+                return "aws-cpp-sdk-" + serviceName.toLowerCase() + "/html/" + escapeCharacters(dirtyName);
             }
             
             function checkResourceExists(url) {  
@@ -101,7 +101,7 @@
                     window.location.href = secondAttempt;
                 }
                 else {
-                    window.location.href = baseUri + "index.html";
+                    window.location.href = defaultUrl;
                 }
             }
             


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updated the crosslink_redirect to generate correct redirects for the new docs domain. Current system has a script to correct the redirects inside CPP Catapult instance which will be removed.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
Current system does not have tests for docs. Ran tests for the changes on local system.
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
