### PR TITLE
fix warning as error on MSVC

### DIFF
--- a/src/aws-cpp-sdk-core/source/utils/local/Random.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/local/Random.cpp
@@ -11,13 +11,13 @@
 #include <thread>
 
 std::mt19937::result_type Aws::Utils::GetRandomValue() {
-  static size_t const processRandomSeed = std::random_device{}();
+  static auto const processRandomSeed = std::random_device{}();
   static std::mt19937 threadRandomSeedGen(processRandomSeed);
   // Threads can be re-used (esp. on OS X), generate a true random per-thread random seed
   static std::mutex threadRandomSeedGenMtx;
-  thread_local std::mt19937 gen([]() -> size_t {
+  thread_local std::mt19937 gen([]() -> std::mt19937::result_type {
     std::unique_lock<std::mutex> const lock(threadRandomSeedGenMtx);
-    return static_cast<size_t>(std::hash<std::thread::id>{}(std::this_thread::get_id()) ^ threadRandomSeedGen());
+    return static_cast<std::mt19937::result_type>(std::hash<std::thread::id>{}(std::this_thread::get_id()) ^ threadRandomSeedGen());
   }());
 
   return gen();


### PR DESCRIPTION
*Description of changes:*

Fixes warnings as error compilation error on recent msvc toolchains

```
C:\aws-cpp-sdk-core\source\utils\local\Random.cpp(15,43): warning C4267: 'argument': conversion from 'size_t' to 'unsigned int', possible loss of data
```

this was due to type casting we had previous relied on in the random generator that got moved into a compilation unit

thi

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
