### PR TITLE
use write data API in bidirectional streaming

### DIFF
--- a/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/InvokeModelWithBidirectionalStreamInput.h
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/include/aws/bedrock-runtime/model/InvokeModelWithBidirectionalStreamInput.h
@@ -7,6 +7,7 @@
 #include <aws/bedrock-runtime/BedrockRuntime_EXPORTS.h>
 #include <aws/bedrock-runtime/model/BidirectionalInputPayloadPart.h>
 #include <aws/core/utils/event/EventStream.h>
+#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
 
 #include <utility>
 
@@ -22,6 +23,9 @@ namespace Model {
  */
 class AWS_BEDROCKRUNTIME_API InvokeModelWithBidirectionalStreamInput : public Aws::Utils::Event::EventEncoderStream {
  public:
+  InvokeModelWithBidirectionalStreamInput() = default;
+  explicit InvokeModelWithBidirectionalStreamInput(std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf)
+      : Aws::Utils::Event::EventEncoderStream(std::move(streambuf)) {}
   InvokeModelWithBidirectionalStreamInput& WriteBidirectionalInputPayloadPart(const BidirectionalInputPayloadPart& value) {
     Aws::Utils::Event::Message msg;
     msg.InsertEventHeader(":message-type", Aws::String("event"));

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/source/BedrockRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/source/BedrockRuntimeClient.cpp
@@ -30,6 +30,7 @@
 #include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 #include <aws/core/utils/threading/Executor.h>
+#include <smithy/client/SmithyBidirectionalStreamingWriteDataTask.h>
 #include <smithy/client/SmithyEventStreamingAsyncTask.h>
 #include <smithy/identity/resolver/built-in/AwsCredentialsProviderIdentityResolver.h>
 #include <smithy/identity/resolver/built-in/DefaultAwsCredentialIdentityResolver.h>
@@ -387,6 +388,30 @@ void BedrockRuntimeClient::InvokeModelWithBidirectionalStreamAsync(
     resolvedEndpoint.AddPathSegments("/invoke-with-bidirectional-stream");
   };
 
+#if AWS_SDK_USE_CRT_HTTP
+  // Push-based WriteData path (CRT HTTP client only)
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, m_httpClient);
+  auto eventEncoderStream = Aws::MakeShared<Model::InvokeModelWithBidirectionalStreamInput>(ALLOCATION_TAG, writeDataStreamBuf);
+  request.SetBody(eventEncoderStream);
+
+  auto requestCopy = Aws::MakeShared<InvokeModelWithBidirectionalStreamRequest>(ALLOCATION_TAG, request);
+
+  auto authCallback = [&](std::shared_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> ctx) -> void {
+    eventEncoderStream->SetSigningCallback([this, ctx, eventEncoderStream](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
+      auto outcome = SignEventMessage(message, seed, ctx);
+      return outcome.IsSuccess();
+    });
+  };
+
+  auto asyncTask = smithy::client::CreateSmithyBidirectionalWriteDataTask<InvokeModelWithBidirectionalStreamOutcome>(
+      this, requestCopy, handler, handlerContext, eventEncoderStream, writeDataStreamBuf, std::move(endpointCallback),
+      std::move(authCallback));
+  auto sem = asyncTask.GetSemaphore();
+  m_clientConfiguration.executor->Submit(std::move(asyncTask));
+  sem->WaitOne();
+  streamReadyHandler(*eventEncoderStream);
+#else
+  // Pull-based path
   auto eventEncoderStream = Aws::MakeShared<Model::InvokeModelWithBidirectionalStreamInput>(ALLOCATION_TAG);
   auto authCallback = [&](std::shared_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> ctx) -> void {
     eventEncoderStream->SetSigningCallback([this, ctx, eventEncoderStream](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
@@ -395,8 +420,8 @@ void BedrockRuntimeClient::InvokeModelWithBidirectionalStreamAsync(
     });
   };
   auto requestCopy = Aws::MakeShared<InvokeModelWithBidirectionalStreamRequest>("InvokeModelWithBidirectionalStream", request);
-  requestCopy->SetBody(eventEncoderStream);  // this becomes the body of the request
-  request.SetBody(eventEncoderStream);       // this becomes the body of the request
+  requestCopy->SetBody(eventEncoderStream);
+  request.SetBody(eventEncoderStream);
 
   auto asyncTask = smithy::client::CreateSmithyBidirectionalEventStreamTask<InvokeModelWithBidirectionalStreamOutcome>(
       this, requestCopy, handler, handlerContext, eventEncoderStream, endpointCallback, authCallback);
@@ -404,6 +429,7 @@ void BedrockRuntimeClient::InvokeModelWithBidirectionalStreamAsync(
   m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
   streamReadyHandler(*eventEncoderStream);
+#endif
 }
 InvokeModelWithResponseStreamOutcome BedrockRuntimeClient::InvokeModelWithResponseStream(
     InvokeModelWithResponseStreamRequest& request) const {

--- a/generated/src/aws-cpp-sdk-connecthealth/include/aws/connecthealth/model/MedicalScribeInputStream.h
+++ b/generated/src/aws-cpp-sdk-connecthealth/include/aws/connecthealth/model/MedicalScribeInputStream.h
@@ -9,6 +9,7 @@
 #include <aws/connecthealth/model/MedicalScribeConfigurationEvent.h>
 #include <aws/connecthealth/model/MedicalScribeSessionControlEvent.h>
 #include <aws/core/utils/event/EventStream.h>
+#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
 
 #include <utility>
 
@@ -24,6 +25,9 @@ namespace Model {
  */
 class AWS_CONNECTHEALTH_API MedicalScribeInputStream : public Aws::Utils::Event::EventEncoderStream {
  public:
+  MedicalScribeInputStream() = default;
+  explicit MedicalScribeInputStream(std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf)
+      : Aws::Utils::Event::EventEncoderStream(std::move(streambuf)) {}
   MedicalScribeInputStream& WriteMedicalScribeAudioEvent(const MedicalScribeAudioEvent& value) {
     Aws::Utils::Event::Message msg;
     msg.InsertEventHeader(":message-type", Aws::String("event"));

--- a/generated/src/aws-cpp-sdk-connecthealth/source/ConnectHealthClient.cpp
+++ b/generated/src/aws-cpp-sdk-connecthealth/source/ConnectHealthClient.cpp
@@ -24,6 +24,7 @@
 #include <aws/connecthealth/model/UntagResourceRequest.h>
 #include <aws/core/auth/AWSAuthSigner.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/client/AWSClientBidirectionalStreaming.h>
 #include <aws/core/client/AWSClientEventStreamingAsyncTask.h>
 #include <aws/core/client/CoreErrors.h>
 #include <aws/core/client/RetryStrategy.h>
@@ -517,10 +518,43 @@ void ConnectHealthClient::StartMedicalScribeListeningSessionAsync(
   }
   endpointResolutionOutcome.GetResult().AddPathSegments("/medical-scribe-stream/");
 
+#if AWS_SDK_USE_CRT_HTTP
+  // Push-based WriteData path (CRT HTTP client only)
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
+
+  auto eventEncoderStream = Aws::MakeShared<Model::MedicalScribeInputStream>(ALLOCATION_TAG, writeDataStreamBuf);
+  eventEncoderStream->SetSigner(signer);
+
+  auto requestCopy = Aws::MakeShared<StartMedicalScribeListeningSessionRequest>(ALLOCATION_TAG, request);
+  request.SetInputStream(eventEncoderStream);
+
+  auto& endpoint = endpointResolutionOutcome.GetResult();
+  auto httpRequest =
+      CreateHttpRequest(endpoint.GetURI(), Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+  httpRequest->SetEventStreamRequest(true);
+  httpRequest->SetHasEventStreamResponse(true);
+  BuildHttpRequest(*requestCopy, httpRequest);
+
+  if (!signer->SignRequest(*httpRequest, nullptr, nullptr, true)) {
+    handler(this, request,
+            StartMedicalScribeListeningSessionOutcome(
+                Aws::Client::AWSError<CoreErrors>(CoreErrors::CLIENT_SIGNING_FAILURE, "", "Failed to sign request", false)),
+            handlerContext);
+    return;
+  }
+  eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(*httpRequest));
+
+  Aws::Client::SubmitBidirectionalStreamingRequest<ConnectHealthClient, StartMedicalScribeListeningSessionOutcome,
+                                                   StartMedicalScribeListeningSessionRequest, Model::MedicalScribeInputStream>(
+      this, request, requestCopy, eventEncoderStream, writeDataStreamBuf, httpRequest, m_clientConfiguration.executor.get(),
+      streamReadyHandler, handler, handlerContext);
+#else
+  // Pull-based path (curl/WinHTTP)
   auto eventEncoderStream = Aws::MakeShared<Model::MedicalScribeInputStream>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
   auto requestCopy = Aws::MakeShared<StartMedicalScribeListeningSessionRequest>("StartMedicalScribeListeningSession", request);
-  requestCopy->SetInputStream(eventEncoderStream);  // this becomes the body of the request
+  requestCopy->SetInputStream(eventEncoderStream);
   request.SetInputStream(eventEncoderStream);
 
   auto asyncTask = CreateBidirectionalEventStreamTask<StartMedicalScribeListeningSessionOutcome>(
@@ -529,6 +563,7 @@ void ConnectHealthClient::StartMedicalScribeListeningSessionAsync(
   m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
   streamReadyHandler(*eventEncoderStream);
+#endif
 }
 StartPatientInsightsJobOutcome ConnectHealthClient::StartPatientInsightsJob(const StartPatientInsightsJobRequest& request) const {
   if (!request.DomainIdHasBeenSet()) {

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/model/StartConversationRequestEventStream.h
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/include/aws/lexv2-runtime/model/StartConversationRequestEventStream.h
@@ -5,6 +5,7 @@
 
 #pragma once
 #include <aws/core/utils/event/EventStream.h>
+#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
 #include <aws/lexv2-runtime/LexRuntimeV2_EXPORTS.h>
 #include <aws/lexv2-runtime/model/AudioInputEvent.h>
 #include <aws/lexv2-runtime/model/ConfigurationEvent.h>
@@ -27,6 +28,9 @@ namespace Model {
  */
 class AWS_LEXRUNTIMEV2_API StartConversationRequestEventStream : public Aws::Utils::Event::EventEncoderStream {
  public:
+  StartConversationRequestEventStream() = default;
+  explicit StartConversationRequestEventStream(std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf)
+      : Aws::Utils::Event::EventEncoderStream(std::move(streambuf)) {}
   StartConversationRequestEventStream& WriteConfigurationEvent(const ConfigurationEvent& value) {
     Aws::Utils::Event::Message msg;
     msg.InsertEventHeader(":message-type", Aws::String("event"));

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/source/LexRuntimeV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/source/LexRuntimeV2Client.cpp
@@ -5,6 +5,7 @@
 
 #include <aws/core/auth/AWSAuthSigner.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/client/AWSClientBidirectionalStreaming.h>
 #include <aws/core/client/AWSClientEventStreamingAsyncTask.h>
 #include <aws/core/client/CoreErrors.h>
 #include <aws/core/client/RetryStrategy.h>
@@ -489,10 +490,43 @@ void LexRuntimeV2Client::StartConversationAsync(Model::StartConversationRequest&
   endpointResolutionOutcome.GetResult().AddPathSegment(request.GetSessionId());
   endpointResolutionOutcome.GetResult().AddPathSegments("/conversation");
 
+#if AWS_SDK_USE_CRT_HTTP
+  // Push-based WriteData path (CRT HTTP client only)
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
+
+  auto eventEncoderStream = Aws::MakeShared<Model::StartConversationRequestEventStream>(ALLOCATION_TAG, writeDataStreamBuf);
+  eventEncoderStream->SetSigner(signer);
+
+  auto requestCopy = Aws::MakeShared<StartConversationRequest>(ALLOCATION_TAG, request);
+  request.SetRequestEventStream(eventEncoderStream);
+
+  auto& endpoint = endpointResolutionOutcome.GetResult();
+  auto httpRequest =
+      CreateHttpRequest(endpoint.GetURI(), Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+  httpRequest->SetEventStreamRequest(true);
+  httpRequest->SetHasEventStreamResponse(true);
+  BuildHttpRequest(*requestCopy, httpRequest);
+
+  if (!signer->SignRequest(*httpRequest, nullptr, nullptr, true)) {
+    handler(this, request,
+            StartConversationOutcome(
+                Aws::Client::AWSError<CoreErrors>(CoreErrors::CLIENT_SIGNING_FAILURE, "", "Failed to sign request", false)),
+            handlerContext);
+    return;
+  }
+  eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(*httpRequest));
+
+  Aws::Client::SubmitBidirectionalStreamingRequest<LexRuntimeV2Client, StartConversationOutcome, StartConversationRequest,
+                                                   Model::StartConversationRequestEventStream>(
+      this, request, requestCopy, eventEncoderStream, writeDataStreamBuf, httpRequest, m_clientConfiguration.executor.get(),
+      streamReadyHandler, handler, handlerContext);
+#else
+  // Pull-based path (curl/WinHTTP)
   auto eventEncoderStream = Aws::MakeShared<Model::StartConversationRequestEventStream>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
   auto requestCopy = Aws::MakeShared<StartConversationRequest>("StartConversation", request);
-  requestCopy->SetRequestEventStream(eventEncoderStream);  // this becomes the body of the request
+  requestCopy->SetRequestEventStream(eventEncoderStream);
   request.SetRequestEventStream(eventEncoderStream);
 
   auto asyncTask = CreateBidirectionalEventStreamTask<StartConversationOutcome>(this, endpointResolutionOutcome.GetResultWithOwnership(),
@@ -501,4 +535,5 @@ void LexRuntimeV2Client::StartConversationAsync(Model::StartConversationRequest&
   m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
   streamReadyHandler(*eventEncoderStream);
+#endif
 }

--- a/generated/src/aws-cpp-sdk-polly/include/aws/polly/model/StartSpeechSynthesisStreamActionStream.h
+++ b/generated/src/aws-cpp-sdk-polly/include/aws/polly/model/StartSpeechSynthesisStreamActionStream.h
@@ -5,6 +5,7 @@
 
 #pragma once
 #include <aws/core/utils/event/EventStream.h>
+#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
 #include <aws/polly/Polly_EXPORTS.h>
 #include <aws/polly/model/CloseStreamEvent.h>
 #include <aws/polly/model/TextEvent.h>
@@ -23,6 +24,9 @@ namespace Model {
  */
 class AWS_POLLY_API StartSpeechSynthesisStreamActionStream : public Aws::Utils::Event::EventEncoderStream {
  public:
+  StartSpeechSynthesisStreamActionStream() = default;
+  explicit StartSpeechSynthesisStreamActionStream(std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf)
+      : Aws::Utils::Event::EventEncoderStream(std::move(streambuf)) {}
   StartSpeechSynthesisStreamActionStream& WriteTextEvent(const TextEvent& value) {
     Aws::Utils::Event::Message msg;
     msg.InsertEventHeader(":message-type", Aws::String("event"));

--- a/generated/src/aws-cpp-sdk-polly/source/PollyClient.cpp
+++ b/generated/src/aws-cpp-sdk-polly/source/PollyClient.cpp
@@ -5,6 +5,7 @@
 
 #include <aws/core/auth/AWSAuthSigner.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/client/AWSClientBidirectionalStreaming.h>
 #include <aws/core/client/AWSClientEventStreamingAsyncTask.h>
 #include <aws/core/client/CoreErrors.h>
 #include <aws/core/client/RetryStrategy.h>
@@ -340,10 +341,43 @@ void PollyClient::StartSpeechSynthesisStreamAsync(Model::StartSpeechSynthesisStr
   }
   endpointResolutionOutcome.GetResult().AddPathSegments("/v1/synthesisStream");
 
+#if AWS_SDK_USE_CRT_HTTP
+  // Push-based WriteData path (CRT HTTP client only)
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
+
+  auto eventEncoderStream = Aws::MakeShared<Model::StartSpeechSynthesisStreamActionStream>(ALLOCATION_TAG, writeDataStreamBuf);
+  eventEncoderStream->SetSigner(signer);
+
+  auto requestCopy = Aws::MakeShared<StartSpeechSynthesisStreamRequest>(ALLOCATION_TAG, request);
+  request.SetActionStream(eventEncoderStream);
+
+  auto& endpoint = endpointResolutionOutcome.GetResult();
+  auto httpRequest =
+      CreateHttpRequest(endpoint.GetURI(), Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+  httpRequest->SetEventStreamRequest(true);
+  httpRequest->SetHasEventStreamResponse(true);
+  BuildHttpRequest(*requestCopy, httpRequest);
+
+  if (!signer->SignRequest(*httpRequest, nullptr, nullptr, true)) {
+    handler(this, request,
+            StartSpeechSynthesisStreamOutcome(
+                Aws::Client::AWSError<CoreErrors>(CoreErrors::CLIENT_SIGNING_FAILURE, "", "Failed to sign request", false)),
+            handlerContext);
+    return;
+  }
+  eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(*httpRequest));
+
+  Aws::Client::SubmitBidirectionalStreamingRequest<PollyClient, StartSpeechSynthesisStreamOutcome, StartSpeechSynthesisStreamRequest,
+                                                   Model::StartSpeechSynthesisStreamActionStream>(
+      this, request, requestCopy, eventEncoderStream, writeDataStreamBuf, httpRequest, m_clientConfiguration.executor.get(),
+      streamReadyHandler, handler, handlerContext);
+#else
+  // Pull-based path (curl/WinHTTP)
   auto eventEncoderStream = Aws::MakeShared<Model::StartSpeechSynthesisStreamActionStream>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
   auto requestCopy = Aws::MakeShared<StartSpeechSynthesisStreamRequest>("StartSpeechSynthesisStream", request);
-  requestCopy->SetActionStream(eventEncoderStream);  // this becomes the body of the request
+  requestCopy->SetActionStream(eventEncoderStream);
   request.SetActionStream(eventEncoderStream);
 
   auto asyncTask = CreateBidirectionalEventStreamTask<StartSpeechSynthesisStreamOutcome>(
@@ -352,6 +386,7 @@ void PollyClient::StartSpeechSynthesisStreamAsync(Model::StartSpeechSynthesisStr
   m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
   streamReadyHandler(*eventEncoderStream);
+#endif
 }
 StartSpeechSynthesisTaskOutcome PollyClient::StartSpeechSynthesisTask(const StartSpeechSynthesisTaskRequest& request) const {
   auto uriResolver = [&](Aws::Endpoint::ResolveEndpointOutcome& endpointResolutionOutcome) {

--- a/generated/src/aws-cpp-sdk-qbusiness/include/aws/qbusiness/model/ChatInputStream.h
+++ b/generated/src/aws-cpp-sdk-qbusiness/include/aws/qbusiness/model/ChatInputStream.h
@@ -6,6 +6,7 @@
 #pragma once
 #include <aws/core/utils/event/EventStream.h>
 #include <aws/core/utils/json/JsonSerializer.h>
+#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
 #include <aws/qbusiness/QBusiness_EXPORTS.h>
 #include <aws/qbusiness/model/ActionExecutionEvent.h>
 #include <aws/qbusiness/model/AttachmentInputEvent.h>
@@ -28,6 +29,9 @@ namespace Model {
  */
 class AWS_QBUSINESS_API ChatInputStream : public Aws::Utils::Event::EventEncoderStream {
  public:
+  ChatInputStream() = default;
+  explicit ChatInputStream(std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf)
+      : Aws::Utils::Event::EventEncoderStream(std::move(streambuf)) {}
   ChatInputStream& WriteConfigurationEvent(const ConfigurationEvent& value) {
     Aws::Utils::Event::Message msg;
     msg.InsertEventHeader(":message-type", Aws::String("event"));

--- a/generated/src/aws-cpp-sdk-qbusiness/source/QBusinessClient.cpp
+++ b/generated/src/aws-cpp-sdk-qbusiness/source/QBusinessClient.cpp
@@ -5,6 +5,7 @@
 
 #include <aws/core/auth/AWSAuthSigner.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/client/AWSClientBidirectionalStreaming.h>
 #include <aws/core/client/AWSClientEventStreamingAsyncTask.h>
 #include <aws/core/client/CoreErrors.h>
 #include <aws/core/client/RetryStrategy.h>
@@ -393,10 +394,41 @@ void QBusinessClient::ChatAsync(Model::ChatRequest& request, const ChatStreamRea
   endpointResolutionOutcome.GetResult().AddPathSegment(request.GetApplicationId());
   endpointResolutionOutcome.GetResult().AddPathSegments("/conversations");
 
+#if AWS_SDK_USE_CRT_HTTP
+  // Push-based WriteData path (CRT HTTP client only)
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
+
+  auto eventEncoderStream = Aws::MakeShared<Model::ChatInputStream>(ALLOCATION_TAG, writeDataStreamBuf);
+  eventEncoderStream->SetSigner(signer);
+
+  auto requestCopy = Aws::MakeShared<ChatRequest>(ALLOCATION_TAG, request);
+  request.SetInputStream(eventEncoderStream);
+
+  auto& endpoint = endpointResolutionOutcome.GetResult();
+  auto httpRequest =
+      CreateHttpRequest(endpoint.GetURI(), Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+  httpRequest->SetEventStreamRequest(true);
+  httpRequest->SetHasEventStreamResponse(true);
+  BuildHttpRequest(*requestCopy, httpRequest);
+
+  if (!signer->SignRequest(*httpRequest, nullptr, nullptr, true)) {
+    handler(this, request,
+            ChatOutcome(Aws::Client::AWSError<CoreErrors>(CoreErrors::CLIENT_SIGNING_FAILURE, "", "Failed to sign request", false)),
+            handlerContext);
+    return;
+  }
+  eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(*httpRequest));
+
+  Aws::Client::SubmitBidirectionalStreamingRequest<QBusinessClient, ChatOutcome, ChatRequest, Model::ChatInputStream>(
+      this, request, requestCopy, eventEncoderStream, writeDataStreamBuf, httpRequest, m_clientConfiguration.executor.get(),
+      streamReadyHandler, handler, handlerContext);
+#else
+  // Pull-based path (curl/WinHTTP)
   auto eventEncoderStream = Aws::MakeShared<Model::ChatInputStream>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
   auto requestCopy = Aws::MakeShared<ChatRequest>("Chat", request);
-  requestCopy->SetInputStream(eventEncoderStream);  // this becomes the body of the request
+  requestCopy->SetInputStream(eventEncoderStream);
   request.SetInputStream(eventEncoderStream);
 
   auto asyncTask = CreateBidirectionalEventStreamTask<ChatOutcome>(this, endpointResolutionOutcome.GetResultWithOwnership(), requestCopy,
@@ -405,6 +437,7 @@ void QBusinessClient::ChatAsync(Model::ChatRequest& request, const ChatStreamRea
   m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
   streamReadyHandler(*eventEncoderStream);
+#endif
 }
 ChatSyncOutcome QBusinessClient::ChatSync(const ChatSyncRequest& request) const {
   if (!request.ApplicationIdHasBeenSet()) {

--- a/generated/src/aws-cpp-sdk-sagemaker-runtime-http2/include/aws/sagemaker-runtime-http2/model/RequestStreamEvent.h
+++ b/generated/src/aws-cpp-sdk-sagemaker-runtime-http2/include/aws/sagemaker-runtime-http2/model/RequestStreamEvent.h
@@ -5,6 +5,7 @@
 
 #pragma once
 #include <aws/core/utils/event/EventStream.h>
+#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
 #include <aws/sagemaker-runtime-http2/SageMakerRuntimeHTTP2_EXPORTS.h>
 #include <aws/sagemaker-runtime-http2/model/RequestPayloadPart.h>
 
@@ -21,6 +22,9 @@ namespace Model {
  */
 class AWS_SAGEMAKERRUNTIMEHTTP2_API RequestStreamEvent : public Aws::Utils::Event::EventEncoderStream {
  public:
+  RequestStreamEvent() = default;
+  explicit RequestStreamEvent(std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf)
+      : Aws::Utils::Event::EventEncoderStream(std::move(streambuf)) {}
   RequestStreamEvent& WriteRequestPayloadPart(const RequestPayloadPart& value) {
     Aws::Utils::Event::Message msg;
     if (!value.GetBytes().empty()) {

--- a/generated/src/aws-cpp-sdk-sagemaker-runtime-http2/source/SageMakerRuntimeHTTP2Client.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-runtime-http2/source/SageMakerRuntimeHTTP2Client.cpp
@@ -5,6 +5,7 @@
 
 #include <aws/core/auth/AWSAuthSigner.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/client/AWSClientBidirectionalStreaming.h>
 #include <aws/core/client/AWSClientEventStreamingAsyncTask.h>
 #include <aws/core/client/CoreErrors.h>
 #include <aws/core/client/RetryStrategy.h>
@@ -227,10 +228,43 @@ void SageMakerRuntimeHTTP2Client::InvokeEndpointWithBidirectionalStreamAsync(
   endpointResolutionOutcome.GetResult().AddPathSegment(request.GetEndpointName());
   endpointResolutionOutcome.GetResult().AddPathSegments("/invocations-bidirectional-stream");
 
+#if AWS_SDK_USE_CRT_HTTP
+  // Push-based WriteData path (CRT HTTP client only)
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
+
+  auto eventEncoderStream = Aws::MakeShared<Model::RequestStreamEvent>(ALLOCATION_TAG, writeDataStreamBuf);
+  eventEncoderStream->SetSigner(signer);
+
+  auto requestCopy = Aws::MakeShared<InvokeEndpointWithBidirectionalStreamRequest>(ALLOCATION_TAG, request);
+  request.SetBody(eventEncoderStream);
+
+  auto& endpoint = endpointResolutionOutcome.GetResult();
+  auto httpRequest =
+      CreateHttpRequest(endpoint.GetURI(), Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+  httpRequest->SetEventStreamRequest(true);
+  httpRequest->SetHasEventStreamResponse(true);
+  BuildHttpRequest(*requestCopy, httpRequest);
+
+  if (!signer->SignRequest(*httpRequest, nullptr, nullptr, true)) {
+    handler(this, request,
+            InvokeEndpointWithBidirectionalStreamOutcome(
+                Aws::Client::AWSError<CoreErrors>(CoreErrors::CLIENT_SIGNING_FAILURE, "", "Failed to sign request", false)),
+            handlerContext);
+    return;
+  }
+  eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(*httpRequest));
+
+  Aws::Client::SubmitBidirectionalStreamingRequest<SageMakerRuntimeHTTP2Client, InvokeEndpointWithBidirectionalStreamOutcome,
+                                                   InvokeEndpointWithBidirectionalStreamRequest, Model::RequestStreamEvent>(
+      this, request, requestCopy, eventEncoderStream, writeDataStreamBuf, httpRequest, m_clientConfiguration.executor.get(),
+      streamReadyHandler, handler, handlerContext);
+#else
+  // Pull-based path (curl/WinHTTP)
   auto eventEncoderStream = Aws::MakeShared<Model::RequestStreamEvent>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
   auto requestCopy = Aws::MakeShared<InvokeEndpointWithBidirectionalStreamRequest>("InvokeEndpointWithBidirectionalStream", request);
-  requestCopy->SetBody(eventEncoderStream);  // this becomes the body of the request
+  requestCopy->SetBody(eventEncoderStream);
   request.SetBody(eventEncoderStream);
 
   auto asyncTask = CreateBidirectionalEventStreamTask<InvokeEndpointWithBidirectionalStreamOutcome>(
@@ -239,4 +273,5 @@ void SageMakerRuntimeHTTP2Client::InvokeEndpointWithBidirectionalStreamAsync(
   m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
   streamReadyHandler(*eventEncoderStream);
+#endif
 }

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/AudioStream.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/AudioStream.h
@@ -5,6 +5,7 @@
 
 #pragma once
 #include <aws/core/utils/event/EventStream.h>
+#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
 #include <aws/transcribestreaming/TranscribeStreamingService_EXPORTS.h>
 #include <aws/transcribestreaming/model/AudioEvent.h>
 #include <aws/transcribestreaming/model/ConfigurationEvent.h>
@@ -25,6 +26,9 @@ namespace Model {
  */
 class AWS_TRANSCRIBESTREAMINGSERVICE_API AudioStream : public Aws::Utils::Event::EventEncoderStream {
  public:
+  AudioStream() = default;
+  explicit AudioStream(std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf)
+      : Aws::Utils::Event::EventEncoderStream(std::move(streambuf)) {}
   AudioStream& WriteAudioEvent(const AudioEvent& value) {
     Aws::Utils::Event::Message msg;
     if (!value.GetAudioChunk().empty()) {

--- a/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/MedicalScribeInputStream.h
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/include/aws/transcribestreaming/model/MedicalScribeInputStream.h
@@ -5,6 +5,7 @@
 
 #pragma once
 #include <aws/core/utils/event/EventStream.h>
+#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
 #include <aws/transcribestreaming/TranscribeStreamingService_EXPORTS.h>
 #include <aws/transcribestreaming/model/MedicalScribeAudioEvent.h>
 #include <aws/transcribestreaming/model/MedicalScribeConfigurationEvent.h>
@@ -29,6 +30,9 @@ namespace Model {
  */
 class AWS_TRANSCRIBESTREAMINGSERVICE_API MedicalScribeInputStream : public Aws::Utils::Event::EventEncoderStream {
  public:
+  MedicalScribeInputStream() = default;
+  explicit MedicalScribeInputStream(std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf)
+      : Aws::Utils::Event::EventEncoderStream(std::move(streambuf)) {}
   MedicalScribeInputStream& WriteMedicalScribeAudioEvent(const MedicalScribeAudioEvent& value) {
     Aws::Utils::Event::Message msg;
     if (!value.GetAudioChunk().empty()) {

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
@@ -5,6 +5,7 @@
 
 #include <aws/core/auth/AWSAuthSigner.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/client/AWSClientBidirectionalStreaming.h>
 #include <aws/core/client/AWSClientEventStreamingAsyncTask.h>
 #include <aws/core/client/CoreErrors.h>
 #include <aws/core/client/RetryStrategy.h>
@@ -256,10 +257,43 @@ void TranscribeStreamingServiceClient::StartCallAnalyticsStreamTranscriptionAsyn
   }
   endpointResolutionOutcome.GetResult().AddPathSegments("/call-analytics-stream-transcription");
 
+#if AWS_SDK_USE_CRT_HTTP
+  // Push-based WriteData path (CRT HTTP client only)
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
+
+  auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG, writeDataStreamBuf);
+  eventEncoderStream->SetSigner(signer);
+
+  auto requestCopy = Aws::MakeShared<StartCallAnalyticsStreamTranscriptionRequest>(ALLOCATION_TAG, request);
+  request.SetAudioStream(eventEncoderStream);
+
+  auto& endpoint = endpointResolutionOutcome.GetResult();
+  auto httpRequest =
+      CreateHttpRequest(endpoint.GetURI(), Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+  httpRequest->SetEventStreamRequest(true);
+  httpRequest->SetHasEventStreamResponse(true);
+  BuildHttpRequest(*requestCopy, httpRequest);
+
+  if (!signer->SignRequest(*httpRequest, nullptr, nullptr, true)) {
+    handler(this, request,
+            StartCallAnalyticsStreamTranscriptionOutcome(
+                Aws::Client::AWSError<CoreErrors>(CoreErrors::CLIENT_SIGNING_FAILURE, "", "Failed to sign request", false)),
+            handlerContext);
+    return;
+  }
+  eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(*httpRequest));
+
+  Aws::Client::SubmitBidirectionalStreamingRequest<TranscribeStreamingServiceClient, StartCallAnalyticsStreamTranscriptionOutcome,
+                                                   StartCallAnalyticsStreamTranscriptionRequest, Model::AudioStream>(
+      this, request, requestCopy, eventEncoderStream, writeDataStreamBuf, httpRequest, m_clientConfiguration.executor.get(),
+      streamReadyHandler, handler, handlerContext);
+#else
+  // Pull-based path (curl/WinHTTP)
   auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
   auto requestCopy = Aws::MakeShared<StartCallAnalyticsStreamTranscriptionRequest>("StartCallAnalyticsStreamTranscription", request);
-  requestCopy->SetAudioStream(eventEncoderStream);  // this becomes the body of the request
+  requestCopy->SetAudioStream(eventEncoderStream);
   request.SetAudioStream(eventEncoderStream);
 
   auto asyncTask = CreateBidirectionalEventStreamTask<StartCallAnalyticsStreamTranscriptionOutcome>(
@@ -268,6 +302,7 @@ void TranscribeStreamingServiceClient::StartCallAnalyticsStreamTranscriptionAsyn
   m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
   streamReadyHandler(*eventEncoderStream);
+#endif
 }
 void TranscribeStreamingServiceClient::StartMedicalScribeStreamAsync(
     Model::StartMedicalScribeStreamRequest& request, const StartMedicalScribeStreamStreamReadyHandler& streamReadyHandler,
@@ -322,10 +357,43 @@ void TranscribeStreamingServiceClient::StartMedicalScribeStreamAsync(
   }
   endpointResolutionOutcome.GetResult().AddPathSegments("/medical-scribe-stream");
 
+#if AWS_SDK_USE_CRT_HTTP
+  // Push-based WriteData path (CRT HTTP client only)
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
+
+  auto eventEncoderStream = Aws::MakeShared<Model::MedicalScribeInputStream>(ALLOCATION_TAG, writeDataStreamBuf);
+  eventEncoderStream->SetSigner(signer);
+
+  auto requestCopy = Aws::MakeShared<StartMedicalScribeStreamRequest>(ALLOCATION_TAG, request);
+  request.SetInputStream(eventEncoderStream);
+
+  auto& endpoint = endpointResolutionOutcome.GetResult();
+  auto httpRequest =
+      CreateHttpRequest(endpoint.GetURI(), Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+  httpRequest->SetEventStreamRequest(true);
+  httpRequest->SetHasEventStreamResponse(true);
+  BuildHttpRequest(*requestCopy, httpRequest);
+
+  if (!signer->SignRequest(*httpRequest, nullptr, nullptr, true)) {
+    handler(this, request,
+            StartMedicalScribeStreamOutcome(
+                Aws::Client::AWSError<CoreErrors>(CoreErrors::CLIENT_SIGNING_FAILURE, "", "Failed to sign request", false)),
+            handlerContext);
+    return;
+  }
+  eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(*httpRequest));
+
+  Aws::Client::SubmitBidirectionalStreamingRequest<TranscribeStreamingServiceClient, StartMedicalScribeStreamOutcome,
+                                                   StartMedicalScribeStreamRequest, Model::MedicalScribeInputStream>(
+      this, request, requestCopy, eventEncoderStream, writeDataStreamBuf, httpRequest, m_clientConfiguration.executor.get(),
+      streamReadyHandler, handler, handlerContext);
+#else
+  // Pull-based path (curl/WinHTTP)
   auto eventEncoderStream = Aws::MakeShared<Model::MedicalScribeInputStream>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
   auto requestCopy = Aws::MakeShared<StartMedicalScribeStreamRequest>("StartMedicalScribeStream", request);
-  requestCopy->SetInputStream(eventEncoderStream);  // this becomes the body of the request
+  requestCopy->SetInputStream(eventEncoderStream);
   request.SetInputStream(eventEncoderStream);
 
   auto asyncTask = CreateBidirectionalEventStreamTask<StartMedicalScribeStreamOutcome>(
@@ -334,6 +402,7 @@ void TranscribeStreamingServiceClient::StartMedicalScribeStreamAsync(
   m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
   streamReadyHandler(*eventEncoderStream);
+#endif
 }
 void TranscribeStreamingServiceClient::StartMedicalStreamTranscriptionAsync(
     Model::StartMedicalStreamTranscriptionRequest& request, const StartMedicalStreamTranscriptionStreamReadyHandler& streamReadyHandler,
@@ -404,10 +473,43 @@ void TranscribeStreamingServiceClient::StartMedicalStreamTranscriptionAsync(
   }
   endpointResolutionOutcome.GetResult().AddPathSegments("/medical-stream-transcription");
 
+#if AWS_SDK_USE_CRT_HTTP
+  // Push-based WriteData path (CRT HTTP client only)
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
+
+  auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG, writeDataStreamBuf);
+  eventEncoderStream->SetSigner(signer);
+
+  auto requestCopy = Aws::MakeShared<StartMedicalStreamTranscriptionRequest>(ALLOCATION_TAG, request);
+  request.SetAudioStream(eventEncoderStream);
+
+  auto& endpoint = endpointResolutionOutcome.GetResult();
+  auto httpRequest =
+      CreateHttpRequest(endpoint.GetURI(), Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+  httpRequest->SetEventStreamRequest(true);
+  httpRequest->SetHasEventStreamResponse(true);
+  BuildHttpRequest(*requestCopy, httpRequest);
+
+  if (!signer->SignRequest(*httpRequest, nullptr, nullptr, true)) {
+    handler(this, request,
+            StartMedicalStreamTranscriptionOutcome(
+                Aws::Client::AWSError<CoreErrors>(CoreErrors::CLIENT_SIGNING_FAILURE, "", "Failed to sign request", false)),
+            handlerContext);
+    return;
+  }
+  eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(*httpRequest));
+
+  Aws::Client::SubmitBidirectionalStreamingRequest<TranscribeStreamingServiceClient, StartMedicalStreamTranscriptionOutcome,
+                                                   StartMedicalStreamTranscriptionRequest, Model::AudioStream>(
+      this, request, requestCopy, eventEncoderStream, writeDataStreamBuf, httpRequest, m_clientConfiguration.executor.get(),
+      streamReadyHandler, handler, handlerContext);
+#else
+  // Pull-based path (curl/WinHTTP)
   auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
   auto requestCopy = Aws::MakeShared<StartMedicalStreamTranscriptionRequest>("StartMedicalStreamTranscription", request);
-  requestCopy->SetAudioStream(eventEncoderStream);  // this becomes the body of the request
+  requestCopy->SetAudioStream(eventEncoderStream);
   request.SetAudioStream(eventEncoderStream);
 
   auto asyncTask = CreateBidirectionalEventStreamTask<StartMedicalStreamTranscriptionOutcome>(
@@ -416,6 +518,7 @@ void TranscribeStreamingServiceClient::StartMedicalStreamTranscriptionAsync(
   m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
   streamReadyHandler(*eventEncoderStream);
+#endif
 }
 void TranscribeStreamingServiceClient::StartStreamTranscriptionAsync(
     Model::StartStreamTranscriptionRequest& request, const StartStreamTranscriptionStreamReadyHandler& streamReadyHandler,
@@ -462,10 +565,43 @@ void TranscribeStreamingServiceClient::StartStreamTranscriptionAsync(
   }
   endpointResolutionOutcome.GetResult().AddPathSegments("/stream-transcription");
 
+#if AWS_SDK_USE_CRT_HTTP
+  // Push-based WriteData path (CRT HTTP client only)
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
+
+  auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG, writeDataStreamBuf);
+  eventEncoderStream->SetSigner(signer);
+
+  auto requestCopy = Aws::MakeShared<StartStreamTranscriptionRequest>(ALLOCATION_TAG, request);
+  request.SetAudioStream(eventEncoderStream);
+
+  auto& endpoint = endpointResolutionOutcome.GetResult();
+  auto httpRequest =
+      CreateHttpRequest(endpoint.GetURI(), Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+  httpRequest->SetEventStreamRequest(true);
+  httpRequest->SetHasEventStreamResponse(true);
+  BuildHttpRequest(*requestCopy, httpRequest);
+
+  if (!signer->SignRequest(*httpRequest, nullptr, nullptr, true)) {
+    handler(this, request,
+            StartStreamTranscriptionOutcome(
+                Aws::Client::AWSError<CoreErrors>(CoreErrors::CLIENT_SIGNING_FAILURE, "", "Failed to sign request", false)),
+            handlerContext);
+    return;
+  }
+  eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(*httpRequest));
+
+  Aws::Client::SubmitBidirectionalStreamingRequest<TranscribeStreamingServiceClient, StartStreamTranscriptionOutcome,
+                                                   StartStreamTranscriptionRequest, Model::AudioStream>(
+      this, request, requestCopy, eventEncoderStream, writeDataStreamBuf, httpRequest, m_clientConfiguration.executor.get(),
+      streamReadyHandler, handler, handlerContext);
+#else
+  // Pull-based path (curl/WinHTTP)
   auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
   auto requestCopy = Aws::MakeShared<StartStreamTranscriptionRequest>("StartStreamTranscription", request);
-  requestCopy->SetAudioStream(eventEncoderStream);  // this becomes the body of the request
+  requestCopy->SetAudioStream(eventEncoderStream);
   request.SetAudioStream(eventEncoderStream);
 
   auto asyncTask = CreateBidirectionalEventStreamTask<StartStreamTranscriptionOutcome>(
@@ -474,4 +610,5 @@ void TranscribeStreamingServiceClient::StartStreamTranscriptionAsync(
   m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
   streamReadyHandler(*eventEncoderStream);
+#endif
 }

--- a/src/aws-cpp-sdk-core/CMakeLists.txt
+++ b/src/aws-cpp-sdk-core/CMakeLists.txt
@@ -64,6 +64,7 @@ file(GLOB UTILS_CHECKSUM_HEADERS "include/aws/core/utils/checksum/*.h")
 file(GLOB UTILS_CRYPTO_HEADERS "include/aws/core/utils/crypto/*.h")
 file(GLOB UTILS_JSON_HEADERS "include/aws/core/utils/json/*.h")
 file(GLOB UTILS_LOCAL_HEADERS "include/aws/core/utils/local/*.h")
+file(GLOB UTILS_LOCAL_STREAM_HEADERS "include/aws/core/utils/local/stream/*.h")
 file(GLOB UTILS_CBOR_HEADERS "include/aws/core/utils/cbor/*.h")
 file(GLOB UTILS_THREADING_HEADERS "include/aws/core/utils/threading/*.h")
 file(GLOB UTILS_XML_HEADERS "include/aws/core/utils/xml/*.h")
@@ -121,6 +122,7 @@ file(GLOB UTILS_CHECKSUM_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/utils/checks
 file(GLOB UTILS_CRYPTO_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/utils/crypto/*.cpp")
 file(GLOB UTILS_JSON_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/utils/json/*.cpp")
 file(GLOB UTILS_LOCAL_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/utils/local/*.cpp")
+file(GLOB UTILS_LOCAL_STREAM_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/utils/local/stream/*.cpp")
 file(GLOB UTILS_CBOR_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/utils/cbor/*.cpp")
 file(GLOB UTILS_THREADING_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/utils/threading/*.cpp")
 file(GLOB UTILS_XML_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/source/utils/xml/*.cpp")
@@ -277,6 +279,7 @@ file(GLOB AWS_NATIVE_SDK_COMMON_HEADERS
   ${UTILS_CRYPTO_HEADERS}
   ${UTILS_JSON_HEADERS}
   ${UTILS_LOCAL_HEADERS}
+  ${UTILS_LOCAL_STREAM_HEADERS}
   ${UTILS_CBOR_HEADERS}
   ${UTILS_THREADING_HEADERS}
   ${UTILS_RETRY_HEADERS}
@@ -364,6 +367,7 @@ file(GLOB AWS_NATIVE_SDK_NON_UNITY_SRC
     ${UTILS_CRYPTO_FACTORY_SOURCE}
     ${UTILS_JSON_SOURCE}
     ${UTILS_LOCAL_SOURCE}
+    ${UTILS_LOCAL_STREAM_SOURCE}
     ${UTILS_CBOR_SOURCE}
     ${UTILS_EVENT_SOURCE}
     ${UTILS_SOURCE}
@@ -426,6 +430,7 @@ if(MSVC)
     source_group("Header Files\\aws\\core\\utils\\exceptions" FILES ${UTILS_EXCEPTIONS_HEADERS})
     source_group("Header Files\\aws\\core\\utils\\json" FILES ${UTILS_JSON_HEADERS})
     source_group("Header Files\\aws\\core\\utils\\local" FILES ${UTILS_LOCAL_HEADERS})
+    source_group("Header Files\\aws\\core\\utils\\local" FILES ${UTILS_LOCAL_STREAM_HEADERS})
     source_group("Header Files\\aws\\core\\utils\\cbor" FILES ${UTILS_CBOR_HEADERS})
     source_group("Header Files\\aws\\core\\utils\\threading" FILES ${UTILS_THREADING_HEADERS})
     source_group("Header Files\\aws\\core\\utils\\xml" FILES ${UTILS_XML_HEADERS})
@@ -497,6 +502,7 @@ if(MSVC)
     source_group("Source Files\\utils\\exceptions" FILES ${UTILS_EXCEPTIONS_SOURCE})
     source_group("Source Files\\utils\\json" FILES ${UTILS_JSON_SOURCE})
     source_group("Source Files\\utils\\local" FILES ${UTILS_LOCAL_SOURCE})
+    source_group("Source Files\\utils\\local" FILES ${UTILS_LOCAL_STREAM_SOURCE})
     source_group("Source Files\\utils\\cbor" FILES ${UTILS_CBOR_SOURCE})
     source_group("Source Files\\utils\\threading" FILES ${UTILS_THREADING_SOURCE})
     source_group("Source Files\\utils\\xml" FILES ${UTILS_XML_SOURCE})

--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSClientAsyncCRTP.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSClientAsyncCRTP.h
@@ -11,6 +11,11 @@
 
 namespace Aws
 {
+namespace Http { class HttpRequest; }
+namespace Utils {
+  namespace Stream { class HttpWriteDataStreamBuf; }
+  namespace Threading { class Executor; }
+}
 namespace Client
 {
     class AsyncCallerContext;
@@ -208,6 +213,14 @@ namespace Client
     protected:
         template <typename OutcomeT, typename ClientT, typename AWSEndpointT, typename RequestT, typename HandlerT>
         friend class BidirectionalEventStreamingTask; // allow BidirectionalEventStreamingTask to access m_isInitialized
+
+        template <typename ClientT, typename OutcomeT, typename RequestT, typename EncoderStreamT,
+                  typename HandlerT, typename StreamReadyHandlerT>
+        friend void SubmitBidirectionalStreamingRequest(
+            const ClientT*, RequestT&, std::shared_ptr<RequestT>, std::shared_ptr<EncoderStreamT>,
+            std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf>, const std::shared_ptr<Aws::Http::HttpRequest>&,
+            Aws::Utils::Threading::Executor*,
+            const StreamReadyHandlerT&, const HandlerT&, const std::shared_ptr<const Aws::Client::AsyncCallerContext>&);
 
         std::atomic<bool> m_isInitialized;
         mutable std::atomic<size_t> m_operationsProcessed;

--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSClientBidirectionalStreaming.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSClientBidirectionalStreaming.h
@@ -1,0 +1,137 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+
+#include <aws/core/Core_EXPORTS.h>
+#include <aws/core/NoResult.h>
+#include <aws/core/client/AsyncCallerContext.h>
+#include <aws/core/client/CoreErrors.h>
+#include <aws/core/utils/DNS.h>
+#include <aws/core/utils/RAIICounter.h>
+#include <aws/core/utils/event/EventDecoderStream.h>
+#include <aws/core/utils/event/EventEncoderStream.h>
+#include <aws/core/utils/logging/LogMacros.h>
+#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
+#include <aws/core/utils/threading/Executor.h>
+
+namespace Aws {
+namespace Client {
+
+/**
+ * Initializes an HTTP/2 connection and submits an executor task that waits for
+ * bidirectional stream completion using the push-based WriteData API.
+ *
+ * The caller is responsible for:
+ *   - Validating request parameters and resolving the endpoint
+ *   - Creating the encoder stream (with HttpWriteDataStreamBuf) and setting it on the request
+ *   - Building and signing the HTTP request
+ *   - Seeding event signing on the encoder stream
+ *
+ * This function handles:
+ *   - Wiring the initial response handler and response stream factory
+ *   - Initializing the HTTP/2 connection via HttpWriteDataStreamBuf
+ *   - Submitting the executor task with shutdown safety (m_isInitialized, RAIICounter)
+ *   - Calling streamReadyHandler once the connection is live
+ */
+template <
+    typename ClientT,
+    typename OutcomeT,
+    typename RequestT,
+    typename EncoderStreamT,
+    typename HandlerT,
+    typename StreamReadyHandlerT>
+void SubmitBidirectionalStreamingRequest(
+    const ClientT* client,
+    RequestT& request,
+    std::shared_ptr<RequestT> requestCopy,
+    std::shared_ptr<EncoderStreamT> eventEncoderStream,
+    std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> writeDataStreamBuf,
+    const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest,
+    Aws::Utils::Threading::Executor* executor,
+    const StreamReadyHandlerT& streamReadyHandler,
+    const HandlerT& handler,
+    const std::shared_ptr<const Aws::Client::AsyncCallerContext>& handlerContext)
+{
+  const char* allocationTag = ClientT::GetAllocationTag();
+
+  // Validate host name
+  if (!Aws::Utils::IsValidHost(httpRequest->GetUri().GetHost())) {
+    handler(client, *requestCopy,
+            OutcomeT(Aws::Client::AWSError<Aws::Client::CoreErrors>(Aws::Client::CoreErrors::VALIDATION, "",
+                                                                    "Invalid DNS Label found in URI host", false)),
+            handlerContext);
+    return;
+  }
+
+  // Fix decoder pointer after copy construction
+  std::weak_ptr<RequestT> wReq = requestCopy;
+  requestCopy->SetEventStreamHandler(requestCopy->GetEventStreamHandler());
+
+  // Wire initial response handler on httpRequest (CRT reads it from there)
+  httpRequest->SetHeadersReceivedEventHandler(
+      [wReq](const Aws::Http::HttpRequest*, Aws::Http::HttpResponse* response) {
+        auto req = wReq.lock();
+        if (!req || !response) return;
+        auto& cb = req->GetEventStreamHandler().GetInitialResponseCallbackEx();
+        if (cb) {
+          cb({response->GetHeaders()}, Aws::Utils::Event::InitialResponseType::ON_RESPONSE);
+        }
+      });
+
+  // Wire response stream factory (weak_ptr breaks reference cycle)
+  auto responseStreamFactory = [wReq, allocationTag]() -> Aws::IOStream* {
+    auto req = wReq.lock();
+    if (!req) return nullptr;
+    req->GetEventStreamDecoder().Reset();
+    return Aws::New<Aws::Utils::Event::EventDecoderStream>(allocationTag, req->GetEventStreamDecoder());
+  };
+  requestCopy->SetResponseStreamFactory(responseStreamFactory);
+  httpRequest->SetResponseStreamFactory(responseStreamFactory);
+
+  // Initialize the HTTP/2 connection
+  auto initError = writeDataStreamBuf->Initialize(httpRequest);
+  if (initError.has_value()) {
+    handler(client, request, OutcomeT(initError.value()), handlerContext);
+    return;
+  }
+
+  // Submit executor task — waits for stream completion, then invokes handler
+  executor->Submit(
+      [client, requestCopy, eventEncoderStream, handler, handlerContext, writeDataStreamBuf, allocationTag]() {
+        if (!client->m_isInitialized) {
+          AWS_LOGSTREAM_ERROR(allocationTag, "Client is not initialized or already terminated");
+          handler(client, *requestCopy,
+              OutcomeT(Aws::Client::AWSError<CoreErrors>(
+                  CoreErrors::NOT_INITIALIZED, "NOT_INITIALIZED",
+                  "Client is not initialized or already terminated", false)),
+              handlerContext);
+          return;
+        }
+        Aws::Utils::RAIICounter raiiGuard(client->m_operationsProcessed, &client->m_shutdownSignal);
+
+        writeDataStreamBuf->WaitForStreamComplete();
+        auto response = writeDataStreamBuf->GetResponse();
+
+        // Flush any remaining buffered response data through the EventDecoderStream
+        if (response) {
+          response->GetResponseBody().flush();
+        }
+
+        if (response && response->HasClientError()) {
+          eventEncoderStream->Close();
+          handler(client, *requestCopy,
+              OutcomeT(Aws::Client::AWSError<CoreErrors>(
+                  response->GetClientErrorType(), "", response->GetClientErrorMessage(), false)),
+              handlerContext);
+        } else {
+          handler(client, *requestCopy, OutcomeT(Aws::NoResult()), handlerContext);
+        }
+      });
+
+  streamReadyHandler(*eventEncoderStream);
+}
+
+}  // namespace Client
+}  // namespace Aws

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/event/EventEncoderStream.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/event/EventEncoderStream.h
@@ -20,6 +20,19 @@ namespace Aws
 
     namespace Utils
     {
+        namespace Stream
+        {
+          class HttpWriteDataStreamBuf;
+
+          /**
+           * Adapter that virtualizes streambuf lifecycle operations (close, drain)
+           * so EventEncoderStream can work with different underlying streambufs
+           * (e.g. ConcurrentStreamBuf for the pull model, HttpWriteDataStreamBuf
+           * for the push model).
+           */
+          class CloseableStreamBuf;
+        }
+
         namespace Event
         {
             extern AWS_CORE_API const size_t DEFAULT_BUF_SIZE;
@@ -36,6 +49,12 @@ namespace Aws
                  * @param bufferSize The length of the underlying buffer.
                  */
                 explicit EventEncoderStream(size_t bufferSize = DEFAULT_BUF_SIZE);
+
+                /**
+                 * Creates a stream for encoding events sent by the client.
+                 * @param streambuf the underlying buffer used by event encoder.
+                 */
+                explicit EventEncoderStream(std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf);
 
                 /**
                  * Sets the signature seed used by event-stream events.
@@ -65,16 +84,15 @@ namespace Aws
                  * Any writes to the stream after this call are not guaranteed to be read by another concurrent
                  * read thread.
                  */
-                void Close() { m_streambuf.SetEofInput(this); }
+                void Close();
 
                 /**
                  * Blocks the current thread until all submitted data is consumed.
                  * Returns false on timeout, and true if GetArea and back buffer are empty.
                  */
                 bool WaitForDrain(int64_t timeoutMs = 1000);
-
             private:
-                Stream::ConcurrentStreamBuf m_streambuf;
+                std::shared_ptr<Aws::Utils::Stream::CloseableStreamBuf> m_streambuf;
                 EventStreamEncoder m_encoder;
             };
         }

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/local/stream/CloseableStreamBuf.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/local/stream/CloseableStreamBuf.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+
+#include <aws/core/Core_EXPORTS.h>
+#include <aws/core/utils/memory/stl/AWSStreamFwd.h>
+#include <memory>
+
+namespace Aws {
+namespace Utils {
+namespace Stream {
+class HttpWriteDataStreamBuf;
+
+class CloseableStreamBuf {
+ public:
+  explicit CloseableStreamBuf(std::shared_ptr<std::streambuf> streambuf) : m_streambuf(std::move(streambuf)) {}
+  std::streambuf* GetStreamBufHandler() { return m_streambuf.get(); }
+  virtual ~CloseableStreamBuf() = default;
+  virtual bool WaitForDrain(int64_t timeout);
+  virtual void Close(Aws::IOStream* pStreamToClose = nullptr);
+
+ private:
+  std::shared_ptr<std::streambuf> m_streambuf;
+};
+
+class CloseableConcurrentStreamBuf : public Aws::Utils::Stream::CloseableStreamBuf {
+ public:
+  explicit CloseableConcurrentStreamBuf(size_t bufferSize);
+  bool WaitForDrain(int64_t timeoutMs) override;
+  void Close(Aws::IOStream* stream) override;
+};
+
+class CloseableHttpWriteDataStreamBuf : public Aws::Utils::Stream::CloseableStreamBuf {
+ public:
+  explicit CloseableHttpWriteDataStreamBuf(std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf);
+  void Close(Aws::IOStream* stream) override;
+};
+}  // namespace Stream
+}  // namespace Utils
+}  // namespace Aws

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/stream/HttpWriteDataStreamBuf.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/stream/HttpWriteDataStreamBuf.h
@@ -1,0 +1,118 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+
+#include <aws/core/Core_EXPORTS.h>
+#include <aws/core/client/AWSError.h>
+#include <aws/core/client/CoreErrors.h>
+#include <aws/core/utils/Array.h>
+#include <aws/crt/Types.h>
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+
+namespace Aws {
+namespace Http {
+class HttpClient;
+class HttpRequest;
+class HttpResponse;
+class Connection;
+class ClientStream;
+}  // namespace Http
+namespace Utils {
+namespace Stream {
+
+/**
+ * Write-only streambuf that pushes data to an HTTP/2 connection via ClientStream::WriteData.
+ *
+ * Lifecycle: construct → Initialize() → write via ostream → Close() → WaitForStreamComplete().
+ * Close() sends endStream=true. Destructor calls Close() + WaitForStreamComplete().
+ *
+ * Not copyable or movable. CRT HTTP client only.
+ */
+class AWS_CORE_API HttpWriteDataStreamBuf : public std::streambuf {
+ public:
+  explicit HttpWriteDataStreamBuf(const std::shared_ptr<Aws::Http::HttpClient>& client, size_t bufferLength = 8 * 1024);
+  HttpWriteDataStreamBuf(const HttpWriteDataStreamBuf& other) = delete;
+  HttpWriteDataStreamBuf(HttpWriteDataStreamBuf&& other) noexcept = delete;
+  HttpWriteDataStreamBuf& operator=(const HttpWriteDataStreamBuf& other) = delete;
+  HttpWriteDataStreamBuf& operator=(HttpWriteDataStreamBuf&& other) noexcept = delete;
+  ~HttpWriteDataStreamBuf() override;
+
+  /**
+   * Acquires a connection and creates a client stream. Must be called before any writes.
+   * Returns an error if connection acquisition or stream creation fails.
+   */
+  Aws::Crt::Optional<Aws::Client::AWSError<Aws::Client::CoreErrors>> Initialize(const std::shared_ptr<Aws::Http::HttpRequest>& request);
+
+  /**
+   * Flushes remaining buffer with endStream=true. Idempotent.
+   * Does not block on stream completion — call WaitForStreamComplete() for that.
+   */
+  void Close();
+
+  /**
+   * Returns the HTTP response from the underlying stream. Must be called after Initialize().
+   */
+  std::shared_ptr<Aws::Http::HttpResponse> GetResponse() const;
+
+  /**
+   * Blocks until the CRT fires the stream-complete callback.
+   * No-op if Initialize() was never called. Close() must be called first.
+   */
+  void WaitForStreamComplete();
+
+ protected:
+  // Write support
+  int_type overflow(int_type c) override;
+  std::streamsize xsputn(const char* s, std::streamsize n) override;
+  int sync() override;
+
+  // Disable reads
+  int_type underflow() override { return traits_type::eof(); }
+  int_type uflow() override { return traits_type::eof(); }
+  std::streamsize xsgetn(char*, std::streamsize) override { return 0; }
+  int_type pbackfail(int_type) override { return traits_type::eof(); }
+
+  // Disable seeking
+  pos_type seekoff(off_type, std::ios_base::seekdir, std::ios_base::openmode) override { return pos_type(off_type(-1)); }
+  pos_type seekpos(pos_type, std::ios_base::openmode) override { return pos_type(off_type(-1)); }
+
+ private:
+  /**
+   * Sends buffer contents via WriteData, blocks until completion callback fires.
+   * Returns false on error.
+   */
+  bool SendBuffer(bool endStream = false);
+  void ResetPutArea();
+
+  // Client state
+  std::shared_ptr<Aws::Http::HttpClient> m_client;
+  std::shared_ptr<Aws::Http::Connection> m_connection;
+  std::shared_ptr<Aws::Http::ClientStream> m_stream;
+
+  // Data buffer
+  Aws::Utils::Array<unsigned char> m_buffer;
+
+  // WriteData synchronization
+  std::mutex m_writeMutex;
+  std::condition_variable m_writeComplete;
+  bool m_writeInProgress{false};
+  bool m_writeError{false};
+
+  // State management
+  enum class STATE {
+    UNINITIALIZED,
+    INITIALIZED,
+    SHUT_DOWN,
+  } m_state{STATE::UNINITIALIZED};
+  std::condition_variable m_shutdownCondition;
+  std::mutex m_shutdownMutex;
+  bool m_streamComplete{false};
+};
+}  // namespace Stream
+}  // namespace Utils
+}  // namespace Aws

--- a/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClient.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClient.h
@@ -142,6 +142,9 @@ namespace client
         template <typename OutcomeT, typename ClientT, typename RequestT, typename HandlerT>
         friend class SmithyBidirectionalStreamingTask;
 
+        template <typename OutcomeT, typename ClientT, typename RequestT, typename EncoderStreamT, typename HandlerT>
+        friend class SmithyBidirectionalStreamingWriteDataTask;
+
         void initClient() {
           if (m_endpointProvider && m_authSchemeResolver) {
             m_endpointProvider->InitBuiltInParameters(m_clientConfiguration);

--- a/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientBase.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientBase.h
@@ -167,6 +167,9 @@ namespace client
     protected:
         template <typename OutcomeT, typename ClientT, typename RequestT, typename HandlerT>
         friend class SmithyBidirectionalEventStreamingTask;
+
+        template <typename OutcomeT, typename ClientT, typename RequestT, typename EncoderStreamT, typename HandlerT>
+        friend class SmithyBidirectionalStreamingWriteDataTask;
         
         //for backwards compatibility
         const std::shared_ptr<Aws::Client::AWSErrorMarshaller>& GetErrorMarshaller() const

--- a/src/aws-cpp-sdk-core/include/smithy/client/SmithyBidirectionalStreamingWriteDataTask.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/SmithyBidirectionalStreamingWriteDataTask.h
@@ -1,0 +1,205 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#pragma once
+
+#include <aws/core/Core_EXPORTS.h>
+#include <aws/core/NoResult.h>
+#include <aws/core/client/AWSClient.h>
+#include <aws/core/client/AWSClientBidirectionalStreaming.h>
+#include <aws/core/utils/event/EventDecoderStream.h>
+#include <aws/core/utils/event/EventEncoderStream.h>
+#include <aws/core/utils/logging/ErrorMacros.h>
+#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
+#include <smithy/client/AwsSmithyClientAsyncRequestContext.h>
+#include <smithy/client/AwsSmithyClientBase.h>
+
+namespace smithy {
+namespace client {
+
+/**
+ * Push-based bidirectional streaming task for Smithy clients using the WriteData API.
+ * Replaces SmithyBidirectionalStreamingTask when CRT HTTP client is available.
+ */
+template <typename OutcomeT, typename ClientT, typename RequestT, typename EncoderStreamT, typename HandlerT>
+class AWS_CORE_LOCAL SmithyBidirectionalStreamingWriteDataTask final {
+ public:
+  using AuthResolvedCallback = std::function<void(std::shared_ptr<AwsSmithyClientAsyncRequestContext>)>;
+  using EndpointUpdateCallback = std::function<void(Aws::Endpoint::AWSEndpoint&)>;
+
+  SmithyBidirectionalStreamingWriteDataTask(
+      const ClientT* client,
+      const std::shared_ptr<RequestT>& request,
+      const HandlerT& handler,
+      const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context,
+      const std::shared_ptr<EncoderStreamT>& stream,
+      std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> writeDataStreamBuf,
+      EndpointUpdateCallback&& endpointCallback,
+      AuthResolvedCallback&& authCallback)
+      : m_client(client),
+        m_request(request),
+        m_handler(handler),
+        m_context(context),
+        m_stream(stream),
+        m_writeDataStreamBuf(std::move(writeDataStreamBuf)),
+        m_authCallback(std::move(authCallback)),
+        m_endpointCallback(std::move(endpointCallback)) {
+
+    // Fix decoder pointer after copy construction
+    m_request->SetEventStreamHandler(m_request->GetEventStreamHandler());
+
+    std::weak_ptr<RequestT> wRequest = m_request;
+
+    // Wire response stream factory
+    m_request->SetResponseStreamFactory([wRequest]() -> Aws::IOStream* {
+      auto req = wRequest.lock();
+      if (!req) return nullptr;
+      req->GetEventStreamDecoder().Reset();
+      return Aws::New<Aws::Utils::Event::EventDecoderStream>("SmithyBidirectionalStreamingWriteDataTask",
+                                                              req->GetEventStreamDecoder());
+    });
+  }
+
+  void operator()() {
+    // Resolve auth and endpoint
+    auto pExecutor = Aws::MakeShared<Aws::Utils::Threading::DefaultExecutor>("SmithyBidiWriteData");
+    auto authResolver = m_request->GetRequestSpecificSupportedAuth().empty() ? nullptr
+        : Aws::MakeShared<smithy::GenericAuthSchemeResolver<>>("SmithyBidiWriteData",
+            m_request->GetRequestSpecificSupportedAuth());
+    auto ctx = Aws::MakeShared<AwsSmithyClientAsyncRequestContext>("SmithyBidiWriteData",
+        m_request.get(), m_request->GetServiceRequestName(), pExecutor, authResolver);
+    ctx->m_method = Aws::Http::HttpMethod::HTTP_POST;
+
+    bool resolvedIdenity = m_client->ResolveIdentityAuth(
+        ctx,
+        [](AwsSmithyClientBase::HttpResponseOutcome&& outcome) {
+          if (!outcome.IsSuccess()) {
+            AWS_LOGSTREAM_ERROR("SmithyBidiWriteData", "Failed to resolve identity/auth");
+          }
+        },
+        EndpointUpdateCallback(m_endpointCallback));
+
+    if (!resolvedIdenity) {
+      m_handler(m_client, *m_request,
+          OutcomeT(Aws::Client::AWSError<Aws::Client::CoreErrors>(
+              Aws::Client::CoreErrors::CLIENT_SIGNING_FAILURE, "", "Failed to resolve identity", false)),
+          m_context);
+      return;
+    }
+
+    // Wire event signing
+    if (m_authCallback) {
+      m_authCallback(ctx);
+    }
+
+    // Validate host name
+    if (!Aws::Utils::IsValidHost(ctx->m_endpoint.GetURI().GetHost())) {
+      m_handler(m_client, *m_request,
+                OutcomeT(Aws::Client::AWSError<Aws::Client::CoreErrors>(Aws::Client::CoreErrors::VALIDATION, "",
+                                                                        "Invalid DNS Label found in URI host", false)),
+                m_context);
+      return;
+    }
+
+    // Build and sign HTTP request
+    m_client->UpdateAuthSchemeFromEndpoint(ctx->m_endpoint, ctx->m_authSchemeOption);
+    auto httpRequest = m_client->BuildHttpRequest(ctx, ctx->m_endpoint.GetURI(), Aws::Http::HttpMethod::HTTP_POST);
+    if (!httpRequest) {
+      m_handler(m_client, *m_request,
+          OutcomeT(Aws::Client::AWSError<Aws::Client::CoreErrors>(
+              Aws::Client::CoreErrors::VALIDATION, "", "Unable to create HttpRequest", false)),
+          m_context);
+      return;
+    }
+    httpRequest->SetEventStreamRequest(true);
+    httpRequest->SetHasEventStreamResponse(true);
+    httpRequest->SetResponseStreamFactory(m_request->GetResponseStreamFactory());
+
+    // Wire initial response handler on httpRequest (CRT reads it from here)
+    std::weak_ptr<RequestT> wReq = m_request;
+    httpRequest->SetHeadersReceivedEventHandler(
+        [wReq](const Aws::Http::HttpRequest*, Aws::Http::HttpResponse* response) {
+          auto req = wReq.lock();
+          if (!req || !response) return;
+          auto& cb = req->GetEventStreamHandler().GetInitialResponseCallbackEx();
+          if (cb) {
+            cb({response->GetHeaders()}, Aws::Utils::Event::InitialResponseType::ON_RESPONSE);
+          }
+        });
+
+    auto signingOutcome = m_client->SignHttpRequest(httpRequest, *ctx);
+    if (!signingOutcome.IsSuccess()) {
+      m_handler(m_client, *m_request,
+          OutcomeT(Aws::Client::AWSError<Aws::Client::CoreErrors>(
+              Aws::Client::CoreErrors::CLIENT_SIGNING_FAILURE, "", "Failed to sign request", false)),
+          m_context);
+      return;
+    }
+    httpRequest = signingOutcome.GetResultWithOwnership();
+
+    // Seed event signing
+    m_stream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(*httpRequest));
+
+    // Initialize connection
+    auto initError = m_writeDataStreamBuf->Initialize(httpRequest);
+    if (initError.has_value()) {
+      m_handler(m_client, *m_request, OutcomeT(initError.value()), m_context);
+      return;
+    }
+
+    // Signal that stream is ready (caller is waiting on semaphore)
+    m_sem->ReleaseAll();
+
+    // Wait for stream to complete
+    m_writeDataStreamBuf->WaitForStreamComplete();
+    auto response = m_writeDataStreamBuf->GetResponse();
+
+    // Flush any remaining buffered response data through the EventDecoderStream
+    if (response) {
+      response->GetResponseBody().flush();
+    }
+    if (response && response->HasClientError()) {
+      m_stream->Close();
+      m_handler(m_client, *m_request,
+          OutcomeT(Aws::Client::AWSError<Aws::Client::CoreErrors>(
+              response->GetClientErrorType(), "", response->GetClientErrorMessage(), false)),
+          m_context);
+    } else {
+      m_handler(m_client, *m_request, OutcomeT(Aws::NoResult()), m_context);
+    }
+  }
+
+  const std::shared_ptr<Aws::Utils::Threading::Semaphore>& GetSemaphore() const { return m_sem; }
+
+ private:
+  const ClientT* m_client;
+  std::shared_ptr<RequestT> m_request;
+  HandlerT m_handler;
+  std::shared_ptr<const Aws::Client::AsyncCallerContext> m_context;
+  std::shared_ptr<EncoderStreamT> m_stream;
+  std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> m_writeDataStreamBuf;
+  AuthResolvedCallback m_authCallback;
+  EndpointUpdateCallback m_endpointCallback;
+  std::shared_ptr<Aws::Utils::Threading::Semaphore> m_sem{
+      Aws::MakeShared<Aws::Utils::Threading::Semaphore>("SmithyBidiWriteData", 0, 1)};
+};
+
+template <typename OutcomeT, typename ClientT, typename RequestT, typename EncoderStreamT, typename HandlerT>
+static SmithyBidirectionalStreamingWriteDataTask<OutcomeT, ClientT, RequestT, EncoderStreamT, HandlerT>
+CreateSmithyBidirectionalWriteDataTask(
+    const ClientT* client,
+    std::shared_ptr<RequestT> request,
+    const HandlerT& handler,
+    const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context,
+    const std::shared_ptr<EncoderStreamT>& stream,
+    std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> writeDataStreamBuf,
+    std::function<void(Aws::Endpoint::AWSEndpoint&)>&& endpointCallback,
+    std::function<void(std::shared_ptr<AwsSmithyClientAsyncRequestContext>)>&& authCallback) {
+  return SmithyBidirectionalStreamingWriteDataTask<OutcomeT, ClientT, RequestT, EncoderStreamT, HandlerT>(
+      client, request, handler, context, stream, std::move(writeDataStreamBuf),
+      std::move(endpointCallback), std::move(authCallback));
+}
+
+}  // namespace client
+}  // namespace smithy

--- a/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
@@ -195,6 +195,10 @@ class CRTClientStream : public Aws::Http::ClientStream {
 
   int WriteData(std::shared_ptr<Aws::IOStream> stream, const std::function<void(int errorCode)>& onComplete, bool endStream) override {
     auto crtStream = std::make_shared<Aws::Crt::Io::StdIOStreamInputStream>(stream, Aws::Crt::ApiAllocator());
+    if (!crtStream->IsValid()) {
+      onComplete(AWS_ERROR_HTTP_STREAM_HAS_COMPLETED);
+      return AWS_ERROR_HTTP_STREAM_HAS_COMPLETED;
+    }
     return m_stream->WriteData(crtStream,
         [onComplete](std::shared_ptr<Aws::Crt::Http::HttpStream>&, int errorCode) {
             onComplete(errorCode);

--- a/src/aws-cpp-sdk-core/source/utils/event/EventEncoderStream.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/event/EventEncoderStream.cpp
@@ -2,10 +2,13 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
-#include <aws/core/utils/event/EventEncoderStream.h>
-#include <iostream>
-
 #include <aws/core/utils/HashingUtils.h>
+#include <aws/core/utils/event/EventEncoderStream.h>
+#include <aws/core/utils/local/stream/CloseableStreamBuf.h>
+
+namespace {
+const char* LOG_TAG = "EventEncoderStream";
+}  // namespace
 
 namespace Aws
 {
@@ -14,14 +17,22 @@ namespace Aws
         namespace Event
         {
             EventEncoderStream::EventEncoderStream(size_t bufferSize) :
-                Aws::IOStream(&m_streambuf),
-                m_streambuf(bufferSize)
+                Aws::IOStream(nullptr),
+                m_streambuf{Aws::MakeUnique<Aws::Utils::Stream::CloseableConcurrentStreamBuf>(LOG_TAG, bufferSize)}
             {
+              rdbuf(m_streambuf->GetStreamBufHandler());
             }
+
+            EventEncoderStream::EventEncoderStream(std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf)
+                : Aws::IOStream(nullptr), m_streambuf{Aws::MakeShared<Aws::Utils::Stream::CloseableHttpWriteDataStreamBuf>(LOG_TAG, std::move(streambuf))} {
+              rdbuf(m_streambuf->GetStreamBufHandler());
+            }
+
+            void EventEncoderStream::Close() { m_streambuf->Close(this); }
 
             bool EventEncoderStream::WaitForDrain(int64_t timeoutMs)
             {
-                return m_streambuf.WaitForDrain(timeoutMs);
+                return m_streambuf->WaitForDrain(timeoutMs);
             }
 
             EventEncoderStream& EventEncoderStream::WriteEvent(const Aws::Utils::Event::Message& msg)
@@ -31,11 +42,9 @@ namespace Aws
                 AWS_LOGSTREAM_TRACE("EventEncoderStream::WriteEvent", "Encoded event (base64 encoded): " <<
                                     Aws::Utils::HashingUtils::Base64Encode(Aws::Utils::ByteBuffer(bits.data(), bits.size())));
 
-                // write buffer to underlying rdbuf (ConcurrentStreamBuf), this may call overflow()
-                // and block until data is consumed by HTTP Client
+                // write encoded event to the underlying streambuf, may block
+                // if the streambuf applies backpressure (e.g. HttpWriteDataStreamBuf)
                 write(reinterpret_cast<char*>(bits.data()), bits.size());
-                // force flushing ConcurrentStreamBuf to move data from PutArea to the back buffer
-                // so that consuming HTTP Client will have data to send
                 flush();
                 return *this;
             }

--- a/src/aws-cpp-sdk-core/source/utils/local/stream/CloseableStreamBuf.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/local/stream/CloseableStreamBuf.cpp
@@ -1,0 +1,39 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/core/utils/UnreferencedParam.h>
+#include <aws/core/utils/local/stream/CloseableStreamBuf.h>
+#include <aws/core/utils/stream/ConcurrentStreamBuf.h>
+#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
+
+namespace {
+const char* LOG_TAG = "CloseableStreamBuf";
+}
+
+bool Aws::Utils::Stream::CloseableStreamBuf::WaitForDrain(int64_t timeout) {
+  AWS_UNREFERENCED_PARAM(timeout);
+  return true;
+}
+
+void Aws::Utils::Stream::CloseableStreamBuf::Close(Aws::IOStream* pStreamToClose) { AWS_UNREFERENCED_PARAM(pStreamToClose); }
+
+Aws::Utils::Stream::CloseableConcurrentStreamBuf::CloseableConcurrentStreamBuf(size_t bufferSize)
+    : CloseableStreamBuf(Aws::MakeUnique<Aws::Utils::Stream::ConcurrentStreamBuf>(LOG_TAG, bufferSize)) {}
+
+bool Aws::Utils::Stream::CloseableConcurrentStreamBuf::WaitForDrain(int64_t timeoutMs) {
+  return static_cast<Aws::Utils::Stream::ConcurrentStreamBuf*>(GetStreamBufHandler())->WaitForDrain(timeoutMs);
+}
+
+void Aws::Utils::Stream::CloseableConcurrentStreamBuf::Close(Aws::IOStream* stream) {
+  static_cast<Aws::Utils::Stream::ConcurrentStreamBuf*>(GetStreamBufHandler())->SetEofInput(stream);
+}
+
+Aws::Utils::Stream::CloseableHttpWriteDataStreamBuf::CloseableHttpWriteDataStreamBuf(
+    std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf)
+    : CloseableStreamBuf(std::move(streambuf)) {}
+
+void Aws::Utils::Stream::CloseableHttpWriteDataStreamBuf::Close(Aws::IOStream* stream) {
+  AWS_UNREFERENCED_PARAM(stream);
+  static_cast<Aws::Utils::Stream::HttpWriteDataStreamBuf*>(GetStreamBufHandler())->Close();
+}

--- a/src/aws-cpp-sdk-core/source/utils/stream/HttpWriteDataStreamBuf.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/stream/HttpWriteDataStreamBuf.cpp
@@ -1,0 +1,171 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/core/http/HttpClient.h>
+#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
+
+#include <utility>
+
+namespace {
+const char* WRITE_DATA_BUF_LOG_NAME = "HttpWriteDataStreamBuf";
+}
+
+Aws::Utils::Stream::HttpWriteDataStreamBuf::HttpWriteDataStreamBuf(const std::shared_ptr<Aws::Http::HttpClient>& client,
+                                                                   size_t bufferLength)
+    : m_client{client}, m_buffer{bufferLength} {
+  ResetPutArea();
+}
+
+void Aws::Utils::Stream::HttpWriteDataStreamBuf::ResetPutArea() {
+  auto* base = reinterpret_cast<char*>(m_buffer.GetUnderlyingData());
+  setp(base, base + m_buffer.GetLength());
+}
+
+Aws::Utils::Stream::HttpWriteDataStreamBuf::~HttpWriteDataStreamBuf() {
+  Close();
+  WaitForStreamComplete();
+}
+
+Aws::Crt::Optional<Aws::Client::AWSError<Aws::Client::CoreErrors>> Aws::Utils::Stream::HttpWriteDataStreamBuf::Initialize(
+    const std::shared_ptr<Aws::Http::HttpRequest>& request) {
+  std::mutex acquireMutex;
+  std::condition_variable acquireCondition;
+  bool connectionAcquired = false;
+  Aws::Crt::Optional<Aws::Client::AWSError<Aws::Client::CoreErrors>> error;
+
+  // Callback captures stack locals by reference. This is safe because
+  // we block on acquireCondition.wait() below, keeping the stack frame
+  // alive until the callback has fired.
+  m_client->AcquireConnection(request,
+                              [&acquireMutex, &acquireCondition, &connectionAcquired, &error, this](
+                                  std::shared_ptr<Aws::Http::Connection> connection, int errorCode) -> void {
+                                {
+                                  std::unique_lock<std::mutex> const lock{acquireMutex};
+                                  if (errorCode != AWS_ERROR_SUCCESS) {
+                                    error =
+                                        Aws::Client::AWSError<Aws::Client::CoreErrors>(Aws::Client::CoreErrors::NETWORK_CONNECTION, false);
+                                  }
+                                  m_connection = std::move(connection);
+                                  connectionAcquired = true;
+                                }
+                                acquireCondition.notify_all();
+                              });
+
+  std::unique_lock<std::mutex> lock{acquireMutex};
+  acquireCondition.wait(lock, [&connectionAcquired]() -> bool { return connectionAcquired; });
+
+  if (error.has_value()) {
+    return error;
+  }
+
+  m_stream = m_connection->NewClientStream(request, [this](int errorCode) -> void {
+    {
+      std::unique_lock<std::mutex> const lock{m_shutdownMutex};
+      if (errorCode != AWS_ERROR_SUCCESS) {
+        AWS_LOGSTREAM_ERROR(WRITE_DATA_BUF_LOG_NAME, "Stream completed with error: " << errorCode);
+        m_writeError = true;
+      }
+      m_streamComplete = true;
+    }
+    m_shutdownCondition.notify_all();
+  });
+
+  if (!m_stream) {
+    return Aws::Client::AWSError<Aws::Client::CoreErrors>(Aws::Client::CoreErrors::NETWORK_CONNECTION, false);
+  }
+
+  m_stream->Activate();
+  m_state = STATE::INITIALIZED;
+  return error;
+}
+
+void Aws::Utils::Stream::HttpWriteDataStreamBuf::Close() {
+  {
+    std::unique_lock<std::mutex> const lock{m_shutdownMutex};
+    if (m_state != STATE::INITIALIZED) {
+      return;
+    }
+    m_state = STATE::SHUT_DOWN;
+  }
+
+  SendBuffer(/*endStream=*/true);
+}
+
+std::shared_ptr<Aws::Http::HttpResponse> Aws::Utils::Stream::HttpWriteDataStreamBuf::GetResponse() const {
+  assert(m_stream);
+  return m_stream->GetResponse();
+}
+
+void Aws::Utils::Stream::HttpWriteDataStreamBuf::WaitForStreamComplete() {
+  std::unique_lock<std::mutex> lock{m_shutdownMutex};
+  if (m_state == STATE::UNINITIALIZED) {
+    return;
+  }
+  m_shutdownCondition.wait(lock, [this]() -> bool { return m_streamComplete; });
+}
+
+std::streambuf::int_type Aws::Utils::Stream::HttpWriteDataStreamBuf::overflow(std::streambuf::int_type c) {
+  if (traits_type::eq_int_type(c, traits_type::eof())) {
+    return traits_type::not_eof(c);
+  }
+
+  if (!SendBuffer(false)) {
+    return traits_type::eof();
+  }
+
+  *pptr() = traits_type::to_char_type(c);
+  pbump(1);
+  return c;
+}
+
+std::streamsize Aws::Utils::Stream::HttpWriteDataStreamBuf::xsputn(const char* s, std::streamsize n) {
+  std::streamsize written = 0;
+  while (written < n) {
+    std::streamsize const space = epptr() - pptr();
+    std::streamsize const chunk = std::min(space, n - written);
+
+    std::memcpy(pptr(), s + written, static_cast<size_t>(chunk));
+    pbump(static_cast<int>(chunk));
+    written += chunk;
+
+    if (pptr() == epptr()) {
+      if (!SendBuffer(false)) {
+        return written;
+      }
+    }
+  }
+  return written;
+}
+
+int Aws::Utils::Stream::HttpWriteDataStreamBuf::sync() {
+  return SendBuffer(false) ? 0 : -1;
+}
+
+bool Aws::Utils::Stream::HttpWriteDataStreamBuf::SendBuffer(bool endStream) {
+  if (!endStream && (m_writeError || m_state != STATE::INITIALIZED)) {
+    return false;
+  }
+
+  auto data = Aws::MakeShared<Aws::StringStream>(WRITE_DATA_BUF_LOG_NAME);
+  data->write(pbase(), pptr() - pbase());
+
+  m_writeInProgress = true;
+
+  m_stream->WriteData(
+      data,
+      [this](int errorCode) -> void {
+        std::unique_lock<std::mutex> const lock{m_writeMutex};
+        m_writeInProgress = false;
+        m_writeError = (errorCode != AWS_ERROR_SUCCESS);
+        m_writeComplete.notify_one();
+      },
+      endStream);
+
+  std::unique_lock<std::mutex> lock{m_writeMutex};
+  m_writeComplete.wait(lock, [this]() -> bool { return !m_writeInProgress; });
+
+  ResetPutArea();
+
+  return !m_writeError;
+}

--- a/tests/aws-cpp-sdk-core-tests/utils/stream/HttpWriteDataStreamBufTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/stream/HttpWriteDataStreamBufTest.cpp
@@ -1,0 +1,182 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
+#include <aws/testing/AwsCppSdkGTestSuite.h>
+#include <aws/testing/mocks/http/MockHttpClient.h>
+
+namespace {
+const char* TEST_ALLOCATION_LOG_TAG = "HttpWriteDataStreamBufTest";
+}
+
+class HttpWriteDataStreamBufTest : public Aws::Testing::AwsCppSdkGTestSuite {
+ protected:
+  void SetUp() override {
+    auto options = GetSdkOptions();
+    options.httpOptions.httpClientFactory_create_fn = [this]() -> std::shared_ptr<Aws::Http::HttpClientFactory> {
+      client_factory_->SetClient(client_);
+      return client_factory_;
+    };
+    Aws::InitAPI(options);
+    client_factory_ = Aws::MakeShared<MockHttpClientFactory>(TEST_ALLOCATION_LOG_TAG);
+    client_ = Aws::MakeShared<MockHttpClient>(TEST_ALLOCATION_LOG_TAG);
+  };
+
+  void TearDown() override { Aws::ShutdownAPI(GetSdkOptions()); }
+
+  std::shared_ptr<MockHttpClientFactory> client_factory_;
+  std::shared_ptr<MockHttpClient> client_;
+};
+
+TEST_F(HttpWriteDataStreamBufTest, TestShouldWriteData) {
+  auto output = Aws::MakeShared<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG);
+  auto request = Aws::Http::CreateHttpRequest(Aws::String{"http://www.amazon.com/"}, Aws::Http::HttpMethod::HTTP_POST,
+                                              []() -> Aws::IOStream* { return Aws::New<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG); });
+  auto response = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(TEST_ALLOCATION_LOG_TAG, request);
+  ConnectionTestCase testCase{};
+  testCase.writeDataStream = output;
+  testCase.response = response;
+  client_->SetConnectionTestCase(testCase);
+  {
+    Aws::Utils::Stream::HttpWriteDataStreamBuf data_stream_buf{client_, 10};
+    data_stream_buf.Initialize(request);
+    Aws::IOStream stream(&data_stream_buf);
+    stream << "I backed my car into a cop car the other day ";
+    stream << "Well, he just drove off, sometimes life's okay ";
+    stream << "I ran my mouth off a bit too much, oh, what did I say? ";
+    stream << "Well, you just laughed it off, it was all okay ";
+    stream << "And we'll all float on, okay";
+  }
+
+  EXPECT_STREQ(output->str().c_str(),
+               "I backed my car into a cop car the other day Well, he just drove off, sometimes life's okay I ran my mouth off a bit too "
+               "much, oh, what did I say? Well, you just laughed it off, it was all okay And we'll all float on, okay");
+}
+
+TEST_F(HttpWriteDataStreamBufTest, TestConnectionAcquireFailure) {
+  auto request = Aws::Http::CreateHttpRequest(Aws::String{"http://www.amazon.com/"}, Aws::Http::HttpMethod::HTTP_POST,
+                                              []() -> Aws::IOStream* { return Aws::New<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG); });
+  ConnectionTestCase testCase{};
+  testCase.connectionErrorCode = 1;
+  client_->SetConnectionTestCase(testCase);
+
+  Aws::Utils::Stream::HttpWriteDataStreamBuf data_stream_buf{client_, 10};
+  auto error = data_stream_buf.Initialize(request);
+  ASSERT_TRUE(error.has_value());
+  EXPECT_EQ(error->GetErrorType(), Aws::Client::CoreErrors::NETWORK_CONNECTION);
+}
+
+TEST_F(HttpWriteDataStreamBufTest, TestWriteDataCallbackError) {
+  auto output = Aws::MakeShared<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG);
+  auto request = Aws::Http::CreateHttpRequest(Aws::String{"http://www.amazon.com/"}, Aws::Http::HttpMethod::HTTP_POST,
+                                              []() -> Aws::IOStream* { return Aws::New<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG); });
+  auto response = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(TEST_ALLOCATION_LOG_TAG, request);
+  ConnectionTestCase testCase{};
+  testCase.writeDataStream = output;
+  testCase.writeDataCompleteErrorCode = 1;
+  testCase.response = response;
+  client_->SetConnectionTestCase(testCase);
+
+  Aws::Utils::Stream::HttpWriteDataStreamBuf data_stream_buf{client_, 10};
+  data_stream_buf.Initialize(request);
+  Aws::IOStream stream(&data_stream_buf);
+  stream << "Eating snowflakes with plastic forks ";
+  EXPECT_TRUE(stream.fail() || output->str().size() < 38);
+}
+
+TEST_F(HttpWriteDataStreamBufTest, TestSingleCharOverflow) {
+  auto output = Aws::MakeShared<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG);
+  auto request = Aws::Http::CreateHttpRequest(Aws::String{"http://www.amazon.com/"}, Aws::Http::HttpMethod::HTTP_POST,
+                                              []() -> Aws::IOStream* { return Aws::New<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG); });
+  auto response = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(TEST_ALLOCATION_LOG_TAG, request);
+  ConnectionTestCase testCase{};
+  testCase.writeDataStream = output;
+  testCase.response = response;
+  client_->SetConnectionTestCase(testCase);
+  {
+    // Buffer of 1 forces overflow on every character
+    Aws::Utils::Stream::HttpWriteDataStreamBuf data_stream_buf{client_, 1};
+    data_stream_buf.Initialize(request);
+    Aws::IOStream stream(&data_stream_buf);
+    stream << "Everything that keeps me together is falling apart";
+  }
+
+  EXPECT_STREQ(output->str().c_str(), "Everything that keeps me together is falling apart");
+}
+
+TEST_F(HttpWriteDataStreamBufTest, TestLargeBufferNoFlushUntilClose) {
+  auto output = Aws::MakeShared<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG);
+  auto request = Aws::Http::CreateHttpRequest(Aws::String{"http://www.amazon.com/"}, Aws::Http::HttpMethod::HTTP_POST,
+                                              []() -> Aws::IOStream* { return Aws::New<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG); });
+  auto response = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(TEST_ALLOCATION_LOG_TAG, request);
+  ConnectionTestCase testCase{};
+  testCase.writeDataStream = output;
+  testCase.response = response;
+  client_->SetConnectionTestCase(testCase);
+  {
+    // Buffer larger than the data, so it all flushes on Close
+    Aws::Utils::Stream::HttpWriteDataStreamBuf data_stream_buf{client_, 4096};
+    data_stream_buf.Initialize(request);
+    Aws::IOStream stream(&data_stream_buf);
+    stream << "The universe is shaped exactly like the earth";
+    EXPECT_STREQ(output->str().c_str(), "");
+  }
+
+  EXPECT_STREQ(output->str().c_str(), "The universe is shaped exactly like the earth");
+}
+
+TEST_F(HttpWriteDataStreamBufTest, TestEmptyWrite) {
+  auto output = Aws::MakeShared<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG);
+  auto request = Aws::Http::CreateHttpRequest(Aws::String{"http://www.amazon.com/"}, Aws::Http::HttpMethod::HTTP_POST,
+                                              []() -> Aws::IOStream* { return Aws::New<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG); });
+  auto response = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(TEST_ALLOCATION_LOG_TAG, request);
+  ConnectionTestCase testCase{};
+  testCase.writeDataStream = output;
+  testCase.response = response;
+  client_->SetConnectionTestCase(testCase);
+  {
+    Aws::Utils::Stream::HttpWriteDataStreamBuf data_stream_buf{client_, 10};
+    data_stream_buf.Initialize(request);
+    Aws::IOStream stream(&data_stream_buf);
+  }
+
+  EXPECT_STREQ(output->str().c_str(), "");
+}
+
+TEST_F(HttpWriteDataStreamBufTest, TestGetResponse) {
+  auto request = Aws::Http::CreateHttpRequest(Aws::String{"http://www.amazon.com/"}, Aws::Http::HttpMethod::HTTP_POST,
+                                              []() -> Aws::IOStream* { return Aws::New<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG); });
+  auto response = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(TEST_ALLOCATION_LOG_TAG, request);
+  response->SetResponseCode(Aws::Http::HttpResponseCode::OK);
+  auto output = Aws::MakeShared<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG);
+  ConnectionTestCase testCase{};
+  testCase.writeDataStream = output;
+  testCase.response = response;
+  client_->SetConnectionTestCase(testCase);
+
+  Aws::Utils::Stream::HttpWriteDataStreamBuf data_stream_buf{client_, 10};
+  data_stream_buf.Initialize(request);
+  auto resp = data_stream_buf.GetResponse();
+  ASSERT_NE(resp, nullptr);
+  EXPECT_EQ(resp->GetResponseCode(), Aws::Http::HttpResponseCode::OK);
+}
+
+TEST_F(HttpWriteDataStreamBufTest, TestExactBufferBoundary) {
+  auto output = Aws::MakeShared<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG);
+  auto request = Aws::Http::CreateHttpRequest(Aws::String{"http://www.amazon.com/"}, Aws::Http::HttpMethod::HTTP_POST,
+                                              []() -> Aws::IOStream* { return Aws::New<Aws::StringStream>(TEST_ALLOCATION_LOG_TAG); });
+  auto response = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(TEST_ALLOCATION_LOG_TAG, request);
+  ConnectionTestCase testCase{};
+  testCase.writeDataStream = output;
+  testCase.response = response;
+  client_->SetConnectionTestCase(testCase);
+  {
+    Aws::Utils::Stream::HttpWriteDataStreamBuf data_stream_buf{client_, 10};
+    data_stream_buf.Initialize(request);
+    Aws::IOStream stream(&data_stream_buf);
+    stream << "well we are";
+  }
+
+  EXPECT_STREQ(output->str().c_str(), "well we are");
+}

--- a/tests/testing-resources/include/aws/testing/mocks/http/MockConnection.h
+++ b/tests/testing-resources/include/aws/testing/mocks/http/MockConnection.h
@@ -1,0 +1,60 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+#include <aws/core/client/AWSError.h>
+#include <aws/core/client/CoreErrors.h>
+#include <aws/core/http/HttpClientStream.h>
+#include <aws/crt/Types.h>
+
+#include <utility>
+
+struct ConnectionTestCase {
+  Aws::Crt::Optional<Aws::Client::AWSError<Aws::Client::CoreErrors>> connectionError{};
+  int connectionErrorCode{0};
+  int streamCompleteErrorCode{0};
+  int writeDataErrorCode{0};
+  int writeDataCompleteErrorCode{0};
+  std::shared_ptr<Aws::IOStream> writeDataStream;
+  std::shared_ptr<Aws::Http::HttpResponse> response;
+};
+
+class MockClientStream : public Aws::Http::ClientStream {
+ public:
+  MockClientStream(const ConnectionTestCase& testCase, std::function<void(int errorCode)> onStreamComplete)
+      : m_testCase{testCase}, m_onStreamComplete{std::move(onStreamComplete)} {}
+  ~MockClientStream() override = default;
+
+  bool Activate() override { return true; }
+
+  int WriteData(std::shared_ptr<Aws::IOStream> stream, const std::function<void(int errorCode)>& onComplete, bool endStream) override {
+    *m_testCase.writeDataStream << stream->rdbuf();
+    onComplete(m_testCase.writeDataCompleteErrorCode);
+    if (endStream) {
+      m_onStreamComplete(m_testCase.streamCompleteErrorCode);
+    }
+    return m_testCase.writeDataErrorCode;
+  }
+
+  std::shared_ptr<Aws::Http::HttpResponse> GetResponse() const override { return m_testCase.response; }
+
+ private:
+  ConnectionTestCase m_testCase;
+  std::function<void(int errorCode)> m_onStreamComplete;
+};
+
+class MockConnection : public Aws::Http::Connection {
+ public:
+  MockConnection(const ConnectionTestCase& testCase) : m_testCase{testCase} {}
+  ~MockConnection() override = default;
+  std::shared_ptr<Aws::Http::ClientStream> NewClientStream(const std::shared_ptr<Aws::Http::HttpRequest>& request,
+                                                           std::function<void(int errorCode)> onStreamComplete) override {
+    AWS_UNREFERENCED_PARAM(request);
+    return Aws::MakeShared<MockClientStream>("MockConnection", m_testCase, std::move(onStreamComplete));
+  }
+
+ private:
+  ConnectionTestCase m_testCase;
+};

--- a/tests/testing-resources/include/aws/testing/mocks/http/MockHttpClient.h
+++ b/tests/testing-resources/include/aws/testing/mocks/http/MockHttpClient.h
@@ -8,13 +8,14 @@
 #include <assert.h>
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/http/HttpClient.h>
+#include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/http/URI.h>
 #include <aws/core/http/standard/StandardHttpRequest.h>
 #include <aws/core/http/standard/StandardHttpResponse.h>
-#include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/utils/UnreferencedParam.h>
-#include <aws/core/utils/memory/stl/AWSVector.h>
 #include <aws/core/utils/memory/stl/AWSQueue.h>
+#include <aws/core/utils/memory/stl/AWSVector.h>
+#include <aws/testing/mocks/http/MockConnection.h>
 
 static const char MockHttpAllocationTag[] = "MockHttp";
 
@@ -86,9 +87,19 @@ public:
         std::swap(m_responsesToUse, empty);
     }
 
+  void SetConnectionTestCase(const ConnectionTestCase& testCase) { m_connectionTestCase = testCase; }
 
+  Aws::Crt::Optional<Aws::Client::AWSError<Aws::Client::CoreErrors>> AcquireConnection(
+        const std::shared_ptr<Aws::Http::HttpRequest>& request,
+        const std::function<void(std::shared_ptr<Aws::Http::Connection>, int)>& onClientConnectionAvailable) override {
+      AWS_UNREFERENCED_PARAM(request);
+      auto connection = Aws::MakeShared<MockConnection>(MockHttpAllocationTag, m_connectionTestCase);
+      onClientConnectionAvailable(connection, m_connectionTestCase.connectionErrorCode);
+      return m_connectionTestCase.connectionError;
+    }
 
-private:
+   private:
+    mutable ConnectionTestCase m_connectionTestCase;
     mutable Aws::Vector<Aws::Http::Standard::StandardHttpRequest> m_requestsMade;
     mutable Aws::Queue<ResponseCallbackTuple> m_responsesToUse;
     mutable Aws::Queue<ResponseAndRequestCallbackTuple> m_responseAndRequestsCallback;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceHeaders.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ServiceClientSourceHeaders.vm
@@ -12,8 +12,10 @@
 #if($hasEventStreamRequest)
 #if($serviceModel.useSmithyClient)
 \#include <smithy/client/SmithyEventStreamingAsyncTask.h>
+\#include <smithy/client/SmithyBidirectionalStreamingWriteDataTask.h>
 #else
 \#include <aws/core/client/AWSClientEventStreamingAsyncTask.h>
+\#include <aws/core/client/AWSClientBidirectionalStreaming.h>
 #end
 #end
 \#include <aws/core/utils/event/EventStream.h>

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/cbor/EventStreamHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/cbor/EventStreamHeader.vm
@@ -9,6 +9,7 @@
 \#include $header
 #end
 \#include <aws/core/utils/event/EventStream.h>
+\#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
 #foreach($entry in $shape.members.entrySet())
     #if($entry.value.shape.isEvent())
         #foreach($eventMemberEntry in $entry.value.shape.members.entrySet())
@@ -43,6 +44,10 @@ namespace Model
 class $typeInfo.exportValue $typeInfo.className : public Aws::Utils::Event::EventEncoderStream
 {
 public:
+    ${typeInfo.className}() = default;
+    explicit ${typeInfo.className}(std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf)
+        : Aws::Utils::Event::EventEncoderStream(std::move(streambuf)) {}
+
 #foreach($entry in $shape.members.entrySet())
     #if($entry.value.shape.isEvent())
         ${typeInfo.className}& Write${entry.value.shape.name}(const ${entry.value.shape.name}& value)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/EventStreamHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/EventStreamHeader.vm
@@ -9,6 +9,7 @@
 \#include $header
 #end
 \#include <aws/core/utils/event/EventStream.h>
+\#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
 #foreach($entry in $shape.members.entrySet())
 #if($entry.value.shape.isEvent())
 #foreach($eventMemberEntry in $entry.value.shape.members.entrySet())
@@ -43,6 +44,9 @@ namespace Model
   class $typeInfo.exportValue $typeInfo.className : public Aws::Utils::Event::EventEncoderStream
   {
   public:
+    ${typeInfo.className}() = default;
+    explicit ${typeInfo.className}(std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf)
+        : Aws::Utils::Event::EventEncoderStream(std::move(streambuf)) {}
 #foreach($entry in $shape.members.entrySet())
 #if($entry.value.shape.isEvent())
     ${typeInfo.className}& Write${entry.value.shape.name}(const ${entry.value.shape.name}& value)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceEventStreamOperationsSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceEventStreamOperationsSource.vm
@@ -25,11 +25,48 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
 #end
 #end
 #set($streamModelNameWithFirstLetterCapitalized = $CppViewHelper.capitalizeFirstChar($streamModelName))
-  auto eventEncoderStream = Aws::MakeShared<Model::$streamModelType>(ALLOCATION_TAG);
+\#if AWS_SDK_USE_CRT_HTTP
+  // Push-based WriteData path (CRT HTTP client only)
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
+
+  auto eventEncoderStream = Aws::MakeShared<Model::${streamModelType}>(ALLOCATION_TAG, writeDataStreamBuf);
+  eventEncoderStream->SetSigner(signer);
+
+  auto requestCopy = Aws::MakeShared<${operation.request.shape.name}>(ALLOCATION_TAG, request);
+  request.Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream);
+
+  auto& endpoint = endpointResolutionOutcome.GetResult();
+  auto httpRequest = CreateHttpRequest(
+      endpoint.GetURI(), Aws::Http::HttpMethod::HTTP_${operation.http.method},
+      Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+  httpRequest->SetEventStreamRequest(true);
+  httpRequest->SetHasEventStreamResponse(true);
+  BuildHttpRequest(*requestCopy, httpRequest);
+
+  if (!signer->SignRequest(*httpRequest, nullptr, nullptr, true)) {
+    handler(this, request,
+        ${operation.name}Outcome(Aws::Client::AWSError<CoreErrors>(
+            CoreErrors::CLIENT_SIGNING_FAILURE, "", "Failed to sign request", false)),
+        handlerContext);
+    return;
+  }
+  eventEncoderStream->SetSignatureSeed(Aws::Client::GetAuthorizationHeader(*httpRequest));
+
+  Aws::Client::SubmitBidirectionalStreamingRequest<
+      ${className},
+      ${operation.name}Outcome,
+      ${operation.request.shape.name},
+      Model::${streamModelType}>(
+    this, request, requestCopy, eventEncoderStream, writeDataStreamBuf,
+    httpRequest, m_clientConfiguration.executor.get(),
+    streamReadyHandler, handler, handlerContext);
+\#else
+  // Pull-based path (curl/WinHTTP)
+  auto eventEncoderStream = Aws::MakeShared<Model::${streamModelType}>(ALLOCATION_TAG);
   eventEncoderStream->SetSigner(GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER));
   auto requestCopy = Aws::MakeShared<${operation.request.shape.name}>("${operation.name}", request);
-  requestCopy->Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream); // this becomes the body of the request
-##TODO 1.12: remove next line
+  requestCopy->Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream);
   request.Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream);
 
   auto asyncTask = CreateBidirectionalEventStreamTask<${operation.name}Outcome>(this,
@@ -42,4 +79,5 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
   m_clientConfiguration.executor->Submit(std::move(asyncTask));
   sem->WaitOne();
   streamReadyHandler(*eventEncoderStream);
+#endif
 }

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyEventStreamHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyEventStreamHeader.vm
@@ -9,6 +9,7 @@
 \#include $header
 #end
 \#include <aws/core/utils/event/EventStream.h>
+\#include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
 #foreach($entry in $shape.members.entrySet())
 #if($entry.value.shape.isEvent())
 #foreach($eventMemberEntry in $entry.value.shape.members.entrySet())
@@ -43,6 +44,9 @@ namespace Model
   class $typeInfo.exportValue $typeInfo.className : public Aws::Utils::Event::EventEncoderStream
   {
   public:
+    ${typeInfo.className}() = default;
+    explicit ${typeInfo.className}(std::shared_ptr<Aws::Utils::Stream::HttpWriteDataStreamBuf> streambuf)
+        : Aws::Utils::Event::EventEncoderStream(std::move(streambuf)) {}
 #foreach($entry in $shape.members.entrySet())
 #if($entry.value.shape.isEvent())
     ${typeInfo.className}& Write${entry.value.shape.name}(const ${entry.value.shape.name}& value)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyJsonServiceEventStreamOperationsSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyJsonServiceEventStreamOperationsSource.vm
@@ -27,7 +27,31 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
 #end
 #end
 #set($streamModelNameWithFirstLetterCapitalized = $CppViewHelper.capitalizeFirstChar($streamModelName))
-  auto eventEncoderStream = Aws::MakeShared<Model::$streamModelType>(ALLOCATION_TAG);
+\#if AWS_SDK_USE_CRT_HTTP
+  // Push-based WriteData path (CRT HTTP client only)
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, m_httpClient);
+  auto eventEncoderStream = Aws::MakeShared<Model::${streamModelType}>(ALLOCATION_TAG, writeDataStreamBuf);
+  request.Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream);
+
+  auto requestCopy = Aws::MakeShared<${operation.request.shape.name}>(ALLOCATION_TAG, request);
+
+  auto authCallback = [&](std::shared_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> ctx) -> void {
+    eventEncoderStream->SetSigningCallback([this, ctx, eventEncoderStream](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
+      auto outcome = SignEventMessage(message, seed, ctx);
+      return outcome.IsSuccess();
+    });
+  };
+
+  auto asyncTask = smithy::client::CreateSmithyBidirectionalWriteDataTask<${operation.name}Outcome>(
+      this, requestCopy, handler, handlerContext, eventEncoderStream, writeDataStreamBuf,
+      std::move(endpointCallback), std::move(authCallback));
+  auto sem = asyncTask.GetSemaphore();
+  m_clientConfiguration.executor->Submit(std::move(asyncTask));
+  sem->WaitOne();
+  streamReadyHandler(*eventEncoderStream);
+\#else
+  // Pull-based path
+  auto eventEncoderStream = Aws::MakeShared<Model::${streamModelType}>(ALLOCATION_TAG);
   auto authCallback = [&](std::shared_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> ctx) -> void {
     eventEncoderStream->SetSigningCallback([this, ctx, eventEncoderStream](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
       auto outcome = SignEventMessage(message, seed, ctx);
@@ -35,8 +59,8 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
         });
     };
   auto requestCopy = Aws::MakeShared<${operation.request.shape.name}>("${operation.name}", request);
-  requestCopy->Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream); // this becomes the body of the request
-  request.Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream); // this becomes the body of the request
+  requestCopy->Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream);
+  request.Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream);
 
   auto asyncTask = smithy::client::CreateSmithyBidirectionalEventStreamTask<${operation.name}Outcome>(this,
         requestCopy,
@@ -49,4 +73,5 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
     m_clientConfiguration.executor->Submit(std::move(asyncTask));
     sem->WaitOne();
     streamReadyHandler(*eventEncoderStream);
+#endif
 }


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/3257

*Description of changes:*

This changes the implementation of bidirectional streaming when using the CRT HTTP client to use a push-based API rather than a polling-based API. Previously, bidirectional streaming used a `ConcurrentStreamBuf` that the HTTP client polled in a hot loop waiting for data/ Now, when built with `-DUSE_CRT_HTTP_CLIENT=ON`, the SDK uses `HttpWriteDataStreamBuf` which pushes data directly to the HTTP/2 connection the moment it's written. This is fully backwards compatible. No code changes required. The same streaming code automatically benefits:

```cpp
// HttpWriteDataStreamBuf is a std::streambuf that writes to an HTTP/2 connection
class HttpWriteDataStreamBuf : public std::streambuf {
  // When the buffer fills, push it to the wire immediately
  bool SendBuffer(bool endStream) {
    m_stream->WriteData(data, onComplete, endStream);  // CRT push API
  }
};

// AudioStream uses it as its underlying streambuf
class AudioStream : public EventEncoderStream {
  AudioStream(shared_ptr<HttpWriteDataStreamBuf> buf)
    : EventEncoderStream(buf) {}  // writes go directly to wire

  void WriteAudioEvent(const AudioEvent& event) {
    // encode + sign event, write to streambuf → WriteData → wire
    WriteEvent(encode(event));
  }
}

auto OnStreamReady = [](AudioStream& stream) {
  stream.WriteAudioEvent(audioEvent);  // now pushes directly to wire
  stream.Close();
};

client.StartStreamTranscriptionAsync(request, OnStreamReady, OnResponseCallback, nullptr);
```

This has been verified against the current [transcribe example](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/cpp/example_code/transcribe-streaming/get_transcript.cpp) where CPU usage dropped from 100% to background noise levels. This applies to all bidirectional streaming operations across all services (Transcribe, Bedrock, QBusiness, Polly, ConnectHealth, etc.) and is only active when built with `-DUSE_CRT_HTTP_CLIENT=ON`. The legacy path (libcurl/winhttp) is unchanged.

Additionally this is an ongoing effort where the CRT HTTP client will eventually become the default client of the SDK. This fix will not be ported to libcurl or winhttp.
 
*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
