### PR TITLE
Validate DateTime range and bound parser field widths (defense in depth)

### DIFF
--- a/src/aws-cpp-sdk-core/source/utils/DateTimeCommon.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/DateTimeCommon.cpp
@@ -10,6 +10,7 @@
 #include <aws/core/utils/logging/LogMacros.h>
 #include <time.h>
 #include <cassert>
+#include <cstdint>
 #include <iostream>
 #include <cstring>
 #include <iomanip>
@@ -477,7 +478,7 @@ public:
                     }
                     break;
                 case 2:
-                    if (isdigit(c))
+                    if (isdigit(c) && index - stateStartIndex < 2)
                     {
                         m_parsedTimestamp.tm_mday = m_parsedTimestamp.tm_mday * 10 + (c - '0');
                     }
@@ -525,7 +526,7 @@ public:
                         stateStartIndex = index + 1;
                         m_parsedTimestamp.tm_year += 2000 - 1900;
                     }
-                    else if (isdigit(c))
+                    else if (isdigit(c) && index - stateStartIndex < 4)
                     {
                         m_parsedTimestamp.tm_year = m_parsedTimestamp.tm_year * 10 + (c - '0');
                     }
@@ -540,7 +541,7 @@ public:
                         m_state = 6;
                         stateStartIndex = index + 1;
                     }
-                    else if (isdigit(c))
+                    else if (isdigit(c) && index - stateStartIndex < 2)
                     {
                         m_parsedTimestamp.tm_hour = m_parsedTimestamp.tm_hour * 10 + (c - '0');
                     }
@@ -555,7 +556,7 @@ public:
                         m_state = 7;
                         stateStartIndex = index + 1;
                     }
-                    else if (isdigit(c))
+                    else if (isdigit(c) && index - stateStartIndex < 2)
                     {
                         m_parsedTimestamp.tm_min = m_parsedTimestamp.tm_min * 10 + (c - '0');
                     }
@@ -570,7 +571,7 @@ public:
                         m_state = 8;
                         stateStartIndex = index + 1;
                     }
-                    else if (isdigit(c))
+                    else if (isdigit(c) && index - stateStartIndex < 2)
                     {
                         m_parsedTimestamp.tm_sec = m_parsedTimestamp.tm_sec * 10 + (c - '0');
                     }
@@ -746,7 +747,7 @@ public:
                         stateStartIndex = index + 1;
                         m_parsedTimestamp.tm_year -= 1900;
                     }
-                    else if (isdigit(c))
+                    else if (isdigit(c) && index - stateStartIndex < 4)
                     {
                         m_parsedTimestamp.tm_year = m_parsedTimestamp.tm_year * 10 + (c - '0');
                     }
@@ -762,7 +763,7 @@ public:
                         stateStartIndex = index + 1;
                         m_parsedTimestamp.tm_mon -= 1;
                     }
-                    else if (isdigit(c))
+                    else if (isdigit(c) && index - stateStartIndex < 2)
                     {
                         m_parsedTimestamp.tm_mon = m_parsedTimestamp.tm_mon * 10 + (c - '0');
                     }
@@ -778,7 +779,7 @@ public:
                         m_state = 3;
                         stateStartIndex = index + 1;
                     }
-                    else if (isdigit(c))
+                    else if (isdigit(c) && index - stateStartIndex < 2)
                     {
                         m_parsedTimestamp.tm_mday = m_parsedTimestamp.tm_mday * 10 + (c - '0');
                     }
@@ -794,7 +795,7 @@ public:
                         m_state = 4;
                         stateStartIndex = index + 1;
                     }
-                    else if (isdigit(c))
+                    else if (isdigit(c) && index - stateStartIndex < 2)
                     {
                         m_parsedTimestamp.tm_hour = m_parsedTimestamp.tm_hour * 10 + (c - '0');
                     }
@@ -810,7 +811,7 @@ public:
                         m_state = 5;
                         stateStartIndex = index + 1;
                     }
-                    else if (isdigit(c))
+                    else if (isdigit(c) && index - stateStartIndex < 2)
                     {
                         m_parsedTimestamp.tm_min = m_parsedTimestamp.tm_min * 10 + (c - '0');
                     }
@@ -832,7 +833,7 @@ public:
                         m_state = 6;
                         stateStartIndex = index + 1;
                     }
-                    else if (isdigit(c))
+                    else if (isdigit(c) && index - stateStartIndex < 2)
                     {
                         m_parsedTimestamp.tm_sec = m_parsedTimestamp.tm_sec * 10 + (c - '0');
                     }
@@ -983,7 +984,7 @@ public:
                         m_state = 3;
                         stateStartIndex = index + 1;
                     }
-                    else if (isdigit(c))
+                    else if (isdigit(c) && index - stateStartIndex < 2)
                     {
                         m_parsedTimestamp.tm_mday = m_parsedTimestamp.tm_mday * 10 + (c - '0');
                     }
@@ -1108,8 +1109,20 @@ private:
 
     int m_state;
 };
-    
-} // namespace 
+
+static bool IsSecondsSinceEpochRepresentable(std::time_t seconds)
+{
+    using SysClock = std::chrono::system_clock;
+    static const int64_t minSeconds = std::chrono::duration_cast<std::chrono::seconds>(
+        SysClock::time_point::min().time_since_epoch()).count();
+    static const int64_t maxSeconds = std::chrono::duration_cast<std::chrono::seconds>(
+        SysClock::time_point::max().time_since_epoch()).count();
+
+    const int64_t asInt64 = static_cast<int64_t>(seconds);
+    return asInt64 >= minSeconds && asInt64 <= maxSeconds;
+}
+
+} // namespace
 
 DateTime::DateTime(const std::chrono::system_clock::time_point& timepointToAssign) : m_time(timepointToAssign), m_valid(true)
 {
@@ -1503,7 +1516,16 @@ void DateTime::ConvertTimestampStringToTimePoint(const char* timestamp, DateForm
             AWS_LOGSTREAM_ERROR(CLASS_TAG, "Non-UTC timestamp detected. This is always a bug. Make the world a better place and fix whatever sent you this timestamp: " << timestamp)
             tt = std::mktime(&timeStruct);
         }
-        m_time = std::chrono::system_clock::from_time_t(tt);
+
+        if (IsSecondsSinceEpochRepresentable(tt))
+        {
+            m_time = std::chrono::system_clock::from_time_t(tt);
+        }
+        else
+        {
+            AWS_LOGSTREAM_WARN(CLASS_TAG, "Parsed timestamp is outside the range representable by the system clock and cannot be converted: " << timestamp)
+            m_valid = false;
+        }
     }
 }
 

--- a/tests/aws-cpp-sdk-core-tests/utils/DateTimeTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/utils/DateTimeTest.cpp
@@ -6,11 +6,19 @@
 #include <aws/testing/AwsCppSdkGTestSuite.h>
 #include <aws/core/utils/DateTime.h>
 
+#include <chrono>
+
 using namespace Aws::Utils;
 
 class DateTimeTest : public Aws::Testing::AwsCppSdkGTestSuite
 {
 };
+
+static bool SystemClockSaturatesNear2262()
+{
+    return std::chrono::system_clock::period::num == 1 &&
+           std::chrono::system_clock::period::den == 1000000000;
+}
 
 TEST_F(DateTimeTest, TestDefault)
 {
@@ -58,6 +66,130 @@ TEST_F(DateTimeTest, TestRFC822Parsing_WrongFormat)
     const char* gmtDateStr = "Wed, 02 Oct 2002";
     DateTime gmtDate(gmtDateStr, DateFormat::RFC822);
     ASSERT_FALSE(gmtDate.WasParseSuccessful());
+}
+
+TEST_F(DateTimeTest, TestRFC822Parsing_DayOverflow)
+{
+    const char* gmtDateStr = "Fri, 99999999999 Dec 2021 00:00:00 GMT";
+    DateTime date(gmtDateStr, DateFormat::RFC822);
+    ASSERT_FALSE(date.WasParseSuccessful());
+}
+
+TEST_F(DateTimeTest, TestRFC822Parsing_NeverExpiresSentinelIsSafe)
+{
+    if (!SystemClockSaturatesNear2262())
+    {
+        GTEST_SKIP() << "year 9999 is only out of range (and rejected) on a nanosecond system_clock";
+    }
+    const char* neverExpires = "Fri, 31 Dec 9999 23:59:59 GMT";
+    DateTime date(neverExpires, DateFormat::RFC822);
+    ASSERT_FALSE(date.WasParseSuccessful());
+}
+
+TEST_F(DateTimeTest, TestISO_8601Parsing_OutOfRangeSentinelIsSafe)
+{
+    if (!SystemClockSaturatesNear2262())
+    {
+        GTEST_SKIP() << "year 9999 is only out of range (and rejected) on a nanosecond system_clock";
+    }
+    const char* neverExpires = "9999-12-31T23:59:59Z";
+    DateTime date(neverExpires, DateFormat::ISO_8601);
+    ASSERT_FALSE(date.WasParseSuccessful());
+}
+
+TEST_F(DateTimeTest, TestISO_8601Parsing_InRangeFarFutureStillParses)
+{
+    const char* gmtDateStr = "2200-01-01T00:00:00Z";
+    DateTime date(gmtDateStr, DateFormat::ISO_8601);
+    ASSERT_TRUE(date.WasParseSuccessful());
+    ASSERT_EQ(2200, date.GetYear());
+    ASSERT_EQ(gmtDateStr, date.ToGmtString(DateFormat::ISO_8601));
+}
+
+TEST_F(DateTimeTest, TestISO_8601Parsing_UpperBoundaryRoundTrips)
+{
+    const char* gmtDateStr = "2262-04-11T00:00:00Z";
+    DateTime date(gmtDateStr, DateFormat::ISO_8601);
+    ASSERT_TRUE(date.WasParseSuccessful());
+    ASSERT_EQ(gmtDateStr, date.ToGmtString(DateFormat::ISO_8601));
+}
+
+TEST_F(DateTimeTest, TestISO_8601Parsing_LowerBoundaryIsSafe)
+{
+    const char* gmtDateStr = "1677-09-22T00:00:00Z";
+    DateTime date(gmtDateStr, DateFormat::ISO_8601);
+    ASSERT_TRUE(date.WasParseSuccessful());
+    ASSERT_LE(date.Seconds(), 0);
+}
+
+TEST_F(DateTimeTest, TestISO_8601Parsing_OnePastUpperBoundaryIsSafe)
+{
+    const char* gmtDateStr = "2262-04-12T00:00:00Z";
+    DateTime date(gmtDateStr, DateFormat::ISO_8601);
+    if (SystemClockSaturatesNear2262())
+    {
+        ASSERT_FALSE(date.WasParseSuccessful());
+    }
+    else
+    {
+        ASSERT_TRUE(date.WasParseSuccessful());
+        ASSERT_EQ(2262, date.GetYear());
+    }
+}
+
+TEST_F(DateTimeTest, TestISO_8601Parsing_PreEpochArchivalIsSafe)
+{
+    const char* gmtDateStr = "1600-01-01T00:00:00Z";
+    DateTime date(gmtDateStr, DateFormat::ISO_8601);
+    if (SystemClockSaturatesNear2262())
+    {
+        ASSERT_FALSE(date.WasParseSuccessful());
+    }
+    else
+    {
+        ASSERT_TRUE(date.WasParseSuccessful());
+        ASSERT_LE(date.Seconds(), 0);
+    }
+}
+
+TEST_F(DateTimeTest, TestISO_8601Parsing_MidRangeFutureIsSafe)
+{
+    const char* gmtDateStr = "2500-01-01T00:00:00Z";
+    DateTime date(gmtDateStr, DateFormat::ISO_8601);
+    if (SystemClockSaturatesNear2262())
+    {
+        ASSERT_FALSE(date.WasParseSuccessful());
+    }
+    else
+    {
+        ASSERT_TRUE(date.WasParseSuccessful());
+        ASSERT_EQ(2500, date.GetYear());
+    }
+}
+
+TEST_F(DateTimeTest, TestRFC822Parsing_NineDigitDayRejected)
+{
+    const char* gmtDateStr = "Wed, 999999999 Oct 2002 08:00:00 GMT";
+    DateTime date(gmtDateStr, DateFormat::RFC822);
+    ASSERT_FALSE(date.WasParseSuccessful());
+}
+
+TEST_F(DateTimeTest, TestRFC822Parsing_TwentyDigitDayRejected)
+{
+    const char* gmtDateStr = "Wed, 99999999999999999999 Oct 2002 08:00:00 GMT";
+    DateTime date(gmtDateStr, DateFormat::RFC822);
+    ASSERT_FALSE(date.WasParseSuccessful());
+}
+
+TEST_F(DateTimeTest, TestAutoDetectParsing_NeverExpiresSentinelIsSafe)
+{
+    if (!SystemClockSaturatesNear2262())
+    {
+        GTEST_SKIP() << "year 9999 is only out of range (and rejected) on a nanosecond system_clock";
+    }
+    const char* neverExpires = "Fri, 31 Dec 9999 23:59:59 GMT";
+    DateTime date(neverExpires, DateFormat::AutoDetect);
+    ASSERT_FALSE(date.WasParseSuccessful());
 }
 
 TEST_F(DateTimeTest, TestISO_8601Parsing)


### PR DESCRIPTION
Aws::Utils::DateTime accumulated timestamp fields digit-by-digit with no bound on the digit count, so the int accumulators could overflow (signed-integer overflow is undefined behavior). It also converted parsed timestamps to std::chrono::system_clock::time_point without a range check; that conversion scales seconds up to the clock's tick period, overflowing the time_point's int64_t representation for dates far from the epoch (outside ~1677-2262 on a nanosecond clock) and reporting the resulting wrong value as a successful parse.

Bound each delimiter-driven accumulator by its field width in the RFC822, ISO-8601 and ISO-8601-Basic parsers, and reject timestamps outside the range representable by the system clock before converting them, deriving the window from the platform clock rather than hard-coding it.

Acknowledgement: We would like to thank Lucas Carvalho Cordeiro (@lucasccordeiro) and Rafael Sa Menezes (@rafaelsamenezes) of the University of Manchester, who reported these issues and supplied the field-width patch, via the coordinated vulnerability disclosure process.

*Issue #, if available:*

*Description of changes:*

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
