### PR TITLE
Fix Android CMake argument formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ To build for Android, add `-DTARGET_ARCH=ANDROID` to your CMake command line. Cu
 Building for Android on Windows requires some additional setup. In particular, you will need to run CMake from a Visual Studio developer command prompt (2015 or higher). Additionally, you will need 'git' and 'patch' in your path. If you have Git installed on a Windows system, then the patch is likely found in a sibling directory (.../Git/usr/bin/). Once you've verified these requirements, your CMake command line will change slightly to use nmake:
 
    ```sh
-   cmake -G "NMake Makefiles" `-DTARGET_ARCH=ANDROID` <other options> ..
+   cmake -G "NMake Makefiles" -DTARGET_ARCH=ANDROID <other options> ..
    ```
 
 Nmake builds targets in a serial fashion. To make things quicker, we recommend installing JOM as an alternative to nmake and then changing the CMake invocation to:
 
    ```sh
-   cmake -G "NMake Makefiles JOM" `-DTARGET_ARCH=ANDROID` <other options> ..
+   cmake -G "NMake Makefiles JOM" -DTARGET_ARCH=ANDROID <other options> ..
    ```
 
 ### Building aws-sdk-cpp - Using vcpkg


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Remove shell backticks around `-DTARGET_ARCH=ANDROID` in the NMake and JOM commands. Backticks are command-substitution syntax rather than part of a CMake `-D` option, so the examples now pass the option literally as described.

Validation:
- Ran `git diff --check`.
- Confirmed the section contains two literal `-DTARGET_ARCH=ANDROID` arguments and no backtick-wrapped occurrences.

Generated with assistance from AI tools and reviewed by @eyesofish.

*Check all that applies:*
- [x] Did a review by yourself.
- [ ] Added proper tests to cover this PR. (Not applicable: documentation-only command correction.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [ ] Linux
- [ ] Windows
- [ ] Android
- [ ] MacOS
- [ ] IOS
- [ ] Other Platforms

No SDK build was required for this documentation-only correction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
