### PR TITLE
Smithy sigv4a long term creds fix

### DIFF
--- a/src/aws-cpp-sdk-core/include/smithy/identity/signer/built-in/SigV4aSigner.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/signer/built-in/SigV4aSigner.h
@@ -157,7 +157,6 @@ namespace smithy {
           Aws::Crt::Auth::SignatureType signatureType)
         {
             assert(httpRequest);
-            assert(identity.expiration().has_value());
 
             const auto legacyCreds = [&identity]() -> Aws::Auth::AWSCredentials {
               if(identity.sessionToken().has_value() && identity.expiration().has_value())
@@ -191,11 +190,13 @@ namespace smithy {
             httpRequest->SetSigningAccessKey(legacyCreds.GetAWSAccessKeyId());
             httpRequest->SetSigningRegion(regionOverride);
 
+            //Expiration should always have a value, since we default construct it to std::chrono::time_point<std::chrono::system_clock>::max in AWSCredentials.h
+            //SessionToken will be null for long-term credentials
             auto crtCredentials = Aws::MakeShared<Aws::Crt::Auth::Credentials>(v4AsymmetricLogTag,
                 Aws::Crt::ByteCursorFromCString(identity.accessKeyId().c_str()),
                 Aws::Crt::ByteCursorFromCString(identity.secretAccessKey().c_str()),
-                Aws::Crt::ByteCursorFromCString((*identity.sessionToken()).c_str()),
-                (*identity.expiration()).Seconds());
+                Aws::Crt::ByteCursorFromCString(identity.sessionToken().has_value() ? identity.sessionToken()->c_str() : ""),
+                identity.expiration().has_value() ? identity.expiration()->Seconds() : UINT64_MAX);
 
             Aws::Crt::Auth::AwsSigningConfig awsSigningConfig;
 

--- a/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/smithy/client/SmithyClientTest.cpp
@@ -275,6 +275,55 @@ TEST_F(SmithyClientTest, testSigV4) {
 }
 
 
+TEST_F(SmithyClientTest, testSigV4WithLongTermCredentials) {
+
+    std::shared_ptr<MyServiceAuthSchemeResolver> authSchemeResolver = Aws::MakeShared<smithy::GenericAuthSchemeResolver<> >(ALLOCATION_TAG, Aws::Vector<smithy::AuthSchemeOption>({smithy::SigV4AuthSchemeOption::sigV4AuthSchemeOption}));
+
+    Aws::UnorderedMap<Aws::String, SigVariant> authSchemesMap;
+
+    Aws::String key{"aws.auth#sigv4"};
+
+    auto credentialsResolver = Aws::MakeShared<smithy::DefaultAwsCredentialIdentityResolver>(ALLOCATION_TAG, credsProviderChain);
+
+    SigVariant val{smithy::SigV4AuthScheme( credentialsResolver, "MyService", "us-west-2")};
+
+    authSchemesMap.emplace(key, val);
+
+    std::shared_ptr<TestClient> ptr = Aws::MakeShared<TestClient>(
+        ALLOCATION_TAG,
+        clientConfig,
+        "MyService",
+        httpClient,
+        errorMarshaller,
+        endPointProvider,
+        authSchemeResolver,
+        authSchemesMap);
+    smithy::client::AwsSmithyClientAsyncRequestContext ctx;
+    ctx.m_pRequest = nullptr;
+
+    auto res = ptr->SelectAuthSchemeOption(ctx);
+    EXPECT_EQ(res.IsSuccess(), true);
+    ctx.m_authSchemeOption = res.GetResultWithOwnership();
+
+    // Long-term credentials: no session token, no expiration
+    ctx.m_awsIdentity = Aws::MakeShared<smithy::AwsCredentialIdentity>(ALLOCATION_TAG,
+        "longTermAccessKey",
+        "longTermSecretKey",
+        Aws::Crt::Optional<Aws::String>{},
+        Aws::Crt::Optional<Aws::Utils::DateTime>{},
+        Aws::Crt::Optional<Aws::String>{});
+
+    Aws::String uri{"https://treasureisland-cb93079d-24a0-4862-8es2-88456ead.xyz.amazonaws.com"};
+
+    std::shared_ptr<Aws::Http::HttpRequest> httpRequest(Aws::Http::CreateHttpRequest(uri, Aws::Http::HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
+
+    auto res2 = ptr->SignRequest(httpRequest, ctx);
+
+    EXPECT_EQ(res2.IsSuccess(), true);
+    EXPECT_EQ(res2.GetResult()->GetSigningAccessKey(), "longTermAccessKey");
+}
+
+
 TEST_F(SmithyClientTest, testSigV4a) {
 
     std::shared_ptr<MyServiceAuthSchemeResolver> authSchemeResolver = Aws::MakeShared<smithy::GenericAuthSchemeResolver<>>(ALLOCATION_TAG, Aws::Vector<smithy::AuthSchemeOption>({smithy::SigV4aAuthSchemeOption::sigV4aAuthSchemeOption}));
@@ -319,6 +368,54 @@ TEST_F(SmithyClientTest, testSigV4a) {
 
     EXPECT_EQ(res2.IsSuccess(), true);
     EXPECT_TRUE(!res2.GetResult()->GetSigningAccessKey().empty());
+    EXPECT_FALSE(res2.GetResult()->GetUri().GetURIString(true).empty());
+}
+
+TEST_F(SmithyClientTest, testSigV4aWithLongTermCredentials) {
+
+    std::shared_ptr<MyServiceAuthSchemeResolver> authSchemeResolver = Aws::MakeShared<smithy::GenericAuthSchemeResolver<>>(ALLOCATION_TAG, Aws::Vector<smithy::AuthSchemeOption>({smithy::SigV4aAuthSchemeOption::sigV4aAuthSchemeOption}));
+
+    Aws::UnorderedMap<Aws::String, SigVariant> authSchemesMap;
+
+    Aws::String key{"aws.auth#sigv4a"};
+    auto credentialsResolver = Aws::MakeShared<smithy::DefaultAwsCredentialIdentityResolver>(ALLOCATION_TAG, credsProviderChain);
+
+    SigVariant val{smithy::SigV4aAuthScheme(credentialsResolver, "MyService", "us-west-2")};
+
+    authSchemesMap.emplace(key, val);
+
+    std::shared_ptr<TestClient> ptr = Aws::MakeShared<TestClient>(
+        ALLOCATION_TAG,
+        clientConfig,
+        "MyAuthaService",
+        httpClient,
+        errorMarshaller,
+        endPointProvider,
+        authSchemeResolver,
+        authSchemesMap);
+    smithy::client::AwsSmithyClientAsyncRequestContext ctx;
+    ctx.m_pRequest = nullptr;
+
+    auto res = ptr->SelectAuthSchemeOption(ctx);
+    EXPECT_EQ(res.IsSuccess(), true);
+    ctx.m_authSchemeOption = res.GetResultWithOwnership();
+
+    // Long-term credentials: no session token, no expiration
+    ctx.m_awsIdentity = Aws::MakeShared<smithy::AwsCredentialIdentity>(ALLOCATION_TAG,
+        "longTermAccessKey",
+        "longTermSecretKey",
+        Aws::Crt::Optional<Aws::String>{},
+        Aws::Crt::Optional<Aws::Utils::DateTime>{},
+        Aws::Crt::Optional<Aws::String>{});
+
+    Aws::String uri{"https://treasureisland-cb93079d-24a0-4862-8es2-88456ead.xyz.amazonaws.com"};
+
+    std::shared_ptr<Aws::Http::HttpRequest> httpRequest(Aws::Http::CreateHttpRequest(uri, Aws::Http::HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
+
+    auto res2 = ptr->SignRequest(httpRequest, ctx);
+
+    EXPECT_EQ(res2.IsSuccess(), true);
+    EXPECT_EQ(res2.GetResult()->GetSigningAccessKey(), "longTermAccessKey");
     EXPECT_FALSE(res2.GetResult()->GetUri().GetURIString(true).empty());
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Sigv4ASigner incorrectly directly dereferences `(*identity.sessionToken())`. Fixed to be conditional since this is a optional value (also done for expiration)

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
