### PR TITLE
Add cstdint #include for uint64_t

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/crypto/SecureRandom.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/crypto/SecureRandom.h
@@ -6,6 +6,7 @@
 #include <type_traits>
 #include <memory>
 #include <cassert>
+#include <cstdint>
 
 namespace Aws
 {


### PR DESCRIPTION
*Description of changes:*
`aws/core/utils/crypto/SecureRandom.h` uses `uint64_t` without including `cstdint`, that causes a compilation error on gcc-15.
This PR is adding the `#include` to fix the compile error.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
  - I believe this PR is simple enough to skip the test.
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
