### PR TITLE
Fix Windows GetEnv mangling non-ASCII environment values (UTF-8)

### DIFF
--- a/src/aws-cpp-sdk-core/source/platform/windows/Environment.cpp
+++ b/src/aws-cpp-sdk-core/source/platform/windows/Environment.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <aws/core/platform/Environment.h>
+#include <aws/core/utils/StringUtils.h>
 
 #include <stdio.h>
 #include <utility>
@@ -13,25 +14,19 @@ namespace Aws
 namespace Environment
 {
 
-/*
-using std::getenv generates a warning on windows so we use _dupenv_s instead.  The character array returned by this function is our responsibility to clean up, so rather than returning raw strings
-that would need to be manually freed in all the client functions, just copy it into a Aws::String instead, freeing it here.
-
-since _dupenv_s is a non-standard function, on non-Microsoft compilers we will fall back to using std::getenv instead.
-*/
 Aws::String GetEnv(const char *variableName)
 {
-#ifdef _MSC_VER    
-    char* variableValue = nullptr;
+#ifdef _MSC_VER
+    wchar_t* variableValue = nullptr;
     std::size_t valueSize = 0;
-    auto queryResult = _dupenv_s(&variableValue, &valueSize, variableName);
+    const auto queryResult = _wdupenv_s(&variableValue, &valueSize, Aws::Utils::StringUtils::ToWString(variableName).c_str());
 
     Aws::String result;
-    if(queryResult == 0 && variableValue != nullptr && valueSize > 0)
+    if(queryResult == 0 && variableValue != nullptr)
     {
-        result.assign(variableValue, valueSize - 1);  // don't copy the c-string terminator byte
-        free(variableValue);
+        result = Aws::Utils::StringUtils::FromWString(variableValue);
     }
+    free(variableValue);
 
     return result;
 #else

--- a/tests/aws-cpp-sdk-core-tests/utils/FileSystemUtilsTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/FileSystemUtilsTest.cpp
@@ -3,11 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#include <aws/core/platform/Environment.h>
 #include <aws/core/platform/FileSystem.h>
 #include <aws/core/utils/FileSystemUtils.h>
 #include <aws/core/utils/memory/stl/AWSSet.h>
 #include <aws/testing/AwsCppSdkGTestSuite.h>
 #include <fstream>
+#ifdef _MSC_VER
+#include <stdlib.h> // _wputenv_s
+#endif
 #if defined(HAS_PATHCONF)
 #include <unistd.h>
 #include <climits>
@@ -30,6 +34,22 @@ TEST_F(FileTest, HomeDirectory)
 
     ASSERT_TRUE(homeDirectory.size() > 0);
     ASSERT_EQ(Aws::FileSystem::PATH_DELIM, homeDirectory.back());
+}
+
+TEST_F(FileTest, GetEnvReturnsNonAsciiValueAsUtf8)
+{
+#ifdef _MSC_VER
+    const char* varName = "AWS_SDK_TEST_NONASCII";
+    // Set via the wide CRT API so the true Unicode value is stored, not a pre-mangled narrow one.
+    ASSERT_EQ(0, _wputenv_s(L"AWS_SDK_TEST_NONASCII", L"José"));
+
+    const auto value = Aws::Environment::GetEnv(varName);
+    _wputenv_s(L"AWS_SDK_TEST_NONASCII", L"");
+
+    ASSERT_EQ(Aws::String("Jos\xC3\xA9"), value); // "José" in UTF-8
+#else
+    GTEST_SKIP() << "Non-ASCII environment encoding fix is Windows-specific.";
+#endif
 }
 
 TEST_F(FileTest, TestInvalidDirectoryPath)

--- a/tests/aws-cpp-sdk-core-tests/utils/FileSystemUtilsTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/FileSystemUtilsTest.cpp
@@ -3,11 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#include <aws/core/platform/Environment.h>
 #include <aws/core/platform/FileSystem.h>
 #include <aws/core/utils/FileSystemUtils.h>
 #include <aws/core/utils/memory/stl/AWSSet.h>
 #include <aws/testing/AwsCppSdkGTestSuite.h>
 #include <fstream>
+#ifdef _MSC_VER
+#include <stdlib.h> // _wputenv_s
+#endif
 #if defined(HAS_PATHCONF)
 #include <unistd.h>
 #include <climits>
@@ -31,6 +35,20 @@ TEST_F(FileTest, HomeDirectory)
     ASSERT_TRUE(homeDirectory.size() > 0);
     ASSERT_EQ(Aws::FileSystem::PATH_DELIM, homeDirectory.back());
 }
+
+#ifdef _MSC_VER
+TEST_F(FileTest, GetEnvReturnsNonAsciiValueAsUtf8)
+{
+    const char* varName = "AWS_SDK_TEST_NONASCII";
+    // Set via the wide CRT API so the true Unicode value is stored, not a pre-mangled narrow one.
+    ASSERT_EQ(0, _wputenv_s(L"AWS_SDK_TEST_NONASCII", L"José"));
+
+    const auto value = Aws::Environment::GetEnv(varName);
+    _wputenv_s(L"AWS_SDK_TEST_NONASCII", L"");
+
+    ASSERT_EQ(Aws::String("Jos\xC3\xA9"), value); // "José" in UTF-8
+}
+#endif
 
 TEST_F(FileTest, TestInvalidDirectoryPath)
 {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-cpp/issues/3520

*Description of changes:*
On Windows, `Aws::Environment::GetEnv` read variables through the narrow
  `_dupenv_s`, which returns the value in the active ANSI code page (e.g.
  CP-1252). Any non-ASCII value — an accented username in a home path, a
  region/proxy set to a localized string — was then reinterpreted elsewhere in
  the SDK as UTF-8 and came out as mojibake (e.g. `José` → `Jos\xE9` instead of
  `Jos\xC3\xA9`).

  This changes the Windows implementation to read through the wide `_wdupenv_s`
  and convert explicitly to UTF-8 via `StringUtils::FromWString`, since Windows
  stores environment variables natively as UTF-16. This mirrors the same fix
  made in the CRT (awslabs/aws-c-common#1260). `_wdupenv_s` is
  MSVC-specific, so non-MSVC compilers keep the existing `std::getenv` path.

  Added a regression test (`FileSystemUtilsTest.GetEnvReturnsNonAsciiValueAsUtf8`)
  that injects a non-ASCII value via the wide CRT API (`_wputenv_s`, so the true
  Unicode value is stored rather than a pre-mangled narrow one) and asserts
  `GetEnv` returns the correct UTF-8 bytes. The test is Windows-only and skips
  elsewhere.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
