### PR TITLE
Fix variable shadowing in nested map/list deserialization code generation

### DIFF
--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/ModelInternalMapOrListJsonDeserializer.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/ModelInternalMapOrListJsonDeserializer.vm
@@ -2,7 +2,11 @@
 #set($template.currentShape = $currentShape)
 #set($template.jsonValue = $jsonValue)
 #set($template.memberKey = $memberKey)
+#if($recursionDepth > 1)
+#set($template.lowerCaseVarName = $CppViewHelper.computeVariableName($template.memberKey) + $recursionDepth)
+#else
 #set($template.lowerCaseVarName = $CppViewHelper.computeVariableName($template.memberKey))
+#end
 #set($template.containerVar = $containerVar)
 #set($template.recursionDepth = $recursionDepth)
 #set($template.atBottom = false)
@@ -44,9 +48,17 @@
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/json/ModelInternalMapOrListJsonDeserializer.vm")
 #end
 #if($template.currentShape.mapValue.shape.map)
+#if($template.recursionDepth > 0)
+#set($template.internalCollectionName = $CppViewHelper.computeVariableName($template.currentShape.mapValue.shape.name) + ($template.recursionDepth + 1) + "Map")
+#else
 #set($template.internalCollectionName = $CppViewHelper.computeVariableName($template.currentShape.mapValue.shape.name) + "Map")
+#end
 #elseif($template.currentShape.mapValue.shape.list)
+#if($template.recursionDepth > 0)
+#set($template.internalCollectionName = $CppViewHelper.computeVariableName($template.currentShape.mapValue.shape.name) + ($template.recursionDepth + 1) + "List")
+#else
 #set($template.internalCollectionName = $CppViewHelper.computeVariableName($template.currentShape.mapValue.shape.name) + "List")
+#end
 #end
 #if(!$template.atBottom)
 #if($template.currentShape.mapKey.shape.enum)
@@ -92,9 +104,17 @@
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/json/ModelInternalMapOrListJsonDeserializer.vm")
 #end
 #if($template.currentShape.listMember.shape.map)
+#if($template.recursionDepth > 0)
+#set($template.internalCollectionName = $CppViewHelper.computeVariableName($template.currentShape.listMember.shape.name) + ($template.recursionDepth + 1) + "Map")
+#else
 #set($template.internalCollectionName = $CppViewHelper.computeVariableName($template.currentShape.listMember.shape.name) + "Map")
+#end
 #elseif($template.currentShape.mapValue.shape.list || $template.currentShape.listMember.shape.list)
+#if($template.recursionDepth > 0)
+#set($template.internalCollectionName = $CppViewHelper.computeVariableName($template.currentShape.listMember.shape.name) + ($template.recursionDepth + 1) + "List")
+#else
 #set($template.internalCollectionName = $CppViewHelper.computeVariableName($template.currentShape.listMember.shape.name) + "List")
+#end
 #end
 #if(!$template.atBottom)
   ${template.currentSpaces}  ${template.containerVar}.push_back(std::move(${template.internalCollectionName}));


### PR DESCRIPTION
*Description of changes:* Fixed variable shadowing in the code generator template for nested map/list deserialization. The template now appends recursion depth to variable names when processing nested structures, preventing MSVC C4456 warnings that are treated as errors.                                                                                                                     
                                                                                                                                                                                     
Changes to ModelInternalMapOrListJsonDeserializer.vm:                                                                                                                                
- Append recursion depth to variable names when depth > 1                                                                                                                            
- Update internal collection names to include recursion depth for both map values and list members                                                                                   
- Ensures unique variable names at each nesting level (e.g., conditionJsonMap, condition2JsonMap, condition3JsonList)   

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
