### PR TITLE
Place isSet members at the bottom of model classes to reduce class size

### DIFF
--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassMembersAndInlines.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassMembersAndInlines.vm
@@ -155,3 +155,14 @@
 
 #end
 #end##if($shape.members.size() > 0)
+#foreach($member in $shape.members.entrySet())
+#if(!($CppViewHelper.isStreamingPayloadMember($shape, $member.key) && $shape.request))
+#set($isStreamingMember = ($shape.payload && ($shape.payload == $entry.key && !$entry.value.shape.structure)))
+#set($isRequired = $useRequiredField && $member.value.required)
+#if(($isRequired || $member.value.idempotencyToken) && !$isStreamingMember && !$member.value.shape.isEventStream())
+    bool ${CppViewHelper.computeVariableHasBeenSetName($member.key)} = true;
+#else
+    bool ${CppViewHelper.computeVariableHasBeenSetName($member.key)} = false;
+#end
+#end
+#end##if($shape.members.size() > 0)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/model/ServiceClientModelHeaderMemberDeclaration.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/common/model/ServiceClientModelHeaderMemberDeclaration.vm
@@ -31,10 +31,3 @@
 #end
     $cppType $memberVariableName$initializer;
 #end
-#set($isStreamingMember = ($shape.payload && ($shape.payload == $entry.key && !$entry.value.shape.structure)))
-#set($isRequired = $useRequiredField && $member.value.required)
-#if(($isRequired || $isIdempontencyToken) && !$isStreamingMember && !$member.value.shape.isEventStream())
-    bool ${CppViewHelper.computeVariableHasBeenSetName($member.key)} = true;
-#else
-    bool ${CppViewHelper.computeVariableHasBeenSetName($member.key)} = false;
-#end


### PR DESCRIPTION
*Description of changes:*

Moves m_IsSet members to the bottom of generated models so they're more closely packed, which reduces the size of models. As a random sample `Aws::RDS::Model::DBCluster` is currently 2864 bytes, after regenerating with this patch it is 2368 bytes. Which is a saving of 18%. This doesn't affect any APIs but will be an ABI change.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

I ran the usual generated tests and they all continued to pass.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
