### PR TITLE
check for null headers in header callback

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -510,7 +510,7 @@ int S3CrtClient::S3CrtRequestHeadersCallback(struct aws_s3_meta_request* meta_re
                                              int response_status, void* user_data) {
   AWS_UNREFERENCED_PARAM(meta_request);
   auto* userData = static_cast<S3CrtClient::CrtRequestCallbackUserData*>(user_data);
-  if (!userData || !userData->response || !userData->originalRequest) {
+  if (!userData || !userData->response || !userData->originalRequest || !headers) {
     return AWS_OP_ERR;
   }
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
@@ -21,7 +21,7 @@ int S3CrtClient::S3CrtRequestHeadersCallback(struct aws_s3_meta_request *meta_re
 {
   AWS_UNREFERENCED_PARAM(meta_request);
   auto *userData = static_cast<S3CrtClient::CrtRequestCallbackUserData*>(user_data);
-  if (!userData || !userData->response || !userData->originalRequest) {
+  if (!userData || !userData->response || !userData->originalRequest || !headers) {
     return AWS_OP_ERR;
   }
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/SmithyS3CrtSpecificOperations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/SmithyS3CrtSpecificOperations.vm
@@ -21,7 +21,7 @@ int S3CrtClient::S3CrtRequestHeadersCallback(struct aws_s3_meta_request *meta_re
 {
   AWS_UNREFERENCED_PARAM(meta_request);
   auto *userData = static_cast<S3CrtClient::CrtRequestCallbackUserData*>(user_data);
-  if (!userData || !userData->response || !userData->originalRequest) {
+  if (!userData || !userData->response || !userData->originalRequest || !headers) {
     return AWS_OP_ERR;
   }
 


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/3646

*Description of changes:*

When the S3Crt encounters a `AWS_ERROR_HTTP_CHANNEL_THROUGHPUT_FAILURE ` error, we will segfault in the header callbacks because crt will pass use null headers. This checks for null headers and fails the callback if they are missing. This will allow the request to complete if the request has been configured to allow periods where no data is transferred by setting `s3CrtConfig.lowSpeedLimit = 0;`.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
Creating a `AWS_ERROR_HTTP_CHANNEL_THROUGHPUT_FAILURE` error is not easy at test time and would require specific setup. The fix was manually tested and verified using the code from the initial ticket.
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
