### PR TITLE
fix event stream responses in CRT http client

### DIFF
--- a/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
@@ -97,7 +97,7 @@ void OnResponseBodyReceived(Aws::Crt::Http::HttpStream&, const Aws::Crt::ByteCur
     AWS_LOGSTREAM_ERROR(CRT_HTTP_CLIENT_TAG, "Failed to write " << body.len << " (eof: " << ref.eof() << ", bad: " << ref.bad() << ")");
   }
 
-  if (request->IsEventStreamRequest() && !response->HasHeader(Aws::Http::X_AMZN_ERROR_TYPE)) {
+  if ((request->IsEventStreamRequest() || request->HasEventStreamResponse()) && !response->HasHeader(Aws::Http::X_AMZN_ERROR_TYPE)) {
     response->GetResponseBody().flush();
   }
 


### PR DESCRIPTION
*Description of changes:*

because of a missing flush in the CRT HTTP client for requests that use response event streams, the json deserializer would fail for a empty body as the response would not have been flushed. in the libcurl implementation we do this.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
