### PR TITLE
Stop using the now deprecated std::is_trivial.

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/memory/AWSMemory.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/memory/AWSMemory.h
@@ -304,7 +304,7 @@ namespace Aws
     template<typename T, typename ...ArgTypes>
     UniquePtr<T> MakeUnique(const char* allocationTag, ArgTypes&&... args)
     {
-        static_assert(!std::is_array<T>::value || std::is_trivial<T>::value,
+        static_assert(!std::is_array<T>::value || (std::is_trivially_default_constructible<T>::value && std::is_trivially_copyable<T>::value),
                 "This wrapper/function is not designed to support non-trivial arrays.");
         return UniquePtr<T>(Aws::New<T>(allocationTag, std::forward<ArgTypes>(args)...));
     }
@@ -312,7 +312,7 @@ namespace Aws
     template<typename T, typename D = Deleter<T>, typename ...ArgTypes>
     UniquePtrSafeDeleted<T, D> MakeUniqueSafeDeleted(const char* allocationTag, ArgTypes&&... args)
     {
-        static_assert(!std::is_array<T>::value || std::is_trivial<T>::value,
+        static_assert(!std::is_array<T>::value || (std::is_trivially_default_constructible<T>::value && std::is_trivially_copyable<T>::value),
                       "This wrapper/function is not designed to support non-trivial arrays.");
 
         return UniquePtrSafeDeleted<T, D>(Aws::New<T>(allocationTag, std::forward<ArgTypes>(args)...), D());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

std::is_trivial is deprecated in C++26. Using gcc 15 and C++26 yields this warning:

```
/data/mwrep/res/mdw/SIOTF/internal/osp/aws_sdk/25-0-0-1/include/aws/core/utils/memory/AWSMemory.h: In function 'Aws::UniquePtr<T> Aws::MakeUnique(const char*, ArgTypes&& ...)': /data/mwrep/res/mdw/SIOTF/internal/osp/aws_sdk/25-0-0-1/include/aws/core/utils/memory/AWSMemory.h:307:56: error: 'template<class _Tp> struct std::is_trivial' is deprecated: use 'is_trivially_default_constructible && is_triviall y_copyable' instead [-Werror=deprecated-declarations]
  307 |         static_assert(!std::is_array<T>::value || std::is_trivial<T>::value,
      |                                                        ^~~~~~~~~~
```

So do as gcc suggests, and replace it by a combination of is_trivially_default_constructible and is_trivially_copyable.

*Check all that applies:*
- [X] Did a review by yourself.
- [X] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [X] Checked if this PR is a breaking (APIs have been changed) change.
- [X] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [X] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [X] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
