### PR TITLE
Update Bedrock InvokeModel test to use non-legacy model 

### DIFF
--- a/tests/aws-cpp-sdk-bedrock-runtime-integration-tests/IntegrationTests.cpp
+++ b/tests/aws-cpp-sdk-bedrock-runtime-integration-tests/IntegrationTests.cpp
@@ -80,7 +80,7 @@ TEST_F(BedrockRuntimeTests, TestStreaming)
 
 TEST_F(BedrockRuntimeTests, TestInvokeModel)
 {
-  auto bedrockRequest = Aws::BedrockRuntime::Model::InvokeModelRequest{}.WithModelId("us.anthropic.claude-3-5-haiku-20241022-v1:0").WithAccept("application/json") ;
+  auto bedrockRequest = Aws::BedrockRuntime::Model::InvokeModelRequest{}.WithModelId("us.anthropic.claude-haiku-4-5-20251001-v1:0").WithAccept("application/json") ;
 
   bedrockRequest.SetBody(Aws::MakeShared<Aws::StringStream>(
         "BedrockRuntimeTests::TestInvokeModel",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update model from 3.5 sonnet (legacy) to 4.5 haiku

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
