### PR TITLE
Update bedrock-runtime-integration-tests request timeout

### DIFF
--- a/tests/aws-cpp-sdk-bedrock-runtime-integration-tests/IntegrationTests.cpp
+++ b/tests/aws-cpp-sdk-bedrock-runtime-integration-tests/IntegrationTests.cpp
@@ -40,6 +40,8 @@ protected:
     void SetUp()
     {
         Aws::Client::ClientConfiguration config;
+        config.connectTimeoutMs = 30000;
+        config.requestTimeoutMs = 30000;
         config.region = AWS_TEST_REGION;
         m_client = Aws::MakeShared<BedrockRuntimeClient>(ALLOCATION_TAG, config);
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update request and connection timeout to 30s for integration tests for bedrock-runtime as InvokeModel sometimes takes some time to return a response. 

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [x] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
