### PR TITLE
fix codegen when a model explicitly specifies the enum value NOT_SET

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/PlatformAndKeywordSanitizer.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/cpp/PlatformAndKeywordSanitizer.java
@@ -166,6 +166,17 @@ public class PlatformAndKeywordSanitizer {
     public static String fixEnumValue (String enumValue) {
         String enumMemberName = enumValue;
 
+        // NOT_SET is a special value in C++ SDK enums used in two scenarios:
+        // 1. When an enum cannot be deserialized from a string value
+        // 2. When accessing an enum created from an invalid string value
+        // Note: Services may still use NOT_SET as a valid key in maps
+        //
+        // TODO: model this as a crt or std optional to represent "absent of value"
+        //       instead of using a common-ish predetermined value.
+        if (enumValue.equals("NOT_SET")) {
+            return "NOT_SET_VALUE";
+        }
+
         for (String invalid : ENUM_CHARS_MAPPING.keySet()) {
             enumMemberName = enumMemberName.replace(invalid, ENUM_CHARS_MAPPING.get(invalid));
         }


### PR DESCRIPTION
*Description of changes:*

If a service model uses the enum value `NOT_SET` it will conflict with the SDKs implicit enum value of `NOT_SET` which is encountered when:
* an enum cannot be deserialized from a string value
* accessing an enum created from an invalid string value

This re-maps the modeled value from `NOT_SET` to `NOT_SET_VALUE`. this really should be modeled as a optional in a future breaking release.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
