### PR TITLE
Only calculate full body checksum for checksums that support it

### DIFF
--- a/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
+++ b/src/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp
@@ -407,18 +407,18 @@ namespace Aws
             bool isRetry = !handle->GetMultiPartId().empty();
             uint64_t sentBytes = 0;
 
-            const auto fullObjectHashCalculator = [](const std::shared_ptr<TransferHandle>& handle, bool isRetry, S3::Model::ChecksumAlgorithm algorithm) -> std::shared_ptr<Aws::Utils::Crypto::Hash> {
+            const auto fullObjectHashCalculator = [](const std::shared_ptr<TransferHandle>& handle, bool isRetry,
+                                                     S3::Model::ChecksumAlgorithm algorithm) -> std::shared_ptr<Aws::Utils::Crypto::Hash> {
                 if (handle->GetChecksum().empty() && !isRetry) {
-                    if (algorithm == S3::Model::ChecksumAlgorithm::CRC32 || algorithm == S3::Model::ChecksumAlgorithm::CRC32C) {
+                    if (algorithm == S3::Model::ChecksumAlgorithm::CRC64NVME) {
+                      return Aws::MakeShared<Aws::Utils::Crypto::CRC64>("TransferManager");
+                    }
+                    if (algorithm == S3::Model::ChecksumAlgorithm::CRC32) {
                         return Aws::MakeShared<Aws::Utils::Crypto::CRC32>("TransferManager");
                     }
-                    if (algorithm == S3::Model::ChecksumAlgorithm::SHA1) {
-                        return Aws::MakeShared<Aws::Utils::Crypto::Sha1>("TransferManager");
+                    if (algorithm == S3::Model::ChecksumAlgorithm::CRC32C) {
+                        return Aws::MakeShared<Aws::Utils::Crypto::CRC32C>("TransferManager");
                     }
-                    if (algorithm == S3::Model::ChecksumAlgorithm::SHA256) {
-                        return Aws::MakeShared<Aws::Utils::Crypto::Sha256>("TransferManager");
-                    }
-                    return Aws::MakeShared<Aws::Utils::Crypto::CRC64>("TransferManager");
                 }
                 return nullptr;
             }(handle, isRetry, m_transferConfig.checksumAlgorithm);
@@ -431,6 +431,10 @@ namespace Aws
               createMultipartRequest.SetContentType(handle->GetContentType());
               createMultipartRequest.SetKey(handle->GetKey());
               createMultipartRequest.SetMetadata(handle->GetMetadata());
+
+              if (fullObjectHashCalculator) {
+                createMultipartRequest.SetChecksumType(Aws::S3::Model::ChecksumType::FULL_OBJECT);
+              }
 
               auto createMultipartResponse = m_transferConfig.s3Client->CreateMultipartUpload(createMultipartRequest);
               if (createMultipartResponse.IsSuccess()) {


### PR DESCRIPTION
*Description of changes:*

A bug introduced in https://github.com/aws/aws-sdk-cpp/pull/3625 breaks MPU for object uploaded using non-default CRC64, specifically CRC32 or CRC32C. specifically an example

```c++
#include <aws/core/Aws.h>
#include <aws/core/utils/threading/Executor.h>
#include <aws/s3/S3Client.h>
#include <aws/transfer/TransferManager.h>

#include <iostream>
#include <thread>

using namespace Aws;
using namespace Aws::S3;
using namespace Aws::Transfer;

namespace {
class sdk_guard {
 public:
  sdk_guard(SDKOptions&& options) : options_(std::move(options)) { Aws::InitAPI(options_); }
  ~sdk_guard() { Aws::ShutdownAPI(options_); }

 private:
  SDKOptions options_;
};
}  // namespace

int main(int argc, char** argv) {
  if (argc < 4) {
    std::cerr << "Usage: " << argv[0] << " <bucket> <key> <file-path>" << std::endl;
    return 1;
  }
  const Aws::String bucket = argv[1];
  const Aws::String key = argv[2];
  const Aws::String filePath = argv[3];

  SDKOptions options{};
  options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
  sdk_guard guard(std::move(options));

  const unsigned threads = std::max(1u, std::thread::hardware_concurrency());
  auto executor = Aws::MakeShared<Aws::Utils::Threading::PooledThreadExecutor>("executor", threads);
  auto s3Client = Aws::MakeShared<S3Client>("s3Client");

  TransferManagerConfiguration transferConfig(executor.get());
  transferConfig.s3Client = s3Client;
  transferConfig.bufferSize = 16 * 1024 * 1024;
  transferConfig.transferBufferMaxHeapSize = threads * transferConfig.bufferSize;
  transferConfig.checksumAlgorithm = Model::ChecksumAlgorithm::CRC32;

  auto transferManager = TransferManager::Create(transferConfig);

  auto handle = transferManager->UploadFile(filePath, bucket, key, "application/octet-stream", {});
  handle->WaitUntilFinished();

  if (handle->GetStatus() != TransferStatus::COMPLETED) {
    std::cerr << "Upload failed: " << handle->GetLastError().GetMessage() << std::endl;
    return 1;
  }

  std::cout << "Uploaded " << filePath << " to s3://" << bucket << "/" << key << std::endl;
  return 0;
}
```

This is because we would attempt to multipart upload with a full body checksum on checksums that do not support full body.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Ran a manual test:

```c++
#include <aws/core/Aws.h>
#include <aws/core/utils/threading/Executor.h>
#include <aws/s3/S3Client.h>
#include <aws/s3/model/GetObjectRequest.h>
#include <aws/transfer/TransferManager.h>

#include <iostream>
#include <thread>

using namespace Aws;
using namespace Aws::S3;
using namespace Aws::Transfer;

namespace {
class sdk_guard {
 public:
  sdk_guard(SDKOptions&& options) : options_(std::move(options)) { Aws::InitAPI(options_); }
  ~sdk_guard() { Aws::ShutdownAPI(options_); }

 private:
  SDKOptions options_;
};
}  // namespace

int main(int argc, char** argv) {
  if (argc < 4) {
    std::cerr << "Usage: " << argv[0] << " <bucket> <key> <file-path>" << std::endl;
    return 1;
  }
  const Aws::String bucket = argv[1];
  const Aws::String key = argv[2];
  const Aws::String filePath = argv[3];

  SDKOptions options{};
  options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
  sdk_guard guard(std::move(options));

  const unsigned threads = std::max(1u, std::thread::hardware_concurrency());
  auto executor = Aws::MakeShared<Aws::Utils::Threading::PooledThreadExecutor>("executor", threads);
  auto s3Client = Aws::MakeShared<S3Client>("s3Client");

  const std::pair<Model::ChecksumAlgorithm, const char*> algos[] = {
      {Model::ChecksumAlgorithm::CRC64NVME, "CRC64"},
      {Model::ChecksumAlgorithm::CRC32, "CRC32"},
      {Model::ChecksumAlgorithm::CRC32C, "CRC32C"},
      {Model::ChecksumAlgorithm::SHA256, "SHA256"},
  };

  for (const auto& [algo, name] : algos) {
    std::cout << "=== Algorithm: " << name << " ===" << std::endl;

    TransferManagerConfiguration transferConfig(executor.get());
    transferConfig.s3Client = s3Client;
    transferConfig.bufferSize = 16 * 1024 * 1024;
    transferConfig.transferBufferMaxHeapSize = threads * transferConfig.bufferSize;
    transferConfig.checksumAlgorithm = algo;

    auto transferManager = TransferManager::Create(transferConfig);

    const Aws::String iterKey = key + "." + name;

    auto handle = transferManager->UploadFile(filePath, bucket, iterKey, "application/octet-stream", {});
    handle->WaitUntilFinished();

    if (handle->GetStatus() != TransferStatus::COMPLETED) {
      std::cerr << "[" << name << "] Upload failed: " << handle->GetLastError().GetMessage() << std::endl;
      return 1;
    }
    std::cout << "[" << name << "] Uploaded to s3://" << bucket << "/" << iterKey << std::endl;

    Model::GetObjectRequest getRequest;
    getRequest.SetBucket(bucket);
    getRequest.SetKey(iterKey);
    auto getResult = s3Client->GetObject(getRequest);
    if (!getResult.IsSuccess()) {
      std::cerr << "[" << name << "] GetObject failed: " << getResult.GetError().GetMessage() << std::endl;
      return 1;
    }
    std::cout << "[" << name << "] GetObject OK — content-length="
              << getResult.GetResult().GetContentLength()
              << " etag=" << getResult.GetResult().GetETag() << std::endl;

    const Aws::String downloadPath = filePath + "." + name + ".downloaded";
    auto downloadHandle = transferManager->DownloadFile(bucket, iterKey, downloadPath);
    downloadHandle->WaitUntilFinished();

    if (downloadHandle->GetStatus() != TransferStatus::COMPLETED) {
      std::cerr << "[" << name << "] Download failed: " << downloadHandle->GetLastError().GetMessage() << std::endl;
      return 1;
    }
    std::cout << "[" << name << "] Download OK — " << downloadHandle->GetBytesTransferred()
              << " bytes -> " << downloadPath << std::endl;
  }

  return 0;
}
```

to verify that the checksums were working as expected. to be pulled into a integration tests later due to urgency of fix.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
