### PR TITLE
#3651: Don't discard return values in MakeCallWithTiming when the meter doesn't return a histogram

### DIFF
--- a/src/aws-cpp-sdk-core/source/smithy/tracing/TracingUtils.cpp
+++ b/src/aws-cpp-sdk-core/source/smithy/tracing/TracingUtils.cpp
@@ -29,3 +29,20 @@ const char TracingUtils::SMITHY_METRICS_SSL_DURATION[] = "smithy.client.http.ssl
 const char TracingUtils::SMITHY_METRICS_DOWNLOAD_SPEED_METRIC[] = "smithy.client.http.download_speed";
 const char TracingUtils::SMITHY_METRICS_UPLOAD_SPEED_METRIC[] = "smithy.client.http.upload_speed";
 const char TracingUtils::SMITHY_METRICS_UNKNOWN_METRIC[] = "smithy.client.http.unknown_metric";
+
+void TracingUtils::RecordExecutionDuration(
+    SteadyTime before,
+    SteadyTime after,
+    Aws::String metricName,
+    const Meter &meter,
+    Aws::Map<Aws::String, Aws::String> attributes,
+    Aws::String description
+) {
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(after - before).count();
+    auto histogram = meter.CreateHistogram(std::move(metricName), MICROSECOND_METRIC_TYPE, description);
+    if (!histogram) {
+        AWS_LOG_ERROR("TracingUtil", "Failed to create histogram");
+    } else {
+        histogram->record((double) duration, std::move(attributes));
+    }
+}

--- a/tests/aws-cpp-sdk-core-tests/smithy/tracing/SmithyTracingUtilsTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/smithy/tracing/SmithyTracingUtilsTest.cpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/testing/AwsCppSdkGTestSuite.h>
+#include <smithy/tracing/NoopTracerProvider.h>
+#include <smithy/tracing/NoopMeterProvider.h>
+#include "smithy/tracing/TracingUtils.h"
+
+using namespace smithy::components::tracing;
+
+static const char *ALLOC_TAG = "SMITHY_TRACING_ALLOC";
+
+class SmithyTracingUtilsTest : public Aws::Testing::AwsCppSdkGTestSuite {
+};
+
+TEST_F(SmithyTracingUtilsTest, TestMakeCallWithTiming) {
+    auto provider = Aws::MakeUnique<NoopMeterProvider>(ALLOC_TAG);
+    auto meter = provider->GetMeter("scope", {});
+
+    auto value = TracingUtils::MakeCallWithTiming<int>(
+        []() { return 42; },
+        TracingUtils::SMITHY_CLIENT_DURATION_METRIC,
+        *meter,
+        { { TracingUtils::SMITHY_SYSTEM_DIMENSION, TracingUtils::SMITHY_METHOD_AWS_VALUE } },
+        "test duration metric"
+    );
+
+    ASSERT_EQ(value, 42);
+}
+
+class NullMeter : public NoopMeter {
+public:
+    Aws::UniquePtr<Histogram> CreateHistogram(Aws::String name, Aws::String units, Aws::String description) const override {
+        AWS_UNREFERENCED_PARAM(name);
+        AWS_UNREFERENCED_PARAM(units);
+        AWS_UNREFERENCED_PARAM(description);
+
+        return nullptr;
+    }
+};
+
+TEST_F(SmithyTracingUtilsTest, TestMakeCallWithTimingNullHistogram) {
+    auto meter = Aws::MakeUnique<NullMeter>(ALLOC_TAG);
+
+    auto value = TracingUtils::MakeCallWithTiming<int>(
+        []() { return 42; },
+        TracingUtils::SMITHY_CLIENT_DURATION_METRIC,
+        *meter,
+        { { TracingUtils::SMITHY_SYSTEM_DIMENSION, TracingUtils::SMITHY_METHOD_AWS_VALUE } },
+        "test duration metric"
+    );
+
+    ASSERT_EQ(value, 42);
+}


### PR DESCRIPTION

*Issue #3651

*Description of changes:*

Removes the empty returns when a meter returns a null histogram so the return value is preserved. Also fixed a null pointer dereference in `EmitCoreHttpMetrics`.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
