### PR TITLE
aws-cpp-sdk-s3-crt: raise error when failing to write download data

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -577,6 +577,11 @@ int S3CrtClient::S3CrtRequestGetBodyCallback(struct aws_s3_meta_request *meta_re
   {
     bodyStream.flush();
   }
+  if (bodyStream.fail()) {
+    AWS_LOGSTREAM_ERROR(ALLOCATION_TAG, "Failed to write download data");
+    aws_raise_error(AWS_ERROR_FILE_WRITE_FAILURE);
+    return AWS_OP_ERR;
+  }
 
   // Replenish flow-control window (no-op if enable_read_backpressure is not set):
   aws_s3_meta_request_increment_read_window(meta_request, body->len);


### PR DESCRIPTION
Currently the `S3CrtClient` neither logs nor raises an error when failing to write download data.

To avoid the problem of silent failure, check the `failbit/badbit` after the calls to `write()` and `flush()`.
Raise and log the error cause.
Return `AWS_OP_ERR` to mark the download as failed.

Resolves #3824.

Tested on Linux/ubuntu 22.04.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
