### PR TITLE
Bdd naming

### DIFF
--- a/tools/code-generation/smithy/cpp-codegen/smithy-cpp-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/ServiceNameUtil.java
+++ b/tools/code-generation/smithy/cpp-codegen/smithy-cpp-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/ServiceNameUtil.java
@@ -8,6 +8,7 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.aws.traits.ServiceTrait;
 
 import java.util.Map;
+import java.util.Optional;
 
 public final class ServiceNameUtil {
     
@@ -170,12 +171,18 @@ public final class ServiceNameUtil {
      * Follows C2J convention: AWS_{UPPERCASED_SERVICE_NAME}_LOCAL
      *
      * @param service The service shape to generate the macro for
-     * @param serviceMap Service ID mappings for namespace overrides (reserved for future consistency with getSmithyServiceName)
+     * @param serviceMap Service ID mappings, used to resolve the key into namespaceMap
+     * @param namespaceMap Namespace overrides, keyed by smithy service name; the macro must follow the
+     *                     override because the C2J-generated {@code <Prefix>_EXPORTS.h} defines it off
+     *                     {@code metadata.classNamePrefix}
      * @return The local macro in format AWS_{SERVICE_NAME}_LOCAL
      */
-    public static String getLocalMacro(ServiceShape service, Map<String, String> serviceMap) {
-        String serviceName = getServiceName(service);
-        return "AWS_" + serviceName.toUpperCase() + "_LOCAL";
+    public static String getLocalMacro(ServiceShape service, Map<String, String> serviceMap,
+                                       Map<String, String> namespaceMap) {
+        return Optional.ofNullable(namespaceMap.get(getSmithyServiceName(service, serviceMap)))
+            .orElseGet(() -> getServiceName(service))
+            .toUpperCase()
+            .transform(name -> "AWS_" + name + "_LOCAL");
     }
 
     public static boolean isS3CrtProjection(ServiceShape service) {

--- a/tools/code-generation/smithy/cpp-codegen/smithy-cpp-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/endpointrules/EndpointRulesCodegenPlugin.java
+++ b/tools/code-generation/smithy/cpp-codegen/smithy-cpp-codegen/src/main/java/com/amazonaws/util/awsclientsmithygenerator/generators/endpointrules/EndpointRulesCodegenPlugin.java
@@ -76,7 +76,7 @@ public class EndpointRulesCodegenPlugin implements SmithyBuildPlugin {
                                        Map<String, String> namespaceMap, String pythonExecutable,
                                        String bddBytecoderPath, CppWriterDelegator writerDelegator) {
         String smithyServiceName = ServiceNameUtil.getSmithyServiceName(service, serviceMap);
-        String localMacro = ServiceNameUtil.getLocalMacro(service, serviceMap);
+        String localMacro = ServiceNameUtil.getLocalMacro(service, serviceMap, namespaceMap);
         String namespace = namespaceMap.getOrDefault(smithyServiceName, ServiceNameUtil.getServiceName(service));
         String classPrefix = Optional.ofNullable(namespaceMap.get(smithyServiceName))
             .map(ServiceNameUtil::capitalize)


### PR DESCRIPTION
*Description of changes:*

Fixes a issue where code gen for a service where service name and smithy name does not match up for a new service. specifically in the macro for a local symbol.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
