### PR TITLE
S3CrtClient unclamp partsize

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -378,7 +378,7 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config,
   s3CrtConfig.signing_config = &m_s3CrtSigningConfig;
 
   static const size_t DEFAULT_PART_SIZE = 8 * 1024 * 1024;  // 8MB
-  s3CrtConfig.part_size = config.partSize < DEFAULT_PART_SIZE ? DEFAULT_PART_SIZE : config.partSize;
+  s3CrtConfig.part_size = config.partSize ? config.partSize : DEFAULT_PART_SIZE;
   s3CrtConfig.multipart_upload_threshold = config.multipartUploadThreshold;
 
   Aws::Crt::Io::TlsConnectionOptions* rawPTlsConnectionOptions = nullptr;

--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -377,8 +377,7 @@ void S3CrtClient::init(const S3Crt::ClientConfiguration& config,
   m_s3CrtSigningConfig.flags.use_double_uri_encode = false;
   s3CrtConfig.signing_config = &m_s3CrtSigningConfig;
 
-  static const size_t DEFAULT_PART_SIZE = 8 * 1024 * 1024;  // 8MB
-  s3CrtConfig.part_size = config.partSize ? config.partSize : DEFAULT_PART_SIZE;
+  s3CrtConfig.part_size = config.partSize;
   s3CrtConfig.multipart_upload_threshold = config.multipartUploadThreshold;
 
   Aws::Crt::Io::TlsConnectionOptions* rawPTlsConnectionOptions = nullptr;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -421,8 +421,7 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
   m_s3CrtSigningConfig.flags.use_double_uri_encode = false;
   s3CrtConfig.signing_config = &m_s3CrtSigningConfig;
 
-  static const size_t DEFAULT_PART_SIZE = 8 * 1024 * 1024; // 8MB
-  s3CrtConfig.part_size = config.partSize ? config.partSize : DEFAULT_PART_SIZE;
+  s3CrtConfig.part_size = config.partSize;
   s3CrtConfig.multipart_upload_threshold = config.multipartUploadThreshold;
 
   Aws::Crt::Io::TlsConnectionOptions *rawPTlsConnectionOptions = nullptr;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtServiceClientSourceInit.vm
@@ -422,7 +422,7 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
   s3CrtConfig.signing_config = &m_s3CrtSigningConfig;
 
   static const size_t DEFAULT_PART_SIZE = 8 * 1024 * 1024; // 8MB
-  s3CrtConfig.part_size = config.partSize < DEFAULT_PART_SIZE ? DEFAULT_PART_SIZE : config.partSize;
+  s3CrtConfig.part_size = config.partSize ? config.partSize : DEFAULT_PART_SIZE;
   s3CrtConfig.multipart_upload_threshold = config.multipartUploadThreshold;
 
   Aws::Crt::Io::TlsConnectionOptions *rawPTlsConnectionOptions = nullptr;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/SmithyS3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/SmithyS3CrtServiceClientSourceInit.vm
@@ -364,7 +364,7 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
   s3CrtConfig.signing_config = &m_s3CrtSigningConfig;
 
   static const size_t DEFAULT_PART_SIZE = 8 * 1024 * 1024; // 8MB
-  s3CrtConfig.part_size = config.partSize < DEFAULT_PART_SIZE ? DEFAULT_PART_SIZE : config.partSize;
+  s3CrtConfig.part_size = config.partSize ? config.partSize : DEFAULT_PART_SIZE;
   s3CrtConfig.multipart_upload_threshold = config.multipartUploadThreshold;
 
   Aws::Crt::Io::TlsConnectionOptions *rawPTlsConnectionOptions = nullptr;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/SmithyS3CrtServiceClientSourceInit.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/SmithyS3CrtServiceClientSourceInit.vm
@@ -363,8 +363,7 @@ void ${className}::init(const ${clientConfigurationNamespace}::ClientConfigurati
   m_s3CrtSigningConfig.flags.use_double_uri_encode = false;
   s3CrtConfig.signing_config = &m_s3CrtSigningConfig;
 
-  static const size_t DEFAULT_PART_SIZE = 8 * 1024 * 1024; // 8MB
-  s3CrtConfig.part_size = config.partSize ? config.partSize : DEFAULT_PART_SIZE;
+  s3CrtConfig.part_size = config.partSize;
   s3CrtConfig.multipart_upload_threshold = config.multipartUploadThreshold;
 
   Aws::Crt::Io::TlsConnectionOptions *rawPTlsConnectionOptions = nullptr;


### PR DESCRIPTION
*Issue #, if available:*
#3839

*Description of changes:*
Unclamp partsize for S3CrtClient (allow less than 8mib)

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
