### PR TITLE
Replace push_back with emplace_back to avoid unnecessary temporary co…

### DIFF
--- a/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
@@ -196,8 +196,9 @@ Aws::Vector<Aws::String> calculateAuthPreferences() {
   Aws::Vector<Aws::String> res;
   auto prefs = Aws::Environment::GetEnv("AWS_AUTH_SCHEME_PREFERENCE");
   Aws::Vector<Aws::String> prefsList  = Aws::Utils::StringUtils::Split(prefs, ',');
+  res.reserve(prefsList.size());  // avoid repeated allocations
   for (auto& pref : prefsList) {
-    res.push_back(Aws::Utils::StringUtils::Trim(pref.c_str()));
+    res.emplace_back(Aws::Utils::StringUtils::Trim(pref.c_str()));
   }
   return res;
 }

--- a/src/aws-cpp-sdk-text-to-speech/source/text-to-speech/TextToSpeechManager.cpp
+++ b/src/aws-cpp-sdk-text-to-speech/source/text-to-speech/TextToSpeechManager.cpp
@@ -93,8 +93,7 @@ namespace Aws
                 for (auto& deviceInfo : driver->EnumerateDevices())
                 {
                     AWS_LOGSTREAM_DEBUG(CLASS_TAG, "Adding device " << deviceInfo.deviceName << " for driver " << driver->GetName());
-                    OutputDevicePair device(deviceInfo, driver);
-                    deviceDriverList.push_back(device);
+                    deviceDriverList.emplace_back(deviceInfo, driver);
                 }
             }
             
@@ -120,9 +119,11 @@ namespace Aws
             auto voicesOutcome = m_pollyClient->DescribeVoices(describeVoices);
             if (voicesOutcome.IsSuccess())
             {
-                for (auto& voice : voicesOutcome.GetResult().GetVoices())
+                auto& voices = voicesOutcome.GetResult().GetVoices();
+                m_voices.reserve(voices.size());
+                for (const auto& voice : voices)
                 {
-                    m_voices.push_back(std::pair<Aws::String, Aws::String>(voice.GetName(), voice.GetLanguageName()));
+                    m_voices.emplace_back(voice.GetName(), voice.GetLanguageName());
                 }
             }
             else


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:

Optimized vector insertions in TextToSpeechManager.cpp & ClientConfiguration.cpp by replacing push_back with emplace_back.
In EnumerateDevices(), OutputDevicePair is now constructed directly in the vector memory instead of creating a temporary and pushing it.
In ListAvailableVoices(), voice name/language pairs are now constructed directly in place, and the vector reserves capacity upfront to reduce reallocations.
In calculateAuthPreferences(), insertion happens with more optimal way.
These changes eliminate unnecessary temporaries, slightly improve performance, and adhere to modern C++ best practices.
No functional changes or API changes; fully backward-compatible.
Check all that applies:

 Did a review by yourself.
 Added proper tests to cover this PR. (Existing unit tests verify correctness; no new tests required.)
 Checked if this PR is a breaking (APIs have been changed) change.
 Checked if this PR will not introduce cross-platform inconsistent behavior.
 Checked if this PR would require a ReadMe/Wiki update.
Check which platforms you have built SDK on to verify the correctness of this PR:

 Linux
 Windows
 Android
 MacOS
 IOS
 Other Platforms
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

