### PR TITLE
only chunk put object for non-mrap objects

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -64,6 +64,9 @@
     "ALLOC",
     "ISOE",
     "isoe",
+    "authscheme",
+    "Vistor",
+    "eventstreaming",
     // AWS general
     "Arns",
     "AMZN",
@@ -77,6 +80,9 @@
     "AWSSTL",
     "reparsed",
     "reparses",
+    "MRAP",
+    "ISOF",
+    "isof",
     // AWS Signature
     "SIGV",
     "AUTHV",

--- a/src/aws-cpp-sdk-core/include/smithy/interceptor/Interceptor.h
+++ b/src/aws-cpp-sdk-core/include/smithy/interceptor/Interceptor.h
@@ -16,6 +16,7 @@ namespace smithy
 
             using ModifyRequestOutcome = Aws::Utils::Outcome<std::shared_ptr<Aws::Http::HttpRequest>, Aws::Client::AWSError<Aws::Client::CoreErrors>>;
             virtual ModifyRequestOutcome ModifyBeforeSigning(InterceptorContext& context) = 0;
+            virtual ModifyRequestOutcome ModifyBeforeTransmit(InterceptorContext& context) { return context.GetTransmitRequest(); }
 
             using ModifyResponseOutcome = Aws::Utils::Outcome<std::shared_ptr<Aws::Http::HttpResponse>, Aws::Client::AWSError<Aws::Client::CoreErrors>>;
             virtual ModifyResponseOutcome ModifyBeforeDeserialization(InterceptorContext& context) = 0;

--- a/src/aws-cpp-sdk-core/include/smithy/interceptor/InterceptorContext.h
+++ b/src/aws-cpp-sdk-core/include/smithy/interceptor/InterceptorContext.h
@@ -9,6 +9,7 @@
 #include <aws/core/http/HttpRequest.h>
 #include <aws/core/http/HttpResponse.h>
 #include <aws/core/client/CoreErrors.h>
+#include <aws/crt/Optional.h>
 
 namespace smithy
 {
@@ -53,9 +54,12 @@ namespace smithy
                 m_transmitResponse = transmitResponse;
             }
 
-            Aws::String GetAttribute(const Aws::String& key) const
-            {
-                return m_attributes.at(key);
+            Aws::Crt::Optional<Aws::String> GetAttribute(const Aws::String& key) const {
+              const auto attribute = m_attributes.find(key);
+              if (attribute == m_attributes.end()) {
+                return {};
+              }
+              return attribute->second;
             }
 
             void SetAttribute(const Aws::String& key, const Aws::String& value)


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/3679

*Description of changes:*

Reverted to pre-refactor of chunked encoding to ONLY chunk encode for sigv4 requests. Chunk encoding broke mrap as it is a sigv4a client. This will behave the same as it did before.

Additionally a s3-control integration test was commented out, we are re-enabling it as it would have caught this.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
