### PR TITLE
using compact XML serialization in XmlDocument::ConvertToString

### DIFF
--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/AssociateDistributionTenantWebACL2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/AssociateDistributionTenantWebACL2020_05_31Request.cpp
@@ -26,7 +26,7 @@ Aws::String AssociateDistributionTenantWebACL2020_05_31Request::SerializePayload
     webACLArnNode.SetText(m_webACLArn);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection AssociateDistributionTenantWebACL2020_05_31Request::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/AssociateDistributionWebACL2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/AssociateDistributionWebACL2020_05_31Request.cpp
@@ -26,7 +26,7 @@ Aws::String AssociateDistributionWebACL2020_05_31Request::SerializePayload() con
     webACLArnNode.SetText(m_webACLArn);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection AssociateDistributionWebACL2020_05_31Request::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CopyDistribution2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CopyDistribution2020_05_31Request.cpp
@@ -33,7 +33,7 @@ Aws::String CopyDistribution2020_05_31Request::SerializePayload() const {
     ss.str("");
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection CopyDistribution2020_05_31Request::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateAnycastIpList2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateAnycastIpList2020_05_31Request.cpp
@@ -51,5 +51,5 @@ Aws::String CreateAnycastIpList2020_05_31Request::SerializePayload() const {
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateCachePolicy2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateCachePolicy2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateCachePolicy2020_05_31Request::SerializePayload() const {
 
   m_cachePolicyConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateCloudFrontOriginAccessIdentity2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateCloudFrontOriginAccessIdentity2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateCloudFrontOriginAccessIdentity2020_05_31Request::SerializePayl
 
   m_cloudFrontOriginAccessIdentityConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateConnectionFunction2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateConnectionFunction2020_05_31Request.cpp
@@ -42,5 +42,5 @@ Aws::String CreateConnectionFunction2020_05_31Request::SerializePayload() const 
     m_tags.AddToNode(tagsNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateConnectionGroup2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateConnectionGroup2020_05_31Request.cpp
@@ -50,5 +50,5 @@ Aws::String CreateConnectionGroup2020_05_31Request::SerializePayload() const {
     ss.str("");
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateContinuousDeploymentPolicy2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateContinuousDeploymentPolicy2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateContinuousDeploymentPolicy2020_05_31Request::SerializePayload(
 
   m_continuousDeploymentPolicyConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateDistribution2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateDistribution2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateDistribution2020_05_31Request::SerializePayload() const {
 
   m_distributionConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateDistributionTenant2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateDistributionTenant2020_05_31Request.cpp
@@ -74,5 +74,5 @@ Aws::String CreateDistributionTenant2020_05_31Request::SerializePayload() const 
     ss.str("");
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateDistributionWithTags2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateDistributionWithTags2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateDistributionWithTags2020_05_31Request::SerializePayload() cons
 
   m_distributionConfigWithTags.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateFieldLevelEncryptionConfig2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateFieldLevelEncryptionConfig2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateFieldLevelEncryptionConfig2020_05_31Request::SerializePayload(
 
   m_fieldLevelEncryptionConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateFieldLevelEncryptionProfile2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateFieldLevelEncryptionProfile2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateFieldLevelEncryptionProfile2020_05_31Request::SerializePayload
 
   m_fieldLevelEncryptionProfileConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateFunction2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateFunction2020_05_31Request.cpp
@@ -42,5 +42,5 @@ Aws::String CreateFunction2020_05_31Request::SerializePayload() const {
     m_tags.AddToNode(tagsNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateInvalidation2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateInvalidation2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateInvalidation2020_05_31Request::SerializePayload() const {
 
   m_invalidationBatch.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateInvalidationForDistributionTenant2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateInvalidationForDistributionTenant2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateInvalidationForDistributionTenant2020_05_31Request::SerializeP
 
   m_invalidationBatch.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateKeyGroup2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateKeyGroup2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateKeyGroup2020_05_31Request::SerializePayload() const {
 
   m_keyGroupConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateKeyValueStore2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateKeyValueStore2020_05_31Request.cpp
@@ -41,5 +41,5 @@ Aws::String CreateKeyValueStore2020_05_31Request::SerializePayload() const {
     m_tags.AddToNode(tagsNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateMonitoringSubscription2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateMonitoringSubscription2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateMonitoringSubscription2020_05_31Request::SerializePayload() co
 
   m_monitoringSubscription.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateOriginAccessControl2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateOriginAccessControl2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateOriginAccessControl2020_05_31Request::SerializePayload() const
 
   m_originAccessControlConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateOriginRequestPolicy2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateOriginRequestPolicy2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateOriginRequestPolicy2020_05_31Request::SerializePayload() const
 
   m_originRequestPolicyConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreatePublicKey2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreatePublicKey2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreatePublicKey2020_05_31Request::SerializePayload() const {
 
   m_publicKeyConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateRealtimeLogConfig2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateRealtimeLogConfig2020_05_31Request.cpp
@@ -49,5 +49,5 @@ Aws::String CreateRealtimeLogConfig2020_05_31Request::SerializePayload() const {
     ss.str("");
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateResponseHeadersPolicy2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateResponseHeadersPolicy2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateResponseHeadersPolicy2020_05_31Request::SerializePayload() con
 
   m_responseHeadersPolicyConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateStreamingDistribution2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateStreamingDistribution2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateStreamingDistribution2020_05_31Request::SerializePayload() con
 
   m_streamingDistributionConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateStreamingDistributionWithTags2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateStreamingDistributionWithTags2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String CreateStreamingDistributionWithTags2020_05_31Request::SerializePaylo
 
   m_streamingDistributionConfigWithTags.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateTrustStore2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateTrustStore2020_05_31Request.cpp
@@ -43,5 +43,5 @@ Aws::String CreateTrustStore2020_05_31Request::SerializePayload() const {
     m_tags.AddToNode(tagsNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateVpcOrigin2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/CreateVpcOrigin2020_05_31Request.cpp
@@ -31,5 +31,5 @@ Aws::String CreateVpcOrigin2020_05_31Request::SerializePayload() const {
     m_tags.AddToNode(tagsNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/DeleteRealtimeLogConfig2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/DeleteRealtimeLogConfig2020_05_31Request.cpp
@@ -31,5 +31,5 @@ Aws::String DeleteRealtimeLogConfig2020_05_31Request::SerializePayload() const {
     aRNNode.SetText(m_aRN);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/DeleteResourcePolicy2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/DeleteResourcePolicy2020_05_31Request.cpp
@@ -26,5 +26,5 @@ Aws::String DeleteResourcePolicy2020_05_31Request::SerializePayload() const {
     resourceArnNode.SetText(m_resourceArn);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/GetRealtimeLogConfig2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/GetRealtimeLogConfig2020_05_31Request.cpp
@@ -31,5 +31,5 @@ Aws::String GetRealtimeLogConfig2020_05_31Request::SerializePayload() const {
     aRNNode.SetText(m_aRN);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/GetResourcePolicy2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/GetResourcePolicy2020_05_31Request.cpp
@@ -26,5 +26,5 @@ Aws::String GetResourcePolicy2020_05_31Request::SerializePayload() const {
     resourceArnNode.SetText(m_resourceArn);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/ListConnectionFunctions2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/ListConnectionFunctions2020_05_31Request.cpp
@@ -38,5 +38,5 @@ Aws::String ListConnectionFunctions2020_05_31Request::SerializePayload() const {
     stageNode.SetText(FunctionStageMapper::GetNameForFunctionStage(m_stage));
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/ListConnectionGroups2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/ListConnectionGroups2020_05_31Request.cpp
@@ -38,5 +38,5 @@ Aws::String ListConnectionGroups2020_05_31Request::SerializePayload() const {
     ss.str("");
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/ListDistributionTenants2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/ListDistributionTenants2020_05_31Request.cpp
@@ -38,5 +38,5 @@ Aws::String ListDistributionTenants2020_05_31Request::SerializePayload() const {
     ss.str("");
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/ListDistributionTenantsByCustomization2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/ListDistributionTenantsByCustomization2020_05_31Request.cpp
@@ -43,5 +43,5 @@ Aws::String ListDistributionTenantsByCustomization2020_05_31Request::SerializePa
     ss.str("");
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/ListDistributionsByRealtimeLogConfig2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/ListDistributionsByRealtimeLogConfig2020_05_31Request.cpp
@@ -41,5 +41,5 @@ Aws::String ListDistributionsByRealtimeLogConfig2020_05_31Request::SerializePayl
     realtimeLogConfigArnNode.SetText(m_realtimeLogConfigArn);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/ListDomainConflicts2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/ListDomainConflicts2020_05_31Request.cpp
@@ -43,5 +43,5 @@ Aws::String ListDomainConflicts2020_05_31Request::SerializePayload() const {
     markerNode.SetText(m_marker);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/ListTrustStores2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/ListTrustStores2020_05_31Request.cpp
@@ -33,5 +33,5 @@ Aws::String ListTrustStores2020_05_31Request::SerializePayload() const {
     ss.str("");
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/PutResourcePolicy2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/PutResourcePolicy2020_05_31Request.cpp
@@ -31,5 +31,5 @@ Aws::String PutResourcePolicy2020_05_31Request::SerializePayload() const {
     policyDocumentNode.SetText(m_policyDocument);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/TagResource2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/TagResource2020_05_31Request.cpp
@@ -24,7 +24,7 @@ Aws::String TagResource2020_05_31Request::SerializePayload() const {
 
   m_tags.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/TestConnectionFunction2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/TestConnectionFunction2020_05_31Request.cpp
@@ -32,7 +32,7 @@ Aws::String TestConnectionFunction2020_05_31Request::SerializePayload() const {
     connectionObjectNode.SetText(HashingUtils::Base64Encode(m_connectionObject));
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection TestConnectionFunction2020_05_31Request::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/TestFunction2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/TestFunction2020_05_31Request.cpp
@@ -32,7 +32,7 @@ Aws::String TestFunction2020_05_31Request::SerializePayload() const {
     eventObjectNode.SetText(HashingUtils::Base64Encode(m_eventObject));
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection TestFunction2020_05_31Request::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UntagResource2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UntagResource2020_05_31Request.cpp
@@ -24,7 +24,7 @@ Aws::String UntagResource2020_05_31Request::SerializePayload() const {
 
   m_tagKeys.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateAnycastIpList2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateAnycastIpList2020_05_31Request.cpp
@@ -34,7 +34,7 @@ Aws::String UpdateAnycastIpList2020_05_31Request::SerializePayload() const {
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection UpdateAnycastIpList2020_05_31Request::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateCachePolicy2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateCachePolicy2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String UpdateCachePolicy2020_05_31Request::SerializePayload() const {
 
   m_cachePolicyConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateCloudFrontOriginAccessIdentity2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateCloudFrontOriginAccessIdentity2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String UpdateCloudFrontOriginAccessIdentity2020_05_31Request::SerializePayl
 
   m_cloudFrontOriginAccessIdentityConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateConnectionFunction2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateConnectionFunction2020_05_31Request.cpp
@@ -32,7 +32,7 @@ Aws::String UpdateConnectionFunction2020_05_31Request::SerializePayload() const 
     connectionFunctionCodeNode.SetText(HashingUtils::Base64Encode(m_connectionFunctionCode));
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection UpdateConnectionFunction2020_05_31Request::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateConnectionGroup2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateConnectionGroup2020_05_31Request.cpp
@@ -40,7 +40,7 @@ Aws::String UpdateConnectionGroup2020_05_31Request::SerializePayload() const {
     ss.str("");
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection UpdateConnectionGroup2020_05_31Request::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateContinuousDeploymentPolicy2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateContinuousDeploymentPolicy2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String UpdateContinuousDeploymentPolicy2020_05_31Request::SerializePayload(
 
   m_continuousDeploymentPolicyConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateDistribution2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateDistribution2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String UpdateDistribution2020_05_31Request::SerializePayload() const {
 
   m_distributionConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateDistributionTenant2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateDistributionTenant2020_05_31Request.cpp
@@ -64,7 +64,7 @@ Aws::String UpdateDistributionTenant2020_05_31Request::SerializePayload() const 
     ss.str("");
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection UpdateDistributionTenant2020_05_31Request::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateDomainAssociation2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateDomainAssociation2020_05_31Request.cpp
@@ -31,7 +31,7 @@ Aws::String UpdateDomainAssociation2020_05_31Request::SerializePayload() const {
     m_targetResource.AddToNode(targetResourceNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection UpdateDomainAssociation2020_05_31Request::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateFieldLevelEncryptionConfig2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateFieldLevelEncryptionConfig2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String UpdateFieldLevelEncryptionConfig2020_05_31Request::SerializePayload(
 
   m_fieldLevelEncryptionConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateFieldLevelEncryptionProfile2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateFieldLevelEncryptionProfile2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String UpdateFieldLevelEncryptionProfile2020_05_31Request::SerializePayload
 
   m_fieldLevelEncryptionProfileConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateFunction2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateFunction2020_05_31Request.cpp
@@ -32,7 +32,7 @@ Aws::String UpdateFunction2020_05_31Request::SerializePayload() const {
     functionCodeNode.SetText(HashingUtils::Base64Encode(m_functionCode));
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection UpdateFunction2020_05_31Request::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateKeyGroup2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateKeyGroup2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String UpdateKeyGroup2020_05_31Request::SerializePayload() const {
 
   m_keyGroupConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateKeyValueStore2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateKeyValueStore2020_05_31Request.cpp
@@ -26,7 +26,7 @@ Aws::String UpdateKeyValueStore2020_05_31Request::SerializePayload() const {
     commentNode.SetText(m_comment);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection UpdateKeyValueStore2020_05_31Request::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateOriginAccessControl2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateOriginAccessControl2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String UpdateOriginAccessControl2020_05_31Request::SerializePayload() const
 
   m_originAccessControlConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateOriginRequestPolicy2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateOriginRequestPolicy2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String UpdateOriginRequestPolicy2020_05_31Request::SerializePayload() const
 
   m_originRequestPolicyConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdatePublicKey2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdatePublicKey2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String UpdatePublicKey2020_05_31Request::SerializePayload() const {
 
   m_publicKeyConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateRealtimeLogConfig2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateRealtimeLogConfig2020_05_31Request.cpp
@@ -54,5 +54,5 @@ Aws::String UpdateRealtimeLogConfig2020_05_31Request::SerializePayload() const {
     ss.str("");
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateResponseHeadersPolicy2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateResponseHeadersPolicy2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String UpdateResponseHeadersPolicy2020_05_31Request::SerializePayload() con
 
   m_responseHeadersPolicyConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateStreamingDistribution2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateStreamingDistribution2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String UpdateStreamingDistribution2020_05_31Request::SerializePayload() con
 
   m_streamingDistributionConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateTrustStore2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateTrustStore2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String UpdateTrustStore2020_05_31Request::SerializePayload() const {
 
   m_caCertificatesBundleSource.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateVpcOrigin2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/UpdateVpcOrigin2020_05_31Request.cpp
@@ -22,7 +22,7 @@ Aws::String UpdateVpcOrigin2020_05_31Request::SerializePayload() const {
 
   m_vpcOriginEndpointConfig.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-cloudfront/source/model/VerifyDnsConfiguration2020_05_31Request.cpp
+++ b/generated/src/aws-cpp-sdk-cloudfront/source/model/VerifyDnsConfiguration2020_05_31Request.cpp
@@ -31,5 +31,5 @@ Aws::String VerifyDnsConfiguration2020_05_31Request::SerializePayload() const {
     identifierNode.SetText(m_identifier);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/AssociateVPCWithHostedZoneRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/AssociateVPCWithHostedZoneRequest.cpp
@@ -31,5 +31,5 @@ Aws::String AssociateVPCWithHostedZoneRequest::SerializePayload() const {
     commentNode.SetText(m_comment);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/ChangeCidrCollectionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/ChangeCidrCollectionRequest.cpp
@@ -36,5 +36,5 @@ Aws::String ChangeCidrCollectionRequest::SerializePayload() const {
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/ChangeResourceRecordSetsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/ChangeResourceRecordSetsRequest.cpp
@@ -26,5 +26,5 @@ Aws::String ChangeResourceRecordSetsRequest::SerializePayload() const {
     m_changeBatch.AddToNode(changeBatchNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/ChangeTagsForResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/ChangeTagsForResourceRequest.cpp
@@ -37,5 +37,5 @@ Aws::String ChangeTagsForResourceRequest::SerializePayload() const {
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/CreateCidrCollectionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/CreateCidrCollectionRequest.cpp
@@ -31,5 +31,5 @@ Aws::String CreateCidrCollectionRequest::SerializePayload() const {
     callerReferenceNode.SetText(m_callerReference);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/CreateHealthCheckRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/CreateHealthCheckRequest.cpp
@@ -31,5 +31,5 @@ Aws::String CreateHealthCheckRequest::SerializePayload() const {
     m_healthCheckConfig.AddToNode(healthCheckConfigNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/CreateHostedZoneRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/CreateHostedZoneRequest.cpp
@@ -46,5 +46,5 @@ Aws::String CreateHostedZoneRequest::SerializePayload() const {
     delegationSetIdNode.SetText(m_delegationSetId);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/CreateKeySigningKeyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/CreateKeySigningKeyRequest.cpp
@@ -46,5 +46,5 @@ Aws::String CreateKeySigningKeyRequest::SerializePayload() const {
     statusNode.SetText(m_status);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/CreateQueryLoggingConfigRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/CreateQueryLoggingConfigRequest.cpp
@@ -31,5 +31,5 @@ Aws::String CreateQueryLoggingConfigRequest::SerializePayload() const {
     cloudWatchLogsLogGroupArnNode.SetText(m_cloudWatchLogsLogGroupArn);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/CreateReusableDelegationSetRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/CreateReusableDelegationSetRequest.cpp
@@ -31,5 +31,5 @@ Aws::String CreateReusableDelegationSetRequest::SerializePayload() const {
     hostedZoneIdNode.SetText(m_hostedZoneId);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/CreateTrafficPolicyInstanceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/CreateTrafficPolicyInstanceRequest.cpp
@@ -50,5 +50,5 @@ Aws::String CreateTrafficPolicyInstanceRequest::SerializePayload() const {
     ss.str("");
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/CreateTrafficPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/CreateTrafficPolicyRequest.cpp
@@ -36,5 +36,5 @@ Aws::String CreateTrafficPolicyRequest::SerializePayload() const {
     commentNode.SetText(m_comment);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/CreateTrafficPolicyVersionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/CreateTrafficPolicyVersionRequest.cpp
@@ -31,5 +31,5 @@ Aws::String CreateTrafficPolicyVersionRequest::SerializePayload() const {
     commentNode.SetText(m_comment);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/CreateVPCAssociationAuthorizationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/CreateVPCAssociationAuthorizationRequest.cpp
@@ -26,5 +26,5 @@ Aws::String CreateVPCAssociationAuthorizationRequest::SerializePayload() const {
     m_vPC.AddToNode(vPCNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/DeleteVPCAssociationAuthorizationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/DeleteVPCAssociationAuthorizationRequest.cpp
@@ -26,5 +26,5 @@ Aws::String DeleteVPCAssociationAuthorizationRequest::SerializePayload() const {
     m_vPC.AddToNode(vPCNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/DisassociateVPCFromHostedZoneRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/DisassociateVPCFromHostedZoneRequest.cpp
@@ -31,5 +31,5 @@ Aws::String DisassociateVPCFromHostedZoneRequest::SerializePayload() const {
     commentNode.SetText(m_comment);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/ListTagsForResourcesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/ListTagsForResourcesRequest.cpp
@@ -29,5 +29,5 @@ Aws::String ListTagsForResourcesRequest::SerializePayload() const {
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/UpdateHealthCheckRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/UpdateHealthCheckRequest.cpp
@@ -125,5 +125,5 @@ Aws::String UpdateHealthCheckRequest::SerializePayload() const {
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/UpdateHostedZoneCommentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/UpdateHostedZoneCommentRequest.cpp
@@ -26,5 +26,5 @@ Aws::String UpdateHostedZoneCommentRequest::SerializePayload() const {
     commentNode.SetText(m_comment);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/UpdateHostedZoneFeaturesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/UpdateHostedZoneFeaturesRequest.cpp
@@ -28,5 +28,5 @@ Aws::String UpdateHostedZoneFeaturesRequest::SerializePayload() const {
     ss.str("");
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/UpdateTrafficPolicyCommentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/UpdateTrafficPolicyCommentRequest.cpp
@@ -26,5 +26,5 @@ Aws::String UpdateTrafficPolicyCommentRequest::SerializePayload() const {
     commentNode.SetText(m_comment);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-route53/source/model/UpdateTrafficPolicyInstanceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-route53/source/model/UpdateTrafficPolicyInstanceRequest.cpp
@@ -40,5 +40,5 @@ Aws::String UpdateTrafficPolicyInstanceRequest::SerializePayload() const {
     ss.str("");
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/CompleteMultipartUploadRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/CompleteMultipartUploadRequest.cpp
@@ -41,7 +41,7 @@ Aws::String CompleteMultipartUploadRequest::SerializePayload() const {
 
   m_multipartUpload.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateBucketMetadataConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateBucketMetadataConfigurationRequest.cpp
@@ -24,7 +24,7 @@ Aws::String CreateBucketMetadataConfigurationRequest::SerializePayload() const {
 
   m_metadataConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateBucketMetadataTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateBucketMetadataTableConfigurationRequest.cpp
@@ -24,7 +24,7 @@ Aws::String CreateBucketMetadataTableConfigurationRequest::SerializePayload() co
 
   m_metadataTableConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateBucketRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/CreateBucketRequest.cpp
@@ -41,7 +41,7 @@ Aws::String CreateBucketRequest::SerializePayload() const {
 
   m_createBucketConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/DeleteObjectsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/DeleteObjectsRequest.cpp
@@ -41,7 +41,7 @@ Aws::String DeleteObjectsRequest::SerializePayload() const {
 
   m_delete.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAbacRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAbacRequest.cpp
@@ -24,7 +24,7 @@ Aws::String PutBucketAbacRequest::SerializePayload() const {
 
   m_abacStatus.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAccelerateConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAccelerateConfigurationRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketAccelerateConfigurationRequest::SerializePayload() const {
 
   m_accelerateConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAclRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAclRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketAclRequest::SerializePayload() const {
 
   m_accessControlPolicy.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAnalyticsConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketAnalyticsConfigurationRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketAnalyticsConfigurationRequest::SerializePayload() const {
 
   m_analyticsConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketCorsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketCorsRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketCorsRequest::SerializePayload() const {
 
   m_cORSConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketEncryptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketEncryptionRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketEncryptionRequest::SerializePayload() const {
 
   m_serverSideEncryptionConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketIntelligentTieringConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketIntelligentTieringConfigurationRequest.cpp
@@ -42,7 +42,7 @@ Aws::String PutBucketIntelligentTieringConfigurationRequest::SerializePayload() 
 
   m_intelligentTieringConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketInventoryConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketInventoryConfigurationRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketInventoryConfigurationRequest::SerializePayload() const {
 
   m_inventoryConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketLifecycleConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketLifecycleConfigurationRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketLifecycleConfigurationRequest::SerializePayload() const {
 
   m_lifecycleConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketLoggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketLoggingRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketLoggingRequest::SerializePayload() const {
 
   m_bucketLoggingStatus.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketMetricsConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketMetricsConfigurationRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketMetricsConfigurationRequest::SerializePayload() const {
 
   m_metricsConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketNotificationConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketNotificationConfigurationRequest.cpp
@@ -24,7 +24,7 @@ Aws::String PutBucketNotificationConfigurationRequest::SerializePayload() const 
 
   m_notificationConfiguration.AddToNode(parentNode);
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 void PutBucketNotificationConfigurationRequest::AddQueryStringParameters(URI& uri) const {

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketOwnershipControlsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketOwnershipControlsRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketOwnershipControlsRequest::SerializePayload() const {
 
   m_ownershipControls.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketReplicationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketReplicationRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketReplicationRequest::SerializePayload() const {
 
   m_replicationConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketRequestPaymentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketRequestPaymentRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketRequestPaymentRequest::SerializePayload() const {
 
   m_requestPaymentConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketTaggingRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketTaggingRequest::SerializePayload() const {
 
   m_tagging.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketVersioningRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketVersioningRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketVersioningRequest::SerializePayload() const {
 
   m_versioningConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketWebsiteRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutBucketWebsiteRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketWebsiteRequest::SerializePayload() const {
 
   m_websiteConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectAclRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectAclRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutObjectAclRequest::SerializePayload() const {
 
   m_accessControlPolicy.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectLegalHoldRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectLegalHoldRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutObjectLegalHoldRequest::SerializePayload() const {
 
   m_legalHold.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectLockConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectLockConfigurationRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutObjectLockConfigurationRequest::SerializePayload() const {
 
   m_objectLockConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectRetentionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectRetentionRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutObjectRetentionRequest::SerializePayload() const {
 
   m_retention.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutObjectTaggingRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutObjectTaggingRequest::SerializePayload() const {
 
   m_tagging.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/PutPublicAccessBlockRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/PutPublicAccessBlockRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutPublicAccessBlockRequest::SerializePayload() const {
 
   m_publicAccessBlockConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/RestoreObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/RestoreObjectRequest.cpp
@@ -41,7 +41,7 @@ Aws::String RestoreObjectRequest::SerializePayload() const {
 
   m_restoreRequest.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/SelectObjectContentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/SelectObjectContentRequest.cpp
@@ -70,7 +70,7 @@ Aws::String SelectObjectContentRequest::SerializePayload() const {
     m_scanRange.AddToNode(scanRangeNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 void SelectObjectContentRequest::AddQueryStringParameters(URI& uri) const {

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateBucketMetadataAnnotationTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateBucketMetadataAnnotationTableConfigurationRequest.cpp
@@ -24,7 +24,7 @@ Aws::String UpdateBucketMetadataAnnotationTableConfigurationRequest::SerializePa
 
   m_annotationTableConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateBucketMetadataInventoryTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateBucketMetadataInventoryTableConfigurationRequest.cpp
@@ -24,7 +24,7 @@ Aws::String UpdateBucketMetadataInventoryTableConfigurationRequest::SerializePay
 
   m_inventoryTableConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateBucketMetadataJournalTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateBucketMetadataJournalTableConfigurationRequest.cpp
@@ -24,7 +24,7 @@ Aws::String UpdateBucketMetadataJournalTableConfigurationRequest::SerializePaylo
 
   m_journalTableConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateObjectEncryptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3-crt/source/model/UpdateObjectEncryptionRequest.cpp
@@ -24,7 +24,7 @@ Aws::String UpdateObjectEncryptionRequest::SerializePayload() const {
 
   m_objectEncryption.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/CompleteMultipartUploadRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/CompleteMultipartUploadRequest.cpp
@@ -41,7 +41,7 @@ Aws::String CompleteMultipartUploadRequest::SerializePayload() const {
 
   m_multipartUpload.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/CreateBucketMetadataConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/CreateBucketMetadataConfigurationRequest.cpp
@@ -24,7 +24,7 @@ Aws::String CreateBucketMetadataConfigurationRequest::SerializePayload() const {
 
   m_metadataConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/CreateBucketMetadataTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/CreateBucketMetadataTableConfigurationRequest.cpp
@@ -24,7 +24,7 @@ Aws::String CreateBucketMetadataTableConfigurationRequest::SerializePayload() co
 
   m_metadataTableConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/CreateBucketRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/CreateBucketRequest.cpp
@@ -41,7 +41,7 @@ Aws::String CreateBucketRequest::SerializePayload() const {
 
   m_createBucketConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/DeleteObjectsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/DeleteObjectsRequest.cpp
@@ -41,7 +41,7 @@ Aws::String DeleteObjectsRequest::SerializePayload() const {
 
   m_delete.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAbacRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAbacRequest.cpp
@@ -24,7 +24,7 @@ Aws::String PutBucketAbacRequest::SerializePayload() const {
 
   m_abacStatus.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAccelerateConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAccelerateConfigurationRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketAccelerateConfigurationRequest::SerializePayload() const {
 
   m_accelerateConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAclRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAclRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketAclRequest::SerializePayload() const {
 
   m_accessControlPolicy.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAnalyticsConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketAnalyticsConfigurationRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketAnalyticsConfigurationRequest::SerializePayload() const {
 
   m_analyticsConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketCorsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketCorsRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketCorsRequest::SerializePayload() const {
 
   m_cORSConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketEncryptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketEncryptionRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketEncryptionRequest::SerializePayload() const {
 
   m_serverSideEncryptionConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketIntelligentTieringConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketIntelligentTieringConfigurationRequest.cpp
@@ -42,7 +42,7 @@ Aws::String PutBucketIntelligentTieringConfigurationRequest::SerializePayload() 
 
   m_intelligentTieringConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketInventoryConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketInventoryConfigurationRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketInventoryConfigurationRequest::SerializePayload() const {
 
   m_inventoryConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketLifecycleConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketLifecycleConfigurationRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketLifecycleConfigurationRequest::SerializePayload() const {
 
   m_lifecycleConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketLoggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketLoggingRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketLoggingRequest::SerializePayload() const {
 
   m_bucketLoggingStatus.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketMetricsConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketMetricsConfigurationRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketMetricsConfigurationRequest::SerializePayload() const {
 
   m_metricsConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketNotificationConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketNotificationConfigurationRequest.cpp
@@ -24,7 +24,7 @@ Aws::String PutBucketNotificationConfigurationRequest::SerializePayload() const 
 
   m_notificationConfiguration.AddToNode(parentNode);
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 void PutBucketNotificationConfigurationRequest::AddQueryStringParameters(URI& uri) const {

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketOwnershipControlsRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketOwnershipControlsRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketOwnershipControlsRequest::SerializePayload() const {
 
   m_ownershipControls.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketReplicationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketReplicationRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketReplicationRequest::SerializePayload() const {
 
   m_replicationConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketRequestPaymentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketRequestPaymentRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketRequestPaymentRequest::SerializePayload() const {
 
   m_requestPaymentConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketTaggingRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketTaggingRequest::SerializePayload() const {
 
   m_tagging.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketVersioningRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketVersioningRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketVersioningRequest::SerializePayload() const {
 
   m_versioningConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutBucketWebsiteRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutBucketWebsiteRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutBucketWebsiteRequest::SerializePayload() const {
 
   m_websiteConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectAclRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectAclRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutObjectAclRequest::SerializePayload() const {
 
   m_accessControlPolicy.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectLegalHoldRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectLegalHoldRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutObjectLegalHoldRequest::SerializePayload() const {
 
   m_legalHold.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectLockConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectLockConfigurationRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutObjectLockConfigurationRequest::SerializePayload() const {
 
   m_objectLockConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectRetentionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectRetentionRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutObjectRetentionRequest::SerializePayload() const {
 
   m_retention.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutObjectTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutObjectTaggingRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutObjectTaggingRequest::SerializePayload() const {
 
   m_tagging.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/PutPublicAccessBlockRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/PutPublicAccessBlockRequest.cpp
@@ -41,7 +41,7 @@ Aws::String PutPublicAccessBlockRequest::SerializePayload() const {
 
   m_publicAccessBlockConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/RestoreObjectRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/RestoreObjectRequest.cpp
@@ -41,7 +41,7 @@ Aws::String RestoreObjectRequest::SerializePayload() const {
 
   m_restoreRequest.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/SelectObjectContentRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/SelectObjectContentRequest.cpp
@@ -70,7 +70,7 @@ Aws::String SelectObjectContentRequest::SerializePayload() const {
     m_scanRange.AddToNode(scanRangeNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 void SelectObjectContentRequest::AddQueryStringParameters(URI& uri) const {

--- a/generated/src/aws-cpp-sdk-s3/source/model/UpdateBucketMetadataAnnotationTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/UpdateBucketMetadataAnnotationTableConfigurationRequest.cpp
@@ -24,7 +24,7 @@ Aws::String UpdateBucketMetadataAnnotationTableConfigurationRequest::SerializePa
 
   m_annotationTableConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/UpdateBucketMetadataInventoryTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/UpdateBucketMetadataInventoryTableConfigurationRequest.cpp
@@ -24,7 +24,7 @@ Aws::String UpdateBucketMetadataInventoryTableConfigurationRequest::SerializePay
 
   m_inventoryTableConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/UpdateBucketMetadataJournalTableConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/UpdateBucketMetadataJournalTableConfigurationRequest.cpp
@@ -24,7 +24,7 @@ Aws::String UpdateBucketMetadataJournalTableConfigurationRequest::SerializePaylo
 
   m_journalTableConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3/source/model/UpdateObjectEncryptionRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3/source/model/UpdateObjectEncryptionRequest.cpp
@@ -24,7 +24,7 @@ Aws::String UpdateObjectEncryptionRequest::SerializePayload() const {
 
   m_objectEncryption.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3control/source/model/AssociateAccessGrantsIdentityCenterRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/AssociateAccessGrantsIdentityCenterRequest.cpp
@@ -26,7 +26,7 @@ Aws::String AssociateAccessGrantsIdentityCenterRequest::SerializePayload() const
     identityCenterArnNode.SetText(m_identityCenterArn);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection AssociateAccessGrantsIdentityCenterRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/CreateAccessGrantRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/CreateAccessGrantRequest.cpp
@@ -59,7 +59,7 @@ Aws::String CreateAccessGrantRequest::SerializePayload() const {
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection CreateAccessGrantRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/CreateAccessGrantsInstanceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/CreateAccessGrantsInstanceRequest.cpp
@@ -34,7 +34,7 @@ Aws::String CreateAccessGrantsInstanceRequest::SerializePayload() const {
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection CreateAccessGrantsInstanceRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/CreateAccessGrantsLocationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/CreateAccessGrantsLocationRequest.cpp
@@ -39,7 +39,7 @@ Aws::String CreateAccessGrantsLocationRequest::SerializePayload() const {
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection CreateAccessGrantsLocationRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/CreateAccessPointForObjectLambdaRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/CreateAccessPointForObjectLambdaRequest.cpp
@@ -26,7 +26,7 @@ Aws::String CreateAccessPointForObjectLambdaRequest::SerializePayload() const {
     m_configuration.AddToNode(configurationNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection CreateAccessPointForObjectLambdaRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/CreateAccessPointRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/CreateAccessPointRequest.cpp
@@ -54,7 +54,7 @@ Aws::String CreateAccessPointRequest::SerializePayload() const {
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection CreateAccessPointRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/CreateBucketRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/CreateBucketRequest.cpp
@@ -22,7 +22,7 @@ Aws::String CreateBucketRequest::SerializePayload() const {
 
   m_createBucketConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3control/source/model/CreateJobRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/CreateJobRequest.cpp
@@ -78,7 +78,7 @@ Aws::String CreateJobRequest::SerializePayload() const {
     m_manifestGenerator.AddToNode(manifestGeneratorNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection CreateJobRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/CreateMultiRegionAccessPointRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/CreateMultiRegionAccessPointRequest.cpp
@@ -31,7 +31,7 @@ Aws::String CreateMultiRegionAccessPointRequest::SerializePayload() const {
     m_details.AddToNode(detailsNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection CreateMultiRegionAccessPointRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/CreateStorageLensGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/CreateStorageLensGroupRequest.cpp
@@ -34,7 +34,7 @@ Aws::String CreateStorageLensGroupRequest::SerializePayload() const {
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection CreateStorageLensGroupRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/DeleteMultiRegionAccessPointRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/DeleteMultiRegionAccessPointRequest.cpp
@@ -31,7 +31,7 @@ Aws::String DeleteMultiRegionAccessPointRequest::SerializePayload() const {
     m_details.AddToNode(detailsNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection DeleteMultiRegionAccessPointRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutAccessGrantsInstanceResourcePolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutAccessGrantsInstanceResourcePolicyRequest.cpp
@@ -31,7 +31,7 @@ Aws::String PutAccessGrantsInstanceResourcePolicyRequest::SerializePayload() con
     organizationNode.SetText(m_organization);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection PutAccessGrantsInstanceResourcePolicyRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutAccessPointConfigurationForObjectLambdaRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutAccessPointConfigurationForObjectLambdaRequest.cpp
@@ -26,7 +26,7 @@ Aws::String PutAccessPointConfigurationForObjectLambdaRequest::SerializePayload(
     m_configuration.AddToNode(configurationNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection PutAccessPointConfigurationForObjectLambdaRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutAccessPointPolicyForObjectLambdaRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutAccessPointPolicyForObjectLambdaRequest.cpp
@@ -26,7 +26,7 @@ Aws::String PutAccessPointPolicyForObjectLambdaRequest::SerializePayload() const
     policyNode.SetText(m_policy);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection PutAccessPointPolicyForObjectLambdaRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutAccessPointPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutAccessPointPolicyRequest.cpp
@@ -26,7 +26,7 @@ Aws::String PutAccessPointPolicyRequest::SerializePayload() const {
     policyNode.SetText(m_policy);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection PutAccessPointPolicyRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutAccessPointScopeRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutAccessPointScopeRequest.cpp
@@ -26,7 +26,7 @@ Aws::String PutAccessPointScopeRequest::SerializePayload() const {
     m_scope.AddToNode(scopeNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection PutAccessPointScopeRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutBucketLifecycleConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutBucketLifecycleConfigurationRequest.cpp
@@ -22,7 +22,7 @@ Aws::String PutBucketLifecycleConfigurationRequest::SerializePayload() const {
 
   m_lifecycleConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutBucketPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutBucketPolicyRequest.cpp
@@ -26,7 +26,7 @@ Aws::String PutBucketPolicyRequest::SerializePayload() const {
     policyNode.SetText(m_policy);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection PutBucketPolicyRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutBucketReplicationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutBucketReplicationRequest.cpp
@@ -22,7 +22,7 @@ Aws::String PutBucketReplicationRequest::SerializePayload() const {
 
   m_replicationConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutBucketTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutBucketTaggingRequest.cpp
@@ -22,7 +22,7 @@ Aws::String PutBucketTaggingRequest::SerializePayload() const {
 
   m_tagging.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutBucketVersioningRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutBucketVersioningRequest.cpp
@@ -22,7 +22,7 @@ Aws::String PutBucketVersioningRequest::SerializePayload() const {
 
   m_versioningConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutJobTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutJobTaggingRequest.cpp
@@ -29,7 +29,7 @@ Aws::String PutJobTaggingRequest::SerializePayload() const {
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection PutJobTaggingRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutMultiRegionAccessPointPolicyRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutMultiRegionAccessPointPolicyRequest.cpp
@@ -31,7 +31,7 @@ Aws::String PutMultiRegionAccessPointPolicyRequest::SerializePayload() const {
     m_details.AddToNode(detailsNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection PutMultiRegionAccessPointPolicyRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutPublicAccessBlockRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutPublicAccessBlockRequest.cpp
@@ -22,7 +22,7 @@ Aws::String PutPublicAccessBlockRequest::SerializePayload() const {
 
   m_publicAccessBlockConfiguration.AddToNode(parentNode);
   if (parentNode.HasChildren()) {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutStorageLensConfigurationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutStorageLensConfigurationRequest.cpp
@@ -34,7 +34,7 @@ Aws::String PutStorageLensConfigurationRequest::SerializePayload() const {
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection PutStorageLensConfigurationRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/PutStorageLensConfigurationTaggingRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/PutStorageLensConfigurationTaggingRequest.cpp
@@ -29,7 +29,7 @@ Aws::String PutStorageLensConfigurationTaggingRequest::SerializePayload() const 
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection PutStorageLensConfigurationTaggingRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/SubmitMultiRegionAccessPointRoutesRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/SubmitMultiRegionAccessPointRoutesRequest.cpp
@@ -29,7 +29,7 @@ Aws::String SubmitMultiRegionAccessPointRoutesRequest::SerializePayload() const 
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection SubmitMultiRegionAccessPointRoutesRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/TagResourceRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/TagResourceRequest.cpp
@@ -29,7 +29,7 @@ Aws::String TagResourceRequest::SerializePayload() const {
     }
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection TagResourceRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/UpdateAccessGrantsLocationRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/UpdateAccessGrantsLocationRequest.cpp
@@ -26,7 +26,7 @@ Aws::String UpdateAccessGrantsLocationRequest::SerializePayload() const {
     iAMRoleArnNode.SetText(m_iAMRoleArn);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection UpdateAccessGrantsLocationRequest::GetRequestSpecificHeaders() const {

--- a/generated/src/aws-cpp-sdk-s3control/source/model/UpdateStorageLensGroupRequest.cpp
+++ b/generated/src/aws-cpp-sdk-s3control/source/model/UpdateStorageLensGroupRequest.cpp
@@ -26,7 +26,7 @@ Aws::String UpdateStorageLensGroupRequest::SerializePayload() const {
     m_storageLensGroup.AddToNode(storageLensGroupNode);
   }
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 }
 
 Aws::Http::HeaderValueCollection UpdateStorageLensGroupRequest::GetRequestSpecificHeaders() const {

--- a/src/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceRequest.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/AmazonWebServiceRequest.h
@@ -248,6 +248,17 @@ namespace Aws
          * @return true of a request has a user set checksum
          */
         inline virtual bool ChecksumAlgorithmIsSet() const { return false; }
+
+        /**
+         * Set by the client from ClientConfiguration::compactXmlSerialization before the payload is
+         * serialized. When true, XML request payloads are serialized without pretty-printing
+         * whitespace (indentation and newlines), producing a smaller payload.
+         */
+        void SetUseCompactXmlPayload(bool useCompactXmlPayload) const { m_useCompactXmlPayload = useCompactXmlPayload; }
+        /**
+         * Whether the XML request payload should be serialized in compact form.
+         */
+        bool ShouldUseCompactXmlPayload() const { return m_useCompactXmlPayload; }
     protected:
         /**
          * Default does nothing. Override this to convert what would otherwise be the payload of the
@@ -268,6 +279,7 @@ namespace Aws
         mutable std::shared_ptr<Aws::Http::ServiceSpecificParameters> m_serviceSpecificParameters;
         mutable Aws::Set<Client::UserAgentFeature> m_userAgentFeatures;
         mutable Aws::RetryContext m_retryContext;
+        mutable bool m_useCompactXmlPayload = false;
     };
 
 } // namespace Aws

--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
@@ -365,6 +365,7 @@ namespace Aws
             Aws::Vector<std::shared_ptr<smithy::interceptor::Interceptor>> m_interceptors;
             bool m_enableNewRetries;
             bool m_disableExpectHeader;
+            bool m_compactXmlSerialization;
         };
 
         AWS_CORE_API Aws::String GetAuthorizationHeader(const Aws::Http::HttpRequest& httpRequest);

--- a/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h
@@ -399,6 +399,12 @@ namespace Aws
             bool enableHttpClientTrace = false;
 
             /**
+             * Serialize XML request payloads without pretty-printing whitespace (indentation and newlines),
+             * producing a smaller payload. Defaults to false to preserve existing serialization behavior.
+             */
+            bool compactXmlSerialization = false;
+
+            /**
              * profileName in config file that will be used by this object to resolve more configurations.
              */
             Aws::String profileName;

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/xml/XmlSerializer.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/xml/XmlSerializer.h
@@ -176,6 +176,11 @@ namespace Aws
                  */
                 Aws::String ConvertToString() const;
                 /**
+                 * Convert entire document to string. When compact is true, the output omits pretty-printing
+                 * whitespace (indentation and newlines), producing a smaller payload.
+                 */
+                Aws::String ConvertToString(bool compact) const;
+                /**
                  * Returns true if the call to CreateFromXml* was successful, otherwise false.
                  * if this returns false, you can call GetErrorMessage() to see details.
                  */

--- a/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -145,7 +145,8 @@ AWSClient::AWSClient(const Aws::Client::ClientConfiguration& configuration,
         configuration.awsChunkedBufferSize),
         m_userAgentInterceptor},
     m_enableNewRetries{Aws::Utils::StringUtils::ToLower(Aws::Environment::GetEnv("AWS_NEW_RETRIES_2026").c_str()) == "true"},
-    m_disableExpectHeader(configuration.disableExpectHeader)
+    m_disableExpectHeader(configuration.disableExpectHeader),
+    m_compactXmlSerialization(configuration.compactXmlSerialization)
 {
 }
 
@@ -176,7 +177,8 @@ AWSClient::AWSClient(const Aws::Client::ClientConfiguration& configuration,
         configuration.awsChunkedBufferSize),
         m_userAgentInterceptor},
     m_enableNewRetries{Aws::Utils::StringUtils::ToLower(Aws::Environment::GetEnv("AWS_NEW_RETRIES_2026").c_str()) == "true"},
-    m_disableExpectHeader(configuration.disableExpectHeader)
+    m_disableExpectHeader(configuration.disableExpectHeader),
+    m_compactXmlSerialization(configuration.compactXmlSerialization)
 {
 }
 
@@ -916,6 +918,9 @@ void AWSClient::BuildHttpRequest(const Aws::AmazonWebServiceRequest& request, co
     //do headers first since the request likely will set content-length as its own header.
     AddHeadersToRequest(httpRequest, request.GetHeaders());
     AddHeadersToRequest(httpRequest, request.GetAdditionalCustomHeaders());
+
+    // Propagate the compact XML serialization preference to the request before its payload is serialized.
+    request.SetUseCompactXmlPayload(m_compactXmlSerialization);
 
     if (request.IsEventStreamRequest())
     {

--- a/src/aws-cpp-sdk-core/source/utils/xml/XmlSerializer.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/xml/XmlSerializer.cpp
@@ -275,9 +275,14 @@ Aws::String XmlDocument::GetErrorMessage() const
 
 Aws::String XmlDocument::ConvertToString() const
 {
+    return ConvertToString(false);
+}
+
+Aws::String XmlDocument::ConvertToString(bool compact) const
+{
     if (!m_doc) return "";
 
-    Aws::External::tinyxml2::XMLPrinter printer(nullptr,/*compact=*/true);
+    Aws::External::tinyxml2::XMLPrinter printer(nullptr, compact);
     printer.PushHeader(false, true);
     m_doc->Accept(&printer);
 

--- a/src/aws-cpp-sdk-core/source/utils/xml/XmlSerializer.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/xml/XmlSerializer.cpp
@@ -277,7 +277,7 @@ Aws::String XmlDocument::ConvertToString() const
 {
     if (!m_doc) return "";
 
-    Aws::External::tinyxml2::XMLPrinter printer;
+    Aws::External::tinyxml2::XMLPrinter printer(nullptr,/*compact=*/true);
     printer.PushHeader(false, true);
     m_doc->Accept(&printer);
 

--- a/tests/aws-cpp-sdk-core-tests/utils/xml/XmlSerializerTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/xml/XmlSerializerTest.cpp
@@ -77,6 +77,31 @@ TEST_F(XmlSerializerTest, TestXmlSerialize)
     ASSERT_TRUE(doc.GetErrorMessage().empty());
 }
 
+TEST_F(XmlSerializerTest, TestXmlSerializeCompact)
+{
+    XmlDocument doc = XmlDocument::CreateWithRootNode("ToDo");
+    XmlNode rootElement = doc.GetRootElement();
+    XmlNode item1 = rootElement.CreateChildElement("Item");
+    item1.SetAttributeValue("priority", "1");
+    item1.SetText("Go to the <bold>Toy store!</bold>");
+    XmlNode item2 = rootElement.CreateChildElement("Item");
+    item2.SetAttributeValue("priority", "2");
+    item2.SetText("Do bills");
+
+    Aws::String serializedXml = doc.ConvertToString(true);
+
+    Aws::String toCompare = "<?xml version=\"1.0\"?>"
+        "<ToDo>"
+        "<Item priority=\"1\">Go to the &lt;bold&gt;Toy store!&lt;/bold&gt;</Item>"
+        "<Item priority=\"2\">Do bills</Item>"
+        "</ToDo>";
+    ASSERT_EQ(toCompare, serializedXml);
+    ASSERT_TRUE(doc.GetErrorMessage().empty());
+
+    // The no-arg overload preserves the pretty-printed default.
+    ASSERT_EQ(doc.ConvertToString(false), doc.ConvertToString());
+}
+
 TEST_F(XmlSerializerTest, TestXmlSerializeNewlines)
 {
     XmlDocument doc = XmlDocument::CreateWithRootNode("Newlines");

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/PutBucketNotificationConfigurationRequest.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/s3/PutBucketNotificationConfigurationRequest.vm
@@ -57,11 +57,11 @@ Aws::String ${typeInfo.className}::SerializePayload() const
 #if($payloadMember)
   ${CppViewHelper.computeMemberVariableName($shape.payload)}.AddToNode(parentNode);
 
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 #else
 #set($useRequiredField = true)
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/ModelClassMembersXmlizeSource.vm")
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 #end
 #else
   return {};

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlRequestSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/XmlRequestSource.vm
@@ -119,7 +119,7 @@ Aws::String ${typeInfo.className}::SerializePayload() const
   ${CppViewHelper.computeMemberVariableName($shape.payload)}.AddToNode(parentNode);
   if(parentNode.HasChildren())
   {
-    return payloadDoc.ConvertToString();
+    return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
   }
 
   return {};
@@ -128,7 +128,7 @@ Aws::String ${typeInfo.className}::SerializePayload() const
 #set($useRequiredField = true)
 #set($callFromRequestShape = true)
 #parse("com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/ModelClassMembersXmlizeSource.vm")
-  return payloadDoc.ConvertToString();
+  return payloadDoc.ConvertToString(ShouldUseCompactXmlPayload());
 #end
 #else
   return {};


### PR DESCRIPTION
*Issue #3891*

Adds an opt-in `ClientConfiguration::compactXmlSerialization` flag (default `false`) that serializes XML request payloads without pretty-print whitespace, producing smaller request bodies. When off, output is unchanged.            
                                                                                                                                                                                                                                         
  - New `XmlDocument::ConvertToString(bool compact)` overload; no-arg version delegates with `false`.                                                                                                                                    
  - `AWSClient` reads the config flag and sets it on the request before payload serialization.                                                                                                                                           
  - XML request templates regenerated to pass `ShouldUseCompactXmlPayload()`.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
