### PR TITLE
fix dynamo default credentials provider chain

### DIFF
--- a/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClient.cpp
+++ b/generated/src/aws-cpp-sdk-dynamodb/source/DynamoDBClient.cpp
@@ -101,15 +101,16 @@ const char* DynamoDBClient::GetAllocationTag() { return ALLOCATION_TAG; }
 
 DynamoDBClient::DynamoDBClient(const DynamoDB::DynamoDBClientConfiguration& clientConfiguration,
                                std::shared_ptr<DynamoDBEndpointProviderBase> endpointProvider)
-    : AwsSmithyClientT(clientConfiguration, GetServiceName(), "DynamoDB", Aws::Http::CreateHttpClient(clientConfiguration),
-                       Aws::MakeShared<DynamoDBErrorMarshaller>(ALLOCATION_TAG),
-                       endpointProvider ? endpointProvider : Aws::MakeShared<DynamoDBEndpointProvider>(ALLOCATION_TAG),
-                       Aws::MakeShared<smithy::GenericAuthSchemeResolver<>>(
-                           ALLOCATION_TAG, Aws::Vector<smithy::AuthSchemeOption>({smithy::SigV4AuthSchemeOption::sigV4AuthSchemeOption})),
-                       {
-                           {smithy::SigV4AuthSchemeOption::sigV4AuthSchemeOption.schemeId,
-                            smithy::SigV4AuthScheme{GetServiceName(), clientConfiguration.region}},
-                       }) {}
+    : AwsSmithyClientT(
+          clientConfiguration, GetServiceName(), "DynamoDB", Aws::Http::CreateHttpClient(clientConfiguration),
+          Aws::MakeShared<DynamoDBErrorMarshaller>(ALLOCATION_TAG),
+          endpointProvider ? endpointProvider : Aws::MakeShared<DynamoDBEndpointProvider>(ALLOCATION_TAG),
+          Aws::MakeShared<smithy::GenericAuthSchemeResolver<>>(
+              ALLOCATION_TAG, Aws::Vector<smithy::AuthSchemeOption>({smithy::SigV4AuthSchemeOption::sigV4AuthSchemeOption})),
+          {
+              {smithy::SigV4AuthSchemeOption::sigV4AuthSchemeOption.schemeId,
+               smithy::SigV4AuthScheme{GetServiceName(), clientConfiguration.region, clientConfiguration.credentialProviderConfig}},
+          }) {}
 
 DynamoDBClient::DynamoDBClient(const AWSCredentials& credentials, std::shared_ptr<DynamoDBEndpointProviderBase> endpointProvider,
                                const DynamoDB::DynamoDBClientConfiguration& clientConfiguration)
@@ -148,7 +149,8 @@ DynamoDBClient::DynamoDBClient(const Client::ClientConfiguration& clientConfigur
                            ALLOCATION_TAG, Aws::Vector<smithy::AuthSchemeOption>({smithy::SigV4AuthSchemeOption::sigV4AuthSchemeOption})),
                        {
                            {smithy::SigV4AuthSchemeOption::sigV4AuthSchemeOption.schemeId,
-                            smithy::SigV4AuthScheme{Aws::MakeShared<smithy::DefaultAwsCredentialIdentityResolver>(ALLOCATION_TAG),
+                            smithy::SigV4AuthScheme{Aws::MakeShared<smithy::DefaultAwsCredentialIdentityResolver>(
+                                                        ALLOCATION_TAG, clientConfiguration.credentialProviderConfig),
                                                     GetServiceName(), clientConfiguration.region}},
                        }) {}
 

--- a/src/aws-cpp-sdk-core/include/smithy/identity/auth/built-in/BearerTokenAuthScheme.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/auth/built-in/BearerTokenAuthScheme.h
@@ -33,6 +33,14 @@ class BearerTokenAuthScheme : public AuthScheme<AwsBearerTokenIdentityBase>
         assert(m_signer);
     }
 
+    explicit BearerTokenAuthScheme(const Aws::String &serviceName, const Aws::String &region,
+                                   const Aws::Client::ClientConfiguration::CredentialProviderConfiguration& config)
+        : BearerTokenAuthScheme(Aws::MakeShared<DefaultAwsBearerTokenIdentityResolver>("BearerTokenAuthScheme"), serviceName, region) {
+      AWS_UNREFERENCED_PARAM(config);
+      assert(m_identityResolver);
+      assert(m_signer);
+    }
+
     explicit BearerTokenAuthScheme(const Aws::String &serviceName,
                                    const Aws::String &region)
         : BearerTokenAuthScheme(

--- a/src/aws-cpp-sdk-core/include/smithy/identity/auth/built-in/NoAuthScheme.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/auth/built-in/NoAuthScheme.h
@@ -51,6 +51,15 @@ namespace smithy {
           assert(m_identityResolver);
         }
 
+        explicit NoAuthScheme(const Aws::String& serviceName, const Aws::String& region,
+                              const Aws::Client::ClientConfiguration::CredentialProviderConfiguration& config)
+            : NoAuthScheme(nullptr, serviceName, region)
+        {
+          AWS_UNREFERENCED_PARAM(config);
+          assert(m_signer);
+          assert(m_identityResolver);
+        }
+
         //legacy constructors
         explicit NoAuthScheme(std::shared_ptr<AwsCredentialIdentityResolverT> identityResolver, const Aws::String& serviceName, const Aws::String& region, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy policy, bool urlEscape)
             :  AuthScheme(NOAUTH),

--- a/src/aws-cpp-sdk-core/include/smithy/identity/auth/built-in/SigV4AuthScheme.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/auth/built-in/SigV4AuthScheme.h
@@ -59,6 +59,12 @@ namespace smithy {
         {
         }
 
+        explicit SigV4AuthScheme(const Aws::String& serviceName, const Aws::String& region,
+                                 const Aws::Client::ClientConfiguration::CredentialProviderConfiguration& config)
+            : SigV4AuthScheme(
+                  Aws::MakeShared<DefaultAwsCredentialIdentityResolver>("SigV4AuthScheme", config),
+                  serviceName, region) {}
+
         //For legacy constructors, signing requires additional input parameters
         explicit SigV4AuthScheme(const Aws::String& serviceName,
                                  const Aws::String& region,

--- a/src/aws-cpp-sdk-core/include/smithy/identity/auth/built-in/SigV4aAuthScheme.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/auth/built-in/SigV4aAuthScheme.h
@@ -36,6 +36,15 @@ namespace smithy {
             assert(m_signer);
         }
 
+        explicit SigV4aAuthScheme(const Aws::String& serviceName, const Aws::String& region,
+                                  const Aws::Client::ClientConfiguration::CredentialProviderConfiguration& config)
+            : SigV4aAuthScheme(
+                  Aws::MakeShared<DefaultAwsCredentialIdentityResolver>("SigV4aAuthScheme", config),
+                  serviceName, region) {
+          assert(m_identityResolver);
+          assert(m_signer);
+        }
+
         explicit SigV4aAuthScheme(const Aws::String& serviceName,
                                   const Aws::String& region)
             : SigV4aAuthScheme(Aws::MakeShared<DefaultAwsCredentialIdentityResolver>("SigV4aAuthScheme"), serviceName, region)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyClientSourceInit.vm
@@ -69,7 +69,7 @@ ${className}::${className}(const ${clientConfiguration}& clientConfiguration,
         {
 #if($serviceModel.metadata.serviceId == "S3")
             [&]() ->  Aws::UnorderedMap<Aws::String, ${rootNamespace}::Crt::Variant<${AuthSchemeVariants}> > {
-                  auto credsResolver = Aws::MakeShared<smithy::DefaultAwsCredentialIdentityResolver>(ALLOCATION_TAG);
+                  auto credsResolver = Aws::MakeShared<smithy::DefaultAwsCredentialIdentityResolver>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig);
                   return {
 #foreach($entry in $AuthSchemeMapEntries)
 #if($AuthSchemes && $AuthSchemes[$foreach.index] == $s3_express_auth)
@@ -82,7 +82,7 @@ ${className}::${className}(const ${clientConfiguration}& clientConfiguration,
             }()
 #else
 #foreach($entry in $AuthSchemeMapEntries)
-            {${entry}{GetServiceName(), clientConfiguration.region}},
+            {${entry}{GetServiceName(), clientConfiguration.region, clientConfiguration.credentialProviderConfig}},
 #end
 #end
         })
@@ -188,7 +188,7 @@ ${className}::${className}(const Client::ClientConfiguration& clientConfiguratio
       Aws::MakeShared<${AuthSchemeResolver}>(ALLOCATION_TAG),
       {
             [&]() ->  Aws::UnorderedMap<Aws::String, ${rootNamespace}::Crt::Variant<${AuthSchemeVariants}> > {
-                  auto credsResolver = Aws::MakeShared<smithy::DefaultAwsCredentialIdentityResolver>(ALLOCATION_TAG);
+                  auto credsResolver = Aws::MakeShared<smithy::DefaultAwsCredentialIdentityResolver>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig);
                   return {
 #foreach($entry in $AuthSchemeMapEntries)
 #if($AuthSchemes && $AuthSchemes[$foreach.index] == $s3_express_auth)
@@ -271,7 +271,7 @@ ${className}::${className}(const ${className} &rhs) :
     Aws::Client::ClientWithAsyncTemplateMethods<S3Client>(), AwsSmithyClientT(rhs) {
      m_authSchemes =
           [&]() ->  Aws::UnorderedMap<Aws::String, ${rootNamespace}::Crt::Variant<${AuthSchemeVariants}> > {
-            auto credsResolver = Aws::MakeShared<smithy::DefaultAwsCredentialIdentityResolver>(ALLOCATION_TAG);
+            auto credsResolver = Aws::MakeShared<smithy::DefaultAwsCredentialIdentityResolver>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig);
             return {
 #foreach($entry in $AuthSchemeMapEntries)
 #if($AuthSchemes && $AuthSchemes[$foreach.index] == $s3_express_auth)
@@ -304,7 +304,7 @@ ${className}::${className}(const Client::ClientConfiguration& clientConfiguratio
 #if($entry.contains("smithy::BearerTokenAuthScheme"))
           {${entry}{Aws::MakeShared<smithy::AwsBearerTokenIdentityResolver>(ALLOCATION_TAG), GetServiceName(), clientConfiguration.region}},
 #else
-          {$entry{Aws::MakeShared<smithy::DefaultAwsCredentialIdentityResolver>(ALLOCATION_TAG), GetServiceName(), clientConfiguration.region}},
+          {$entry{Aws::MakeShared<smithy::DefaultAwsCredentialIdentityResolver>(ALLOCATION_TAG, clientConfiguration.credentialProviderConfig), GetServiceName(), clientConfiguration.region}},
 #end
 #end
       })


### PR DESCRIPTION
*Description of changes:*

We previously [added support for credentials providers to use configuraiton defined in the central client configuration](https://github.com/aws/aws-sdk-cpp/pull/3492). this change was not properly propagated down to smithy based clients, this closes that gap.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
