### PR TITLE
[Tool] Build burro aws cpp sdk

### DIFF
--- a/build-debian.bash
+++ b/build-debian.bash
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+
+mkdir build && cd build
+cmake .. \
+  -DLEGACY_BUILD=ON \
+  -DBUILD_ONLY=secretsmanager \
+  -DBUILD_TESTING=OFF \
+  -DBUILD_DEPS=ON \
+  -DENABLE_UNITY_BUILD=ON \
+  -DBUILD_SHARED_LIBS=ON \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+  -DCMAKE_INSTALL_PREFIX=/usr/local
+
+make -j$(nproc)
+make install DESTDIR=../../burro-aws-sdk-cpp
+
+pushd ../../
+
+cat <<EOF > burro-aws-sdk-cpp/DEBIAN/control
+Package: burro-aws-sdk-cpp
+Version: 1.9.0
+Architecture: amd64
+Maintainer: Wolf Liang <debo@burro.ai>
+Depends: libcurl4-openssl-dev, zlib1g-dev
+Description: AWS SDK for C++ (Secrets Manager) for Burro
+ Compiled AWS SDK C++ library with Secrets Manager support.
+ Built for Ubuntu 20.04 with shared libraries enabled.
+EOF
+
+
+cat <<EOF > burro-aws-sdk-cpp/DEBIAN/postinst
+#!/bin/bash
+ldconfig
+EOF
+
+chmod 755 burro-aws-sdk-cpp/DEBIAN/postinst
+
+dpkg-deb --build burro-aws-sdk-cpp
+
+echo "burro-aws-sdk-cpp.deb is built, feel free to install"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Motivation: using git submodule to include the build time dependencies `aws-cpp-sdk` use a lot of space ( 1.5 GB )
- Add a tool to package required built-time aws-cpp-sdk library for use to install in build environment.


*Check all that applies:*
- [ ] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [ ] Checked if this PR is a breaking (APIs have been changed) change.
- [ ] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [ ] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
