### PR TITLE
fixing getter name collision with enclosing class name in code generator

### DIFF
--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassMembersAndInlines.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassMembersAndInlines.vm
@@ -63,7 +63,7 @@
 #set($setterWithMove = " { ${setHasBeenSet}${memberVariableName} = std::forward<${memberKeyWithFirstLetterCapitalized}T>(value); }")
 #end
 #set($getterFunctionName = "Get${memberKeyWithFirstLetterCapitalized}")
-#if($getterFunctionName == ${member.value.shape.name})
+#if($getterFunctionName == ${member.value.shape.name} || $getterFunctionName == ${typeInfo.className})
 #set($getterFunctionName = "Get${getterFunctionName}")
 #end
 #if($shape.request)


### PR DESCRIPTION
codegen fix: getter name collision with enclosing class name in code generator

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
