### PR TITLE
fix linker error because of missing exported symbols on windows

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/stream/StreamBufProtectedWriter.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/stream/StreamBufProtectedWriter.h
@@ -23,7 +23,7 @@ namespace Aws
             /**
              * This is a wrapper to perform a hack to write directly to the put area of the underlying streambuf
              */
-            class AWS_CORE_API StreamBufProtectedWriter : public std::streambuf
+            class StreamBufProtectedWriter : public std::streambuf
             {
             public:
                 StreamBufProtectedWriter() = delete;


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/3616

*Description of changes:*

We added a test `StreamBufProtectedWriterTest` that uses the class `StreamBufProtectedWriter` when we recently made edits to it. This class is only used in the windows http client. When using with on a MSVC toolchain, and using the CRT HTTP option, the static inlined symbols are not generated creating a linker error for the tests. this fixes this by removing the export on this class all together as it is header only.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
