### PR TITLE
Removeing -std=c++11 from pkgconfig Cflags

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -22,7 +22,7 @@ function(set_compiler_flags target)
     if(NOT MSVC)
         set_gcc_flags()
         target_compile_options(${target} PRIVATE "${AWS_COMPILER_FLAGS}")
-        string(REPLACE ";" " " _TMP "${AWS_COMPILER_FLAGS}")
+        string(REPLACE ";" " " _TMP "${AWS_PUBLIC_COMPILER_FLAGS}")
         set(PKG_CONFIG_CFLAGS "${_TMP}" CACHE INTERNAL "C++ compiler flags which affect the ABI")
     endif()
 endfunction()
@@ -36,17 +36,26 @@ endfunction()
 
 
 macro(set_gcc_flags)
-    list(APPEND AWS_COMPILER_FLAGS "-fno-exceptions" "-std=c++${CPP_STANDARD}")
+    # Internal flags - only for SDK compilation
+    list(APPEND AWS_COMPILER_FLAGS "-std=c++${CPP_STANDARD}")
+    
+    # Public flags - needed by downstream projects for ABI compatibility
+    list(APPEND AWS_COMPILER_FLAGS "-fno-exceptions")
+    list(APPEND AWS_PUBLIC_COMPILER_FLAGS "-fno-exceptions")
+    
     if(COMPILER_IS_MINGW)
         list(APPEND AWS_COMPILER_FLAGS -D__USE_MINGW_ANSI_STDIO=1)
+        list(APPEND AWS_PUBLIC_COMPILER_FLAGS -D__USE_MINGW_ANSI_STDIO=1)
     endif()
 
     if(NOT BUILD_SHARED_LIBS)
         list(APPEND AWS_COMPILER_FLAGS "-fPIC")
+        list(APPEND AWS_PUBLIC_COMPILER_FLAGS "-fPIC")
     endif()
 
     if(NOT ENABLE_RTTI)
         list(APPEND AWS_COMPILER_FLAGS "-fno-rtti")
+        list(APPEND AWS_PUBLIC_COMPILER_FLAGS "-fno-rtti")
     endif()
 
     if(MINIMIZE_SIZE AND COMPILER_GCC)


### PR DESCRIPTION
*Issue*: #3613

*Description of changes:* Fixed an issue where the SDK's pkgconfig was including -std=c++11 in the Cflags, preventing downstream projects from using C++14+ features. Separated internal SDK compilation flags 
from public interface flags so projects can choose their own C++ standard while still getting necessary ABI compatibility flags like `-fno-exceptions`.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
