### PR TITLE
Stop using the now deprecated std::is_trivial.

### DIFF
--- a/src/aws-cpp-sdk-core/include/aws/core/utils/memory/AWSMemory.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/memory/AWSMemory.h
@@ -304,7 +304,7 @@ namespace Aws
     template<typename T, typename ...ArgTypes>
     UniquePtr<T> MakeUnique(const char* allocationTag, ArgTypes&&... args)
     {
-        static_assert(!std::is_array<T>::value || std::is_trivial<T>::value,
+        static_assert(!std::is_array<T>::value || (std::is_trivially_default_constructible<T>::value && std::is_trivially_copyable<T>::value),
                 "This wrapper/function is not designed to support non-trivial arrays.");
         return UniquePtr<T>(Aws::New<T>(allocationTag, std::forward<ArgTypes>(args)...));
     }
@@ -312,7 +312,7 @@ namespace Aws
     template<typename T, typename D = Deleter<T>, typename ...ArgTypes>
     UniquePtrSafeDeleted<T, D> MakeUniqueSafeDeleted(const char* allocationTag, ArgTypes&&... args)
     {
-        static_assert(!std::is_array<T>::value || std::is_trivial<T>::value,
+        static_assert(!std::is_array<T>::value || (std::is_trivially_default_constructible<T>::value && std::is_trivially_copyable<T>::value),
                       "This wrapper/function is not designed to support non-trivial arrays.");
 
         return UniquePtrSafeDeleted<T, D>(Aws::New<T>(allocationTag, std::forward<ArgTypes>(args)...), D());


### PR DESCRIPTION
mergable version of https://github.com/aws/aws-sdk-cpp/pull/3819

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
