### PR TITLE
Custom Codegen param

### DIFF
--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/ServiceModel.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/domainmodels/codegeneration/ServiceModel.java
@@ -31,6 +31,7 @@ public class ServiceModel {
     Map<String, Shape> shapes;
     Map<String, Operation> operations;
     boolean enableVirtualOperations;
+    boolean disableSmithyGeneration;
     Collection<Error> serviceErrors;
     Collection<CustomPresignedUtility> presigners;
     Map<String, String> queryCompatibleErrorMappings;

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/DirectFromC2jGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/DirectFromC2jGenerator.java
@@ -44,7 +44,7 @@ public class DirectFromC2jGenerator {
     public ByteArrayOutputStream generateServiceSourceFromJson(String rawJson, String endpointRuleSet, String endpointRulesTests,
                                                                String languageBinding, String serviceName, String namespace,
                                                                String licenseText, boolean generateStandalonePackage,
-                                                               boolean enableVirtualOperations, boolean useSmithyClient) throws Exception {
+                                                               boolean enableVirtualOperations, boolean disableSmithyGeneration, boolean useSmithyClient) throws Exception {
         GsonBuilder gsonBuilder = new GsonBuilder();
         gsonBuilder.registerTypeAdapter(EndpointTests.EndpointTestParams.class, new EndpointTestParamsDeserializer());
         gsonBuilder.registerTypeAdapter(EndpointParameterValue.class, new EndpointParameterValueDeserializer());
@@ -61,7 +61,7 @@ public class DirectFromC2jGenerator {
             c2jServiceModel.setEndpointTests(endpointTestsModel);
         }
         return mainClientGenerator.generateSourceFromC2jModel(c2jServiceModel, serviceName, languageBinding, namespace,
-                licenseText, generateStandalonePackage, enableVirtualOperations, useSmithyClient);
+                licenseText, generateStandalonePackage, enableVirtualOperations, disableSmithyGeneration, useSmithyClient);
     }
 
     /**
@@ -79,7 +79,7 @@ public class DirectFromC2jGenerator {
      */
     public ByteArrayOutputStream generatePartitionsSourceFromJson(String rawJson, String languageBinding, String serviceName,
                                                                  String namespace, String licenseText,
-                                                                 boolean generateStandalonePackage, boolean enableVirtualOperations) throws Exception {
+                                                                 boolean generateStandalonePackage, boolean enableVirtualOperations, boolean disableSmithyGeneration) throws Exception {
         PartitionsModel partitionsBom = parsePartitions(rawJson);
         partitionsBom.setPartitionsBlob(rawJson);
 
@@ -101,7 +101,7 @@ public class DirectFromC2jGenerator {
      */
     public ByteArrayOutputStream generateDefaultsSourceFromJson(String rawJson, String languageBinding, String serviceName,
                                                                 String namespace, String licenseText,
-                                                                boolean generateStandalonePackage, boolean enableVirtualOperations) throws Exception {
+                                                                boolean generateStandalonePackage, boolean enableVirtualOperations, boolean disableSmithyGeneration) throws Exception {
         DefaultClientConfigs clientConfigBom = parseRawJson(rawJson);
 
         return mainClientGenerator.generateDefaultsSourceFromModel(clientConfigBom, languageBinding, namespace, licenseText);

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/MainGenerator.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/generators/MainGenerator.java
@@ -35,7 +35,7 @@ public class MainGenerator {
     public ByteArrayOutputStream generateSourceFromC2jModel(C2jServiceModel c2jModel,
                                                             String serviceName, String languageBinding,
                                                             String namespace, String licenseText, boolean generateStandalonePackage,
-                                                            boolean enableVirtualOperations, boolean useSmithyClient) throws Exception {
+                                                            boolean enableVirtualOperations, boolean disableSmithyGeneration, boolean useSmithyClient) throws Exception {
 
         SdkSpec spec = new SdkSpec(languageBinding, serviceName, null);
         // Transform to ServiceModel
@@ -47,6 +47,7 @@ public class MainGenerator {
         serviceModel.setNamespace(namespace);
         serviceModel.setLicenseText(licenseText);
         serviceModel.setEnableVirtualOperations(enableVirtualOperations);
+        serviceModel.setDisableSmithyGeneration(disableSmithyGeneration);
         serviceModel.setUseSmithyClient(useSmithyClient);
 
         spec.setVersion(serviceModel.getMetadata().getApiVersion());

--- a/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/main.java
+++ b/tools/code-generation/generator/src/main/java/com/amazonaws/util/awsclientgenerator/main.java
@@ -44,6 +44,7 @@ public class main {
     static final String LICENSE_TEXT = "license-text";
     static final String STANDALONE_OPTION = "standalone";
     static final String ENABLE_VIRTUAL_OPERATIONS = "enable-virtual-operations";
+    static final String DISABLE_SMITHY_GENERATION = "disable-smithy-generation";
     static final String USE_SMITHY_CLIENT = "use-smithy-client";
 
     public static void main(String[] args) throws IOException {
@@ -86,6 +87,7 @@ public class main {
             String languageBinding = argPairs.get(LANGUAGE_BINDING_OPTION);
             String serviceName = argPairs.get(SERVICE_OPTION);
             boolean enableVirtualOperations = argPairs.containsKey(ENABLE_VIRTUAL_OPERATIONS);
+            boolean disableSmithyGeneration = argPairs.containsKey(DISABLE_SMITHY_GENERATION);
 
             String arbitraryJson = readFile(argPairs.getOrDefault(INPUT_FILE_NAME, ""));
             String endpointRules = null;
@@ -124,7 +126,7 @@ public class main {
                     if (serviceName != null && !serviceName.isEmpty()) {
                         if (!generateTests) {
                             generated = generateService(arbitraryJson, endpointRules, endpointRuleTests, languageBinding, serviceName, namespace,
-                                    licenseText, generateStandalonePackage, enableVirtualOperations, useSmithyClient);
+                                    licenseText, generateStandalonePackage, enableVirtualOperations, disableSmithyGeneration, useSmithyClient);
 
                             componentOutputName = String.format("aws-cpp-sdk-%s", serviceName);
                         } else if (argPairs.containsKey(ENDPOINT_TESTS)) {
@@ -150,10 +152,10 @@ public class main {
 
                         if (selectedOption.equalsIgnoreCase(DEFAULTS_OPTION)) {
                             generated = generateDefaults(arbitraryJson, languageBinding, serviceName, namespace,
-                                    licenseText, generateStandalonePackage, enableVirtualOperations);
+                                    licenseText, generateStandalonePackage, enableVirtualOperations, disableSmithyGeneration);
                         } else if (selectedOption.equalsIgnoreCase(PARTITIONS_OPTION)) {
                             generated = generatePartitions(arbitraryJson, languageBinding, serviceName, namespace,
-                                    licenseText, generateStandalonePackage, enableVirtualOperations);
+                                    licenseText, generateStandalonePackage, enableVirtualOperations, disableSmithyGeneration);
                         } else {
                             System.err.println(String.format("Unsupported core component %s requested for generation", selectedOption));
                             System.exit(-1);
@@ -205,6 +207,7 @@ public class main {
                                                          String licenseText,
                                                          boolean generateStandalonePackage,
                                                          boolean enableVirtualOperations,
+                                                         boolean disableSmithyGeneration,
                                                          boolean useSmithyClient) throws Exception {
         MainGenerator generator = new MainGenerator();
         DirectFromC2jGenerator directFromC2jGenerator = new DirectFromC2jGenerator(generator);
@@ -219,6 +222,7 @@ public class main {
                 licenseText,
                 generateStandalonePackage,
                 enableVirtualOperations,
+                disableSmithyGeneration,
                 useSmithyClient);
         return outputStream;
     }
@@ -263,7 +267,7 @@ public class main {
 
     private static ByteArrayOutputStream generateDefaults(String arbitraryJson, String languageBinding, String serviceName,
                                          String namespace, String licenseText,
-                                         boolean generateStandalonePackage, boolean enableVirtualOperations) throws Exception {
+                                         boolean generateStandalonePackage, boolean enableVirtualOperations, boolean disableSmithyGeneration) throws Exception {
         MainGenerator generator = new MainGenerator();
         DirectFromC2jGenerator defaultsGenerator = new DirectFromC2jGenerator(generator);
 
@@ -273,13 +277,14 @@ public class main {
                 namespace,
                 licenseText,
                 generateStandalonePackage,
-                enableVirtualOperations);
+                enableVirtualOperations,
+                disableSmithyGeneration);
         return outputStream;
     }
 
     private static ByteArrayOutputStream generatePartitions(String arbitraryJson, String languageBinding, String serviceName,
                                                            String namespace, String licenseText,
-                                                           boolean generateStandalonePackage, boolean enableVirtualOperations) throws Exception {
+                                                           boolean generateStandalonePackage, boolean enableVirtualOperations, boolean disableSmithyGeneration) throws Exception {
         MainGenerator generator = new MainGenerator();
         DirectFromC2jGenerator defaultsGenerator = new DirectFromC2jGenerator(generator);
 
@@ -289,7 +294,8 @@ public class main {
                 namespace,
                 licenseText,
                 generateStandalonePackage,
-                enableVirtualOperations);
+                enableVirtualOperations,
+                disableSmithyGeneration);
         return outputStream;
     }
 
@@ -330,6 +336,7 @@ public class main {
 
         System.out.println("\t\t--inputfile Reads the c2j model from the file.");
         System.out.println("\t\t--outputfile Writes the generated zip archive to the file.");
+        System.out.println("\t\t--disable-smithy-generation Disable smithy-based generation (default: enabled)");
 
     }
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceClientHeader.vm
@@ -11,7 +11,9 @@
 \#include <aws/core/client/AWSClientAsyncCRTP.h>
 \#include <aws/core/utils/json/JsonSerializer.h>
 \#include <aws/$metadata.projectName/${metadata.classNamePrefix}ServiceClientModel.h>
+#if(!$serviceModel.disableSmithyGeneration)
 \#include <aws/$metadata.projectName/${metadata.classNamePrefix}PaginationBase.h>
+#end
 
 namespace ${rootNamespace}
 {
@@ -26,7 +28,11 @@ namespace ${serviceNamespace}
 #if($serviceModel.enableVirtualOperations)
 #set($finalClass = "")
 #end
+#if(!$serviceModel.disableSmithyGeneration)
   class ${CppViewHelper.computeExportValue($metadata.classNamePrefix)} ${className}${finalClass} : public Aws::Client::AWSJsonClient, public Aws::Client::ClientWithAsyncTemplateMethods<${className}>, public ${metadata.classNamePrefix}PaginationBase<${className}>
+#else
+  class ${CppViewHelper.computeExportValue($metadata.classNamePrefix)} ${className}${finalClass} : public Aws::Client::AWSJsonClient, public Aws::Client::ClientWithAsyncTemplateMethods<${className}>
+#end
   {
     public:
       typedef Aws::Client::AWSJsonClient BASECLASS;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/S3ClientHeader.vm
@@ -22,7 +22,9 @@
 \#include <aws/core/utils/xml/XmlSerializer.h>
 \#include <aws/core/utils/DNS.h>
 \#include <aws/$metadata.projectName/${metadata.classNamePrefix}ServiceClientModel.h>
+#if(!$serviceModel.disableSmithyGeneration)
 \#include <aws/$metadata.projectName/${metadata.classNamePrefix}PaginationBase.h>
+#end
 #if($serviceNamespace == "S3Crt")
 \#include <aws/$metadata.projectName/S3ExpressIdentityProvider.h>
 \#include <aws/$metadata.projectName/S3CrtIdentityProviderAdapter.h>
@@ -95,7 +97,11 @@ namespace ${rootNamespace}
 #if($serviceModel.enableVirtualOperations)
 #set($finalClass = "")
 #end
+#if(!$serviceModel.disableSmithyGeneration)
     class ${CppViewHelper.computeExportValue($metadata.classNamePrefix)} ${className}${finalClass} : public Aws::Client::AWSXMLClient, public Aws::Client::ClientWithAsyncTemplateMethods<${className}>, public ${metadata.classNamePrefix}PaginationBase<${className}>
+#else
+    class ${CppViewHelper.computeExportValue($metadata.classNamePrefix)} ${className}${finalClass} : public Aws::Client::AWSXMLClient, public Aws::Client::ClientWithAsyncTemplateMethods<${className}>
+#end
     {
     public:
         typedef Aws::Client::AWSXMLClient BASECLASS;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyClientHeader.vm
@@ -17,7 +17,9 @@
 \#include <aws/core/client/ClientConfiguration.h>
 \#include <aws/core/client/AWSClientAsyncCRTP.h>
 \#include <aws/$metadata.projectName/${metadata.classNamePrefix}ServiceClientModel.h>
+#if(!$serviceModel.disableSmithyGeneration)
 \#include <aws/$metadata.projectName/${metadata.classNamePrefix}PaginationBase.h>
+#end
 \#include <smithy/client/AwsSmithyClient.h>
 #if($serviceModel.hasBearerAuth())
 \#include <smithy/identity/auth/built-in/BearerTokenAuthScheme.h>
@@ -49,6 +51,7 @@ namespace ${serviceNamespace}
 #if($serviceModel.enableVirtualOperations)
 #set($finalClass = "")
 #end
+#if(!$serviceModel.disableSmithyGeneration)
   class ${CppViewHelper.computeExportValue($metadata.classNamePrefix)} ${className}${finalClass} : Aws::Client::ClientWithAsyncTemplateMethods<${className}>,
     public smithy::client::AwsSmithyClientT<${rootNamespace}::${serviceNamespace}::SERVICE_NAME,
       ${serviceConfiguration},
@@ -59,6 +62,17 @@ namespace ${serviceNamespace}
       smithy::client::$serializerOutcome,
       Aws::Client::${metadata.classNamePrefix}ErrorMarshaller>,
     public ${metadata.classNamePrefix}PaginationBase<${className}>
+#else
+  class ${CppViewHelper.computeExportValue($metadata.classNamePrefix)} ${className}${finalClass} : Aws::Client::ClientWithAsyncTemplateMethods<${className}>,
+    public smithy::client::AwsSmithyClientT<${rootNamespace}::${serviceNamespace}::SERVICE_NAME,
+      ${serviceConfiguration},
+      smithy::AuthSchemeResolverBase<>,
+      ${rootNamespace}::Crt::Variant<${AuthSchemeVariants}>,
+      ${metadata.classNamePrefix}EndpointProviderBase,
+      smithy::client::$serializer,
+      smithy::client::$serializerOutcome,
+      Aws::Client::${metadata.classNamePrefix}ErrorMarshaller>
+#end
   {
     public:
       static const char* GetServiceName();

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlServiceClientHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlServiceClientHeader.vm
@@ -12,7 +12,9 @@
 \#include <aws/core/client/AWSClientAsyncCRTP.h>
 \#include <aws/core/utils/xml/XmlSerializer.h>
 \#include <aws/$metadata.projectName/${metadata.classNamePrefix}ServiceClientModel.h>
+#if(!$serviceModel.disableSmithyGeneration)
 \#include <aws/$metadata.projectName/${metadata.classNamePrefix}PaginationBase.h>
+#end
 
 namespace ${rootNamespace}
 {
@@ -27,7 +29,11 @@ namespace ${serviceNamespace}
 #if($serviceModel.enableVirtualOperations)
 #set($finalClass = "")
 #end
+#if(!$serviceModel.disableSmithyGeneration)
   class ${CppViewHelper.computeExportValue($metadata.classNamePrefix)} ${className}$finalClass : public Aws::Client::AWSXMLClient, public Aws::Client::ClientWithAsyncTemplateMethods<${className}>, public ${metadata.classNamePrefix}PaginationBase<${className}>
+#else
+  class ${CppViewHelper.computeExportValue($metadata.classNamePrefix)} ${className}$finalClass : public Aws::Client::AWSXMLClient, public Aws::Client::ClientWithAsyncTemplateMethods<${className}>
+#end
   {
     public:
       typedef Aws::Client::AWSXMLClient BASECLASS;

--- a/tools/scripts/codegen/legacy_c2j_cpp_gen.py
+++ b/tools/scripts/codegen/legacy_c2j_cpp_gen.py
@@ -83,6 +83,7 @@ class LegacyC2jCppGen(object):
         self.raw_generator_arguments = args["raw_generator_arguments"]
         self.output_location = args["output_location"]
         self.disable_virtual_operations = args.get("disable_virtual_operations", False)
+        self.disable_smithy_generation = args.get("disable_smithy_generation", False)
 
     def generate(self, executor: ProcessPoolExecutor, max_workers: int, args: dict) -> int:
         """
@@ -163,6 +164,8 @@ class LegacyC2jCppGen(object):
             kwargs["language-binding"] = "cpp"  # Always cpp by default in the current code gen
         if not self.disable_virtual_operations:
             kwargs["enable-virtual-operations"] = ""  # Historically always set by default in this project
+        if self.disable_smithy_generation:
+            kwargs["disable-smithy-generation"] = ""  # Disables smithy-based generation in c2j generator
 
         if tmp_dir:
             output_filename = f"{tmp_dir}/{model_files.c2j_model.replace('.normal.json', '.zip')}"

--- a/tools/scripts/run_code_generation.py
+++ b/tools/scripts/run_code_generation.py
@@ -58,6 +58,9 @@ def parse_arguments() -> dict:
                         help="Do NOT mark operation functions in service client as virtual functions",
                         action="store_true")
 
+    parser.add_argument("--disable-smithy-generation",
+                        help="Disable smithy-based generation in c2j generator",
+                        action="store_true")
     parser.add_argument("--generate_smoke_tests",
                         help="Run smithy code generator for smoke tests",
                         action="store_true")
@@ -120,6 +123,7 @@ def parse_arguments() -> dict:
             raw_generator_arguments[raw_argument] = args[raw_argument]
     arg_map["raw_generator_arguments"] = raw_generator_arguments
     arg_map["disable_virtual_operations"] = args.get("disable_virtual_operations", False)
+    arg_map["disable_smithy_generation"] = args.get("disable_smithy_generation", False)
     arg_map["generate_smoke_tests"] = args.get("generate_smoke_tests", None)
     arg_map["generate_protocol_tests"] = args.get("generate_protocol_tests", None)
     if arg_map["debug"]:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
added a new param to set smithy c2j generation to be off (on at default) for custom codegens

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
