### PR TITLE
fix cancel s3crt request callback to not outlive request lifetime

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
@@ -8146,6 +8146,9 @@ class AWS_S3CRT_API S3CrtClient : public Aws::Client::AWSXMLClient, public Aws::
     std::shared_ptr<Aws::Http::HttpResponse> response;
     std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest;
     Aws::UniquePtr<struct aws_s3_checksum_config> checksumConfig;
+    std::mutex requestLifetimeMutex;
+    std::condition_variable requestLifetimeCondition;
+    bool requestLifetimeShouldContinue = true;
   };
 
   Aws::Client::XmlOutcome GenerateXmlOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;
@@ -8167,7 +8170,7 @@ class AWS_S3CRT_API S3CrtClient : public Aws::Client::AWSXMLClient, public Aws::
   };
 
   static void CrtClientShutdownCallback(void* data);
-  void CancelCrtRequestAsync(aws_s3_meta_request* meta_request) const;
+  void CancelCrtRequestAsync(aws_s3_meta_request* meta_request, S3CrtClient::CrtRequestCallbackUserData* userData) const;
   static int S3CrtRequestHeadersCallback(aws_s3_meta_request* meta_request, const struct aws_http_headers* headers, int response_status,
                                          void* user_data);
   static int S3CrtRequestGetBodyCallback(struct aws_s3_meta_request* meta_request, const struct aws_byte_cursor* body, uint64_t range_start,

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
@@ -207,6 +207,9 @@ namespace ${rootNamespace}
           std::shared_ptr<Aws::Http::HttpResponse> response;
           std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest;
           Aws::UniquePtr<struct aws_s3_checksum_config> checksumConfig;
+          std::mutex requestLifetimeMutex;
+          std::condition_variable requestLifetimeCondition;
+          bool requestLifetimeShouldContinue = true;
         };
 
         Aws::Client::XmlOutcome GenerateXmlOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;
@@ -230,7 +233,7 @@ namespace ${rootNamespace}
         };
 
         static void CrtClientShutdownCallback(void *data);
-        void CancelCrtRequestAsync(aws_s3_meta_request *meta_request) const;
+        void CancelCrtRequestAsync(aws_s3_meta_request *meta_request, S3CrtClient::CrtRequestCallbackUserData* userData) const;
         static int S3CrtRequestHeadersCallback(aws_s3_meta_request *meta_request, const struct aws_http_headers *headers, int response_status, void *user_data);
         static int S3CrtRequestGetBodyCallback(struct aws_s3_meta_request *meta_request, const struct aws_byte_cursor *body, uint64_t range_start, void *user_data);
         static void S3CrtRequestProgressCallback(struct aws_s3_meta_request *meta_request, const struct aws_s3_meta_request_progress *progress, void *user_data);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/SmithyS3ClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/SmithyS3ClientHeader.vm
@@ -231,6 +231,9 @@ namespace ${rootNamespace}
           std::shared_ptr<Aws::Http::HttpResponse> response;
           std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest;
           Aws::UniquePtr<struct aws_s3_checksum_config> checksumConfig;
+          std::mutex requestLifetimeMutex;
+          std::condition_variable requestLifetimeCondition;
+          bool requestLifetimeShouldContinue = true;
         };
 
         Aws::Client::XmlOutcome GenerateXmlOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;
@@ -250,7 +253,7 @@ namespace ${rootNamespace}
         };
 
         static void CrtClientShutdownCallback(void *data);
-        void CancelCrtRequestAsync(aws_s3_meta_request *meta_request) const;
+        void CancelCrtRequestAsync(aws_s3_meta_request *meta_request, S3CrtClient::CrtRequestCallbackUserData* userData) const;
         static int S3CrtRequestHeadersCallback(aws_s3_meta_request *meta_request, const struct aws_http_headers *headers, int response_status, void *user_data);
         static int S3CrtRequestGetBodyCallback(struct aws_s3_meta_request *meta_request, const struct aws_byte_cursor *body, uint64_t range_start, void *user_data);
         static void S3CrtRequestProgressCallback(struct aws_s3_meta_request *meta_request, const struct aws_s3_meta_request_progress *progress, void *user_data);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -55,6 +55,8 @@
     #set($hasEventStreamInputOperation = true)
 #end
 #end
+const std::chrono::minutes REQUEST_LIFETIME_WAIT_TIMEOUT = std::chrono::minutes(1);
+
 ${className}::${className}(const ${className} &rhs) :
     BASECLASS(rhs.m_clientConfiguration,
         Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(ALLOCATION_TAG,

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
@@ -11,10 +11,16 @@ void S3CrtClient::CrtClientShutdownCallback(void *data)
   wrappedData->clientShutdownSem->Release();
 }
 
-void S3CrtClient::CancelCrtRequestAsync(aws_s3_meta_request *meta_request) const {
+void S3CrtClient::CancelCrtRequestAsync(aws_s3_meta_request *meta_request, S3CrtClient::CrtRequestCallbackUserData* userData) const {
   assert(meta_request);
-  m_clientConfiguration.executor->Submit([meta_request]() {
-    aws_s3_meta_request_cancel(meta_request);
+  userData->requestLifetimeShouldContinue = false;
+  m_clientConfiguration.executor->Submit([meta_request, userData]() {
+    {
+      std::lock_guard<std::mutex> requestLifetimeLock{userData->requestLifetimeMutex};
+      aws_s3_meta_request_cancel(meta_request);
+      userData->requestLifetimeShouldContinue = true;
+    }
+    userData->requestLifetimeCondition.notify_all();
   });
 }
 
@@ -38,7 +44,7 @@ int S3CrtClient::S3CrtRequestHeadersCallback(struct aws_s3_meta_request *meta_re
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request);
+    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
   }
 
   return AWS_OP_SUCCESS;
@@ -73,7 +79,7 @@ int S3CrtClient::S3CrtRequestGetBodyCallback(struct aws_s3_meta_request *meta_re
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request);
+    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
   }
 
   return AWS_OP_SUCCESS;
@@ -95,7 +101,7 @@ void S3CrtClient::S3CrtRequestProgressCallback(struct aws_s3_meta_request *meta_
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request);
+    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
   }
 
   return;
@@ -158,6 +164,12 @@ void S3CrtClient::S3CrtRequestFinishCallback(struct aws_s3_meta_request *meta_re
 {
   AWS_UNREFERENCED_PARAM(meta_request);
   auto *userData = static_cast<S3CrtClient::CrtRequestCallbackUserData*>(user_data);
+
+  {
+    std::unique_lock<std::mutex> requestLifetimeLock{userData->requestLifetimeMutex};
+    userData->requestLifetimeCondition.wait_for(requestLifetimeLock, REQUEST_LIFETIME_WAIT_TIMEOUT,
+                                            [userData]() -> bool { return userData->requestLifetimeShouldContinue; });
+  }
 
   if (meta_request_result->error_code != AWS_ERROR_SUCCESS && meta_request_result->response_status == 0) {
     /* client side error */

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/SmithyS3CrtSpecificOperations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/SmithyS3CrtSpecificOperations.vm
@@ -11,10 +11,16 @@ void S3CrtClient::CrtClientShutdownCallback(void *data)
   wrappedData->clientShutdownSem->Release();
 }
 
-void S3CrtClient::CancelCrtRequestAsync(aws_s3_meta_request *meta_request) const {
+void S3CrtClient::CancelCrtRequestAsync(aws_s3_meta_request* meta_request, S3CrtClient::CrtRequestCallbackUserData* userData) const {
   assert(meta_request);
-  m_clientConfiguration.executor->Submit([meta_request]() {
-    aws_s3_meta_request_cancel(meta_request);
+  userData->requestLifetimeShouldContinue = false;
+  m_clientConfiguration.executor->Submit([meta_request, userData]() {
+    {
+      std::lock_guard<std::mutex> requestLifetimeLock{userData->requestLifetimeMutex};
+      aws_s3_meta_request_cancel(meta_request);
+      userData->requestLifetimeShouldContinue = true;
+    }
+    userData->requestLifetimeCondition.notify_all();
   });
 }
 
@@ -38,7 +44,7 @@ int S3CrtClient::S3CrtRequestHeadersCallback(struct aws_s3_meta_request *meta_re
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request);
+    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
   }
 
   return AWS_OP_SUCCESS;
@@ -73,7 +79,7 @@ int S3CrtClient::S3CrtRequestGetBodyCallback(struct aws_s3_meta_request *meta_re
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request);
+    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
   }
 
   return AWS_OP_SUCCESS;
@@ -95,7 +101,7 @@ void S3CrtClient::S3CrtRequestProgressCallback(struct aws_s3_meta_request *meta_
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request);
+    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
   }
 
   return;
@@ -158,6 +164,12 @@ void S3CrtClient::S3CrtRequestFinishCallback(struct aws_s3_meta_request *meta_re
 {
   AWS_UNREFERENCED_PARAM(meta_request);
   auto *userData = static_cast<S3CrtClient::CrtRequestCallbackUserData*>(user_data);
+
+  {
+    std::unique_lock<std::mutex> requestLifetimeLock{userData->requestLifetimeMutex};
+    userData->requestLifetimeCondition.wait_for(requestLifetimeLock, REQUEST_LIFETIME_WAIT_TIMEOUT,
+                                            [userData]() -> bool { return userData->requestLifetimeShouldContinue; });
+  }
 
   if (meta_request_result->error_code != AWS_ERROR_SUCCESS && meta_request_result->response_status == 0) {
     /* client side error */


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/3639

*Description of changes:*

there is a problem with the method [`CancelCrtRequestAsync`](https://github.com/aws/aws-sdk-cpp/blob/main/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp#L504-L507). In that method we use the sdk thread executor to spin up a cancel request

```c++
m_clientConfiguration.executor->Submit([meta_request]() { aws_s3_meta_request_cancel(meta_request); });
```

if the request finished before that cleanup request can be processed the cleanup with segfault.


*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
