### PR TITLE
CurlHttpClient.cpp: move HeadersReceivedEventHandler to WriteHeader

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -138,7 +138,8 @@ struct CurlWriteCallbackContext
         m_request(request),
         m_response(response),
         m_rateLimiter(rateLimiter),
-        m_numBytesResponseReceived(0)
+        m_numBytesResponseReceived(0),
+        m_headersReceivedEventFired(false)
     {}
 
     const CurlHttpClient* m_client;
@@ -147,6 +148,7 @@ struct CurlWriteCallbackContext
     HttpResponse* m_response;
     Aws::Utils::RateLimits::RateLimiterInterface* m_rateLimiter;
     int64_t m_numBytesResponseReceived;
+    bool m_headersReceivedEventFired;
 };
 
 static const char* CURL_HTTP_CLIENT_TAG = "CurlHttpClient";
@@ -194,11 +196,6 @@ static size_t WriteData(char* ptr, size_t size, size_t nmemb, void* userdata)
         }
 
         HttpResponse* response = context->m_response;
-        auto& headersHandler = context->m_request->GetHeadersReceivedEventHandler();
-        if (context->m_numBytesResponseReceived == 0 && headersHandler)
-        {
-            headersHandler(context->m_request, context->m_response);
-        }
 
         size_t sizeToWrite = size * nmemb;
         if (context->m_rateLimiter)
@@ -284,6 +281,16 @@ static size_t WriteHeader(char* ptr, size_t size, size_t nmemb, void* userdata)
             curl_easy_getinfo(context->m_curlHandle, CURLINFO_RESPONSE_CODE, &responseCode);
             response->SetResponseCode(static_cast<HttpResponseCode>(responseCode));
             AWS_LOGSTREAM_DEBUG(CURL_HTTP_CLIENT_TAG, "Returned http response code " << responseCode);
+
+            if (!context->m_headersReceivedEventFired)
+            {
+                auto& headersHandler = context->m_request->GetHeadersReceivedEventHandler();
+                if (headersHandler)
+                {
+                    headersHandler(context->m_request, context->m_response);
+                }
+                context->m_headersReceivedEventFired = true;
+            }
         }
 
         return size * nmemb;

--- a/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -138,8 +138,7 @@ struct CurlWriteCallbackContext
         m_request(request),
         m_response(response),
         m_rateLimiter(rateLimiter),
-        m_numBytesResponseReceived(0),
-        m_headersReceivedEventFired(false)
+        m_numBytesResponseReceived(0)
     {}
 
     const CurlHttpClient* m_client;
@@ -148,7 +147,6 @@ struct CurlWriteCallbackContext
     HttpResponse* m_response;
     Aws::Utils::RateLimits::RateLimiterInterface* m_rateLimiter;
     int64_t m_numBytesResponseReceived;
-    bool m_headersReceivedEventFired;
 };
 
 static const char* CURL_HTTP_CLIENT_TAG = "CurlHttpClient";
@@ -281,15 +279,10 @@ static size_t WriteHeader(char* ptr, size_t size, size_t nmemb, void* userdata)
             curl_easy_getinfo(context->m_curlHandle, CURLINFO_RESPONSE_CODE, &responseCode);
             response->SetResponseCode(static_cast<HttpResponseCode>(responseCode));
             AWS_LOGSTREAM_DEBUG(CURL_HTTP_CLIENT_TAG, "Returned http response code " << responseCode);
-
-            if (!context->m_headersReceivedEventFired)
+            auto& headersHandler = context->m_request->GetHeadersReceivedEventHandler();
+            if (headersHandler)
             {
-                auto& headersHandler = context->m_request->GetHeadersReceivedEventHandler();
-                if (headersHandler)
-                {
-                    headersHandler(context->m_request, context->m_response);
-                }
-                context->m_headersReceivedEventFired = true;
+                headersHandler(context->m_request, context->m_response);
             }
         }
 

--- a/src/aws-cpp-sdk-core/source/http/windows/WinSyncHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/windows/WinSyncHttpClient.cpp
@@ -209,6 +209,12 @@ bool WinSyncHttpClient::BuildSuccessResponse(const std::shared_ptr<HttpRequest>&
         }
     }
 
+    auto& headersHandler = request->GetHeadersReceivedEventHandler();
+    if (headersHandler)
+    {
+        headersHandler(request.get(), response.get());
+    }
+
     if (request->GetMethod() != HttpMethod::HTTP_HEAD)
     {
         if(!ContinueRequest(*request) || !IsRequestProcessingEnabled())
@@ -250,12 +256,6 @@ bool WinSyncHttpClient::BuildSuccessResponse(const std::shared_ptr<HttpRequest>&
                                 hashIterator.second->Update(reinterpret_cast<unsigned char*>(dst), static_cast<size_t>(read));
                                 break;
                               }
-                            }
-
-                            auto& headersHandler = request->GetHeadersReceivedEventHandler();
-                            if (headersHandler)
-                            {
-                              headersHandler(request.get(), response.get());
                             }
 
                             if (readLimiter != nullptr)

--- a/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
@@ -2690,6 +2690,32 @@ namespace
       EXPECT_FALSE(outcome.IsSuccess());
     }
 
+    TEST_F(BucketAndObjectOperationTest, TestHeadersReceivedEventHandlerFiresOnEmptyBodyResponse) {
+      const String fullBucketName = CalculateBucketName(BASE_PUT_OBJECTS_BUCKET_NAME.c_str());
+      SCOPED_TRACE(Aws::String("FullBucketName ") + fullBucketName);
+
+      // PutObject returns 200 with headers but an empty body
+      Aws::S3::Model::PutObjectRequest request;
+      request.SetBucket(fullBucketName);
+      request.SetKey("headers-received-handler-test");
+
+      auto body = Aws::MakeShared<Aws::StringStream>(ALLOCATION_TAG, "test content");
+      request.SetBody(body);
+
+      std::atomic<bool> handlerFired{false};
+      Aws::Http::HttpResponseCode capturedCode{Aws::Http::HttpResponseCode::REQUEST_NOT_MADE};
+      request.SetHeadersReceivedEventHandler(
+          [&handlerFired, &capturedCode](const Aws::Http::HttpRequest*, Aws::Http::HttpResponse* response) {
+              handlerFired = true;
+              capturedCode = response->GetResponseCode();
+          });
+
+      auto outcome = Client->PutObject(request);
+      AWS_EXPECT_SUCCESS(outcome);
+      EXPECT_TRUE(handlerFired.load()) << "HeadersReceivedEventHandler must fire even when response body is empty";
+      EXPECT_EQ(Aws::Http::HttpResponseCode::OK, capturedCode);
+    }
+
     TEST_F(BucketAndObjectOperationTest, ShouldSkipResponseValidationOnCompositeChecksums) {
       const auto fullBucketName = CalculateBucketName(BASE_PUT_MULTIPART_COMPOSITE_CHECKSUM_BUCKET_NAME.c_str());
       m_bucketsToDelete.insert(fullBucketName);

--- a/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
@@ -2692,7 +2692,15 @@ namespace
 
     TEST_F(BucketAndObjectOperationTest, TestHeadersReceivedEventHandlerFiresOnEmptyBodyResponse) {
       const String fullBucketName = CalculateBucketName(BASE_PUT_OBJECTS_BUCKET_NAME.c_str());
-      SCOPED_TRACE(Aws::String("FullBucketName ") + fullBucketName);
+      SCOPED_TRACE(Aws::String("FullBucket"
+                               "Name ") + fullBucketName);
+      CreateBucketRequest createBucketRequest;
+      createBucketRequest.SetBucket(fullBucketName);
+      createBucketRequest.SetACL(BucketCannedACL::private_);
+      CreateBucketOutcome createBucketOutcome = CreateBucket(createBucketRequest);
+      AWS_ASSERT_SUCCESS(createBucketOutcome);
+      ASSERT_TRUE(WaitForBucketToPropagate(fullBucketName, Client));
+      TagTestBucket(fullBucketName, Client);
 
       // PutObject returns 200 with headers but an empty body
       Aws::S3::Model::PutObjectRequest request;


### PR DESCRIPTION


*Issue #, if available:*
#3814 

*Description of changes:*
HeaderReceivedEventHandler is invoked from WriteHeader callback (will fire even if there is no body) instead of WriteData callback

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
