### PR TITLE
Remove redundant move

### DIFF
--- a/src/aws-cpp-sdk-core/include/smithy/tracing/TracingUtils.h
+++ b/src/aws-cpp-sdk-core/include/smithy/tracing/TracingUtils.h
@@ -75,7 +75,7 @@ namespace smithy {
                     auto before = std::chrono::steady_clock::now();
                     auto returnValue = func();
                     auto after = std::chrono::steady_clock::now();
-                    RecordExecutionDuration(before, after, std::move(metricName), meter, std::move(attributes), std::move(description));
+                    RecordExecutionDuration(before, after, metricName, meter, attributes, description);
                     return returnValue;
                 }
 


### PR DESCRIPTION
It's redundant as arguments are const. Fixes #3668

*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/3668

*Description of changes:*

https://github.com/aws/aws-sdk-cpp/pull/3669

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
