### PR TITLE
add client configuration for aws-chunked encoding buffer size

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -602,6 +602,18 @@ namespace Aws
            * First available auth scheme will be used for each operation.
            */
           Aws::Vector<Aws::String> authPreferences;
+
+          /**
+           * Buffer size in bytes that will be used to content encode
+           * bodies using aws-chunked. Changing this is useful when you
+           * want to minimize memory use while uploading to S3. Size MUST
+           * be greater than 8KB otherwise S3 will reject the request.
+           *
+           * Defaults to 64KiB.
+           *
+           * https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
+           */
+          size_t awsChunkedBufferSize = 64UL * 1024;
         };
 
         /**

--- a/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientBase.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientBase.h
@@ -107,7 +107,8 @@ namespace client
           m_interceptors({
               Aws::MakeShared<ChecksumInterceptor>("AwsSmithyClientBase", *m_clientConfig),
               Aws::MakeShared<features::ChunkingInterceptor>("AwsSmithyClientBase", 
-                  m_httpClient->IsDefaultAwsHttpClient() ? Aws::Client::HttpClientChunkedMode::DEFAULT : m_clientConfig->httpClientChunkedMode)
+                  m_httpClient->IsDefaultAwsHttpClient() ? Aws::Client::HttpClientChunkedMode::DEFAULT : m_clientConfig->httpClientChunkedMode,
+                  m_clientConfig->awsChunkedBufferSize)
           })
         {
             

--- a/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -141,7 +141,9 @@ AWSClient::AWSClient(const Aws::Client::ClientConfiguration& configuration,
     m_requestCompressionConfig(configuration.requestCompressionConfig),
     m_userAgentInterceptor{Aws::MakeShared<smithy::client::UserAgentInterceptor>(AWS_CLIENT_LOG_TAG, configuration, m_retryStrategy->GetStrategyName(), m_serviceName)},
     m_interceptors{Aws::MakeShared<smithy::client::ChecksumInterceptor>(AWS_CLIENT_LOG_TAG), Aws::MakeShared<smithy::client::features::ChunkingInterceptor>(AWS_CLIENT_LOG_TAG, 
-        m_httpClient->IsDefaultAwsHttpClient() ? Aws::Client::HttpClientChunkedMode::DEFAULT : configuration.httpClientChunkedMode), m_userAgentInterceptor}
+        m_httpClient->IsDefaultAwsHttpClient() ? Aws::Client::HttpClientChunkedMode::DEFAULT : configuration.httpClientChunkedMode,
+        configuration.awsChunkedBufferSize),
+    m_userAgentInterceptor}
 {
 }
 
@@ -168,7 +170,9 @@ AWSClient::AWSClient(const Aws::Client::ClientConfiguration& configuration,
     m_requestCompressionConfig(configuration.requestCompressionConfig),
     m_userAgentInterceptor{Aws::MakeShared<smithy::client::UserAgentInterceptor>(AWS_CLIENT_LOG_TAG, configuration, m_retryStrategy->GetStrategyName(), m_serviceName)},
     m_interceptors{Aws::MakeShared<smithy::client::ChecksumInterceptor>(AWS_CLIENT_LOG_TAG, configuration), Aws::MakeShared<smithy::client::features::ChunkingInterceptor>(AWS_CLIENT_LOG_TAG, 
-        m_httpClient->IsDefaultAwsHttpClient() ? Aws::Client::HttpClientChunkedMode::DEFAULT : configuration.httpClientChunkedMode), m_userAgentInterceptor}
+        m_httpClient->IsDefaultAwsHttpClient() ? Aws::Client::HttpClientChunkedMode::DEFAULT : configuration.httpClientChunkedMode,
+        configuration.awsChunkedBufferSize),
+    m_userAgentInterceptor}
 {
 }
 

--- a/src/aws-cpp-sdk-core/source/smithy/client/AwsSmithyClientBase.cpp
+++ b/src/aws-cpp-sdk-core/source/smithy/client/AwsSmithyClientBase.cpp
@@ -107,7 +107,8 @@ void AwsSmithyClientBase::baseCopyAssign(const AwsSmithyClientBase& other,
   m_interceptors = Aws::Vector<std::shared_ptr<interceptor::Interceptor>>{
       Aws::MakeShared<ChecksumInterceptor>("AwsSmithyClientBase", *m_clientConfig),
       Aws::MakeShared<features::ChunkingInterceptor>("AwsSmithyClientBase", 
-          m_httpClient->IsDefaultAwsHttpClient() ? Aws::Client::HttpClientChunkedMode::DEFAULT : m_clientConfig->httpClientChunkedMode)
+          m_httpClient->IsDefaultAwsHttpClient() ? Aws::Client::HttpClientChunkedMode::DEFAULT : m_clientConfig->httpClientChunkedMode,
+          m_clientConfig->awsChunkedBufferSize)
   };
 
   baseCopyInit();


### PR DESCRIPTION
*Description of changes:*

Adds a client configuration for the buffer that is used to encode aws-chunked content encoded messages. This is extremely useful when running in a memory restricted enviornment and this needs to be smaller than the default 64KiB

example usage
```c++
#include <aws/core/Aws.h>
#include <aws/s3/S3Client.h>
#include <aws/s3/model/PutObjectRequest.h>

#include <fstream>

using namespace Aws;
using namespace Aws::S3;
using namespace Aws::S3::Model;
using namespace Aws::Utils;
using namespace Aws::Utils::Logging;

class sdk_context_context {
 public:
  sdk_context_context(SDKOptions&& options) : options_{std::move(options)} {
    InitAPI(options_);
  }
  ~sdk_context_context() { ShutdownAPI(options_); }

 private:
  SDKOptions options_;
};

auto main() -> int {
  SDKOptions options{};
  options.loggingOptions.logLevel = LogLevel::Debug;
  sdk_context_context context{std::move(options)};

  S3ClientConfiguration configuration{};
  // set to 12 KiB
  configuration.awsChunkedBufferSize = 1024 * 12;
  const S3Client client{configuration};
  auto request = PutObjectRequest{}
                     .WithBucket("bucket")
                     .WithKey("key");
  request.SetBody(Aws::MakeShared<Aws::FStream>(
      "allocation-tag",
      "/some/file/path",
      std::ios_base::in | std::ios_base::out));
  const auto result = client.PutObject(request);
  if (!result.IsSuccess()) {
    std::cout << "Failed to upload file: " << result.GetError().GetMessage()
              << std::endl;
  }
  return 0;
}
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
