### PR TITLE
remove uneeded temporary build artifacts in CI

### DIFF
--- a/tools/scripts/build-tests/build-al2-debug-clang-cxx20.sh
+++ b/tools/scripts/build-tests/build-al2-debug-clang-cxx20.sh
@@ -21,3 +21,11 @@ cd "${PREFIX_DIR}/al2-build"
 cmake -GNinja ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../aws-sdk-cpp/toolchains/clang-c++20.cmake -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}/al2-install" -DAWS_ENABLE_CORE_INTEGRATION_TEST=ON
 ninja-build -j $(grep -c ^processor /proc/cpuinfo)
 ninja-build install
+
+# Clean up temp build files, however leave built integration tests as they have no install target
+rm -rf "${PREFIX_DIR}/al2-build/AWSSDK/"
+rm -rf "${PREFIX_DIR}/al2-build/CMakeFiles/"
+rm -rf "${PREFIX_DIR}/al2-build/crt/"
+rm -rf "${PREFIX_DIR}/al2-build/generated/"
+rm -rf "${PREFIX_DIR}/al2-build/lib/"
+rm -rf "${PREFIX_DIR}/al2-build/src/"

--- a/tools/scripts/build-tests/build-al2-debug-default.sh
+++ b/tools/scripts/build-tests/build-al2-debug-default.sh
@@ -27,3 +27,11 @@ fi
 cmake "${CMAKE_ARGS[@]}"
 ninja-build -j $(grep -c ^processor /proc/cpuinfo)
 ninja-build install
+
+# Clean up temp build files, however leave built integration tests as they have no install target
+rm -rf "${PREFIX_DIR}/al2-build/AWSSDK/"
+rm -rf "${PREFIX_DIR}/al2-build/CMakeFiles/"
+rm -rf "${PREFIX_DIR}/al2-build/crt/"
+find "${PREFIX_DIR}/al2-build/generated/" -mindepth 1 -maxdepth 1 ! -name "smoke-tests" -exec rm -rf {} +
+rm -rf "${PREFIX_DIR}/al2-build/lib/"
+rm -rf "${PREFIX_DIR}/al2-build/src/"

--- a/tools/scripts/build-tests/build-al2-debug-gcc-cxx20.sh
+++ b/tools/scripts/build-tests/build-al2-debug-gcc-cxx20.sh
@@ -21,3 +21,11 @@ cd "${PREFIX_DIR}/al2-build"
 cmake -GNinja ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../aws-sdk-cpp/toolchains/gcc10-c++20.cmake -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}/al2-install" -DAWS_ENABLE_CORE_INTEGRATION_TEST=ON
 ninja-build -j $(grep -c ^processor /proc/cpuinfo)
 ninja-build install
+
+# Clean up temp build files, however leave built integration tests as they have no install target
+rm -rf "${PREFIX_DIR}/al2-build/AWSSDK/"
+rm -rf "${PREFIX_DIR}/al2-build/CMakeFiles/"
+rm -rf "${PREFIX_DIR}/al2-build/crt/"
+rm -rf "${PREFIX_DIR}/al2-build/generated/"
+rm -rf "${PREFIX_DIR}/al2-build/lib/"
+rm -rf "${PREFIX_DIR}/al2-build/src/"

--- a/tools/scripts/build-tests/build-al2-debug-non-unity-default.sh
+++ b/tools/scripts/build-tests/build-al2-debug-non-unity-default.sh
@@ -21,3 +21,11 @@ cd "${PREFIX_DIR}/al2-build"
 cmake -GNinja ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Debug -DENABLE_UNITY_BUILD=OFF -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}/al2-install" -DAWS_ENABLE_CORE_INTEGRATION_TEST=ON
 ninja-build -j $(grep -c ^processor /proc/cpuinfo)
 ninja-build install
+
+# Clean up temp build files, however leave built integration tests as they have no install target
+rm -rf "${PREFIX_DIR}/al2-build/AWSSDK/"
+rm -rf "${PREFIX_DIR}/al2-build/CMakeFiles/"
+rm -rf "${PREFIX_DIR}/al2-build/crt/"
+rm -rf "${PREFIX_DIR}/al2-build/generated/"
+rm -rf "${PREFIX_DIR}/al2-build/lib/"
+rm -rf "${PREFIX_DIR}/al2-build/src/"

--- a/tools/scripts/build-tests/build-al2-default.sh
+++ b/tools/scripts/build-tests/build-al2-default.sh
@@ -21,3 +21,11 @@ cd "${PREFIX_DIR}/al2-build"
 cmake -GNinja ../aws-sdk-cpp -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}/al2-install" -DAWS_ENABLE_CORE_INTEGRATION_TEST=ON
 cmake --build . --parallel $(grep -c ^processor /proc/cpuinfo)
 cmake --build . --target install
+
+# Clean up temp build files, however leave built integration tests as they have no install target
+rm -rf "${PREFIX_DIR}/al2-build/AWSSDK/"
+rm -rf "${PREFIX_DIR}/al2-build/CMakeFiles/"
+rm -rf "${PREFIX_DIR}/al2-build/crt/"
+rm -rf "${PREFIX_DIR}/al2-build/generated/"
+rm -rf "${PREFIX_DIR}/al2-build/lib/"
+rm -rf "${PREFIX_DIR}/al2-build/src/"


### PR DESCRIPTION
*Description of changes:*

During CI we build and install the SDK, however, the integration tests have no install target, so do not clean up the entire build directory. We want the integration test binaries, however we keep the entire build directory in the workspaces. This remove all the unneeded transient files, that sometimes total up to 44 GiB when building in non-unity.
```
$ du -sh */
8.0K	AWSSDK/
1.7M	CMakeFiles/
73M	crt/
42G	generated/
16M	lib/
155M	src/
648M	tests/
```

all we really want is the `tests` directory and the test binaries in them.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
