### PR TITLE
Fix when required

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/CreateBucketMetadataConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/CreateBucketMetadataConfigurationRequest.h
@@ -39,6 +39,7 @@ class CreateBucketMetadataConfigurationRequest : public S3CrtRequest {
   AWS_S3CRT_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/CreateBucketMetadataTableConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/CreateBucketMetadataTableConfigurationRequest.h
@@ -39,6 +39,7 @@ class CreateBucketMetadataTableConfigurationRequest : public S3CrtRequest {
   AWS_S3CRT_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/DeleteObjectsRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/DeleteObjectsRequest.h
@@ -41,6 +41,7 @@ class DeleteObjectsRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketAbacRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketAbacRequest.h
@@ -39,6 +39,7 @@ class PutBucketAbacRequest : public S3CrtRequest {
   AWS_S3CRT_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   /**
    * Helper function to collect parameters (configurable and static hardcoded) required for endpoint computation.
    */

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketAccelerateConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketAccelerateConfigurationRequest.h
@@ -40,6 +40,7 @@ class PutBucketAccelerateConfigurationRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   /**
    * Helper function to collect parameters (configurable and static hardcoded) required for endpoint computation.
    */

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketAclRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketAclRequest.h
@@ -41,6 +41,7 @@ class PutBucketAclRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketCorsRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketCorsRequest.h
@@ -40,6 +40,7 @@ class PutBucketCorsRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketEncryptionRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketEncryptionRequest.h
@@ -40,6 +40,7 @@ class PutBucketEncryptionRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketLifecycleConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketLifecycleConfigurationRequest.h
@@ -41,6 +41,7 @@ class PutBucketLifecycleConfigurationRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketLoggingRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketLoggingRequest.h
@@ -40,6 +40,7 @@ class PutBucketLoggingRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketOwnershipControlsRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketOwnershipControlsRequest.h
@@ -40,6 +40,7 @@ class PutBucketOwnershipControlsRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketPolicyRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketPolicyRequest.h
@@ -37,6 +37,7 @@ class PutBucketPolicyRequest : public StreamingS3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   AWS_S3CRT_API bool IsStreaming() const override { return false; }

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketReplicationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketReplicationRequest.h
@@ -40,6 +40,7 @@ class PutBucketReplicationRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketRequestPaymentRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketRequestPaymentRequest.h
@@ -40,6 +40,7 @@ class PutBucketRequestPaymentRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketTaggingRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketTaggingRequest.h
@@ -40,6 +40,7 @@ class PutBucketTaggingRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketVersioningRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketVersioningRequest.h
@@ -40,6 +40,7 @@ class PutBucketVersioningRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketWebsiteRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutBucketWebsiteRequest.h
@@ -40,6 +40,7 @@ class PutBucketWebsiteRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutObjectAclRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutObjectAclRequest.h
@@ -42,6 +42,7 @@ class PutObjectAclRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutObjectAnnotationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutObjectAnnotationRequest.h
@@ -38,6 +38,7 @@ class PutObjectAnnotationRequest : public StreamingS3CrtRequest {
   AWS_S3CRT_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   AWS_S3CRT_API bool IsStreaming() const override { return false; }
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutObjectLegalHoldRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutObjectLegalHoldRequest.h
@@ -41,6 +41,7 @@ class PutObjectLegalHoldRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutObjectLockConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutObjectLockConfigurationRequest.h
@@ -41,6 +41,7 @@ class PutObjectLockConfigurationRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutObjectRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutObjectRequest.h
@@ -45,6 +45,7 @@ class PutObjectRequest : public StreamingS3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   /**
    * Helper function to collect parameters (configurable and static hardcoded) required for endpoint computation.
    */

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutObjectRetentionRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutObjectRetentionRequest.h
@@ -41,6 +41,7 @@ class PutObjectRetentionRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutObjectTaggingRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutObjectTaggingRequest.h
@@ -41,6 +41,7 @@ class PutObjectTaggingRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutPublicAccessBlockRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/PutPublicAccessBlockRequest.h
@@ -40,6 +40,7 @@ class PutPublicAccessBlockRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/RestoreObjectRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/RestoreObjectRequest.h
@@ -41,6 +41,7 @@ class RestoreObjectRequest : public S3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   /**
    * Helper function to collect parameters (configurable and static hardcoded) required for endpoint computation.
    */

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/UpdateBucketMetadataAnnotationTableConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/UpdateBucketMetadataAnnotationTableConfigurationRequest.h
@@ -39,6 +39,7 @@ class UpdateBucketMetadataAnnotationTableConfigurationRequest : public S3CrtRequ
   AWS_S3CRT_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/UpdateBucketMetadataInventoryTableConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/UpdateBucketMetadataInventoryTableConfigurationRequest.h
@@ -39,6 +39,7 @@ class UpdateBucketMetadataInventoryTableConfigurationRequest : public S3CrtReque
   AWS_S3CRT_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/UpdateBucketMetadataJournalTableConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/UpdateBucketMetadataJournalTableConfigurationRequest.h
@@ -39,6 +39,7 @@ class UpdateBucketMetadataJournalTableConfigurationRequest : public S3CrtRequest
   AWS_S3CRT_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/UpdateObjectEncryptionRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/UpdateObjectEncryptionRequest.h
@@ -40,6 +40,7 @@ class UpdateObjectEncryptionRequest : public S3CrtRequest {
   AWS_S3CRT_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/UploadPartRequest.h
+++ b/generated/src/aws-cpp-sdk-s3-crt/include/aws/s3-crt/model/UploadPartRequest.h
@@ -39,6 +39,7 @@ class UploadPartRequest : public StreamingS3CrtRequest {
 
   AWS_S3CRT_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3CRT_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3CRT_API bool ChecksumAlgorithmIsSet() const override;
   /**
    * Helper function to collect parameters (configurable and static hardcoded) required for endpoint computation.
    */

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateBucketMetadataConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateBucketMetadataConfigurationRequest.cpp
@@ -88,3 +88,5 @@ Aws::String CreateBucketMetadataConfigurationRequest::GetChecksumAlgorithmName()
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool CreateBucketMetadataConfigurationRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateBucketMetadataTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateBucketMetadataTableConfigurationRequest.cpp
@@ -89,3 +89,7 @@ Aws::String CreateBucketMetadataTableConfigurationRequest::GetChecksumAlgorithmN
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool CreateBucketMetadataTableConfigurationRequest::ChecksumAlgorithmIsSet() const {
+  return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET;
+}

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/DeleteObjectsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/DeleteObjectsRequest.cpp
@@ -112,3 +112,5 @@ Aws::String DeleteObjectsRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool DeleteObjectsRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAbacRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAbacRequest.cpp
@@ -85,3 +85,5 @@ Aws::String PutBucketAbacRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketAbacRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAccelerateConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAccelerateConfigurationRequest.cpp
@@ -99,3 +99,5 @@ Aws::String PutBucketAccelerateConfigurationRequest::GetChecksumAlgorithmName() 
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketAccelerateConfigurationRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAclRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAclRequest.cpp
@@ -139,3 +139,5 @@ Aws::String PutBucketAclRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketAclRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketCorsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketCorsRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutBucketCorsRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketCorsRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketEncryptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketEncryptionRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutBucketEncryptionRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketEncryptionRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketLifecycleConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketLifecycleConfigurationRequest.cpp
@@ -106,3 +106,5 @@ Aws::String PutBucketLifecycleConfigurationRequest::GetChecksumAlgorithmName() c
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketLifecycleConfigurationRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketLoggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketLoggingRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutBucketLoggingRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketLoggingRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketOwnershipControlsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketOwnershipControlsRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutBucketOwnershipControlsRequest::GetChecksumAlgorithmName() const 
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketOwnershipControlsRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketPolicyRequest.cpp
@@ -99,3 +99,5 @@ Aws::String PutBucketPolicyRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketPolicyRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketReplicationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketReplicationRequest.cpp
@@ -111,3 +111,5 @@ Aws::String PutBucketReplicationRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketReplicationRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketRequestPaymentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketRequestPaymentRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutBucketRequestPaymentRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketRequestPaymentRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketTaggingRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutBucketTaggingRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketTaggingRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketVersioningRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketVersioningRequest.cpp
@@ -111,3 +111,5 @@ Aws::String PutBucketVersioningRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketVersioningRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketWebsiteRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketWebsiteRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutBucketWebsiteRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketWebsiteRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectAclRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectAclRequest.cpp
@@ -149,3 +149,5 @@ Aws::String PutObjectAclRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutObjectAclRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectAnnotationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectAnnotationRequest.cpp
@@ -157,3 +157,5 @@ Aws::String PutObjectAnnotationRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutObjectAnnotationRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectLegalHoldRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectLegalHoldRequest.cpp
@@ -112,3 +112,5 @@ Aws::String PutObjectLegalHoldRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutObjectLegalHoldRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectLockConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectLockConfigurationRequest.cpp
@@ -112,3 +112,5 @@ Aws::String PutObjectLockConfigurationRequest::GetChecksumAlgorithmName() const 
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutObjectLockConfigurationRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectRequest.cpp
@@ -315,3 +315,5 @@ Aws::String PutObjectRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutObjectRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectRetentionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectRetentionRequest.cpp
@@ -118,3 +118,5 @@ Aws::String PutObjectRetentionRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutObjectRetentionRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectTaggingRequest.cpp
@@ -112,3 +112,5 @@ Aws::String PutObjectTaggingRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutObjectTaggingRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutPublicAccessBlockRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutPublicAccessBlockRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutPublicAccessBlockRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutPublicAccessBlockRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/RestoreObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/RestoreObjectRequest.cpp
@@ -106,3 +106,5 @@ Aws::String RestoreObjectRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool RestoreObjectRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateBucketMetadataAnnotationTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateBucketMetadataAnnotationTableConfigurationRequest.cpp
@@ -89,3 +89,7 @@ Aws::String UpdateBucketMetadataAnnotationTableConfigurationRequest::GetChecksum
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool UpdateBucketMetadataAnnotationTableConfigurationRequest::ChecksumAlgorithmIsSet() const {
+  return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET;
+}

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateBucketMetadataInventoryTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateBucketMetadataInventoryTableConfigurationRequest.cpp
@@ -89,3 +89,7 @@ Aws::String UpdateBucketMetadataInventoryTableConfigurationRequest::GetChecksumA
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool UpdateBucketMetadataInventoryTableConfigurationRequest::ChecksumAlgorithmIsSet() const {
+  return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET;
+}

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateBucketMetadataJournalTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateBucketMetadataJournalTableConfigurationRequest.cpp
@@ -89,3 +89,7 @@ Aws::String UpdateBucketMetadataJournalTableConfigurationRequest::GetChecksumAlg
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool UpdateBucketMetadataJournalTableConfigurationRequest::ChecksumAlgorithmIsSet() const {
+  return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET;
+}

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateObjectEncryptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateObjectEncryptionRequest.cpp
@@ -95,3 +95,5 @@ Aws::String UpdateObjectEncryptionRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool UpdateObjectEncryptionRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/UploadPartRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/UploadPartRequest.cpp
@@ -194,3 +194,5 @@ Aws::String UploadPartRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool UploadPartRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/CreateBucketMetadataConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/CreateBucketMetadataConfigurationRequest.h
@@ -39,6 +39,7 @@ class CreateBucketMetadataConfigurationRequest : public S3Request {
   AWS_S3_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/CreateBucketMetadataTableConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/CreateBucketMetadataTableConfigurationRequest.h
@@ -39,6 +39,7 @@ class CreateBucketMetadataTableConfigurationRequest : public S3Request {
   AWS_S3_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/DeleteObjectsRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/DeleteObjectsRequest.h
@@ -41,6 +41,7 @@ class DeleteObjectsRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketAbacRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketAbacRequest.h
@@ -39,6 +39,7 @@ class PutBucketAbacRequest : public S3Request {
   AWS_S3_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   /**
    * Helper function to collect parameters (configurable and static hardcoded) required for endpoint computation.
    */

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketAccelerateConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketAccelerateConfigurationRequest.h
@@ -40,6 +40,7 @@ class PutBucketAccelerateConfigurationRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   /**
    * Helper function to collect parameters (configurable and static hardcoded) required for endpoint computation.
    */

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketAclRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketAclRequest.h
@@ -41,6 +41,7 @@ class PutBucketAclRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketCorsRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketCorsRequest.h
@@ -40,6 +40,7 @@ class PutBucketCorsRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketEncryptionRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketEncryptionRequest.h
@@ -40,6 +40,7 @@ class PutBucketEncryptionRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketLifecycleConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketLifecycleConfigurationRequest.h
@@ -41,6 +41,7 @@ class PutBucketLifecycleConfigurationRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketLoggingRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketLoggingRequest.h
@@ -40,6 +40,7 @@ class PutBucketLoggingRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketOwnershipControlsRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketOwnershipControlsRequest.h
@@ -40,6 +40,7 @@ class PutBucketOwnershipControlsRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketPolicyRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketPolicyRequest.h
@@ -37,6 +37,7 @@ class PutBucketPolicyRequest : public StreamingS3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   AWS_S3_API bool IsStreaming() const override { return false; }

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketReplicationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketReplicationRequest.h
@@ -40,6 +40,7 @@ class PutBucketReplicationRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketRequestPaymentRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketRequestPaymentRequest.h
@@ -40,6 +40,7 @@ class PutBucketRequestPaymentRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketTaggingRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketTaggingRequest.h
@@ -40,6 +40,7 @@ class PutBucketTaggingRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketVersioningRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketVersioningRequest.h
@@ -40,6 +40,7 @@ class PutBucketVersioningRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketWebsiteRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutBucketWebsiteRequest.h
@@ -40,6 +40,7 @@ class PutBucketWebsiteRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutObjectAclRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutObjectAclRequest.h
@@ -42,6 +42,7 @@ class PutObjectAclRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutObjectAnnotationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutObjectAnnotationRequest.h
@@ -38,6 +38,7 @@ class PutObjectAnnotationRequest : public StreamingS3Request {
   AWS_S3_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   AWS_S3_API bool IsStreaming() const override { return false; }
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutObjectLegalHoldRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutObjectLegalHoldRequest.h
@@ -41,6 +41,7 @@ class PutObjectLegalHoldRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutObjectLockConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutObjectLockConfigurationRequest.h
@@ -41,6 +41,7 @@ class PutObjectLockConfigurationRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutObjectRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutObjectRequest.h
@@ -45,6 +45,7 @@ class PutObjectRequest : public StreamingS3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   /**
    * Helper function to collect parameters (configurable and static hardcoded) required for endpoint computation.
    */

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutObjectRetentionRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutObjectRetentionRequest.h
@@ -41,6 +41,7 @@ class PutObjectRetentionRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutObjectTaggingRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutObjectTaggingRequest.h
@@ -41,6 +41,7 @@ class PutObjectTaggingRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutPublicAccessBlockRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/PutPublicAccessBlockRequest.h
@@ -40,6 +40,7 @@ class PutPublicAccessBlockRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/RestoreObjectRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/RestoreObjectRequest.h
@@ -41,6 +41,7 @@ class RestoreObjectRequest : public S3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   /**
    * Helper function to collect parameters (configurable and static hardcoded) required for endpoint computation.
    */

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/UpdateBucketMetadataAnnotationTableConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/UpdateBucketMetadataAnnotationTableConfigurationRequest.h
@@ -39,6 +39,7 @@ class UpdateBucketMetadataAnnotationTableConfigurationRequest : public S3Request
   AWS_S3_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/UpdateBucketMetadataInventoryTableConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/UpdateBucketMetadataInventoryTableConfigurationRequest.h
@@ -39,6 +39,7 @@ class UpdateBucketMetadataInventoryTableConfigurationRequest : public S3Request 
   AWS_S3_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/UpdateBucketMetadataJournalTableConfigurationRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/UpdateBucketMetadataJournalTableConfigurationRequest.h
@@ -39,6 +39,7 @@ class UpdateBucketMetadataJournalTableConfigurationRequest : public S3Request {
   AWS_S3_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/UpdateObjectEncryptionRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/UpdateObjectEncryptionRequest.h
@@ -40,6 +40,7 @@ class UpdateObjectEncryptionRequest : public S3Request {
   AWS_S3_API Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   inline bool RequestChecksumRequired() const override { return true; };
 
   /**

--- a/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/UploadPartRequest.h
+++ b/generated/src/aws-cpp-sdk-s3/include/aws/s3/model/UploadPartRequest.h
@@ -39,6 +39,7 @@ class UploadPartRequest : public StreamingS3Request {
 
   AWS_S3_API bool HasEmbeddedError(IOStream& body, const Http::HeaderValueCollection& header) const override;
   AWS_S3_API Aws::String GetChecksumAlgorithmName() const override;
+  AWS_S3_API bool ChecksumAlgorithmIsSet() const override;
   /**
    * Helper function to collect parameters (configurable and static hardcoded) required for endpoint computation.
    */

--- a/generated/src/aws-cpp-sdk-s3/source/model/CreateBucketMetadataConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/CreateBucketMetadataConfigurationRequest.cpp
@@ -88,3 +88,5 @@ Aws::String CreateBucketMetadataConfigurationRequest::GetChecksumAlgorithmName()
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool CreateBucketMetadataConfigurationRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/CreateBucketMetadataTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/CreateBucketMetadataTableConfigurationRequest.cpp
@@ -89,3 +89,7 @@ Aws::String CreateBucketMetadataTableConfigurationRequest::GetChecksumAlgorithmN
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool CreateBucketMetadataTableConfigurationRequest::ChecksumAlgorithmIsSet() const {
+  return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET;
+}

--- a/generated/src/aws-cpp-sdk-s3/source/model/DeleteObjectsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/DeleteObjectsRequest.cpp
@@ -112,3 +112,5 @@ Aws::String DeleteObjectsRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool DeleteObjectsRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAbacRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAbacRequest.cpp
@@ -85,3 +85,5 @@ Aws::String PutBucketAbacRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketAbacRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAccelerateConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAccelerateConfigurationRequest.cpp
@@ -99,3 +99,5 @@ Aws::String PutBucketAccelerateConfigurationRequest::GetChecksumAlgorithmName() 
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketAccelerateConfigurationRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAclRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAclRequest.cpp
@@ -139,3 +139,5 @@ Aws::String PutBucketAclRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketAclRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketCorsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketCorsRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutBucketCorsRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketCorsRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketEncryptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketEncryptionRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutBucketEncryptionRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketEncryptionRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketLifecycleConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketLifecycleConfigurationRequest.cpp
@@ -106,3 +106,5 @@ Aws::String PutBucketLifecycleConfigurationRequest::GetChecksumAlgorithmName() c
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketLifecycleConfigurationRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketLoggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketLoggingRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutBucketLoggingRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketLoggingRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketOwnershipControlsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketOwnershipControlsRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutBucketOwnershipControlsRequest::GetChecksumAlgorithmName() const 
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketOwnershipControlsRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketPolicyRequest.cpp
@@ -99,3 +99,5 @@ Aws::String PutBucketPolicyRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketPolicyRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketReplicationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketReplicationRequest.cpp
@@ -111,3 +111,5 @@ Aws::String PutBucketReplicationRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketReplicationRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketRequestPaymentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketRequestPaymentRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutBucketRequestPaymentRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketRequestPaymentRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketTaggingRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutBucketTaggingRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketTaggingRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketVersioningRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketVersioningRequest.cpp
@@ -111,3 +111,5 @@ Aws::String PutBucketVersioningRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketVersioningRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketWebsiteRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketWebsiteRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutBucketWebsiteRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutBucketWebsiteRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectAclRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectAclRequest.cpp
@@ -149,3 +149,5 @@ Aws::String PutObjectAclRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutObjectAclRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectAnnotationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectAnnotationRequest.cpp
@@ -157,3 +157,5 @@ Aws::String PutObjectAnnotationRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutObjectAnnotationRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectLegalHoldRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectLegalHoldRequest.cpp
@@ -112,3 +112,5 @@ Aws::String PutObjectLegalHoldRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutObjectLegalHoldRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectLockConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectLockConfigurationRequest.cpp
@@ -112,3 +112,5 @@ Aws::String PutObjectLockConfigurationRequest::GetChecksumAlgorithmName() const 
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutObjectLockConfigurationRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectRequest.cpp
@@ -315,3 +315,5 @@ Aws::String PutObjectRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutObjectRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectRetentionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectRetentionRequest.cpp
@@ -118,3 +118,5 @@ Aws::String PutObjectRetentionRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutObjectRetentionRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectTaggingRequest.cpp
@@ -112,3 +112,5 @@ Aws::String PutObjectTaggingRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutObjectTaggingRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutPublicAccessBlockRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutPublicAccessBlockRequest.cpp
@@ -105,3 +105,5 @@ Aws::String PutPublicAccessBlockRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool PutPublicAccessBlockRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/RestoreObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/RestoreObjectRequest.cpp
@@ -106,3 +106,5 @@ Aws::String RestoreObjectRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool RestoreObjectRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/UpdateBucketMetadataAnnotationTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/UpdateBucketMetadataAnnotationTableConfigurationRequest.cpp
@@ -89,3 +89,7 @@ Aws::String UpdateBucketMetadataAnnotationTableConfigurationRequest::GetChecksum
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool UpdateBucketMetadataAnnotationTableConfigurationRequest::ChecksumAlgorithmIsSet() const {
+  return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET;
+}

--- a/generated/src/aws-cpp-sdk-s3/source/model/UpdateBucketMetadataInventoryTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/UpdateBucketMetadataInventoryTableConfigurationRequest.cpp
@@ -89,3 +89,7 @@ Aws::String UpdateBucketMetadataInventoryTableConfigurationRequest::GetChecksumA
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool UpdateBucketMetadataInventoryTableConfigurationRequest::ChecksumAlgorithmIsSet() const {
+  return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET;
+}

--- a/generated/src/aws-cpp-sdk-s3/source/model/UpdateBucketMetadataJournalTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/UpdateBucketMetadataJournalTableConfigurationRequest.cpp
@@ -89,3 +89,7 @@ Aws::String UpdateBucketMetadataJournalTableConfigurationRequest::GetChecksumAlg
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool UpdateBucketMetadataJournalTableConfigurationRequest::ChecksumAlgorithmIsSet() const {
+  return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET;
+}

--- a/generated/src/aws-cpp-sdk-s3/source/model/UpdateObjectEncryptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/UpdateObjectEncryptionRequest.cpp
@@ -95,3 +95,5 @@ Aws::String UpdateObjectEncryptionRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool UpdateObjectEncryptionRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/generated/src/aws-cpp-sdk-s3/source/model/UploadPartRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/UploadPartRequest.cpp
@@ -194,3 +194,5 @@ Aws::String UploadPartRequest::GetChecksumAlgorithmName() const {
     return ChecksumAlgorithmMapper::GetNameForChecksumAlgorithm(m_checksumAlgorithm);
   }
 }
+
+bool UploadPartRequest::ChecksumAlgorithmIsSet() const { return m_checksumAlgorithm != ChecksumAlgorithm::NOT_SET; }

--- a/src/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceRequest.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceRequest.h
@@ -240,6 +240,14 @@ namespace Aws
         void SetRetryContext(const RetryContext& context) const { m_retryContext = context; }
 
         virtual Aws::Vector<smithy::AuthSchemeOption> GetRequestSpecificSupportedAuth() const { return {}; }
+
+        /**
+         * A request can return a checksum name, this tells if if it is a user set checksum
+         * or if it was defaulted
+         *
+         * @return true of a request has a user set checksum
+         */
+        inline virtual bool ChecksumAlgorithmIsSet() const { return false; }
     protected:
         /**
          * Default does nothing. Override this to convert what would otherwise be the payload of the

--- a/src/aws-cpp-sdk-core/include/smithy/client/features/ChecksumInterceptor.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/features/ChecksumInterceptor.h
@@ -76,6 +76,7 @@ class ChecksumInterceptor : public smithy::interceptor::Interceptor {
     // Add RequestChecksum
     addChecksumConfigurationFeatures(request);
     if ((!request.GetChecksumAlgorithmName().empty() && m_requestChecksumCalculation == RequestChecksumCalculation::WHEN_SUPPORTED) ||
+        (request.ChecksumAlgorithmIsSet() && m_requestChecksumCalculation == RequestChecksumCalculation::WHEN_REQUIRED) ||
         request.RequestChecksumRequired()) {
       Aws::String checksumAlgorithmName = Aws::Utils::StringUtils::ToLower(request.GetChecksumAlgorithmName().c_str());
       // Check if user has provided the checksum algorithm

--- a/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
+++ b/tests/aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp
@@ -93,6 +93,7 @@ namespace
     static std::string BASE_EVENT_STREAM_LARGE_FILE_TEST_BUCKET_NAME = "largeeventstream";
     static std::string BASE_EVENT_STREAM_ERRORS_IN_EVENT_TEST_BUCKET_NAME = "errorsinevent";
     static std::string BASE_CHECKSUMS_BUCKET_NAME = "checksums";
+    static std::string BASE_CHECKSUMS_WHEN_REQUIRED_BUCKET_NAME = "checksumswhenrequired";
     static std::string BASE_CONTENT_ENCODING_BUCKET_NAME = "contentencoding";
     static std::string BASE_CROSS_REGION_BUCKET_NAME = "crossregion";
     static std::string BASE_ENDPOINT_OVERRIDE_BUCKET_NAME = "endpointoverride";
@@ -1919,6 +1920,43 @@ namespace
 
         auto getObjectOutcome = Client->GetObject(getObjectRequest);
         AWS_ASSERT_SUCCESS(getObjectOutcome);
+    }
+
+    TEST_F(BucketAndObjectOperationTest, TestFlexibleChecksumsWhenRequiredWithExplicitAlgorithm)
+    {
+        const Aws::String fullBucketName = CalculateBucketName(BASE_CHECKSUMS_WHEN_REQUIRED_BUCKET_NAME.c_str());
+        SCOPED_TRACE(Aws::String("FullBucketName ") + fullBucketName);
+
+        CreateBucketRequest createBucketRequest;
+        createBucketRequest.SetBucket(fullBucketName);
+
+        CreateBucketOutcome createBucketOutcome = CreateBucket(createBucketRequest);
+        AWS_ASSERT_SUCCESS(createBucketOutcome);
+        WaitForBucketToPropagate(fullBucketName, Client);
+        TagTestBucket(fullBucketName, Client);
+
+        ClientConfiguration config;
+        config.region = Aws::Region::US_EAST_1;
+        config.checksumConfig.requestChecksumCalculation = RequestChecksumCalculation::WHEN_REQUIRED;
+        const S3Client whenRequiredClient{config};
+
+        std::shared_ptr<Aws::IOStream> objectStream = Aws::MakeShared<Aws::StringStream>(ALLOCATION_TAG);
+        *objectStream << "it's coming football's coming home";
+
+        PutObjectRequest putObjectRequest{};
+        putObjectRequest.SetBucket(fullBucketName);
+        putObjectRequest.SetKey(TEST_OBJ_KEY);
+        putObjectRequest.SetBody(objectStream);
+        putObjectRequest.SetChecksumAlgorithm(ChecksumAlgorithm::CRC32);
+        const auto putObjectOutcome = whenRequiredClient.PutObject(putObjectRequest);
+        AWS_ASSERT_SUCCESS(putObjectOutcome);
+
+        GetObjectRequest getObjectRequest{};
+        getObjectRequest.SetBucket(fullBucketName);
+        getObjectRequest.SetKey(TEST_OBJ_KEY);
+        const auto getOutcome = whenRequiredClient.GetObject(getObjectRequest);
+        AWS_ASSERT_SUCCESS(getOutcome);
+        EXPECT_STREQ(getOutcome.GetResult().GetChecksumCRC32().c_str(), "gR4VoA==");
     }
 
     TEST_F(BucketAndObjectOperationTest, TestMultipartFlexibleChecksums)

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassChecksumMembers.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/ModelClassChecksumMembers.vm
@@ -14,6 +14,11 @@ Aws::String ${typeInfo.className}::GetChecksumAlgorithmName() const
   }
 }
 
+bool ${typeInfo.className}::ChecksumAlgorithmIsSet() const
+{
+  return m_${lowerCaseVarName} != ${checksumAlgorithmMember.shape.name}::NOT_SET;
+}
+
 #end
 #if($operation.requestValidationModeMember)
 #set($requestValidationModeMember = $shape.members.get($operation.requestValidationModeMember))

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/RequestHeader.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/RequestHeader.vm
@@ -88,6 +88,7 @@ namespace Model
 #end
 #if($operation.requestAlgorithmMember)
     ${exportMacro} Aws::String GetChecksumAlgorithmName() const override;
+    ${exportMacro} bool ChecksumAlgorithmIsSet() const override;
 #end
 #if($operation.requestValidationModeMember)
     ${exportMacro} bool ShouldValidateResponseChecksum() const override;


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/3859

*Description of changes:*

Adds a new method on the request base class `ChecksumAlgorithmIsSet` that returns true if the customer has explicitly set a checksum on a request. We can use this signal in the checksum interceptor to override `when_required` configuration on apis that are `when_supported` aligning with other SDKs. for example:

```c++
#include <aws/core/Aws.h>
#include <aws/core/auth/AWSCredentials.h>
#include <aws/s3/S3Client.h>
#include <aws/s3/model/ChecksumAlgorithm.h>
#include <aws/s3/model/PutObjectRequest.h>

using namespace Aws;
using namespace Aws::Client;
using namespace Aws::S3;
using namespace Aws::S3::Model;

namespace {
const char* LOG_TAG = "sample";
const char* BUCKET = "bucket";
const char* KEY = "key";

class sdk_guard {
 public:
  sdk_guard(SDKOptions&& options = SDKOptions())
      : options_(std::move(options)) {
    Aws::InitAPI(options);
  };
  ~sdk_guard() { Aws::ShutdownAPI(options_); }

 private:
  SDKOptions options_;
};
}  // namespace

int main() {
  SDKOptions options{};
  options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
  sdk_guard guard{std::move(options)};

  S3ClientConfiguration configuration{};
  configuration.checksumConfig.requestChecksumCalculation = RequestChecksumCalculation::WHEN_REQUIRED;
  S3Client client{configuration};

  auto body = Aws::MakeShared<StringStream>(LOG_TAG);
  *body << std::string(5 * 1024 * 1024, 'x');
  body->seekg(0);

  auto req = PutObjectRequest{}
    .WithBucket(BUCKET)
    .WithKey(KEY);
  req.SetChecksumAlgorithm(ChecksumAlgorithm::CRC32);
  req.SetBody(body);

  auto outcome = client.PutObject(req);
  if (!outcome.IsSuccess()) {
    std::cerr << outcome.GetError().GetMessage()
              << "\n";
  }
  return 0;
}
```

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
