### PR TITLE
fix windows.h macro collision

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/Outcome.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/Outcome.h
@@ -27,8 +27,8 @@ namespace Aws
         class Outcome
         {
         public:
-            typedef R RESULT;
-            typedef E ERROR;
+            typedef R RESULT_TYPE;
+            typedef E ERROR_TYPE;
 
             Outcome() : result(), error(), success(false)
             {

--- a/src/aws-cpp-sdk-core/include/smithy/client/features/ChunkingInterceptor.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/features/ChunkingInterceptor.h
@@ -80,7 +80,7 @@ protected:
 
         // Set up buffer pointers to read from chunking buffer
         size_t remainingBytes = m_chunkingBufferSize - m_chunkingBufferPos;
-        size_t bytesToRead = std::min(remainingBytes, DataBufferSize);
+        size_t bytesToRead = (std::min)(remainingBytes, DataBufferSize);
         
         setg(m_chunkingBuffer.GetUnderlyingData() + m_chunkingBufferPos, 
              m_chunkingBuffer.GetUnderlyingData() + m_chunkingBufferPos, 


### PR DESCRIPTION
*Description of changes:*

Fixes two windows.h macro collisions

`ERROR` that was added in `Outcome.h`([commit](https://github.com/aws/aws-sdk-cpp/commit/b7fb98fa364eaa981f3ee7047895cabae9bed3e3))

`std::min` that was added in `ChunkingInterceptor.h`([commit](https://github.com/aws/aws-sdk-cpp/commit/205105420142d518fcd8b97cc380c7c8b09804e3))

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
