### PR TITLE
[Feature] Honor requestTimeoutMs for event stream writes via wait_until deadline

### DIFF
--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
@@ -261,7 +261,8 @@ void TranscribeStreamingServiceClient::StartCallAnalyticsStreamTranscriptionAsyn
 
 #if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024,
+                                                                                        m_clientConfiguration.requestTimeoutMs);
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG, writeDataStreamBuf);
@@ -361,7 +362,8 @@ void TranscribeStreamingServiceClient::StartMedicalScribeStreamAsync(
 
 #if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024,
+                                                                                        m_clientConfiguration.requestTimeoutMs);
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::MedicalScribeInputStream>(ALLOCATION_TAG, writeDataStreamBuf);
@@ -477,7 +479,8 @@ void TranscribeStreamingServiceClient::StartMedicalStreamTranscriptionAsync(
 
 #if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024,
+                                                                                        m_clientConfiguration.requestTimeoutMs);
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG, writeDataStreamBuf);
@@ -569,7 +572,8 @@ void TranscribeStreamingServiceClient::StartStreamTranscriptionAsync(
 
 #if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024,
+                                                                                        m_clientConfiguration.requestTimeoutMs);
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG, writeDataStreamBuf);

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/stream/HttpWriteDataStreamBuf.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/stream/HttpWriteDataStreamBuf.h
@@ -10,6 +10,7 @@
 #include <aws/core/utils/Array.h>
 #include <aws/crt/Types.h>
 
+#include <chrono>
 #include <condition_variable>
 #include <memory>
 #include <mutex>
@@ -35,7 +36,7 @@ namespace Stream {
  */
 class AWS_CORE_API HttpWriteDataStreamBuf : public std::streambuf {
  public:
-  explicit HttpWriteDataStreamBuf(const std::shared_ptr<Aws::Http::HttpClient>& client, size_t bufferLength = 8 * 1024);
+  explicit HttpWriteDataStreamBuf(const std::shared_ptr<Aws::Http::HttpClient>& client, size_t bufferLength = 8 * 1024, size_t requestTimeoutMs = 0);
   HttpWriteDataStreamBuf(const HttpWriteDataStreamBuf& other) = delete;
   HttpWriteDataStreamBuf(HttpWriteDataStreamBuf&& other) noexcept = delete;
   HttpWriteDataStreamBuf& operator=(const HttpWriteDataStreamBuf& other) = delete;
@@ -102,6 +103,8 @@ class AWS_CORE_API HttpWriteDataStreamBuf : public std::streambuf {
   std::condition_variable m_writeComplete;
   bool m_writeInProgress{false};
   bool m_writeError{false};
+  bool m_hasDeadline{false};
+  std::chrono::steady_clock::time_point m_deadline;
 
   // State management
   enum class STATE {

--- a/src/aws-cpp-sdk-core/source/utils/stream/HttpWriteDataStreamBuf.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/stream/HttpWriteDataStreamBuf.cpp
@@ -5,6 +5,7 @@
 #include <aws/core/http/HttpClient.h>
 #include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
 
+#include <chrono>
 #include <utility>
 
 namespace {
@@ -12,8 +13,13 @@ const char* WRITE_DATA_BUF_LOG_NAME = "HttpWriteDataStreamBuf";
 }
 
 Aws::Utils::Stream::HttpWriteDataStreamBuf::HttpWriteDataStreamBuf(const std::shared_ptr<Aws::Http::HttpClient>& client,
-                                                                   size_t bufferLength)
+                                                                   size_t bufferLength,
+                                                                   size_t requestTimeoutMs)
     : m_client{client}, m_buffer{bufferLength} {
+  if (requestTimeoutMs > 0) {
+    m_hasDeadline = true;
+    m_deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(requestTimeoutMs);
+  }
   ResetPutArea();
 }
 
@@ -163,7 +169,18 @@ bool Aws::Utils::Stream::HttpWriteDataStreamBuf::SendBuffer(bool endStream) {
       endStream);
 
   std::unique_lock<std::mutex> lock{m_writeMutex};
-  m_writeComplete.wait(lock, [this]() -> bool { return !m_writeInProgress; });
+  if (m_hasDeadline) {
+    bool completed = m_writeComplete.wait_until(lock, m_deadline,
+        [this]() -> bool { return !m_writeInProgress; });
+    if (!completed) {
+      m_writeError = true;
+      m_writeInProgress = false;
+      ResetPutArea();
+      return false;
+    }
+  } else {
+    m_writeComplete.wait(lock, [this]() -> bool { return !m_writeInProgress; });
+  }
 
   ResetPutArea();
 

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceEventStreamOperationsSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceEventStreamOperationsSource.vm
@@ -27,7 +27,7 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
 #set($streamModelNameWithFirstLetterCapitalized = $CppViewHelper.capitalizeFirstChar($streamModelName))
 \#if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024, m_clientConfiguration.requestTimeoutMs);
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::${streamModelType}>(ALLOCATION_TAG, writeDataStreamBuf);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyJsonServiceEventStreamOperationsSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyJsonServiceEventStreamOperationsSource.vm
@@ -29,7 +29,7 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
 #set($streamModelNameWithFirstLetterCapitalized = $CppViewHelper.capitalizeFirstChar($streamModelName))
 \#if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, m_httpClient);
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, m_httpClient, 8 * 1024, m_clientConfig->requestTimeoutMs);
   auto eventEncoderStream = Aws::MakeShared<Model::${streamModelType}>(ALLOCATION_TAG, writeDataStreamBuf);
   request.Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change adds a request-level deadline to HttpWriteDataStreamBuf.
  When requestTimeoutMs > 0, a deadline is computed at construction
  (now + requestTimeoutMs) and each SendBuffer call uses wait_until
  instead of wait. If the deadline passes, the write fails immediately.

  When requestTimeoutMs = 0 (default), behavior is unchanged.


*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
