### PR TITLE
Fix Clang Compatibility and Remove Unused Variables

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/event/EventHeader.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/event/EventHeader.h
@@ -16,7 +16,7 @@
 #include <aws/event-stream/event_stream.h>
 #include <cassert>
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #pragma GCC diagnostic ignored "-Wuninitialized"
@@ -357,6 +357,6 @@ namespace Aws
     }
 }
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinHttpSyncHttpClient.cpp
@@ -335,7 +335,7 @@ static void CALLBACK WinHttpSyncLogCallback(HINTERNET hInternet,
     };
 
     bool found = false;
-    int i;
+    size_t i;
     for (i = 0; i < sizeof(KNOWN_STATUSES) / sizeof(KNOWN_STATUSES[0]) && !found; i++)
     {
         if (dwInternetStatus == KNOWN_STATUSES[i].status)
@@ -402,8 +402,8 @@ WinHttpSyncHttpClient::WinHttpSyncHttpClient(const ClientConfiguration& config) 
     Base(),
     m_usingProxy(!config.proxyHost.empty()),
     m_verifySSL(config.verifySSL),
-    m_version(config.version),
-    m_useAnonymousAuth(config.winHTTPOptions.useAnonymousAuth)
+    m_useAnonymousAuth(config.winHTTPOptions.useAnonymousAuth),
+    m_version(config.version)
 {
     m_enableHttpClientTrace = config.enableHttpClientTrace;
 

--- a/src/aws-cpp-sdk-core/source/platform/windows/OSVersionInfo.cpp
+++ b/src/aws-cpp-sdk-core/source/platform/windows/OSVersionInfo.cpp
@@ -69,7 +69,6 @@ Aws::String ComputeOSVersionString()
     static const char* FILE_TO_CHECK = "Kernel32.dll";
     DWORD fileVersionSize = GetFileVersionInfoSizeA(FILE_TO_CHECK, &uselessParameter);
     void* blob = Aws::Malloc("OSVersionInfo", static_cast<size_t>(fileVersionSize));
-    bool versionFound(false);
 
     if (GetFileVersionInfoA(FILE_TO_CHECK, 0, fileVersionSize, blob))
     {
@@ -95,7 +94,6 @@ Aws::String ComputeOSVersionString()
             if (VerQueryValueA(blob, codePageSS.str().c_str(), &subBlock, &subBlockSize))
             {
                 ss << "#" << static_cast<const char*>(subBlock);
-                versionFound = true;
             }
         }
     }

--- a/tests/aws-cpp-sdk-core-tests/aws/auth/GeneralHTTPCredentialsProviderTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/aws/auth/GeneralHTTPCredentialsProviderTest.cpp
@@ -13,7 +13,7 @@
 #include <aws/core/platform/Environment.h>
 #include <aws/core/platform/FileSystem.h>
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__clang__)
 // disable "warning C4702: unreachable code" from GTEST_SKIP on newer MSVS
 #pragma warning(disable: 4702)
 #endif

--- a/tests/testing-resources/include/aws/testing/AwsCppSdkGTestSuite.h
+++ b/tests/testing-resources/include/aws/testing/AwsCppSdkGTestSuite.h
@@ -13,7 +13,7 @@
 
 #include <aws/core/Aws.h>
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__clang__)
 // disable "warning C4702: unreachable code" from GTEST_SKIP on newer MSVS
 #pragma warning(disable: 4702)
 #endif


### PR DESCRIPTION
This commit improves compatibility with Clang on Windows and MinGW platforms by refining preprocessor conditionals that disable specific compiler warnings. The previous checks only tested for _WIN32 or __MINGW32__, but Clang on these platforms does not require the same warning suppressions, leading to unnecessary or incorrect pragma directives.

Additionally, removes unused variables in OSVersionInfo.cpp and corrects the loop index type in WinHttpSyncHttpClient.cpp to use size_t instead of int. The member initialization order in WinHttpSyncHttpClient's constructor has been reordered to match the declaration order in the class definition.

NOTE: this PR is only completed when applied with this PR (to the `aws-c-common` repo):
https://github.com/awslabs/aws-c-common/pull/1236

* Compiler warning pragmas (AwsCppSdkGTestSuite.h, EventHeader.h, GeneralHTTPCredentialsProviderTest.cpp)
* Unused variable cleanup (OSVersionInfo.cpp)
* Type safety improvements (WinHttpSyncHttpClient.cpp)

Note that this PR partially fixes: https://github.com/aws/aws-sdk-cpp/issues/3481 (at least the `Bedrock` API).

**Generated by CodeLite**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
