### PR TITLE
Fix brace initialization in AuthSchemeResolverBase.h

### DIFF
--- a/src/aws-cpp-sdk-core/include/smithy/identity/auth/AuthSchemeResolverBase.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/auth/AuthSchemeResolverBase.h
@@ -18,12 +18,12 @@ static const char BEARER_PREFERENCE[] = "bearer";
 static const char NO_AUTH_PREFERENCE[] = "noauth";
 
 // Global map from auth scheme name (trimmed ID) to full ID for case insensitive lookup
-static const Aws::Array<std::pair<const char*, const char*>, 4> AUTH_SCHEME_NAME_TO_ID = {
+static const Aws::Array<std::pair<const char*, const char*>, 4> AUTH_SCHEME_NAME_TO_ID = {{
     std::make_pair(SIGV4_PREFERENCE, "aws.auth#sigv4"),
     std::make_pair(SIGV4A_PREFERENCE, "aws.auth#sigv4a"),
     std::make_pair(BEARER_PREFERENCE, "smithy.api#HTTPBearerAuth"),
     std::make_pair(NO_AUTH_PREFERENCE, "smithy.api#noAuth")
-};
+}};
 
 /**
 * A base interface for code-generated interfaces for passing in the data required for determining the


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix brace initialization 

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
