### PR TITLE
Survive static destruction order failure in AWSLogging accessors

### DIFF
--- a/src/aws-cpp-sdk-core/source/utils/logging/AWSLogging.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/logging/AWSLogging.cpp
@@ -14,8 +14,28 @@
 using namespace Aws::Utils;
 using namespace Aws::Utils::Logging;
 
-static std::shared_ptr<LogSystemInterface> AWSLogSystem(nullptr);
-static std::shared_ptr<LogSystemInterface> OldLogger(nullptr);
+namespace {
+
+// AWS clients owned by other globals can be destroyed after this translation
+// unit's statics (static destruction order across translation units is
+// unspecified) and still log through GetLogSystem() while unwinding. The flag
+// is trivially destructible, so it stays readable until the very end of the
+// process; once ~LoggingSet has cleared it, the accessors below behave as
+// if no logger is installed instead of touching the destroyed shared_ptrs.
+bool LoggingSetAlive = true;
+
+struct LoggingSet {
+    std::shared_ptr<LogSystemInterface> AWSLogSystem;
+    std::shared_ptr<LogSystemInterface> OldLogger;
+
+    ~LoggingSet() {
+        LoggingSetAlive = false;
+    }
+};
+
+LoggingSet LogSet;
+
+} // anonymous namespace
 
 namespace Aws
 {
@@ -24,7 +44,9 @@ namespace Utils
 namespace Logging {
 
 void InitializeAWSLogging(const std::shared_ptr<LogSystemInterface> &logSystem) {
-    AWSLogSystem = logSystem;
+    if (LoggingSetAlive) {
+        LogSet.AWSLogSystem = logSystem;
+    }
 }
 
 void ShutdownAWSLogging(void) {
@@ -33,23 +55,31 @@ void ShutdownAWSLogging(void) {
     // so this is a hack to let all other threads finish their log statement after getting a LogSystem pointer
     // otherwise we would need to perform ref-counting on each logging statement
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    OldLogger.reset();
+    if (LoggingSetAlive) {
+        LogSet.OldLogger.reset();
+    }
 }
 
 LogSystemInterface *GetLogSystem() {
-    return AWSLogSystem.get();
+    return LoggingSetAlive ? LogSet.AWSLogSystem.get() : nullptr;
 }
 
 void PushLogger(const std::shared_ptr<LogSystemInterface> &logSystem)
 {
-    OldLogger = AWSLogSystem;
-    AWSLogSystem = logSystem;
+    if (!LoggingSetAlive) {
+        return;
+    }
+    LogSet.OldLogger = LogSet.AWSLogSystem;
+    LogSet.AWSLogSystem = logSystem;
 }
 
 void PopLogger()
 {
-    AWSLogSystem = OldLogger;
-    OldLogger = nullptr;
+    if (!LoggingSetAlive) {
+        return;
+    }
+    LogSet.AWSLogSystem = LogSet.OldLogger;
+    LogSet.OldLogger = nullptr;
 }
 
 } // namespace Logging


### PR DESCRIPTION
*Description of changes:*
The logger is held in two namespace-scope shared_ptr statics. AWS clients owned by other translation units can be destroyed after these statics (the order of static destruction across translation units is unspecified) and may still call GetLogSystem()/Push/PopLogger while unwinding at process exit. Once the shared_ptrs have been destroyed, those calls touch freed objects.

Move the two shared_ptrs into a LoggingSet struct guarded by a trivially destructible bool flag, LoggingSetAlive, which stays readable until the very end of the process. ~LoggingSet clears the flag; afterwards the accessors behave as if no logger is installed instead of reading the destroyed members.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (If tests are not applicable, explain: **the order on destruction is unspecified**)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
