### PR TITLE
make request cancel sync to avoid lifetime issues in CRT

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/S3CrtClient.h
@@ -8146,9 +8146,6 @@ class AWS_S3CRT_API S3CrtClient : public Aws::Client::AWSXMLClient, public Aws::
     std::shared_ptr<Aws::Http::HttpResponse> response;
     std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest;
     Aws::UniquePtr<struct aws_s3_checksum_config> checksumConfig;
-    std::mutex requestLifetimeMutex;
-    std::condition_variable requestLifetimeCondition;
-    bool requestLifetimeShouldContinue = true;
   };
 
   Aws::Client::XmlOutcome GenerateXmlOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;
@@ -8170,7 +8167,7 @@ class AWS_S3CRT_API S3CrtClient : public Aws::Client::AWSXMLClient, public Aws::
   };
 
   static void CrtClientShutdownCallback(void* data);
-  void CancelCrtRequestAsync(aws_s3_meta_request* meta_request, S3CrtClient::CrtRequestCallbackUserData* userData) const;
+  void CancelCrtRequest(aws_s3_meta_request* meta_request) const;
   static int S3CrtRequestHeadersCallback(aws_s3_meta_request* meta_request, const struct aws_http_headers* headers, int response_status,
                                          void* user_data);
   static int S3CrtRequestGetBodyCallback(struct aws_s3_meta_request* meta_request, const struct aws_byte_cursor* body, uint64_t range_start,

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -165,8 +165,6 @@ const char ALLOCATION_TAG[] = "S3CrtClient";
 const char* S3CrtClient::GetServiceName() { return SERVICE_NAME; }
 const char* S3CrtClient::GetAllocationTag() { return ALLOCATION_TAG; }
 
-const std::chrono::minutes REQUEST_LIFETIME_WAIT_TIMEOUT = std::chrono::minutes(1);
-
 S3CrtClient::S3CrtClient(const S3CrtClient& rhs)
     : BASECLASS(rhs.m_clientConfiguration,
                 Aws::MakeShared<Aws::Auth::S3ExpressSignerProvider>(
@@ -503,17 +501,9 @@ void S3CrtClient::CrtClientShutdownCallback(void* data) {
   wrappedData->clientShutdownSem->Release();
 }
 
-void S3CrtClient::CancelCrtRequestAsync(aws_s3_meta_request* meta_request, S3CrtClient::CrtRequestCallbackUserData* userData) const {
+void S3CrtClient::CancelCrtRequest(aws_s3_meta_request* meta_request) const {
   assert(meta_request);
-  userData->requestLifetimeShouldContinue = false;
-  m_clientConfiguration.executor->Submit([meta_request, userData]() {
-    {
-      std::lock_guard<std::mutex> requestLifetimeLock{userData->requestLifetimeMutex};
-      aws_s3_meta_request_cancel(meta_request);
-      userData->requestLifetimeShouldContinue = true;
-    }
-    userData->requestLifetimeCondition.notify_all();
-  });
+  aws_s3_meta_request_cancel(meta_request);
 }
 
 int S3CrtClient::S3CrtRequestHeadersCallback(struct aws_s3_meta_request* meta_request, const struct aws_http_headers* headers,
@@ -535,7 +525,7 @@ int S3CrtClient::S3CrtRequestHeadersCallback(struct aws_s3_meta_request* meta_re
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
+    userData->s3CrtClient->CancelCrtRequest(meta_request);
   }
 
   return AWS_OP_SUCCESS;
@@ -568,7 +558,7 @@ int S3CrtClient::S3CrtRequestGetBodyCallback(struct aws_s3_meta_request* meta_re
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
+    userData->s3CrtClient->CancelCrtRequest(meta_request);
   }
 
   return AWS_OP_SUCCESS;
@@ -590,7 +580,7 @@ void S3CrtClient::S3CrtRequestProgressCallback(struct aws_s3_meta_request* meta_
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
+    userData->s3CrtClient->CancelCrtRequest(meta_request);
   }
 
   return;
@@ -652,12 +642,6 @@ void S3CrtClient::S3CrtRequestFinishCallback(struct aws_s3_meta_request* meta_re
                                              const struct aws_s3_meta_request_result* meta_request_result, void* user_data) {
   AWS_UNREFERENCED_PARAM(meta_request);
   auto* userData = static_cast<S3CrtClient::CrtRequestCallbackUserData*>(user_data);
-
-  {
-    std::unique_lock<std::mutex> requestLifetimeLock{userData->requestLifetimeMutex};
-    userData->requestLifetimeCondition.wait_for(requestLifetimeLock, REQUEST_LIFETIME_WAIT_TIMEOUT,
-                                                [userData]() -> bool { return userData->requestLifetimeShouldContinue; });
-  }
 
   if (meta_request_result->error_code != AWS_ERROR_SUCCESS && meta_request_result->response_status == 0) {
     /* client side error */

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
@@ -207,9 +207,6 @@ namespace ${rootNamespace}
           std::shared_ptr<Aws::Http::HttpResponse> response;
           std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest;
           Aws::UniquePtr<struct aws_s3_checksum_config> checksumConfig;
-          std::mutex requestLifetimeMutex;
-          std::condition_variable requestLifetimeCondition;
-          bool requestLifetimeShouldContinue = true;
         };
 
         Aws::Client::XmlOutcome GenerateXmlOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;
@@ -233,7 +230,7 @@ namespace ${rootNamespace}
         };
 
         static void CrtClientShutdownCallback(void *data);
-        void CancelCrtRequestAsync(aws_s3_meta_request *meta_request, S3CrtClient::CrtRequestCallbackUserData* userData) const;
+        void CancelCrtRequest(aws_s3_meta_request *meta_request) const;
         static int S3CrtRequestHeadersCallback(aws_s3_meta_request *meta_request, const struct aws_http_headers *headers, int response_status, void *user_data);
         static int S3CrtRequestGetBodyCallback(struct aws_s3_meta_request *meta_request, const struct aws_byte_cursor *body, uint64_t range_start, void *user_data);
         static void S3CrtRequestProgressCallback(struct aws_s3_meta_request *meta_request, const struct aws_s3_meta_request_progress *progress, void *user_data);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/SmithyS3ClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/SmithyS3ClientHeader.vm
@@ -231,9 +231,6 @@ namespace ${rootNamespace}
           std::shared_ptr<Aws::Http::HttpResponse> response;
           std::shared_ptr<Aws::Crt::Http::HttpRequest> crtHttpRequest;
           Aws::UniquePtr<struct aws_s3_checksum_config> checksumConfig;
-          std::mutex requestLifetimeMutex;
-          std::condition_variable requestLifetimeCondition;
-          bool requestLifetimeShouldContinue = true;
         };
 
         Aws::Client::XmlOutcome GenerateXmlOutcome(const std::shared_ptr<Http::HttpResponse>& response) const;
@@ -253,7 +250,7 @@ namespace ${rootNamespace}
         };
 
         static void CrtClientShutdownCallback(void *data);
-        void CancelCrtRequestAsync(aws_s3_meta_request *meta_request, S3CrtClient::CrtRequestCallbackUserData* userData) const;
+        void CancelCrtRequest(aws_s3_meta_request *meta_request) const;
         static int S3CrtRequestHeadersCallback(aws_s3_meta_request *meta_request, const struct aws_http_headers *headers, int response_status, void *user_data);
         static int S3CrtRequestGetBodyCallback(struct aws_s3_meta_request *meta_request, const struct aws_byte_cursor *body, uint64_t range_start, void *user_data);
         static void S3CrtRequestProgressCallback(struct aws_s3_meta_request *meta_request, const struct aws_s3_meta_request_progress *progress, void *user_data);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -55,7 +55,6 @@
     #set($hasEventStreamInputOperation = true)
 #end
 #end
-const std::chrono::minutes REQUEST_LIFETIME_WAIT_TIMEOUT = std::chrono::minutes(1);
 
 ${className}::${className}(const ${className} &rhs) :
     BASECLASS(rhs.m_clientConfiguration,

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
@@ -11,17 +11,9 @@ void S3CrtClient::CrtClientShutdownCallback(void *data)
   wrappedData->clientShutdownSem->Release();
 }
 
-void S3CrtClient::CancelCrtRequestAsync(aws_s3_meta_request *meta_request, S3CrtClient::CrtRequestCallbackUserData* userData) const {
+void S3CrtClient::CancelCrtRequest(aws_s3_meta_request *meta_request) const {
   assert(meta_request);
-  userData->requestLifetimeShouldContinue = false;
-  m_clientConfiguration.executor->Submit([meta_request, userData]() {
-    {
-      std::lock_guard<std::mutex> requestLifetimeLock{userData->requestLifetimeMutex};
-      aws_s3_meta_request_cancel(meta_request);
-      userData->requestLifetimeShouldContinue = true;
-    }
-    userData->requestLifetimeCondition.notify_all();
-  });
+  aws_s3_meta_request_cancel(meta_request);
 }
 
 int S3CrtClient::S3CrtRequestHeadersCallback(struct aws_s3_meta_request *meta_request, const struct aws_http_headers *headers,
@@ -44,7 +36,7 @@ int S3CrtClient::S3CrtRequestHeadersCallback(struct aws_s3_meta_request *meta_re
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
+    userData->s3CrtClient->CancelCrtRequest(meta_request);
   }
 
   return AWS_OP_SUCCESS;
@@ -79,7 +71,7 @@ int S3CrtClient::S3CrtRequestGetBodyCallback(struct aws_s3_meta_request *meta_re
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
+    userData->s3CrtClient->CancelCrtRequest(meta_request);
   }
 
   return AWS_OP_SUCCESS;
@@ -101,7 +93,7 @@ void S3CrtClient::S3CrtRequestProgressCallback(struct aws_s3_meta_request *meta_
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
+    userData->s3CrtClient->CancelCrtRequest(meta_request);
   }
 
   return;
@@ -164,12 +156,6 @@ void S3CrtClient::S3CrtRequestFinishCallback(struct aws_s3_meta_request *meta_re
 {
   AWS_UNREFERENCED_PARAM(meta_request);
   auto *userData = static_cast<S3CrtClient::CrtRequestCallbackUserData*>(user_data);
-
-  {
-    std::unique_lock<std::mutex> requestLifetimeLock{userData->requestLifetimeMutex};
-    userData->requestLifetimeCondition.wait_for(requestLifetimeLock, REQUEST_LIFETIME_WAIT_TIMEOUT,
-                                            [userData]() -> bool { return userData->requestLifetimeShouldContinue; });
-  }
 
   if (meta_request_result->error_code != AWS_ERROR_SUCCESS && meta_request_result->response_status == 0) {
     /* client side error */

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/SmithyS3CrtSpecificOperations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/SmithyS3CrtSpecificOperations.vm
@@ -11,17 +11,9 @@ void S3CrtClient::CrtClientShutdownCallback(void *data)
   wrappedData->clientShutdownSem->Release();
 }
 
-void S3CrtClient::CancelCrtRequestAsync(aws_s3_meta_request* meta_request, S3CrtClient::CrtRequestCallbackUserData* userData) const {
+void S3CrtClient::CancelCrtRequest(aws_s3_meta_request* meta_request) const {
   assert(meta_request);
-  userData->requestLifetimeShouldContinue = false;
-  m_clientConfiguration.executor->Submit([meta_request, userData]() {
-    {
-      std::lock_guard<std::mutex> requestLifetimeLock{userData->requestLifetimeMutex};
-      aws_s3_meta_request_cancel(meta_request);
-      userData->requestLifetimeShouldContinue = true;
-    }
-    userData->requestLifetimeCondition.notify_all();
-  });
+  aws_s3_meta_request_cancel(meta_request);
 }
 
 int S3CrtClient::S3CrtRequestHeadersCallback(struct aws_s3_meta_request *meta_request, const struct aws_http_headers *headers,
@@ -44,7 +36,7 @@ int S3CrtClient::S3CrtRequestHeadersCallback(struct aws_s3_meta_request *meta_re
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
+    userData->s3CrtClient->CancelCrtRequest(meta_request);
   }
 
   return AWS_OP_SUCCESS;
@@ -79,7 +71,7 @@ int S3CrtClient::S3CrtRequestGetBodyCallback(struct aws_s3_meta_request *meta_re
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
+    userData->s3CrtClient->CancelCrtRequest(meta_request);
   }
 
   return AWS_OP_SUCCESS;
@@ -101,7 +93,7 @@ void S3CrtClient::S3CrtRequestProgressCallback(struct aws_s3_meta_request *meta_
   auto& shouldContinueFn = userData->originalRequest->GetContinueRequestHandler();
   const HttpRequest* httpRequest = userData->request ? userData->request.get() : nullptr;
   if (shouldContinueFn && !shouldContinueFn(httpRequest)) {
-    userData->s3CrtClient->CancelCrtRequestAsync(meta_request, userData);
+    userData->s3CrtClient->CancelCrtRequest(meta_request);
   }
 
   return;
@@ -164,12 +156,6 @@ void S3CrtClient::S3CrtRequestFinishCallback(struct aws_s3_meta_request *meta_re
 {
   AWS_UNREFERENCED_PARAM(meta_request);
   auto *userData = static_cast<S3CrtClient::CrtRequestCallbackUserData*>(user_data);
-
-  {
-    std::unique_lock<std::mutex> requestLifetimeLock{userData->requestLifetimeMutex};
-    userData->requestLifetimeCondition.wait_for(requestLifetimeLock, REQUEST_LIFETIME_WAIT_TIMEOUT,
-                                            [userData]() -> bool { return userData->requestLifetimeShouldContinue; });
-  }
 
   if (meta_request_result->error_code != AWS_ERROR_SUCCESS && meta_request_result->response_status == 0) {
     /* client side error */


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/3639

*Description of changes:*

We previous made a change https://github.com/aws/aws-sdk-cpp/pull/3643 to preserve the request lifetime of a request so that cancel request can run in parallel without lifetime issues. This change used a `wait_for` that times out at one minute then would crash. This is under the assumption that a cancel request _must_ run in 1 minutes and waiting longer will crash. A customer is still seeing the crash which is indicative that they are running under strain, however we should run this in sync to prevent the lifetime issue all together. Running back of the napkin tests show that sync is actually faster so making this sync seems like the right thing to do.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
