### PR TITLE
Place generated files in `CMAKE_BINARY_DIR`.

### DIFF
--- a/cmake/initialize_project_version.cmake
+++ b/cmake/initialize_project_version.cmake
@@ -6,9 +6,8 @@ if(GIT_FOUND)
 endif()
 
 if(NOT VERSION_STRING)
-    # extract it from the existing generated header file
-    file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/src/aws-cpp-sdk-core/include/aws/core/VersionConfig.h" __SDK_VERSION_LINE LIMIT_COUNT 1 REGEX "AWS_SDK_VERSION_STRING.*[0-9]+\\.[0-9]+\\.[0-9]+" )
-    string( REGEX MATCH "([0-9]+\\.[0-9]+\\.[0-9]+)" VERSION_STRING "${__SDK_VERSION_LINE}" )
+    # read it from the version file
+    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" VERSION_STRING)
 endif()
 
 set(PROJECT_VERSION "${VERSION_STRING}")

--- a/src/aws-cpp-sdk-core/CMakeLists.txt
+++ b/src/aws-cpp-sdk-core/CMakeLists.txt
@@ -20,7 +20,7 @@ if(VERSION_STRING)
     set(AWSSDK_VERSION_PATCH ${AWSSDK_VERSION_PATCH})
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/include/aws/core/VersionConfig.h.in"
-        "${CMAKE_CURRENT_SOURCE_DIR}/include/aws/core/VersionConfig.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/include/aws/core/VersionConfig.h"
         NEWLINE_STYLE UNIX)
 else()
     message("Not able to compute versioning string, not updating.")
@@ -38,7 +38,7 @@ else()
 endif()
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/include/aws/core/SDKConfig.h.in"
-               "${CMAKE_CURRENT_SOURCE_DIR}/include/aws/core/SDKConfig.h"
+               "${CMAKE_CURRENT_BINARY_DIR}/include/aws/core/SDKConfig.h"
                NEWLINE_STYLE UNIX)
 
 file(GLOB AWS_HEADERS "include/aws/core/*.h")
@@ -98,6 +98,8 @@ file(GLOB SMITHY_IDENTITY_SIGNER_BUILTIN_HEADERS "include/smithy/identity/signer
 file(GLOB SMITHY_INTERCEPTOR_HEADERS "include/smithy/interceptor/*.h")
 file(GLOB SMITHY_INTERCEPTOR_IMPL_HEADERS "include/smithy/interceptor/impl/*.h")
 file(GLOB SMITHY_CLIENT_SCHEMA_HEADERS "include/smithy/client/schema/*.h")
+
+file(GLOB AWS_GENERATED_HEADERS "${CMAKE_CURRENT_BINARY_DIR}/include/aws/core/*.h")
 
 file(GLOB AWS_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp")
 file(GLOB AWS_TINYXML2_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/external/tinyxml2/*.cpp")
@@ -409,7 +411,7 @@ file(GLOB AWS_NATIVE_SDK_SRC
 
 # Visual studio project directory structure
 if(MSVC)
-    source_group("Header Files\\aws\\core" FILES ${AWS_HEADERS})
+    source_group("Header Files\\aws\\core" FILES ${AWS_HEADERS} ${AWS_GENERATED_HEADERS})
     source_group("Header Files\\aws\\core\\auth" FILES ${AWS_AUTH_HEADERS})
     source_group("Header Files\\aws\\core\\auth\\signer" FILES ${AWS_AUTH_SIGNER_HEADERS})
     source_group("Header Files\\aws\\core\\auth\\signer-provider" FILES ${AWS_AUTH_SIGNER_PROVIDER_HEADERS})
@@ -627,6 +629,7 @@ endif()
 
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
 if (EXTERNAL_DEPS_INCLUDE_DIRS)
@@ -699,7 +702,7 @@ if(SIMPLE_INSTALL)
     endif()
 endif()
 
-install (FILES ${AWS_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/core)
+install (FILES ${AWS_HEADERS} ${AWS_GENERATED_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/core)
 install (FILES ${AWS_AUTH_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/core/auth)
 install (FILES ${AWS_AUTH_SIGNER_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/core/auth/signer)
 install (FILES ${AWS_AUTH_SIGNER_PROVIDER_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/aws/core/auth/signer-provider)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

> [!NOTE]
> This is a reopening of #3459, which was closed for reasons unknown to me.

This PR updates the CMake project to place generated files in the binary directory, instead of the source directory. This follows best practices, and unblocks the vcpkg port to support configuring `aws-sdk-cpp` in parallel.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [X] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
