### PR TITLE
refactor crosslink_redirect to align with new docs website

### DIFF
--- a/.changelog/documentation-aws-cpp-sdk-core.json
+++ b/.changelog/documentation-aws-cpp-sdk-core.json
@@ -1,0 +1,6 @@
+{
+  "type": "documentation",
+  "category": "aws-cpp-sdk-core",
+  "contributor": "sarveshdesai",
+  "description": "fix redirect in docs website"
+}

--- a/docs/doxygen/static/crosslink_redirect.html
+++ b/docs/doxygen/static/crosslink_redirect.html
@@ -8,7 +8,7 @@
             
             var uidToServiceName = JSON.parse(uidServiceData);            
             
-            var baseUri = "LATEST/";
+            var defaultUrl = "root/html/index.html";
             
             function getQueryStringParameter(name, url) {
                 
@@ -46,7 +46,7 @@
                 var serviceName = uidToServiceName[uid];
                 
                 if(serviceName == null) {
-                    return baseUri;
+                    return defaultUrl;
                 }
                 
                 var dirtyName = "class_aws_1_1_";
@@ -69,7 +69,7 @@
                 }
                 
                 dirtyName += ".html";
-                return baseUri + "aws-cpp-sdk-" + serviceName.toLowerCase() + "/html/" + escapeCharacters(dirtyName);
+                return "aws-cpp-sdk-" + serviceName.toLowerCase() + "/html/" + escapeCharacters(dirtyName);
             }
             
             function checkResourceExists(url) {  
@@ -101,7 +101,7 @@
                     window.location.href = secondAttempt;
                 }
                 else {
-                    window.location.href = baseUri + "index.html";
+                    window.location.href = defaultUrl;
                 }
             }
             


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/pull/3611

*Description of changes:*

fixes client re-directs on docs pages from a previous change.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
