### PR TITLE
fix visibility on smithy base client methods

### DIFF
--- a/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientBase.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientBase.h
@@ -163,6 +163,10 @@ namespace client
                                 EndpointUpdateCallback&& endpointCallback
                                 ) const;
         void AppendToUserAgent(const Aws::String& valueToAppend);
+        virtual void DisableRequestProcessing();
+        virtual void EnableRequestProcessing();
+        inline virtual const char* GetServiceClientName() const { return m_serviceName.c_str(); }
+        inline virtual const std::shared_ptr<Aws::Http::HttpClient>& GetHttpClient() { return m_httpClient; }
 
     protected:
         template <typename OutcomeT, typename ClientT, typename RequestT, typename HandlerT>
@@ -212,11 +216,6 @@ namespace client
 
         virtual void HandleAsyncReply(std::shared_ptr<AwsSmithyClientAsyncRequestContext> pRequestCtx,
                                       std::shared_ptr<Aws::Http::HttpResponse> httpResponse) const;
-
-        inline virtual const char* GetServiceClientName() const { return m_serviceName.c_str(); }
-        inline virtual const std::shared_ptr<Aws::Http::HttpClient>& GetHttpClient() { return m_httpClient; }
-        virtual void DisableRequestProcessing();
-        virtual void EnableRequestProcessing();
 
         virtual ResolveEndpointOutcome ResolveEndpoint(const Aws::Endpoint::EndpointParameters& endpointParameters, EndpointUpdateCallback&& epCallback) const = 0;
         virtual SelectAuthSchemeOptionOutcome SelectAuthSchemeOption(const AwsSmithyClientAsyncRequestContext& ctx) const = 0;


### PR DESCRIPTION
*Description of changes:*

Fixes visibility on on some smithy client operations for example

```c++
#include <aws/core/Aws.h>
#include <aws/s3/S3Client.h>
#include <aws/sts/STSClient.h>

using namespace Aws;
using namespace Aws::S3;
using namespace Aws::STS;

namespace {
class SDKGuard {
 public:
  SDKGuard(SDKOptions&& options) : options_(std::move(options)) { Aws::InitAPI(options_); }
  ~SDKGuard() { Aws::ShutdownAPI(options_); }

 private:
  SDKOptions options_;
};
}  // namespace

int main() {
  SDKGuard guard({});

  {
    S3Client client{};
    // works
    client.DisableRequestProcessing();
  }

  {
    STSClient client{};
    // compile error
    client.DisableRequestProcessing();
  }
  return 0;
}

```

this fixes visibility on all of the protected functions in smithy base client that are public in aws client.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
