### PR TITLE
defense in depth fix for path traversal in transfer manager

### DIFF
--- a/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -1497,6 +1497,7 @@ namespace Aws
                         continue;
                     }
 
+                    bool wasParentRef = false;
                     if(i + 2 < filePath.size() && '.' == filePath[i+1] && '.' == filePath[i+2]) // if "/.."
                     {
                         if(i + 3 == filePath.size() || (i + 3 < filePath.size() && '/' == filePath[i+3])) // if "/.." or "/../"
@@ -1505,9 +1506,13 @@ namespace Aws
                                 return false; // attempting to escape parent
                             }
                             level--;
+                            wasParentRef = true;
                         }
                     }
-                    level++;
+                    if (!wasParentRef)
+                    {
+                        level++;
+                    }
                 }
             }
             return true;

--- a/tests/aws-cpp-sdk-transfer-tests/TransferTests.cpp
+++ b/tests/aws-cpp-sdk-transfer-tests/TransferTests.cpp
@@ -2326,7 +2326,12 @@ TEST_P(TransferTests, TransferManager_TestRelativePrefix)
                 {R"(./)", R"(./.../foo)", true},
                 {R"(./)", R"(./.../../foo)", true},
                 {R"(./)", R"(.//.../../foo)", true},
-                {R"(./)", R"(.////../test)", false}
+                {R"(./)", R"(.////../test)", false},
+
+                {R"(/home/user/dl)", R"(/home/user/dl/safe/../../etc/passwd)", false},
+                {R"(/home/user/dl)", R"(/home/user/dl/x/../../../etc/passwd)", false},
+                {R"(/home/user/dl)", R"(/home/user/dl/a/b/c/../../../../etc/passwd)", false},
+                {R"(/tmp/download)", R"(/tmp/download/subdir/../../../../../../etc/cron.d/evil)", false}
             };
 
     for(const TestHelperTransferManager::TestCaseEntry& TC_ENTRY : TEST_CASES)


### PR DESCRIPTION
*Description of changes:*

Related to [Partial Path Traversal in aws-cpp-sdk-transfer](https://github.com/aws/aws-sdk-cpp/security/advisories/GHSA-g2jj-589x-jvx2) and is a defense in depth fix for further scenarios.

A key like `/home/user/dl/safe/../../etc/passwd` written to `/home/user/dl` would trigger this scenario, and would be able to break out of the running directory and write _in theory_ however in practice it is non-exploitable given that libcurl will compress the url by default resulting in a broken head object failing the transfer. additionally S3 no longer allows a object like this to be created sever side.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
