### PR TITLE
[Bugfix] - codegen to use serviceId

### DIFF
--- a/tools/scripts/codegen/legacy_c2j_cpp_gen.py
+++ b/tools/scripts/codegen/legacy_c2j_cpp_gen.py
@@ -151,7 +151,6 @@ class LegacyC2jCppGen(object):
             return -1
 
         self._create_smithy_namespace_mapping(self.c2j_models)
-        self._update_smithy2c2j_service_map(self.c2j_models)
 
         print(f"Code generation done, (re)generated {len(done)} packages.")  # Including defaults and partitions
         
@@ -381,42 +380,3 @@ class LegacyC2jCppGen(object):
         with open(tmp_path, 'w') as f:
             json.dump(mapping, f, indent=2)
         os.replace(tmp_path, output_path)
-
-    def _update_smithy2c2j_service_map(self, c2j_models: dict):
-        """Update smithy2c2j_service_map.json with entries for services where the
-        Smithy sdkId-derived name differs from the C2J filename-derived name.
-        Only processes the services being generated; merges with existing entries."""
-        output_paths = [
-            f"{self.path_to_api_definitions}/../smithy/cpp-codegen/smithy2c2j_service_map.json",
-            f"{self.path_to_api_definitions}/../smithy/codegen/smithy2c2j_service_map.json",
-        ]
-
-        for output_path in output_paths:
-            if os.path.exists(output_path):
-                with open(output_path, 'r') as f:
-                    mapping = json.load(f)
-            else:
-                mapping = {}
-
-            seen_models = set()
-            for service, model_files in c2j_models.items():
-                # Skip synthetic entries that share a model file with another service (e.g. s3-crt uses s3's model)
-                if model_files.c2j_model in seen_models:
-                    continue
-                seen_models.add(model_files.c2j_model)
-
-                full_model_file_path = f"{self.path_to_api_definitions}/{model_files.c2j_model}"
-                with open(full_model_file_path, 'r') as f:
-                    model = json.load(f)
-                service_id = model.get("metadata", {}).get("serviceId", "")
-                if not service_id:
-                    continue
-                smithy_name = service_id.lower().replace(" ", "-").replace("_", "-")
-                if smithy_name != service:
-                    mapping[smithy_name] = service
-
-            tmp_path = output_path + ".tmp"
-            with open(tmp_path, 'w') as f:
-                json.dump(mapping, f, indent=4, sort_keys=True)
-                f.write("\n")
-            os.replace(tmp_path, output_path)

--- a/tools/scripts/codegen/legacy_c2j_cpp_gen.py
+++ b/tools/scripts/codegen/legacy_c2j_cpp_gen.py
@@ -151,6 +151,7 @@ class LegacyC2jCppGen(object):
             return -1
 
         self._create_smithy_namespace_mapping(self.c2j_models)
+        self._update_smithy2c2j_service_map(self.c2j_models)
 
         print(f"Code generation done, (re)generated {len(done)} packages.")  # Including defaults and partitions
         
@@ -380,3 +381,36 @@ class LegacyC2jCppGen(object):
         with open(tmp_path, 'w') as f:
             json.dump(mapping, f, indent=2)
         os.replace(tmp_path, output_path)
+
+    def _update_smithy2c2j_service_map(self, c2j_models: dict):
+        """Update smithy2c2j_service_map.json with entries for services where the
+        Smithy sdkId-derived name differs from the C2J filename-derived name.
+        Only processes the services being generated; merges with existing entries."""
+        output_paths = [
+            f"{self.path_to_api_definitions}/../smithy/cpp-codegen/smithy2c2j_service_map.json",
+            f"{self.path_to_api_definitions}/../smithy/codegen/smithy2c2j_service_map.json",
+        ]
+
+        for output_path in output_paths:
+            if os.path.exists(output_path):
+                with open(output_path, 'r') as f:
+                    mapping = json.load(f)
+            else:
+                mapping = {}
+
+            for service, model_files in c2j_models.items():
+                full_model_file_path = f"{self.path_to_api_definitions}/{model_files.c2j_model}"
+                with open(full_model_file_path, 'r') as f:
+                    model = json.load(f)
+                service_id = model.get("metadata", {}).get("serviceId", "")
+                if not service_id:
+                    continue
+                smithy_name = service_id.lower().replace(" ", "-").replace("_", "-")
+                if smithy_name != service:
+                    mapping[smithy_name] = service
+
+            tmp_path = output_path + ".tmp"
+            with open(tmp_path, 'w') as f:
+                json.dump(mapping, f, indent=4, sort_keys=True)
+                f.write("\n")
+            os.replace(tmp_path, output_path)

--- a/tools/scripts/codegen/legacy_c2j_cpp_gen.py
+++ b/tools/scripts/codegen/legacy_c2j_cpp_gen.py
@@ -398,7 +398,13 @@ class LegacyC2jCppGen(object):
             else:
                 mapping = {}
 
+            seen_models = set()
             for service, model_files in c2j_models.items():
+                # Skip synthetic entries that share a model file with another service (e.g. s3-crt uses s3's model)
+                if model_files.c2j_model in seen_models:
+                    continue
+                seen_models.add(model_files.c2j_model)
+
                 full_model_file_path = f"{self.path_to_api_definitions}/{model_files.c2j_model}"
                 with open(full_model_file_path, 'r') as f:
                     model = json.load(f)

--- a/tools/scripts/codegen/model_utils.py
+++ b/tools/scripts/codegen/model_utils.py
@@ -104,6 +104,39 @@ class ModelUtils(object):
             return dict((k, self.models_available[k]) for k in clients_to_build if k in clients_to_build)
 
     @staticmethod
+    def _resolve_service_key(raw_key: str, model_filename: str, models_dir: str, legacy_services: set) -> str:
+        """Resolve the package directory name for a service.
+
+        For legacy services (in the frozen set), use the filename-based key.
+        For new services, use the normalized serviceId from the model
+        so it naturally aligns with what Smithy codegen expects.
+        """
+        key = SERVICE_NAME_REMAPS.get(raw_key, raw_key)
+        if "." in key:
+            key = "-".join(reversed(key.split(".")))
+        if ";" in key:
+            key = key.replace(";", "-")
+
+        # Legacy service: keep filename-based name
+        if key in legacy_services:
+            return key
+
+        # New service: use normalized serviceId if it differs from filename-based key
+        full_model_path = os.path.join(models_dir, model_filename)
+        try:
+            with open(full_model_path, 'r') as f:
+                model = json.load(f)
+            service_id = model.get("metadata", {}).get("serviceId", "")
+            if service_id:
+                sdk_id_key = service_id.lower().replace(" ", "-").replace("_", "-")
+                if sdk_id_key != key:
+                    return sdk_id_key
+        except (json.JSONDecodeError, IOError):
+            pass
+
+        return key
+
+    @staticmethod
     def _collect_available_models(models_dir: str, endpoint_rules_dir: str) -> dict:
         """Return a dict of <service_name, ServiceModel> with all available c2j models in a models_dir
 
@@ -111,6 +144,20 @@ class ModelUtils(object):
         :param endpoint_rules_dir: path to the directory with endpoints dir models
         :return: dict<service_name, model_file_name> in models dir
         """
+        # Load the smithy2c2j service map to determine which services are legacy
+        # (any service whose sdkId-derived name appears as a KEY in this map has a known
+        # mismatch and uses the filename-based value)
+        service_map_path = os.path.normpath(
+            os.path.join(models_dir, "../smithy/cpp-codegen/smithy2c2j_service_map.json"))
+        legacy_services = set()
+        if os.path.exists(service_map_path):
+            try:
+                with open(service_map_path, 'r') as f:
+                    service_map = json.load(f)
+                legacy_services = set(service_map.values())
+            except (json.JSONDecodeError, IOError):
+                pass
+
         model_files = os.listdir(models_dir)
         service_name_to_model_filename_date = dict()
 
@@ -133,11 +180,7 @@ class ModelUtils(object):
         service_name_to_model_filename = dict()
         missing = set()
         for raw_key, model_file_date in service_name_to_model_filename_date.items():
-            key = SERVICE_NAME_REMAPS.get(raw_key, raw_key)
-            if "." in key:
-                key = "-".join(reversed(key.split(".")))  # just replicating existing legacy behavior
-            if ";" in key:
-                key = key.replace(";", "-")  # just in case... just replicating existing legacy behavior
+            key = ModelUtils._resolve_service_key(raw_key, model_file_date[0], models_dir, legacy_services)
 
             # fetch endpoint-rules filename which is based on ServiceId in c2j models:
             try:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
  When a service's Smithy sdkId normalizes                                                                                                                                                    
  to a different name than the C2J filename prefix the                                                                                                                                                    
  Smithy pagination/waiters codegen fails to match the service or writes files                                                                                                                                                     
  to the wrong path. Previously this required a manual entry in the map file.                                                                                                                                                      
                                                                                                                                                                                                                                   
  New services will now create files with serviceId matching smithy

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
