### PR TITLE
`AWS_EC2_METADATA_DISABLED` documentation fix

### DIFF
--- a/docs/Credentials_Providers.md
+++ b/docs/Credentials_Providers.md
@@ -8,7 +8,7 @@ The default credential provider chain does the following:
 3. Contacts and logs in to a trusted identity provider (Cognito, Login with Amazon, Facebook, Google). The sdk looks for the login information to these providers either on the environment variables: AWS_ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE, AWS_ROLE_SESSION_NAME. Or on a profile in your $HOME/.aws/credentials.
 4. Checks for an external method set as part of a profile on $HOME/.aws/config to generate or look up credentials that isn't directly supported by AWS.
 5. Contacts the ECS TaskRoleCredentialsProvider service to request credentials if Environment variable AWS_CONTAINER_CREDENTIALS_RELATIVE_URI has been set. 
-6. Contacts the EC2MetadataInstanceProfileCredentialsProvider service to request credentials if AWS_EC2_METADATA_DISABLED is NOT set to ON. 
+6. Contacts the EC2MetadataInstanceProfileCredentialsProvider service to request credentials if the AWS_EC2_METADATA_DISABLED environment variable is NOT set to `true`.
 
 The simplest way to communicate with AWS is to ensure we can find your credentials in one of these locations.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix the documentation surrounding `AWS_EC2_METADATA_DISABLED`, it's treated as a CMake style flag when it isn't.

*Check all that applies:*
- [X] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
(Explanation: Just doc changes)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.
(Unsure if I should tick this)

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
