### PR TITLE
Update CRT to v0.42.0

### DIFF
--- a/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp
@@ -643,6 +643,19 @@ void S3CrtClient::S3CrtRequestProgressCallback(struct aws_s3_meta_request* meta_
   return;
 }
 
+namespace {
+// evil enum name sfinae hacking
+template <typename E>
+constexpr auto PartSizeMismatchError(int) -> decltype(E::AWS_ERROR_S3_INTERNAL_BUFFER_SIZE_MISMATCH_RETRYING_WITH_RANGE) {
+  return E::AWS_ERROR_S3_INTERNAL_BUFFER_SIZE_MISMATCH_RETRYING_WITH_RANGE;
+}
+
+template <typename E>
+constexpr auto PartSizeMismatchError(long) -> decltype(E::AWS_ERROR_S3_INTERNAL_PART_SIZE_MISMATCH_RETRYING_WITH_RANGE) {
+  return E::AWS_ERROR_S3_INTERNAL_PART_SIZE_MISMATCH_RETRYING_WITH_RANGE;
+}
+}  // namespace
+
 CoreErrors MapCrtError(const int crtErrorCode) {
   switch (crtErrorCode) {
     case aws_s3_errors::AWS_ERROR_S3_REQUEST_HAS_COMPLETED:
@@ -674,7 +687,7 @@ CoreErrors MapCrtError(const int crtErrorCode) {
     case aws_s3_errors::AWS_ERROR_S3_LIST_PARTS_PARSE_FAILED:
     case aws_s3_errors::AWS_ERROR_S3_RESUMED_PART_CHECKSUM_MISMATCH:
     case aws_s3_errors::AWS_ERROR_S3_FILE_MODIFIED:
-    case aws_s3_errors::AWS_ERROR_S3_INTERNAL_PART_SIZE_MISMATCH_RETRYING_WITH_RANGE:
+    case PartSizeMismatchError<aws_s3_errors>(0):
     case aws_s3_errors::AWS_ERROR_S3_RECV_FILE_ALREADY_EXISTS:
     case aws_s3_errors::AWS_ERROR_S3_RECV_FILE_NOT_FOUND:
       return CoreErrors::VALIDATION;

--- a/prefetch_crt_dependency.sh
+++ b/prefetch_crt_dependency.sh
@@ -3,21 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 CRT_URI_PREFIX=https://codeload.github.com/awslabs
-CRT_URI=${CRT_URI_PREFIX}/aws-crt-cpp/zip/64429d60265ee8c30ae1c8f2ff8e1b9474eea455  # v0.40.1
+CRT_URI=${CRT_URI_PREFIX}/aws-crt-cpp/zip/4bc47ee0c30a482831f809769a2421385c192a6d  # v0.42.0
 
-AWS_C_AUTH_URI=${CRT_URI_PREFIX}/aws-c-auth/zip/4cb7127fc2fe402310f9b2ccd7719baa348b2a19  # v0.10.3
+AWS_C_AUTH_URI=${CRT_URI_PREFIX}/aws-c-auth/zip/4b5d524bf1a511b05e0fffe5bdc51800770b9427  # v0.10.4
 AWS_C_CAL_URI=${CRT_URI_PREFIX}/aws-c-cal/zip/9edd8eac2b21ca6a04535b91d60d361c2f1bb60f  # v0.9.14
-AWS_C_COMMON_URI=${CRT_URI_PREFIX}/aws-c-common/zip/48dd6cdff7bac0005a9c6b49c15a0765622c0e70  # v0.14.0
+AWS_C_COMMON_URI=${CRT_URI_PREFIX}/aws-c-common/zip/a9d57d2d372582fa18bf1d81741e107c59a23226  # v0.14.2
 AWS_C_COMPRESSION_URI=${CRT_URI_PREFIX}/aws-c-compression/zip/d8264e64f698341eb03039b96b4f44702a9b3f83  # v0.3.2
 AWS_C_EVENT_STREAM_URI=${CRT_URI_PREFIX}/aws-c-event-stream/zip/51bef3c44e1058b1689751539170b2e0f589ccdb  # v0.7.1
 AWS_C_HTTP_URI=${CRT_URI_PREFIX}/aws-c-http/zip/8aefd899fc3210bfd0e3fd414011a3cb708bf6e4  # v0.11.0
-AWS_C_IO_URI=${CRT_URI_PREFIX}/aws-c-io/zip/bdfd85e293965439146bc30a70379e7889c27bb7  # v0.27.0
+AWS_C_IO_URI=${CRT_URI_PREFIX}/aws-c-io/zip/54350963b64dfc6c4b0ea623b08aa252aae3d7d7  # v0.27.4
 AWS_C_MQTT_URI=${CRT_URI_PREFIX}/aws-c-mqtt/zip/2ef9605ec9c50bea3f921e08022ddd57eed70901  # v0.16.0
-AWS_C_S3_URI=${CRT_URI_PREFIX}/aws-c-s3/zip/e8bf59aaa77442d7f066a2df05604f40889f044a  # v0.12.6
-AWS_C_SDKUTILS_URI=${CRT_URI_PREFIX}/aws-c-sdkutils/zip/c70418c17d8f970ff1d80d88d08beeccd425a887  # v0.2.5
+AWS_C_S3_URI=${CRT_URI_PREFIX}/aws-c-s3/zip/142f6c3a12f02b77008676e9c18d163b8ea46a6f  # v0.13.0
+AWS_C_SDKUTILS_URI=${CRT_URI_PREFIX}/aws-c-sdkutils/zip/cb14fea362c82c995eebd34e2e96590ab4e0ed58  # v0.2.7
 AWS_CHECKSUMS_URI=${CRT_URI_PREFIX}/aws-checksums/zip/1d5f2f1f3e5d013aae8810878ceb5b3f6f258c4e  # v0.2.10
-AWS_LC_URI=${CRT_URI_PREFIX}/aws-lc/zip/6f246af4cd1de8cee8c62d76139bcda299c1aa00  # v5.0.0
-S2N_URI=${CRT_URI_PREFIX}/s2n/zip/eaf2c08a78f7fca6279e3704d3fa1c4e6c9a6abc  # v1.7.4
+AWS_LC_URI=${CRT_URI_PREFIX}/aws-lc/zip/683ebde4bf3bcc016a9a710ad6b49c0c91b59161  # v5.2.0
+S2N_URI=${CRT_URI_PREFIX}/s2n/zip/f5f6c6c2ce2370de1aa3ade6899a7321d1127bb8  # v1.7.5
 
 
 echo "Removing CRT"

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/S3CrtSpecificOperations.vm
@@ -104,6 +104,19 @@ void S3CrtClient::S3CrtRequestProgressCallback(struct aws_s3_meta_request *meta_
   return;
 }
 
+namespace {
+//evil enum name sfinae hacking
+template <typename E>
+constexpr auto PartSizeMismatchError(int)
+    -> decltype(E::AWS_ERROR_S3_INTERNAL_BUFFER_SIZE_MISMATCH_RETRYING_WITH_RANGE)
+{ return E::AWS_ERROR_S3_INTERNAL_BUFFER_SIZE_MISMATCH_RETRYING_WITH_RANGE; }
+
+template <typename E>
+constexpr auto PartSizeMismatchError(long)
+    -> decltype(E::AWS_ERROR_S3_INTERNAL_PART_SIZE_MISMATCH_RETRYING_WITH_RANGE)
+{ return E::AWS_ERROR_S3_INTERNAL_PART_SIZE_MISMATCH_RETRYING_WITH_RANGE; }
+}  // namespace
+
 CoreErrors MapCrtError(const int crtErrorCode) {
   switch (crtErrorCode) {
     case aws_s3_errors::AWS_ERROR_S3_REQUEST_HAS_COMPLETED:
@@ -135,7 +148,7 @@ CoreErrors MapCrtError(const int crtErrorCode) {
     case aws_s3_errors::AWS_ERROR_S3_LIST_PARTS_PARSE_FAILED:
     case aws_s3_errors::AWS_ERROR_S3_RESUMED_PART_CHECKSUM_MISMATCH:
     case aws_s3_errors::AWS_ERROR_S3_FILE_MODIFIED:
-    case aws_s3_errors::AWS_ERROR_S3_INTERNAL_PART_SIZE_MISMATCH_RETRYING_WITH_RANGE:
+    case PartSizeMismatchError<aws_s3_errors>(0):
     case aws_s3_errors::AWS_ERROR_S3_RECV_FILE_ALREADY_EXISTS:
     case aws_s3_errors::AWS_ERROR_S3_RECV_FILE_NOT_FOUND:
       return CoreErrors::VALIDATION;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/SmithyS3CrtSpecificOperations.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/s3-crt/SmithyS3CrtSpecificOperations.vm
@@ -104,6 +104,19 @@ void S3CrtClient::S3CrtRequestProgressCallback(struct aws_s3_meta_request *meta_
   return;
 }
 
+namespace {
+//evil enum name sfinae hacking
+template <typename E>
+constexpr auto PartSizeMismatchError(int)
+    -> decltype(E::AWS_ERROR_S3_INTERNAL_BUFFER_SIZE_MISMATCH_RETRYING_WITH_RANGE)
+{ return E::AWS_ERROR_S3_INTERNAL_BUFFER_SIZE_MISMATCH_RETRYING_WITH_RANGE; }
+
+template <typename E>
+constexpr auto PartSizeMismatchError(long)
+    -> decltype(E::AWS_ERROR_S3_INTERNAL_PART_SIZE_MISMATCH_RETRYING_WITH_RANGE)
+{ return E::AWS_ERROR_S3_INTERNAL_PART_SIZE_MISMATCH_RETRYING_WITH_RANGE; }
+}  // namespace
+
 CoreErrors MapCrtError(const int crtErrorCode) {
   switch (crtErrorCode) {
     case aws_s3_errors::AWS_ERROR_S3_REQUEST_HAS_COMPLETED:
@@ -135,7 +148,7 @@ CoreErrors MapCrtError(const int crtErrorCode) {
     case aws_s3_errors::AWS_ERROR_S3_LIST_PARTS_PARSE_FAILED:
     case aws_s3_errors::AWS_ERROR_S3_RESUMED_PART_CHECKSUM_MISMATCH:
     case aws_s3_errors::AWS_ERROR_S3_FILE_MODIFIED:
-    case aws_s3_errors::AWS_ERROR_S3_INTERNAL_PART_SIZE_MISMATCH_RETRYING_WITH_RANGE:
+    case PartSizeMismatchError<aws_s3_errors>(0):
     case aws_s3_errors::AWS_ERROR_S3_RECV_FILE_ALREADY_EXISTS:
     case aws_s3_errors::AWS_ERROR_S3_RECV_FILE_NOT_FOUND:
       return CoreErrors::VALIDATION;


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/3863

*Description of changes:*

updates CRT dependency version, importantly fixes a enum re-name introduced in https://github.com/awslabs/aws-c-s3/commit/a25112e7c6bbbf3324f6366ca8849bbb08e513e3 and picks up https://github.com/awslabs/aws-c-s3/commit/142f6c3a12f02b77008676e9c18d163b8ea46a6f which fixes ordering issue in the crt buffer pool.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
