### PR TITLE
Add lombok annotation processor in maven to fix builds on recent jdk versions

### DIFF
--- a/tools/code-generation/generator/pom.xml
+++ b/tools/code-generation/generator/pom.xml
@@ -11,6 +11,10 @@
     <name>AWS Client Generator</name>
     <url>http://aws.amazon.com</url>
 
+    <properties>
+        <lombok.version>1.18.42</lombok.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -20,6 +24,13 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>
@@ -103,7 +114,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.30</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
*Description of changes:*

Since jdk23 lombok needs to be registered as an annotation processor explicitly otherwise it will not process java sources. This change applies the [lombok recommended method](https://projectlombok.org/setup/maven) of applying the annotation processor to fix builds on jdk23+

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

This doesnt effect generated sdk code, so I don't think any tests should be needed.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
