### PR TITLE
Refactor AWS Chunked logic from HTTP clients

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -78,6 +78,16 @@ namespace Aws
           WHEN_REQUIRED,
         };
 
+        /**
+         * Control HTTP client chunking implementation mode.
+         * DEFAULT: Use SDK's ChunkingInterceptor for aws-chunked encoding
+         * CLIENT_IMPLEMENTATION: Rely on HTTP client's native chunking (default for custom clients)
+         */
+        enum class HttpClientChunkedMode {
+          DEFAULT,
+          CLIENT_IMPLEMENTATION,
+        };
+
         struct RequestCompressionConfig {
           UseRequestCompression useRequestCompression=UseRequestCompression::ENABLE;
           size_t requestMinCompressionSizeBytes = 10240;
@@ -493,6 +503,12 @@ namespace Aws
            * https://docs.aws.amazon.com/sdkref/latest/guide/feature-account-endpoints.html
            */
           Aws::String accountIdEndpointMode = "preferred";
+
+          /**
+           * Control HTTP client chunking implementation mode.
+           * Default is set automatically: CLIENT_IMPLEMENTATION for custom clients, DEFAULT for AWS clients.
+           */
+          HttpClientChunkedMode httpClientChunkedMode = HttpClientChunkedMode::CLIENT_IMPLEMENTATION;
           /**
           * Configuration structure for credential providers in the AWS SDK.
           * This structure allows passing configuration options to credential providers

--- a/src/aws-cpp-sdk-core/include/aws/core/http/HttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/HttpClient.h
@@ -49,6 +49,11 @@ namespace Aws
             virtual bool SupportsChunkedTransferEncoding() const { return true; }
 
             /**
+             * Returns true if this is a default AWS SDK HTTP client implementation.
+             */
+            virtual bool IsDefaultAwsHttpClient() const { return false; }
+
+            /**
              * Stops all requests in progress and prevents any others from initiating.
              */
             void DisableRequestProcessing();

--- a/src/aws-cpp-sdk-core/include/aws/core/http/crt/CRTHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/crt/CRTHttpClient.h
@@ -52,6 +52,8 @@ namespace Aws
                 Aws::Utils::RateLimits::RateLimiterInterface* readLimiter,
                 Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter) const override;
 
+            bool IsDefaultAwsHttpClient() const override { return true; }
+
         private:
             // Yeah, I know, but someone made MakeRequest() const and didn't think about the fact that
             // making an HTTP request most certainly mutates state. It was me. I'm the person that did that, and

--- a/src/aws-cpp-sdk-core/include/aws/core/http/curl/CurlHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/curl/CurlHttpClient.h
@@ -37,6 +37,8 @@ public:
         Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
         Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter = nullptr) const override;
 
+    bool IsDefaultAwsHttpClient() const override { return true; }
+
     static void InitGlobalState();
     static void CleanupGlobalState();
 

--- a/src/aws-cpp-sdk-core/include/aws/core/http/windows/IXmlHttpRequest2HttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/windows/IXmlHttpRequest2HttpClient.h
@@ -54,6 +54,8 @@ namespace Aws
              */
             virtual bool SupportsChunkedTransferEncoding() const override { return false; }
 
+            bool IsDefaultAwsHttpClient() const override { return true; }
+
         protected:
             /**
              * Override any configuration on request handle.

--- a/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinHttpSyncHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinHttpSyncHttpClient.h
@@ -42,6 +42,8 @@ namespace Aws
              */
             const char* GetLogTag() const override { return "WinHttpSyncHttpClient"; }
 
+            bool IsDefaultAwsHttpClient() const override { return true; }
+
         private:
             // WinHttp specific implementations
             void* OpenRequest(const std::shared_ptr<HttpRequest>& request, void* connection, const Aws::StringStream& ss) const override;

--- a/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinINetSyncHttpClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/windows/WinINetSyncHttpClient.h
@@ -39,6 +39,8 @@ namespace Aws
              * Gets log tag for use in logging in the base class.
              */
             const char* GetLogTag() const override { return "WinInetSyncHttpClient"; }
+
+            bool IsDefaultAwsHttpClient() const override { return true; }
         private:
 
             // WinHttp specific implementations

--- a/src/aws-cpp-sdk-core/include/smithy/client/features/ChunkingInterceptor.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/features/ChunkingInterceptor.h
@@ -1,0 +1,225 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+#include <aws/core/http/HttpRequest.h>
+#include <aws/core/utils/Array.h>
+#include <aws/core/utils/StringUtils.h>
+#include <aws/core/utils/HashingUtils.h>
+#include <aws/core/utils/logging/LogMacros.h>
+#include <aws/core/utils/memory/stl/AWSStringStream.h>
+#include <aws/core/utils/memory/stl/AWSVector.h>
+#include <smithy/interceptor/Interceptor.h>
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/core/client/AWSError.h>
+#include <memory>
+
+namespace smithy {
+namespace client {
+namespace features {
+
+static const size_t AWS_DATA_BUFFER_SIZE = 65536;
+static const char* ALLOCATION_TAG = "ChunkingInterceptor";
+static const char* CHECKSUM_HEADER_PREFIX = "x-amz-checksum-";
+
+template <size_t DataBufferSize = AWS_DATA_BUFFER_SIZE>
+class AwsChunkedStreamBuf : public std::streambuf {
+public:
+    AwsChunkedStreamBuf(Aws::Http::HttpRequest* request,
+                        const std::shared_ptr<Aws::IOStream>& stream,
+                        size_t bufferSize = DataBufferSize)
+        : m_request(request),
+          m_stream(stream),
+          m_data(bufferSize)
+    {
+        assert(m_stream != nullptr);
+        if (m_stream == nullptr) {
+            AWS_LOGSTREAM_ERROR("AwsChunkedStream", "stream is null");
+        }
+        assert(m_request != nullptr);
+        if (m_request == nullptr) {
+            AWS_LOGSTREAM_ERROR("AwsChunkedStream", "request is null");
+        }
+    }
+
+protected:
+    int_type underflow() override {
+        if (gptr() && gptr() < egptr()) {
+            return traits_type::to_int_type(*gptr());
+        }
+
+        // only read and write to chunked stream if the underlying stream
+        // is still in a valid state and we have buffer space
+        if (m_stream->good() && m_chunkingBufferPos >= m_chunkingBufferSize) {
+            // Reset buffer for new data only when buffer is consumed
+            m_chunkingBufferPos = 0;
+            m_chunkingBufferSize = 0;
+            
+            // Check if we have enough space for worst-case chunk (data + header + footer)
+            size_t maxChunkSize = m_data.GetLength() + 20; // data + hex header + CRLF
+            if (m_chunkingBufferSize + maxChunkSize <= m_chunkingBuffer.GetLength()) {
+                // Try to read in a 64K chunk, if we cant we know the stream is over
+                m_stream->read(m_data.GetUnderlyingData(), m_data.GetLength());
+                size_t bytesRead = static_cast<size_t>(m_stream->gcount());
+                writeChunk(bytesRead);
+
+                // if we've read everything from the stream, we want to add the trailer
+                // to the underlying stream
+                if ((m_stream->peek() == EOF || m_stream->eof()) && !m_stream->bad()) {
+                    writeTrailerToUnderlyingStream();
+                }
+            }
+        }
+
+        // if the chunking buffer is empty there is nothing to read
+        if (m_chunkingBufferPos >= m_chunkingBufferSize) {
+            return traits_type::eof();
+        }
+
+        // Set up buffer pointers to read from chunking buffer
+        size_t remainingBytes = m_chunkingBufferSize - m_chunkingBufferPos;
+        size_t bytesToRead = std::min(remainingBytes, DataBufferSize);
+        
+        setg(m_chunkingBuffer.GetUnderlyingData() + m_chunkingBufferPos, 
+             m_chunkingBuffer.GetUnderlyingData() + m_chunkingBufferPos, 
+             m_chunkingBuffer.GetUnderlyingData() + m_chunkingBufferPos + bytesToRead);
+        
+        m_chunkingBufferPos += bytesToRead;
+        
+        return traits_type::to_int_type(*gptr());
+    }
+
+private:
+    void writeTrailerToUnderlyingStream() {
+        Aws::String trailer = "0\r\n";
+        if (m_request->GetRequestHash().second != nullptr) {
+            trailer += "x-amz-checksum-" + m_request->GetRequestHash().first + ":"
+                     + Aws::Utils::HashingUtils::Base64Encode(m_request->GetRequestHash().second->GetHash().GetResult()) + "\r\n";
+        }
+        trailer += "\r\n";
+        if (m_chunkingBufferSize + trailer.length() <= m_chunkingBuffer.GetLength()) {
+            std::memcpy(m_chunkingBuffer.GetUnderlyingData() + m_chunkingBufferSize, trailer.c_str(), trailer.length());
+            m_chunkingBufferSize += trailer.length();
+        }
+    }
+
+    void writeChunk(size_t bytesRead) {
+        if (m_request->GetRequestHash().second != nullptr) {
+            m_request->GetRequestHash().second->Update(reinterpret_cast<unsigned char*>(m_data.GetUnderlyingData()), bytesRead);
+        }
+
+        if (bytesRead > 0) {
+            Aws::String chunkHeader = Aws::Utils::StringUtils::ToHexString(bytesRead) + "\r\n";
+            size_t totalSize = chunkHeader.length() + bytesRead + 2;
+            if (m_chunkingBufferSize + totalSize <= m_chunkingBuffer.GetLength()) {
+                std::memcpy(m_chunkingBuffer.GetUnderlyingData() + m_chunkingBufferSize, chunkHeader.c_str(), chunkHeader.length());
+                m_chunkingBufferSize += chunkHeader.length();
+                std::memcpy(m_chunkingBuffer.GetUnderlyingData() + m_chunkingBufferSize, m_data.GetUnderlyingData(), bytesRead);
+                m_chunkingBufferSize += bytesRead;
+                std::memcpy(m_chunkingBuffer.GetUnderlyingData() + m_chunkingBufferSize, "\r\n", 2);
+                m_chunkingBufferSize += 2;
+            }
+        }
+    }
+
+    // Buffer for chunked data plus overhead for HTTP chunked encoding headers, trailers, and safety margin
+    Aws::Utils::Array<char> m_chunkingBuffer{DataBufferSize + 128};
+    size_t m_chunkingBufferSize{0};
+    size_t m_chunkingBufferPos{0};
+    Aws::Http::HttpRequest* m_request{nullptr};
+    std::shared_ptr<Aws::IOStream> m_stream;
+    Aws::Utils::Array<char> m_data;
+};
+
+class AwsChunkedIOStream : public Aws::IOStream {
+public:
+    AwsChunkedIOStream(Aws::Http::HttpRequest* request,
+                       const std::shared_ptr<Aws::IOStream>& originalBody,
+                       size_t bufferSize = AWS_DATA_BUFFER_SIZE)
+        : Aws::IOStream(&m_buf),
+          m_buf(request, originalBody, bufferSize) {}
+
+private:
+    AwsChunkedStreamBuf<> m_buf;
+};
+
+/**
+ * Interceptor that handles chunked encoding for streaming requests with checksums.
+ * Wraps request body with chunked stream and sets appropriate headers.
+ */
+class ChunkingInterceptor : public smithy::interceptor::Interceptor {
+public:
+    explicit ChunkingInterceptor(Aws::Client::HttpClientChunkedMode httpClientChunkedMode)
+        : m_httpClientChunkedMode(httpClientChunkedMode) {}
+    ~ChunkingInterceptor() override = default;
+
+    ModifyRequestOutcome ModifyBeforeSigning(smithy::interceptor::InterceptorContext& context) override {
+        auto request = context.GetTransmitRequest();
+
+        if (!ShouldApplyChunking(request)) {
+            return request;
+        }
+
+        auto originalBody = request->GetContentBody();
+        if (!originalBody) {
+            return request;
+        }
+
+        // Set up chunked encoding headers for checksum calculation
+        const auto& hashPair = request->GetRequestHash();
+        if (hashPair.second != nullptr) {
+            Aws::String checksumHeaderValue = Aws::String(CHECKSUM_HEADER_PREFIX) + hashPair.first;
+            request->DeleteHeader(checksumHeaderValue.c_str());
+            request->SetHeaderValue(Aws::Http::AWS_TRAILER_HEADER, checksumHeaderValue);
+            request->SetTransferEncoding(Aws::Http::CHUNKED_VALUE);
+            
+            if (!request->HasContentEncoding()) {
+                request->SetContentEncoding(Aws::Http::AWS_CHUNKED_VALUE);
+            } else {
+                Aws::String currentEncoding = request->GetContentEncoding();
+                if (currentEncoding.find(Aws::Http::AWS_CHUNKED_VALUE) == Aws::String::npos) {
+                    request->SetContentEncoding(Aws::String{Aws::Http::AWS_CHUNKED_VALUE} + "," + currentEncoding);
+                }
+            }
+
+            if (request->HasHeader(Aws::Http::CONTENT_LENGTH_HEADER)) {
+                request->SetHeaderValue(Aws::Http::DECODED_CONTENT_LENGTH_HEADER, request->GetHeaderValue(Aws::Http::CONTENT_LENGTH_HEADER));
+                request->DeleteHeader(Aws::Http::CONTENT_LENGTH_HEADER);
+            }
+        }
+
+        auto chunkedBody = Aws::MakeShared<AwsChunkedIOStream>(
+            ALLOCATION_TAG, request.get(), originalBody);
+
+        request->AddContentBody(chunkedBody);
+        return request;
+    }
+
+    ModifyResponseOutcome ModifyBeforeDeserialization(smithy::interceptor::InterceptorContext& context) override {
+        return context.GetTransmitResponse();
+    }
+
+private:
+    bool ShouldApplyChunking(const std::shared_ptr<Aws::Http::HttpRequest>& request) const {
+        // Use configuration setting to determine chunking behavior
+        if (m_httpClientChunkedMode != Aws::Client::HttpClientChunkedMode::DEFAULT) {
+            return false;
+        }
+        
+        if (!request || !request->GetContentBody()) {
+            return false;
+        }
+        
+        // Check if request has checksum requirements
+        const auto& hashPair = request->GetRequestHash();
+        return hashPair.second != nullptr;
+    }
+
+    Aws::Client::HttpClientChunkedMode m_httpClientChunkedMode;
+};
+
+} // namespace features
+} // namespace client
+} // namespace smithy

--- a/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -46,6 +46,7 @@
 
 #include <smithy/tracing/TracingUtils.h>
 #include <smithy/client/features/ChecksumInterceptor.h>
+#include <smithy/client/features/ChunkingInterceptor.h>
 
 #include <cstring>
 #include <cassert>
@@ -139,7 +140,8 @@ AWSClient::AWSClient(const Aws::Client::ClientConfiguration& configuration,
     m_enableClockSkewAdjustment(configuration.enableClockSkewAdjustment),
     m_requestCompressionConfig(configuration.requestCompressionConfig),
     m_userAgentInterceptor{Aws::MakeShared<smithy::client::UserAgentInterceptor>(AWS_CLIENT_LOG_TAG, configuration, m_retryStrategy->GetStrategyName(), m_serviceName)},
-    m_interceptors{Aws::MakeShared<smithy::client::ChecksumInterceptor>(AWS_CLIENT_LOG_TAG), m_userAgentInterceptor}
+    m_interceptors{Aws::MakeShared<smithy::client::ChecksumInterceptor>(AWS_CLIENT_LOG_TAG), Aws::MakeShared<smithy::client::features::ChunkingInterceptor>(AWS_CLIENT_LOG_TAG, 
+        m_httpClient->IsDefaultAwsHttpClient() ? Aws::Client::HttpClientChunkedMode::DEFAULT : configuration.httpClientChunkedMode), m_userAgentInterceptor}
 {
 }
 
@@ -165,7 +167,8 @@ AWSClient::AWSClient(const Aws::Client::ClientConfiguration& configuration,
     m_enableClockSkewAdjustment(configuration.enableClockSkewAdjustment),
     m_requestCompressionConfig(configuration.requestCompressionConfig),
     m_userAgentInterceptor{Aws::MakeShared<smithy::client::UserAgentInterceptor>(AWS_CLIENT_LOG_TAG, configuration, m_retryStrategy->GetStrategyName(), m_serviceName)},
-    m_interceptors{Aws::MakeShared<smithy::client::ChecksumInterceptor>(AWS_CLIENT_LOG_TAG, configuration), m_userAgentInterceptor}
+    m_interceptors{Aws::MakeShared<smithy::client::ChecksumInterceptor>(AWS_CLIENT_LOG_TAG, configuration), Aws::MakeShared<smithy::client::features::ChunkingInterceptor>(AWS_CLIENT_LOG_TAG, 
+        m_httpClient->IsDefaultAwsHttpClient() ? Aws::Client::HttpClientChunkedMode::DEFAULT : configuration.httpClientChunkedMode), m_userAgentInterceptor}
 {
 }
 

--- a/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
@@ -220,6 +220,7 @@ void setLegacyClientConfigurationParameters(ClientConfiguration& clientConfig)
     clientConfig.writeRateLimiter = nullptr;
     clientConfig.readRateLimiter = nullptr;
     clientConfig.httpLibOverride = Aws::Http::TransferLibType::DEFAULT_CLIENT;
+    clientConfig.httpClientChunkedMode = HttpClientChunkedMode::CLIENT_IMPLEMENTATION;
     clientConfig.followRedirects = FollowRedirectsPolicy::DEFAULT;
     clientConfig.disableExpectHeader = false;
     clientConfig.enableClockSkewAdjustment = true;

--- a/src/aws-cpp-sdk-core/source/client/UserAgent.cpp
+++ b/src/aws-cpp-sdk-core/source/client/UserAgent.cpp
@@ -183,6 +183,15 @@ Aws::String UserAgent::SerializeWithFeatures(const Aws::Set<UserAgentFeature>& f
     SerializeMetadata(METADATA, m_compilerMetadata);
   }
 
+  // Add HTTP client metadata
+#if AWS_SDK_USE_CRT_HTTP
+  SerializeMetadata(METADATA, "http#crt");
+#elif ENABLE_CURL_CLIENT
+  SerializeMetadata(METADATA, "http#curl");
+#elif ENABLE_WINDOWS_CLIENT
+  SerializeMetadata(METADATA, "http#winhttp");
+#endif
+
   // metrics
   Aws::Vector<Aws::String> encodedMetrics{};
 

--- a/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
@@ -9,7 +9,6 @@
 #include <aws/core/utils/crypto/Hash.h>
 #include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/ratelimiter/RateLimiterInterface.h>
-#include <aws/core/utils/stream/AwsChunkedStream.h>
 #include <aws/crt/http/HttpConnectionManager.h>
 #include <aws/crt/http/HttpRequestResponse.h>
 
@@ -379,11 +378,7 @@ namespace Aws
             if (request->GetContentBody())
             {
                 bool isStreaming = request->IsEventStreamRequest();
-                if (request->HasHeader(Aws::Http::CONTENT_ENCODING_HEADER) && request->GetHeaderValue(Aws::Http::CONTENT_ENCODING_HEADER) == Aws::Http::AWS_CHUNKED_VALUE) {
-                  crtRequest->SetBody(Aws::MakeShared<Aws::Utils::Stream::AwsChunkedStream<>>(CRT_HTTP_CLIENT_TAG, request.get(), request->GetContentBody()));
-                } else {
-                  crtRequest->SetBody(Aws::MakeShared<SDKAdaptingInputStream>(CRT_HTTP_CLIENT_TAG, m_configuration.writeRateLimiter, request->GetContentBody(), *this, *request, isStreaming));
-                }
+                crtRequest->SetBody(Aws::MakeShared<SDKAdaptingInputStream>(CRT_HTTP_CLIENT_TAG, m_configuration.writeRateLimiter, request->GetContentBody(), *this, *request, isStreaming));
             }
 
             Crt::Http::HttpRequestOptions requestOptions;

--- a/src/aws-cpp-sdk-core/source/smithy/client/AwsSmithyClientBase.cpp
+++ b/src/aws-cpp-sdk-core/source/smithy/client/AwsSmithyClientBase.cpp
@@ -25,6 +25,7 @@
 #include <smithy/identity/auth/built-in/GenericAuthSchemeResolver.h>
 
 using namespace smithy::client;
+using namespace smithy::client::features;
 using namespace smithy::interceptor;
 using namespace smithy::components::tracing;
 
@@ -102,7 +103,12 @@ void AwsSmithyClientBase::baseCopyAssign(const AwsSmithyClientBase& other,
   m_serviceUserAgentName = other.m_serviceUserAgentName;
   m_httpClient = std::move(httpClient);
   m_errorMarshaller = std::move(errorMarshaller);
-  m_interceptors = Aws::Vector<std::shared_ptr<interceptor::Interceptor>>{Aws::MakeShared<ChecksumInterceptor>("AwsSmithyClientBase")};
+  
+  m_interceptors = Aws::Vector<std::shared_ptr<interceptor::Interceptor>>{
+      Aws::MakeShared<ChecksumInterceptor>("AwsSmithyClientBase", *m_clientConfig),
+      Aws::MakeShared<features::ChunkingInterceptor>("AwsSmithyClientBase", 
+          m_httpClient->IsDefaultAwsHttpClient() ? Aws::Client::HttpClientChunkedMode::DEFAULT : m_clientConfig->httpClientChunkedMode)
+  };
 
   baseCopyInit();
 }

--- a/tests/aws-cpp-sdk-core-tests/utils/stream/ChunkingInterceptorTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/stream/ChunkingInterceptorTest.cpp
@@ -1,0 +1,162 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/core/http/standard/StandardHttpRequest.h>
+#include <aws/core/utils/crypto/CRC32.h>
+#include <smithy/client/features/ChunkingInterceptor.h>
+#include <aws/testing/AwsCppSdkGTestSuite.h>
+#include <aws/core/client/ClientConfiguration.h>
+#include <smithy/interceptor/InterceptorContext.h>
+#include <aws/core/http/HttpClient.h>
+#include <aws/core/AmazonWebServiceRequest.h>
+#include <aws/core/http/HttpTypes.h>
+
+using namespace Aws;
+using namespace Aws::Http::Standard;
+using namespace smithy::client::features;
+using namespace Aws::Utils::Crypto;
+
+const char* CHUNKING_TEST_LOG_TAG = "CHUNKING_INTERCEPTOR_TEST";
+
+// Mock implementation of AmazonWebServiceRequest
+class MockRequest : public Aws::AmazonWebServiceRequest {
+public:
+    std::shared_ptr<Aws::IOStream> GetBody() const override { return nullptr; }
+    Aws::Http::HeaderValueCollection GetHeaders() const override { return {}; }
+    const char* GetServiceRequestName() const override { return "MockRequest"; }
+};
+
+class ChunkingInterceptorTest : public Aws::Testing::AwsCppSdkGTestSuite {
+protected:
+    template <typename Fn>
+    void withChunkedStream(const std::string& input, size_t bufferSize, Fn&& fn) {
+        StandardHttpRequest request{"test.com", Http::HttpMethod::HTTP_GET};
+        auto requestHash = Aws::MakeShared<CRC32>(CHUNKING_TEST_LOG_TAG);
+        request.SetRequestHash("crc32", requestHash);
+        auto inputStream = Aws::MakeShared<Aws::StringStream>(CHUNKING_TEST_LOG_TAG);
+        *inputStream << input;
+        
+        AwsChunkedIOStream wrapper{&request, inputStream, bufferSize};
+        Aws::IOStream* stream = &wrapper;
+        
+        fn(*stream);
+    }
+};
+
+TEST_F(ChunkingInterceptorTest, ChunkedStreamShouldWork) {
+    withChunkedStream("1234567890123456789012345", 10, [](Aws::IOStream& chunkedStream) {
+        char buffer[100];
+        std::stringstream output;
+        
+        // Read in 10-byte chunks
+        for (int i = 0; i < 4; i++) {
+            chunkedStream.read(buffer, 10);
+            auto bytesRead = chunkedStream.gcount();
+            output.write(buffer, bytesRead);
+        }
+        
+        // Read trailing checksum (greater than 10 chars)
+        chunkedStream.read(buffer, 40);
+        auto bytesRead = static_cast<size_t>(chunkedStream.gcount());
+        EXPECT_EQ(36ul, bytesRead);
+        output.write(buffer, bytesRead);
+        
+        EXPECT_EQ("A\r\n1234567890\r\nA\r\n1234567890\r\n5\r\n12345\r\n0\r\nx-amz-checksum-crc32:78DeVw==\r\n\r\n", output.str());
+    });
+}
+
+TEST_F(ChunkingInterceptorTest, ShouldNotRequireTwoReadsOnSmallChunk) {
+    withChunkedStream("12345", 100, [](Aws::IOStream& chunkedStream) {
+        char buffer[100];
+        chunkedStream.read(buffer, 100);
+        auto bytesRead = static_cast<size_t>(chunkedStream.gcount());
+        EXPECT_EQ(46ul, bytesRead);
+        
+        std::string output(buffer, bytesRead);
+        EXPECT_EQ("5\r\n12345\r\n0\r\nx-amz-checksum-crc32:y/U6HA==\r\n\r\n", output);
+    });
+}
+
+TEST_F(ChunkingInterceptorTest, ShouldWorkOnSmallBuffer) {
+    withChunkedStream("1234567890", 5, [](Aws::IOStream& chunkedStream) {
+        char buffer[100];
+        
+        // First read - explicitly ask for 10 bytes (first chunk: "5\r\n12345\r\n")
+        chunkedStream.read(buffer, 10);
+        auto bytesRead = static_cast<size_t>(chunkedStream.gcount());
+        EXPECT_EQ(10ul, bytesRead);
+        std::string firstRead(buffer, bytesRead);
+        EXPECT_EQ("5\r\n12345\r\n", firstRead);
+        
+        // Second read - now we expect the rest (46 bytes: second chunk + trailer)
+        chunkedStream.read(buffer, 100);
+        bytesRead = static_cast<size_t>(chunkedStream.gcount());
+        EXPECT_EQ(46ul, bytesRead);
+        std::string secondRead(buffer, bytesRead);
+        EXPECT_EQ("5\r\n67890\r\n0\r\nx-amz-checksum-crc32:Jh2u5Q==\r\n\r\n", secondRead);
+        
+        // Subsequent reads should return 0
+        chunkedStream.read(buffer, 100);
+        bytesRead = static_cast<size_t>(chunkedStream.gcount());
+        EXPECT_EQ(0ul, bytesRead);
+    });
+}
+
+TEST_F(ChunkingInterceptorTest, ShouldWorkOnEmptyStream) {
+    withChunkedStream("", 5, [](Aws::IOStream& chunkedStream) {
+        char buffer[100];
+        chunkedStream.read(buffer, 100);
+        auto bytesRead = static_cast<size_t>(chunkedStream.gcount());
+        EXPECT_EQ(36ul, bytesRead);
+        
+        std::string output(buffer, bytesRead);
+        EXPECT_EQ("0\r\nx-amz-checksum-crc32:AAAAAA==\r\n\r\n", output);
+    });
+}
+
+// Custom HTTP client (inherits default IsDefaultAwsHttpClient() = false from base class)
+class CustomHttpClient : public Aws::Http::HttpClient {
+public:
+    std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(const std::shared_ptr<Aws::Http::HttpRequest>&, 
+                                                        Aws::Utils::RateLimits::RateLimiterInterface*, 
+                                                        Aws::Utils::RateLimits::RateLimiterInterface*) const override {
+        return nullptr;
+    }
+};
+
+TEST_F(ChunkingInterceptorTest, ShouldNotApplyChunkingForCustomHttpClient) {
+    // Simulate the GetChunkingConfig behavior from AWSClient.cpp
+    // When IsDefaultAwsHttpClient() returns false, httpClientChunkedMode is set to CLIENT_IMPLEMENTATION
+    Aws::Client::ClientConfiguration config;
+    auto customHttpClient = Aws::MakeShared<CustomHttpClient>(CHUNKING_TEST_LOG_TAG);
+    
+    // This simulates the logic in GetChunkingConfig function
+    if (!customHttpClient->IsDefaultAwsHttpClient()) {
+        config.httpClientChunkedMode = Aws::Client::HttpClientChunkedMode::CLIENT_IMPLEMENTATION;
+    }
+    
+    ChunkingInterceptor interceptor(config.httpClientChunkedMode);
+    
+    // Create request with checksum (would normally trigger chunking)
+    auto request = Aws::MakeShared<StandardHttpRequest>(CHUNKING_TEST_LOG_TAG, "test.com", Http::HttpMethod::HTTP_POST);
+    auto requestHash = Aws::MakeShared<CRC32>(CHUNKING_TEST_LOG_TAG);
+    request->SetRequestHash("crc32", requestHash);
+    
+    auto inputStream = Aws::MakeShared<Aws::StringStream>(CHUNKING_TEST_LOG_TAG);
+    *inputStream << "test data";
+    request->AddContentBody(inputStream);
+    
+    // Create interceptor context with a mock request
+    MockRequest mockRequest;
+    smithy::interceptor::InterceptorContext context(mockRequest);
+    context.SetTransmitRequest(request);
+    
+    // Apply interceptor
+    auto result = interceptor.ModifyBeforeSigning(context);
+    
+    // Verify chunking was NOT applied because custom HTTP client uses default IsDefaultAwsHttpClient() = false
+    EXPECT_EQ(request, result.GetResult());
+    EXPECT_FALSE(request->HasHeader(Aws::Http::AWS_TRAILER_HEADER));
+    EXPECT_FALSE(request->HasHeader(Aws::Http::TRANSFER_ENCODING_HEADER));
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/issues/3297

*Description of changes:*
Our goal is specifically to refactor this logic out of http clients and into a interceptor. We will introduce a core ChunkingInterceptor that owns all aws-chunked behavior for streaming requests and remove the chunking logics from the individual HTTP clients. 

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
