### PR TITLE
Add cbor cloudwatch customization & query compat codegen fix

### DIFF
--- a/generated/src/aws-cpp-sdk-sqs/include/aws/sqs/SQSRequest.h
+++ b/generated/src/aws-cpp-sdk-sqs/include/aws/sqs/SQSRequest.h
@@ -26,8 +26,8 @@ class AWS_SQS_API SQSRequest : public Aws::AmazonSerializableWebServiceRequest {
 
     if (headers.size() == 0 || (headers.size() > 0 && headers.count(Aws::Http::CONTENT_TYPE_HEADER) == 0)) {
       headers.emplace(Aws::Http::HeaderValuePair(Aws::Http::CONTENT_TYPE_HEADER, Aws::AMZN_JSON_CONTENT_TYPE_1_0));
-      headers.emplace(Aws::Http::HeaderValuePair(Aws::Http::X_AMZN_QUERY_MODE, "true"));
     }
+    headers.emplace(Aws::Http::HeaderValuePair(Aws::Http::X_AMZN_QUERY_MODE, "true"));
     headers.emplace(Aws::Http::HeaderValuePair(Aws::Http::API_VERSION_HEADER, "2012-11-05"));
     return headers;
   }

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/config/ServiceGeneratorConfig.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/config/ServiceGeneratorConfig.java
@@ -21,6 +21,7 @@ import com.amazonaws.util.awsclientgenerator.generators.cpp.eventbridge.EventBri
 import com.amazonaws.util.awsclientgenerator.generators.cpp.glacier.GlacierRestJsonCppClientGenerator;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.lambda.LambdaRestJsonCppClientGenerator;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.machinelearning.MachineLearningJsonCppClientGenerator;
+import com.amazonaws.util.awsclientgenerator.generators.cpp.monitoring.CloudwatchMonitoringCborCppClientGenerator;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.monitoring.CloudwatchMonitoringJsonCppClientGenerator;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.neptune.NeptuneCppClientGenerator;
 import com.amazonaws.util.awsclientgenerator.generators.cpp.polly.PollyCppClientGenerator;
@@ -73,6 +74,7 @@ public class ServiceGeneratorConfig {
             SPEC_OVERRIDE_MAPPING.put("cpp-eventbridge-json", new EventBridgeCppClientGenerator());
             SPEC_OVERRIDE_MAPPING.put("cpp-dsql-rest-json", new DsqlCppClientGenerator());
             SPEC_OVERRIDE_MAPPING.put("cpp-monitoring-json", new CloudwatchMonitoringJsonCppClientGenerator());
+            SPEC_OVERRIDE_MAPPING.put("cpp-monitoring-smithy-rpc-v2-cbor", new CloudwatchMonitoringCborCppClientGenerator());
 
             // protocol tests clients
             SPEC_OVERRIDE_MAPPING.put("cpp-ec2-protocol-ec2", new Ec2CppClientGenerator());

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/monitoring/CloudwatchMonitoringCborCppClientGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/cpp/monitoring/CloudwatchMonitoringCborCppClientGenerator.java
@@ -1,0 +1,21 @@
+package com.amazonaws.util.awsclientgenerator.generators.cpp.monitoring;
+
+import com.amazonaws.util.awsclientgenerator.domainmodels.SdkFileEntry;
+import com.amazonaws.util.awsclientgenerator.domainmodels.codegeneration.ServiceModel;
+import com.amazonaws.util.awsclientgenerator.generators.cpp.CborCppClientGenerator;
+import com.google.common.collect.ImmutableMap;
+
+public class CloudwatchMonitoringCborCppClientGenerator extends CborCppClientGenerator {
+    public CloudwatchMonitoringCborCppClientGenerator() throws Exception {
+        super();
+    }
+
+    @Override
+    protected SdkFileEntry generateErrorSourceFile(ServiceModel serviceModel) throws Exception {
+        serviceModel.setQueryCompatibleErrorMappings(ImmutableMap.of(
+                "DASHBOARD_NOT_FOUND", "DashboardNotFoundError"
+        ));
+
+        return super.generateErrorSourceFile(serviceModel);
+    }
+}

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/transform/C2jModelToGeneratorModelTransformer.java
@@ -186,7 +186,7 @@ public class C2jModelToGeneratorModelTransformer {
         // add protocol check. only for json, query protocols
         final String protocol = serviceModel.getMetadata().findFirstSupportedProtocol();
 
-        if ("json".equals(protocol)) {
+        if ("json".equals(protocol) || "smithy-rpc-v2-cbor".equals(protocol)) {
             serviceModel.getMetadata().setAwsQueryCompatible(
                     c2jServiceModel.getMetadata().getAwsQueryCompatible() != null);
         } else {

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/AbstractServiceRequestHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/AbstractServiceRequestHeader.vm
@@ -42,10 +42,10 @@ namespace ${serviceNamespace}
 #if($metadata.acceptHeader)
         headers.emplace(Aws::Http::HeaderValuePair(Aws::Http::ACCEPT_HEADER, "${metadata.acceptHeader}"));
 #end
+        }
 #if ($metadata.awsQueryCompatible)
         headers.emplace(Aws::Http::HeaderValuePair(Aws::Http::X_AMZN_QUERY_MODE,"true"));
 #end
-      }
 #if($metadata.apiVersion)
       headers.emplace(Aws::Http::HeaderValuePair(Aws::Http::API_VERSION_HEADER, "${metadata.apiVersion}"));
 #end


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
An errorName mapping customization we have for cloudwatch (json), added for Cbor. Fixed queryCompatable trait only being applied for json protocols, and fixed query compat header not being added for Cbor requests. 

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
