### PR TITLE
[Feature] Adjusts request signing timestamps 

### DIFF
--- a/.changelog/feature-clock-skew-correction.json
+++ b/.changelog/feature-clock-skew-correction.json
@@ -1,0 +1,6 @@
+{
+  "type": "feature",
+  "category": "aws-cpp-sdk-core",
+  "contributor": "kaiion",
+  "description": "Add clock skew correction: the SDK adjusts request signing timestamps by the observed client-to-service skew and retries signature errors caused by skew, so requests keep working when the client clock is off. Disable with AWS_DISABLE_CLOCK_SKEW_CORRECTION."
+}

--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
@@ -60,6 +60,11 @@ namespace Aws
 
     class AmazonWebServiceRequest;
 
+    namespace Internal
+    {
+        class ClientSkew;
+    }
+
     namespace Client
     {
         template<typename ERROR_TYPE>
@@ -345,7 +350,7 @@ namespace Aws
              * Try to adjust signer's clock
              * return true if signer's clock is adjusted, false otherwise.
              */
-            bool AdjustClockSkew(HttpResponseOutcome& outcome, const char* signerName) const;
+            bool AdjustClockSkew(HttpResponseOutcome& outcome, const Aws::Utils::DateTime& timeRequestSent, const Aws::Utils::DateTime& timeResponseReceived, std::chrono::milliseconds attemptSkew) const;
             void AddHeadersToRequest(const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest, const Http::HeaderValueCollection& headerValues) const;
             void AddContentBodyToRequest(const std::shared_ptr<Aws::Http::HttpRequest>& httpRequest, const std::shared_ptr<Aws::IOStream>& body,
                                          bool needsContentMd5 = false, bool isChunked = false) const;
@@ -359,6 +364,7 @@ namespace Aws
             std::shared_ptr<Aws::Utils::Crypto::Hash> m_hash;
             long m_requestTimeoutMs;
             bool m_enableClockSkewAdjustment;
+            mutable std::shared_ptr<Aws::Internal::ClientSkew> m_clientSkew;
             Aws::String m_serviceName = "AWSBaseClient";
             Aws::Client::RequestCompressionConfig m_requestCompressionConfig;
             std::shared_ptr<smithy::client::UserAgentInterceptor> m_userAgentInterceptor;

--- a/src/aws-cpp-sdk-core/include/aws/core/http/HttpRequest.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/http/HttpRequest.h
@@ -13,6 +13,8 @@
 #include <aws/core/utils/memory/stl/AWSStreamFwd.h>
 #include <aws/core/utils/stream/ResponseStream.h>
 #include <aws/core/utils/UUID.h>
+#include <aws/core/utils/DateTime.h>
+#include <aws/crt/Optional.h>
 #include <aws/core/monitoring/HttpClientMetrics.h>
 #include <memory>
 #include <functional>
@@ -559,6 +561,16 @@ namespace Aws
             inline void SetSigningRegion(const Aws::String& region) { m_signingRegion = region; }
 
             /**
+            * Gets the per-attempt signing timestamp override set for clock-skew correction, if any.
+            */
+            inline const Aws::Crt::Optional<Aws::Utils::DateTime>& GetSigningTimestampOverride() const { return m_signingTimestampOverride; }
+            /**
+            * Sets an explicit signing timestamp for this attempt (now() + AttemptSkew). The signer uses it
+            * instead of its own clock; set per attempt so concurrent operations don't share skew state.
+            */
+            inline void SetSigningTimestampOverride(const Aws::Utils::DateTime& signingTime) { m_signingTimestampOverride = signingTime; }
+
+            /**
              * Add a request metric
              * @param key, HttpClientMetricsKey defined in HttpClientMetrics.cpp
              * @param value, the corresponding value of this key measured during http request.
@@ -618,6 +630,7 @@ namespace Aws
             DataSentEventHandler m_onDataSent;
             ContinueRequestHandler m_continueRequest;
             Aws::String m_signingRegion;
+            Aws::Crt::Optional<Aws::Utils::DateTime> m_signingTimestampOverride;
             Aws::String m_signingAccessKey;
             Aws::String m_resolvedRemoteHost;
             Aws::Monitoring::HttpClientMetricsCollection m_httpRequestMetrics;

--- a/src/aws-cpp-sdk-core/include/aws/core/internal/ClockSkew.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/internal/ClockSkew.h
@@ -110,23 +110,6 @@ namespace Aws
         public:
             explicit ClientSkew(std::chrono::milliseconds initial) : m_skew(initial) {}
 
-            ClientSkew(const ClientSkew& other) : m_skew(other.m_skew.load()) {}
-            ClientSkew(ClientSkew&& other) noexcept : m_skew(other.m_skew.load()) {}
-            ClientSkew& operator=(const ClientSkew& other)
-            {
-                if (this != &other)
-                {
-                    m_skew = other.m_skew.load();
-                }
-                return *this;
-            }
-            ClientSkew& operator=(ClientSkew&& other) noexcept
-            {
-                m_skew = other.m_skew.load();
-                return *this;
-            }
-            ~ClientSkew() = default;
-
             std::chrono::milliseconds Load() const { return m_skew.load(); }
 
             // Runs on every response; a surviving candidate is stored, so a stale value self-heals.

--- a/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClient.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClient.h
@@ -229,11 +229,6 @@ namespace client
           return AwsClientRequestSigning<AuthSchemesVariantT>::SignEventMessage(message, seed, ctx, m_authSchemes);
         }
 
-        bool AdjustClockSkew(HttpResponseOutcome& outcome, const AuthSchemeOption& authSchemeOption) const override
-        {
-            return AwsClientRequestSigning<AuthSchemesVariantT>::AdjustClockSkew(outcome, authSchemeOption, m_authSchemes);
-        }
-
         IdentityOutcome ResolveIdentity(const AwsSmithyClientAsyncRequestContext& ctx) const override {
           return AwsClientRequestSigning<AuthSchemesVariantT>::ResolveIdentity(ctx, m_authSchemes);
         }

--- a/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientAsyncRequestContext.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientAsyncRequestContext.h
@@ -66,6 +66,10 @@ namespace smithy
 
             Aws::Crt::Optional<AwsCoreError> m_lastError;
 
+            std::chrono::milliseconds m_attemptSkew{0};
+            Aws::Utils::DateTime m_timeRequestSent;
+            Aws::Utils::DateTime m_timeResponseReceived;
+
             size_t m_retryCount;
             Aws::Vector<void*> m_monitoringContexts;
 

--- a/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientBase.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/AwsSmithyClientBase.h
@@ -58,6 +58,11 @@ namespace Aws
     }
 
     class AmazonWebServiceRequest;
+
+    namespace Internal
+    {
+        class ClientSkew;
+    }
 }
 
 namespace Aws
@@ -222,7 +227,8 @@ namespace client
         virtual ResolveEndpointOutcome ResolveEndpoint(const Aws::Endpoint::EndpointParameters& endpointParameters, EndpointUpdateCallback&& epCallback) const = 0;
         virtual SelectAuthSchemeOptionOutcome SelectAuthSchemeOption(const AwsSmithyClientAsyncRequestContext& ctx) const = 0;
         virtual SigningOutcome SignHttpRequest(std::shared_ptr<HttpRequest> httpRequest, const AwsSmithyClientAsyncRequestContext& ctx) const = 0;
-        virtual bool AdjustClockSkew(HttpResponseOutcome& outcome, const AuthSchemeOption& authSchemeOption) const = 0;
+        bool AdjustClockSkew(HttpResponseOutcome& outcome, const AwsSmithyClientAsyncRequestContext& ctx) const;
+        void RecordClockSkew(const Aws::Http::HttpResponse& response, const AwsSmithyClientAsyncRequestContext& ctx) const;
         virtual IdentityOutcome ResolveIdentity(const AwsSmithyClientAsyncRequestContext& ctx) const = 0;
         virtual GetContextEndpointParametersOutcome GetContextEndpointParameters(const AwsSmithyClientAsyncRequestContext& ctx) const = 0;
         AwsSmithyClientBase::ResolveEndpointOutcome ResolveEndpointFromRequest(
@@ -241,6 +247,7 @@ namespace client
         std::shared_ptr<Aws::Client::AWSErrorMarshaller> m_errorMarshaller;
         Aws::Vector<std::shared_ptr<smithy::interceptor::Interceptor>> m_interceptors{};
         std::shared_ptr<smithy::client::UserAgentInterceptor> m_userAgentInterceptor;
+        mutable std::shared_ptr<Aws::Internal::ClientSkew> m_clientSkew;
     private:
         void UpdateAuthSchemeFromEndpoint(const Aws::Endpoint::AWSEndpoint& endpoint, AuthSchemeOption& authscheme) const;
 

--- a/src/aws-cpp-sdk-core/include/smithy/client/common/AwsSmithyRequestSigning.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/common/AwsSmithyRequestSigning.h
@@ -26,10 +26,6 @@
 namespace smithy
 {
     static const char AWS_SMITHY_CLIENT_SIGNING_TAG[] = "AwsClientRequestSigning";
-    //4 Minutes
-    static const std::chrono::milliseconds TIME_DIFF_MAX = std::chrono::minutes(4);
-    //-4 Minutes
-    static const std::chrono::milliseconds TIME_DIFF_MIN = std::chrono::minutes(-4);
 
     template <typename AuthSchemesVariantT>
     class AwsClientRequestSigning
@@ -141,28 +137,6 @@ namespace smithy
             const AuthSchemesVariantT& authScheme = authSchemeIt->second;
             return {authScheme};
           }
-
-        static bool AdjustClockSkew(HttpResponseOutcome& outcome, const AuthSchemeOption& authSchemeOption,
-                                    const Aws::UnorderedMap<Aws::String, AuthSchemesVariantT>& authSchemes)
-        {
-            assert(!outcome.IsSuccess());
-            AWS_LOGSTREAM_WARN(AWS_SMITHY_CLIENT_SIGNING_TAG, "If the signature check failed. This could be because of a time skew. Attempting to adjust the signer.");
-
-            using DateTime = Aws::Utils::DateTime;
-            DateTime serverTime = smithy::client::Utils::GetServerTimeFromError(outcome.GetError());
-
-            auto authSchemeOutcome = ResolveAuthScheme(authSchemeOption, authSchemes);
-            if (!authSchemeOutcome.IsSuccess())
-            {
-                return false;
-            }
-
-            ClockSkewVisitor visitor(outcome, serverTime, authSchemeOption);
-            AuthSchemesVariantT authScheme = authSchemeOutcome.GetResult().value();
-            authScheme.Visit(visitor);
-
-            return visitor.m_resultShouldWait;
-        }
 
 
     protected:
@@ -359,62 +333,6 @@ namespace smithy
             }
             return std::move(*visitor.result);
         }
-
-        struct ClockSkewVisitor
-        {
-            using DateTime = Aws::Utils::DateTime;
-            using DateFormat = Aws::Utils::DateFormat;
-            using ClientError = Aws::Client::AWSError<Aws::Client::CoreErrors>;
-
-            ClockSkewVisitor(HttpResponseOutcome& outcome, const DateTime& serverTime, const AuthSchemeOption& targetAuthSchemeOption)
-                : m_outcome(outcome), m_serverTime(serverTime), m_targetAuthSchemeOption(targetAuthSchemeOption)
-            {
-            }
-
-            bool m_resultShouldWait = false;
-            HttpResponseOutcome& m_outcome;
-            const Aws::Utils::DateTime& m_serverTime;
-            const AuthSchemeOption& m_targetAuthSchemeOption;
-
-            template <typename AuthSchemeAlternativeT>
-            void operator()(AuthSchemeAlternativeT& authScheme)
-            {
-                // Auth Scheme Variant alternative contains the requested auth option
-                assert(strcmp(authScheme.schemeId, m_targetAuthSchemeOption.schemeId) == 0);
-
-                using IdentityT = typename std::remove_reference<decltype(authScheme)>::type::IdentityT;
-                using Signer = AwsSignerBase<IdentityT>;
-
-                std::shared_ptr<Signer> signer = authScheme.signer();
-                if (!signer)
-                {
-                    AWS_LOGSTREAM_ERROR(AWS_SMITHY_CLIENT_SIGNING_TAG, "Failed to adjust signing clock skew. Signer is null.");
-                    return;
-                }
-
-                const auto signingTimestamp = signer->GetSigningTimestamp();
-                if (!m_serverTime.WasParseSuccessful() || m_serverTime == DateTime())
-                {
-                    AWS_LOGSTREAM_DEBUG(AWS_SMITHY_CLIENT_SIGNING_TAG, "Date header was not found in the response, can't attempt to detect clock skew");
-                    return;
-                }
-
-                AWS_LOGSTREAM_DEBUG(AWS_SMITHY_CLIENT_SIGNING_TAG, "Server time is " << m_serverTime.ToGmtString(DateFormat::RFC822) << ", while client time is " << DateTime::Now().ToGmtString(DateFormat::RFC822));
-                auto diff = DateTime::Diff(m_serverTime, signingTimestamp);
-                //only try again if clock skew was the cause of the error.
-                if (diff >= TIME_DIFF_MAX || diff <= TIME_DIFF_MIN)
-                {
-                    diff = DateTime::Diff(m_serverTime, DateTime::Now());
-                    AWS_LOGSTREAM_INFO(AWS_SMITHY_CLIENT_SIGNING_TAG, "Computed time difference as " << diff.count() << " milliseconds. Adjusting signer with the skew.");
-                    signer->SetClockSkew(diff);
-                    ClientError newError(m_outcome.GetError());
-                    newError.SetRetryableType(Aws::Client::RetryableType::RETRYABLE);
-
-                    m_outcome = std::move(newError);
-                    m_resultShouldWait = true;
-                }
-            }
-        };
 
     };
 }

--- a/src/aws-cpp-sdk-core/include/smithy/identity/signer/built-in/SigV4aSigner.h
+++ b/src/aws-cpp-sdk-core/include/smithy/identity/signer/built-in/SigV4aSigner.h
@@ -97,7 +97,8 @@ namespace smithy {
             awsSigningConfig.SetSignatureType(signatureType);
             awsSigningConfig.SetRegion(serviceName.c_str());
             awsSigningConfig.SetService(region.c_str());
-            awsSigningConfig.SetSigningTimepoint(GetSigningTimestamp().UnderlyingTimestamp());
+            const Aws::Utils::DateTime sigV4aSigningTime = request.GetSigningTimestampOverride() ? request.GetSigningTimestampOverride().value() : GetSigningTimestamp();
+            awsSigningConfig.SetSigningTimepoint(sigV4aSigningTime.UnderlyingTimestamp());
             awsSigningConfig.SetUseDoubleUriEncode(m_urlEscape);
             awsSigningConfig.SetShouldNormalizeUriPath(true);
             awsSigningConfig.SetOmitSessionToken(false);

--- a/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthEventStreamV4Signer.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthEventStreamV4Signer.cpp
@@ -79,7 +79,7 @@ bool AWSAuthEventStreamV4Signer::SignRequestWithCreds(Http::HttpRequest& request
     request.SetHeaderValue(Aws::Auth::AWSAuthHelper::X_AMZ_CONTENT_SHA256, EVENT_STREAM_CONTENT_SHA256);
 
     //calculate date header to use in internal signature (this also goes into date header).
-    DateTime now = GetSigningTimestamp();
+    DateTime now = request.GetSigningTimestampOverride() ? request.GetSigningTimestampOverride().value() : GetSigningTimestamp();
     Aws::String dateHeaderValue = now.ToGmtString(DateFormat::ISO_8601_BASIC);
     request.SetHeaderValue(AWS_DATE_HEADER, dateHeaderValue);
 

--- a/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
+++ b/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
@@ -96,7 +96,8 @@ bool AWSAuthV4Signer::SignRequestWithSigV4a(Aws::Http::HttpRequest& request, con
     awsSigningConfig.SetSignatureType(signatureType);
     awsSigningConfig.SetRegion(region);
     awsSigningConfig.SetService(serviceName);
-    awsSigningConfig.SetSigningTimepoint(GetSigningTimestamp().UnderlyingTimestamp());
+    const DateTime sigV4aSigningTime = request.GetSigningTimestampOverride() ? request.GetSigningTimestampOverride().value() : GetSigningTimestamp();
+    awsSigningConfig.SetSigningTimepoint(sigV4aSigningTime.UnderlyingTimestamp());
     awsSigningConfig.SetUseDoubleUriEncode(m_urlEscapePath);
     awsSigningConfig.SetShouldNormalizeUriPath(true);
     awsSigningConfig.SetOmitSessionToken(false);
@@ -254,7 +255,7 @@ bool AWSAuthV4Signer::SignRequestWithCreds(Aws::Http::HttpRequest& request, cons
     }
 
     //calculate date header to use in internal signature (this also goes into date header).
-    DateTime now = GetSigningTimestamp();
+    DateTime now = request.GetSigningTimestampOverride() ? request.GetSigningTimestampOverride().value() : GetSigningTimestamp();
     Aws::String dateHeaderValue = now.ToGmtString(DateFormat::ISO_8601_BASIC);
     request.SetHeaderValue(AWS_DATE_HEADER, dateHeaderValue);
 

--- a/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/src/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -28,6 +28,7 @@
 #include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/Globals.h>
 #include <aws/core/utils/EnumParseOverflowContainer.h>
+#include <aws/core/internal/ClockSkew.h>
 #include <aws/core/utils/crypto/MD5.h>
 #include <aws/core/utils/crypto/CRC32.h>
 #include <aws/core/utils/crypto/Sha256.h>
@@ -67,11 +68,6 @@ static const int SUCCESS_RESPONSE_MAX = 299;
 static const char AWS_CLIENT_LOG_TAG[] = "AWSClient";
 static const char AWS_LAMBDA_FUNCTION_NAME[] = "AWS_LAMBDA_FUNCTION_NAME";
 static const char X_AMZN_TRACE_ID[] = "_X_AMZN_TRACE_ID";
-
-//4 Minutes
-static const std::chrono::milliseconds TIME_DIFF_MAX = std::chrono::minutes(4);
-//-4 Minutes
-static const std::chrono::milliseconds TIME_DIFF_MIN = std::chrono::minutes(-4);
 
 CoreErrors AWSClient::GuessBodylessErrorType(Aws::Http::HttpResponseCode responseCode)
 {
@@ -138,6 +134,7 @@ AWSClient::AWSClient(const Aws::Client::ClientConfiguration& configuration,
     m_hash(Aws::Utils::Crypto::CreateMD5Implementation()),
     m_requestTimeoutMs(configuration.requestTimeoutMs),
     m_enableClockSkewAdjustment(configuration.enableClockSkewAdjustment),
+    m_clientSkew(Aws::MakeShared<Aws::Internal::ClientSkew>(AWS_CLIENT_LOG_TAG, std::chrono::milliseconds(0))),
     m_requestCompressionConfig(configuration.requestCompressionConfig),
     m_userAgentInterceptor{Aws::MakeShared<smithy::client::UserAgentInterceptor>(AWS_CLIENT_LOG_TAG, configuration, m_retryStrategy->GetStrategyName(), m_serviceName)},
     m_interceptors{Aws::MakeShared<smithy::client::ChecksumInterceptor>(AWS_CLIENT_LOG_TAG), Aws::MakeShared<smithy::client::features::ChunkingInterceptor>(AWS_CLIENT_LOG_TAG,
@@ -169,6 +166,7 @@ AWSClient::AWSClient(const Aws::Client::ClientConfiguration& configuration,
     m_hash(Aws::Utils::Crypto::CreateMD5Implementation()),
     m_requestTimeoutMs(configuration.requestTimeoutMs),
     m_enableClockSkewAdjustment(configuration.enableClockSkewAdjustment),
+    m_clientSkew(Aws::MakeShared<Aws::Internal::ClientSkew>(AWS_CLIENT_LOG_TAG, std::chrono::milliseconds(0))),
     m_requestCompressionConfig(configuration.requestCompressionConfig),
     m_userAgentInterceptor{Aws::MakeShared<smithy::client::UserAgentInterceptor>(AWS_CLIENT_LOG_TAG, configuration, m_retryStrategy->GetStrategyName(), m_serviceName)},
     m_interceptors{Aws::MakeShared<smithy::client::ChecksumInterceptor>(AWS_CLIENT_LOG_TAG, configuration), Aws::MakeShared<smithy::client::features::ChunkingInterceptor>(AWS_CLIENT_LOG_TAG,
@@ -228,30 +226,16 @@ static DateTime GetServerTimeFromError(const AWSError<CoreErrors> error)
     }
 }
 
-bool AWSClient::AdjustClockSkew(HttpResponseOutcome& outcome, const char* signerName) const
+bool AWSClient::AdjustClockSkew(HttpResponseOutcome& outcome, const Aws::Utils::DateTime& timeRequestSent, const Aws::Utils::DateTime& timeResponseReceived, std::chrono::milliseconds attemptSkew) const
 {
     if (m_enableClockSkewAdjustment)
     {
-        auto signer = GetSignerByName(signerName);
-        //detect clock skew and try to correct.
-        AWS_LOGSTREAM_WARN(AWS_CLIENT_LOG_TAG, "If the signature check failed. This could be because of a time skew. Attempting to adjust the signer.");
-
-        DateTime serverTime = GetServerTimeFromError(outcome.GetError());
-        const auto signingTimestamp = signer->GetSigningTimestamp();
-        if (!serverTime.WasParseSuccessful() || serverTime == DateTime())
+        const auto measurement = Aws::Internal::MakeClockSkewMeasurement(outcome.GetError().GetResponseHeaders(), timeRequestSent, timeResponseReceived);
+        const auto adjustment = m_clientSkew->EvaluateFailure(measurement, attemptSkew);
+        // Force a retry only when the error is a clock-skew error code and the skew exceeds the threshold.
+        if (Aws::Internal::IsClockSkewError(outcome.GetError()) && adjustment.skewExceedsThreshold)
         {
-            AWS_LOGSTREAM_DEBUG(AWS_CLIENT_LOG_TAG, "Date header was not found in the response, can't attempt to detect clock skew");
-            return false;
-        }
-
-        AWS_LOGSTREAM_DEBUG(AWS_CLIENT_LOG_TAG, "Server time is " << serverTime.ToGmtString(DateFormat::RFC822) << ", while client time is " << DateTime::Now().ToGmtString(DateFormat::RFC822));
-        auto diff = DateTime::Diff(serverTime, signingTimestamp);
-        //only try again if clock skew was the cause of the error.
-        if (diff >= TIME_DIFF_MAX || diff <= TIME_DIFF_MIN)
-        {
-            diff = DateTime::Diff(serverTime, DateTime::Now());
-            AWS_LOGSTREAM_INFO(AWS_CLIENT_LOG_TAG, "Computed time difference as " << diff.count() << " milliseconds. Adjusting signer with the skew.");
-            signer->SetClockSkew(diff);
+            AWS_LOGSTREAM_WARN(AWS_CLIENT_LOG_TAG, "Signature check likely failed due to clock skew; adjusting the signing timestamp and retrying.");
             AWSError<CoreErrors> newError(
                 outcome.GetError().GetErrorType(), outcome.GetError().GetExceptionName(), outcome.GetError().GetMessage(), true);
             newError.SetResponseHeaders(outcome.GetError().GetResponseHeaders());
@@ -290,6 +274,8 @@ HttpResponseOutcome AWSClient::AttemptExhaustively(const Aws::Http::URI& uri,
     httpRequest->SetHeaderValue(Http::SDK_REQUEST_HEADER, requestInfo);
     AppendRecursionDetectionHeader(httpRequest);
 
+    // AttemptSkew: seeded from the client-level skew, updated after each attempt.
+    std::chrono::milliseconds attemptSkew = m_clientSkew->Load();
     for (long retries = 0;; retries++)
     {
         if(!m_retryStrategy->HasSendToken())
@@ -303,7 +289,10 @@ HttpResponseOutcome AWSClient::AttemptExhaustively(const Aws::Http::URI& uri,
         httpRequest->SetEventStreamRequest(request.IsEventStreamRequest());
         httpRequest->SetHasEventStreamResponse(request.HasEventStreamResponse());
 
+        const DateTime attemptSentTime = DateTime::Now();
+        httpRequest->SetSigningTimestampOverride(attemptSentTime + attemptSkew);
         outcome = AttemptOneRequest(httpRequest, request, signerName, signerRegion, signerServiceNameOverride);
+        const DateTime timeResponseReceived = DateTime::Now();
         outcome.SetRetryCount(retries);
         if (retries == 0)
         {
@@ -320,6 +309,10 @@ HttpResponseOutcome AWSClient::AttemptExhaustively(const Aws::Http::URI& uri,
              {TracingUtils::SMITHY_SERVICE_DIMENSION, this->GetServiceClientName()}});
         if (outcome.IsSuccess())
         {
+            if (m_enableClockSkewAdjustment && outcome.GetResult())
+            {
+                m_clientSkew->RecordResponse(Aws::Internal::MakeClockSkewMeasurement(outcome.GetResult()->GetHeaders(), attemptSentTime, timeResponseReceived));
+            }
             Aws::Monitoring::OnRequestSucceeded(this->GetServiceClientName(), request.GetServiceRequestName(), httpRequest, outcome, coreMetrics, contexts);
             AWS_LOGSTREAM_TRACE(AWS_CLIENT_LOG_TAG, "Request successful returning.");
             break;
@@ -362,7 +355,8 @@ HttpResponseOutcome AWSClient::AttemptExhaustively(const Aws::Http::URI& uri,
             {{TracingUtils::SMITHY_METHOD_DIMENSION, request.GetServiceRequestName()},{TracingUtils::SMITHY_SERVICE_DIMENSION, this->GetServiceClientName()}});
         //AdjustClockSkew returns true means clock skew was the problem and skew was adjusted, false otherwise.
         //sleep if clock skew and region was NOT the problem. AdjustClockSkew may update error inside outcome.
-        bool shouldSleep = !AdjustClockSkew(outcome, signerName) && !retryWithCorrectRegion;
+        bool shouldSleep = !AdjustClockSkew(outcome, attemptSentTime, timeResponseReceived, attemptSkew) && !retryWithCorrectRegion;
+        attemptSkew = m_clientSkew->Load();
 
         if (!retryWithCorrectRegion && !m_retryStrategy->ShouldRetry(outcome.GetError(), retries))
         {
@@ -464,6 +458,8 @@ HttpResponseOutcome AWSClient::AttemptExhaustively(const Aws::Http::URI& uri,
     httpRequest->SetHeaderValue(Http::SDK_REQUEST_HEADER, requestInfo);
     AppendRecursionDetectionHeader(httpRequest);
 
+    // AttemptSkew: seeded from the client-level skew, updated after each attempt.
+    std::chrono::milliseconds attemptSkew = m_clientSkew->Load();
     for (long retries = 0;; retries++)
     {
         if(!m_retryStrategy->HasSendToken())
@@ -474,7 +470,10 @@ HttpResponseOutcome AWSClient::AttemptExhaustively(const Aws::Http::URI& uri,
                                                             false/*retryable*/));
 
         };
+        const DateTime attemptSentTime = DateTime::Now();
+        httpRequest->SetSigningTimestampOverride(attemptSentTime + attemptSkew);
         outcome = AttemptOneRequest(httpRequest, signerName, requestName, signerRegion, signerServiceNameOverride);
+        const DateTime timeResponseReceived = DateTime::Now();
         outcome.SetRetryCount(retries);
         if (retries == 0)
         {
@@ -490,6 +489,10 @@ HttpResponseOutcome AWSClient::AttemptExhaustively(const Aws::Http::URI& uri,
             {{TracingUtils::SMITHY_METHOD_DIMENSION, requestName},{TracingUtils::SMITHY_SERVICE_DIMENSION, this->GetServiceClientName()}});
         if (outcome.IsSuccess())
         {
+            if (m_enableClockSkewAdjustment && outcome.GetResult())
+            {
+                m_clientSkew->RecordResponse(Aws::Internal::MakeClockSkewMeasurement(outcome.GetResult()->GetHeaders(), attemptSentTime, timeResponseReceived));
+            }
             Aws::Monitoring::OnRequestSucceeded(this->GetServiceClientName(), requestName, httpRequest, outcome, coreMetrics, contexts);
             AWS_LOGSTREAM_TRACE(AWS_CLIENT_LOG_TAG, "Request successful returning.");
             break;
@@ -532,7 +535,8 @@ HttpResponseOutcome AWSClient::AttemptExhaustively(const Aws::Http::URI& uri,
             {{TracingUtils::SMITHY_METHOD_DIMENSION, requestName},{TracingUtils::SMITHY_SERVICE_DIMENSION, this->GetServiceClientName()}});
         //AdjustClockSkew returns true means clock skew was the problem and skew was adjusted, false otherwise.
         //sleep if clock skew and region was NOT the problem. AdjustClockSkew may update error inside outcome.
-        bool shouldSleep = !AdjustClockSkew(outcome, signerName) && !retryWithCorrectRegion;
+        bool shouldSleep = !AdjustClockSkew(outcome, attemptSentTime, timeResponseReceived, attemptSkew) && !retryWithCorrectRegion;
+        attemptSkew = m_clientSkew->Load();
 
         if (!retryWithCorrectRegion && !m_retryStrategy->ShouldRetry(outcome.GetError(), retries))
         {

--- a/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
+++ b/src/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp
@@ -39,6 +39,8 @@ static const char* REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_VAR = "request_min_
 static const char* AWS_EXECUTION_ENV = "AWS_EXECUTION_ENV";
 static const char* DISABLE_IMDSV1_CONFIG_VAR = "AWS_EC2_METADATA_V1_DISABLED";
 static const char* DISABLE_IMDSV1_ENV_VAR = "ec2_metadata_v1_disabled";
+static const char* DISABLE_CLOCK_SKEW_CORRECTION_ENV_VAR = "AWS_DISABLE_CLOCK_SKEW_CORRECTION";
+static const char* DISABLE_CLOCK_SKEW_CORRECTION_CONFIG_VAR = "disable_clock_skew_correction";
 static const char* AWS_ACCOUNT_ID_ENDPOINT_MODE_ENVIRONMENT_VARIABLE = "AWS_ACCOUNT_ID_ENDPOINT_MODE";
 static const char* AWS_ACCOUNT_ID_ENDPOINT_MODE_CONFIG_FILE_OPTION = "account_id_endpoint_mode";
 static const char* AWS_METADATA_SERVICE_TIMEOUT_ENV_VAR = "AWS_METADATA_SERVICE_TIMEOUT";
@@ -334,6 +336,16 @@ void setConfigFromEnvOrProfile(ClientConfiguration &config)
     if (disableIMDSv1 == "true") {
         config.disableImdsV1 = true;
         config.credentialProviderConfig.imdsConfig.disableImdsV1 = true;
+    }
+
+    // Knob is a "disable" flag (AWS ..._DISABLED convention); the config field is "enable" and defaults on.
+    const bool disableClockSkewCorrection = ClientConfiguration::LoadConfigFromEnvOrProfile(DISABLE_CLOCK_SKEW_CORRECTION_ENV_VAR,
+        config.profileName,
+        DISABLE_CLOCK_SKEW_CORRECTION_CONFIG_VAR,
+        {"true", "false"},
+        "false") == "true";
+    if (disableClockSkewCorrection) {
+        config.enableClockSkewAdjustment = false;
     }
 
     // accountId is intentionally not set here: AWS_ACCOUNT_ID env variable may not match the provided credentials.

--- a/src/aws-cpp-sdk-core/source/smithy/client/AwsSmithyClientBase.cpp
+++ b/src/aws-cpp-sdk-core/source/smithy/client/AwsSmithyClientBase.cpp
@@ -12,6 +12,7 @@
 
 #include <aws/core/client/AWSErrorMarshaller.h>
 #include <aws/core/client/CoreErrors.h>
+#include <aws/core/internal/ClockSkew.h>
 #include <aws/core/client/RetryStrategy.h>
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/monitoring/CoreMetrics.h>
@@ -69,6 +70,7 @@ void createFromFactoriesIfPresent(T& entity, std::function<T()>& factory) {
 
 void AwsSmithyClientBase::baseInit() {
   AWS_CHECK_PTR(AWS_SMITHY_CLIENT_LOG, m_clientConfig);
+  m_clientSkew = Aws::MakeShared<Aws::Internal::ClientSkew>(AWS_SMITHY_CLIENT_LOG, std::chrono::milliseconds(0));
   createFromFactories(m_clientConfig->retryStrategy, m_clientConfig->configFactories.retryStrategyCreateFn);
   createFromFactories(m_clientConfig->executor, m_clientConfig->configFactories.executorCreateFn);
   createFromFactories(m_clientConfig->writeRateLimiter, m_clientConfig->configFactories.writeRateLimiterCreateFn);
@@ -85,6 +87,7 @@ void AwsSmithyClientBase::baseInit() {
 
 void AwsSmithyClientBase::baseCopyInit() {
   AWS_CHECK_PTR(AWS_SMITHY_CLIENT_LOG, m_clientConfig);
+  m_clientSkew = Aws::MakeShared<Aws::Internal::ClientSkew>(AWS_SMITHY_CLIENT_LOG, std::chrono::milliseconds(0));
   createFromFactoriesIfPresent(m_clientConfig->retryStrategy, m_clientConfig->configFactories.retryStrategyCreateFn);
   createFromFactoriesIfPresent(m_clientConfig->executor, m_clientConfig->configFactories.executorCreateFn);
   createFromFactoriesIfPresent(m_clientConfig->writeRateLimiter, m_clientConfig->configFactories.writeRateLimiterCreateFn);
@@ -118,6 +121,7 @@ void AwsSmithyClientBase::baseCopyAssign(const AwsSmithyClientBase& other,
 }
 
 void AwsSmithyClientBase::baseMoveAssign(AwsSmithyClientBase&& other) {
+  m_clientSkew = Aws::MakeShared<Aws::Internal::ClientSkew>(AWS_SMITHY_CLIENT_LOG, std::chrono::milliseconds(0));
   m_serviceName = std::move(other.m_serviceName);
   m_serviceUserAgentName = std::move(other.m_serviceUserAgentName);
   m_httpClient = std::move(other.m_httpClient);
@@ -305,6 +309,7 @@ void AwsSmithyClientBase::MakeRequestAsync(Aws::AmazonWebServiceRequest const* c
         return;
     }
     pRequestCtx->m_requestInfo.attempt = 1;
+    pRequestCtx->m_attemptSkew = m_clientSkew->Load();
     pRequestCtx->m_requestInfo.maxAttempts =
         Aws::Environment::GetEnv("AWS_NEW_RETRIES_2026") == "true"
             ? m_clientConfig->retryStrategy->GetMaxAttempts()
@@ -410,6 +415,8 @@ void AwsSmithyClientBase::AttemptOneRequestAsync(std::shared_ptr<AwsSmithyClient
     if (authCallback) {
       authCallback(pRequestCtx);
     }
+    pRequestCtx->m_timeRequestSent = Aws::Utils::DateTime::Now();
+    pRequestCtx->m_httpRequest->SetSigningTimestampOverride(pRequestCtx->m_timeRequestSent + pRequestCtx->m_attemptSkew);
     SigningOutcome signingOutcome = TracingUtils::MakeCallWithTiming<SigningOutcome>([&]() -> SigningOutcome {
             return this->SignHttpRequest(pRequestCtx->m_httpRequest, *pRequestCtx);
         },
@@ -488,10 +495,40 @@ void AwsSmithyClientBase::AttemptOneRequestAsync(std::shared_ptr<AwsSmithyClient
     return;
 }
 
+void AwsSmithyClientBase::RecordClockSkew(const Aws::Http::HttpResponse& response, const AwsSmithyClientAsyncRequestContext& ctx) const
+{
+    if (m_clientConfig->enableClockSkewAdjustment)
+    {
+        m_clientSkew->RecordResponse(Aws::Internal::MakeClockSkewMeasurement(response.GetHeaders(), ctx.m_timeRequestSent, ctx.m_timeResponseReceived));
+    }
+}
+
+bool AwsSmithyClientBase::AdjustClockSkew(HttpResponseOutcome& outcome, const AwsSmithyClientAsyncRequestContext& ctx) const
+{
+    if (!m_clientConfig->enableClockSkewAdjustment)
+    {
+        return false;
+    }
+    const auto measurement = Aws::Internal::MakeClockSkewMeasurement(outcome.GetError().GetResponseHeaders(), ctx.m_timeRequestSent, ctx.m_timeResponseReceived);
+    const auto adjustment = m_clientSkew->EvaluateFailure(measurement, ctx.m_attemptSkew);
+    // Force a retry only when the error is a clock-skew error code and the skew exceeds the threshold.
+    if (Aws::Internal::IsClockSkewError(outcome.GetError()) && adjustment.skewExceedsThreshold)
+    {
+        AWS_LOGSTREAM_WARN(AWS_SMITHY_CLIENT_LOG, "Signature check likely failed due to clock skew; adjusting the signing timestamp and retrying.");
+        auto newError = outcome.GetError();
+        newError.SetRetryableType(Aws::Client::RetryableType::RETRYABLE);
+        outcome = std::move(newError);
+        return true;
+    }
+    return false;
+}
+
 void AwsSmithyClientBase::HandleAsyncReply(std::shared_ptr<AwsSmithyClientAsyncRequestContext> pRequestCtx,
                                            std::shared_ptr<Aws::Http::HttpResponse> httpResponse) const
 {
     assert(pRequestCtx && httpResponse);
+
+    pRequestCtx->m_timeResponseReceived = Aws::Utils::DateTime::Now();
 
     pRequestCtx->m_interceptorContext->SetTransmitResponse(httpResponse);
     for (const auto& interceptor : m_interceptors)
@@ -546,6 +583,10 @@ void AwsSmithyClientBase::HandleAsyncReply(std::shared_ptr<AwsSmithyClientAsyncR
              {TracingUtils::SMITHY_SERVICE_DIMENSION, this->GetServiceClientName()}});
         if (outcome.IsSuccess())
         {
+            if (outcome.GetResult())
+            {
+                RecordClockSkew(*outcome.GetResult(), *pRequestCtx);
+            }
             Aws::Monitoring::OnRequestSucceeded(this->GetServiceClientName(),
                                                 pRequestCtx->m_requestName,
                                                 pRequestCtx->m_httpRequest,
@@ -612,13 +653,9 @@ void AwsSmithyClientBase::HandleAsyncReply(std::shared_ptr<AwsSmithyClientAsyncR
             *m_clientConfig->telemetryProvider->getMeter(this->GetServiceClientName(), {}),
             {{TracingUtils::SMITHY_METHOD_DIMENSION, pRequestCtx->m_requestName},
              {TracingUtils::SMITHY_SERVICE_DIMENSION, this->GetServiceClientName()}});
-        bool shouldSleep = !retryWithCorrectRegion;
-        if (m_clientConfig->enableClockSkewAdjustment)
-        {
-            // AdjustClockSkew returns true means clock skew was the problem and skew was adjusted, false otherwise.
-            // sleep if clock skew and region was NOT the problem. AdjustClockSkew may update error inside outcome.
-            shouldSleep |= !this->AdjustClockSkew(outcome, pRequestCtx->m_authSchemeOption);
-        }
+        // Sleep only if neither clock skew nor region caused the failure. AdjustClockSkew self-gates on the disable knob.
+        bool shouldSleep = !this->AdjustClockSkew(outcome, *pRequestCtx) && !retryWithCorrectRegion;
+        pRequestCtx->m_attemptSkew = m_clientSkew->Load();
 
         if (!retryWithCorrectRegion && !m_clientConfig->retryStrategy->ShouldRetry(outcome.GetError(), static_cast<long>(pRequestCtx->m_retryCount)))
         {

--- a/tests/aws-cpp-sdk-core-tests/aws/client/AWSClientTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/aws/client/AWSClientTest.cpp
@@ -137,6 +137,22 @@ protected:
         mockHttpClient->AddResponseToReturn(httpResponse);
     }
 
+    void QueueMockResponse(HttpResponseCode code, CoreErrors errorType, const HeaderValueCollection& headers)
+    {
+        auto httpRequest = CreateHttpRequest(URI("http://www.uri.com/path/to/res"),
+                HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+        httpRequest->SetResolvedRemoteHost("127.0.0.1");
+        auto httpResponse = Aws::MakeShared<StandardHttpResponse>(ALLOCATION_TAG, httpRequest);
+        httpResponse->SetResponseCode(code);
+        httpResponse->SetClientErrorType(errorType);
+        httpResponse->GetResponseBody() << "";
+        for(auto&& header : headers)
+        {
+            httpResponse->AddHeader(header.first, header.second);
+        }
+        mockHttpClient->AddResponseToReturn(httpResponse);
+    }
+
     Aws::String ExtractFromRequestInfo(const Aws::String& requestInfo, const Aws::String& key)
     {
         auto iter = requestInfo.find(key + "=");
@@ -216,8 +232,8 @@ TEST_F(AWSClientTestSuite, TestClockSkewOutsideAcceptableRange)
     HeaderValueCollection responseHeaders;
     responseHeaders.emplace("Date", (DateTime::Now() + std::chrono::hours(1)).ToGmtString(DateFormat::RFC822)); // server is ahead of us by 1 hour
     AmazonWebServiceRequestMock request;
-    QueueMockResponse(HttpResponseCode::BAD_REQUEST, responseHeaders);
-    QueueMockResponse(HttpResponseCode::BAD_REQUEST, responseHeaders);
+    QueueMockResponse(HttpResponseCode::BAD_REQUEST, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
+    QueueMockResponse(HttpResponseCode::BAD_REQUEST, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
     auto outcome = client->MakeRequest(request);
     ASSERT_FALSE(outcome.IsSuccess());
     ASSERT_EQ(1, client->GetRequestAttemptedRetries());
@@ -228,7 +244,7 @@ TEST_F(AWSClientTestSuite, TestClockSkewWithinAcceptableRange)
     HeaderValueCollection responseHeaders;
     responseHeaders.emplace("Date", (DateTime::Now() + std::chrono::minutes(2)).ToGmtString(DateFormat::RFC822)); // server is ahead of us by 2 minutes
     AmazonWebServiceRequestMock request;
-    QueueMockResponse(HttpResponseCode::BAD_REQUEST, responseHeaders);
+    QueueMockResponse(HttpResponseCode::BAD_REQUEST, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
     auto outcome = client->MakeRequest(request);
     ASSERT_FALSE(outcome.IsSuccess());
     ASSERT_EQ(0, client->GetRequestAttemptedRetries());
@@ -240,22 +256,22 @@ TEST_F(AWSClientTestSuite, TestClockSkewConsecutiveRequests)
     HeaderValueCollection responseHeaders;
     responseHeaders.emplace("Date", (DateTime::Now() + std::chrono::hours(1)).ToGmtString(DateFormat::RFC822)); // server is ahead of us by 1 hour
     AmazonWebServiceRequestMock request;
-    QueueMockResponse(HttpResponseCode::BAD_REQUEST, responseHeaders);
-    QueueMockResponse(HttpResponseCode::BAD_REQUEST, responseHeaders);
+    QueueMockResponse(HttpResponseCode::BAD_REQUEST, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
+    QueueMockResponse(HttpResponseCode::BAD_REQUEST, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
     auto outcome = client->MakeRequest(request);
     ASSERT_FALSE(outcome.IsSuccess());
     ASSERT_EQ(1, client->GetRequestAttemptedRetries());
 
-    QueueMockResponse(HttpResponseCode::UNAUTHORIZED, responseHeaders);
+    QueueMockResponse(HttpResponseCode::UNAUTHORIZED, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
     outcome = client->MakeRequest(request);
-    ASSERT_FALSE(outcome.IsSuccess()); // should _not_ attempt to adjust clock skew and retry the request.
+    ASSERT_FALSE(outcome.IsSuccess()); // skew already applied; the offset now matches, so no retry.
     ASSERT_EQ(HttpResponseCode::UNAUTHORIZED, outcome.GetError().GetResponseCode());
     ASSERT_STREQ("127.0.0.1", outcome.GetError().GetRemoteHostIpAddress().c_str());
     ASSERT_EQ(0, client->GetRequestAttemptedRetries());
 
-    QueueMockResponse(HttpResponseCode::FORBIDDEN, responseHeaders);
+    QueueMockResponse(HttpResponseCode::FORBIDDEN, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
     outcome = client->MakeRequest(request);
-    ASSERT_FALSE(outcome.IsSuccess()); // should _not_ attempt to adjust clock skew and retry the request.
+    ASSERT_FALSE(outcome.IsSuccess()); // skew already applied; the offset now matches, so no retry.
     ASSERT_EQ(HttpResponseCode::FORBIDDEN, outcome.GetError().GetResponseCode());
     ASSERT_STREQ("127.0.0.1", outcome.GetError().GetRemoteHostIpAddress().c_str());
     ASSERT_EQ(0, client->GetRequestAttemptedRetries());
@@ -271,8 +287,8 @@ TEST_F(AWSClientTestSuite, TestClockChangesAfterSkewHasBeenSet)
     HeaderValueCollection responseHeaders;
     responseHeaders.emplace("Date", (DateTime::Now() + std::chrono::hours(1)).ToGmtString(DateFormat::RFC822)); // server is ahead of us by 1 hour
     AmazonWebServiceRequestMock request;
-    QueueMockResponse(HttpResponseCode::BAD_REQUEST, responseHeaders);
-    QueueMockResponse(HttpResponseCode::BAD_REQUEST, responseHeaders);
+    QueueMockResponse(HttpResponseCode::BAD_REQUEST, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
+    QueueMockResponse(HttpResponseCode::BAD_REQUEST, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
     auto outcome = client->MakeRequest(request);
     ASSERT_FALSE(outcome.IsSuccess());
     ASSERT_EQ(1, client->GetRequestAttemptedRetries());
@@ -280,8 +296,8 @@ TEST_F(AWSClientTestSuite, TestClockChangesAfterSkewHasBeenSet)
     // make another request with the clock skewed even further
     responseHeaders.clear();
     responseHeaders.emplace("Date", (DateTime::Now() + std::chrono::hours(2)).ToGmtString(DateFormat::RFC822)); // server is ahead of us by 2 hours
-    QueueMockResponse(HttpResponseCode::FORBIDDEN, responseHeaders);
-    QueueMockResponse(HttpResponseCode::FORBIDDEN, responseHeaders);
+    QueueMockResponse(HttpResponseCode::FORBIDDEN, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
+    QueueMockResponse(HttpResponseCode::FORBIDDEN, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
     outcome = client->MakeRequest(request);
     ASSERT_FALSE(outcome.IsSuccess());
     ASSERT_EQ(1, client->GetRequestAttemptedRetries());
@@ -289,8 +305,8 @@ TEST_F(AWSClientTestSuite, TestClockChangesAfterSkewHasBeenSet)
     // make another request with the clock in sync with the server
     responseHeaders.clear();
     responseHeaders.emplace("Date", DateTime::Now().ToGmtString(DateFormat::RFC822)); // server is in sync with client
-    QueueMockResponse(HttpResponseCode::FORBIDDEN, responseHeaders);
-    QueueMockResponse(HttpResponseCode::FORBIDDEN, responseHeaders);
+    QueueMockResponse(HttpResponseCode::FORBIDDEN, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
+    QueueMockResponse(HttpResponseCode::FORBIDDEN, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
     outcome = client->MakeRequest(request);
     ASSERT_FALSE(outcome.IsSuccess());
     ASSERT_EQ(1, client->GetRequestAttemptedRetries());
@@ -300,10 +316,10 @@ TEST_F(AWSClientTestSuite, TestRetryHeaders)
 {
     // The first server time is ahead of us by 1 hour.
     DateTime serverTime1 = DateTime::Now() + std::chrono::hours(1);
-    QueueMockResponse(HttpResponseCode::REQUEST_NOT_MADE, HeaderValueCollection{std::make_pair("Date", serverTime1.ToGmtString(DateFormat::RFC822))});
+    QueueMockResponse(HttpResponseCode::REQUEST_NOT_MADE, CoreErrors::SIGNATURE_DOES_NOT_MATCH, HeaderValueCollection{std::make_pair("Date", serverTime1.ToGmtString(DateFormat::RFC822))});
     // The second server time is ahead of us by 2 hour.
     DateTime serverTime2 = DateTime::Now() + std::chrono::hours(2);
-    QueueMockResponse(HttpResponseCode::REQUEST_NOT_MADE, HeaderValueCollection{std::make_pair("Date", serverTime2.ToGmtString(DateFormat::RFC822))});
+    QueueMockResponse(HttpResponseCode::REQUEST_NOT_MADE, CoreErrors::SIGNATURE_DOES_NOT_MATCH, HeaderValueCollection{std::make_pair("Date", serverTime2.ToGmtString(DateFormat::RFC822))});
     // The third server time is ahead of us by 3 hour.
     DateTime serverTime3 = DateTime::Now() + std::chrono::hours(3);
     QueueMockResponse(HttpResponseCode::OK, HeaderValueCollection{std::make_pair("Date", serverTime3.ToGmtString(DateFormat::RFC822))});
@@ -345,8 +361,8 @@ TEST_F(AWSClientTestSuite, TestRetryURIs)
 {
     HeaderValueCollection responseHeaders;
     responseHeaders.emplace("Date", (DateTime::Now() + std::chrono::hours(1)).ToGmtString(DateFormat::RFC822)); // server is ahead of us by 1 hour
-    QueueMockResponse(HttpResponseCode::INTERNAL_SERVER_ERROR, responseHeaders);
-    QueueMockResponse(HttpResponseCode::INTERNAL_SERVER_ERROR, responseHeaders);
+    QueueMockResponse(HttpResponseCode::INTERNAL_SERVER_ERROR, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
+    QueueMockResponse(HttpResponseCode::INTERNAL_SERVER_ERROR, CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
     URI uri("http://www.uri.com/path with space/to/res");
     AmazonWebServiceRequestMock request;
     auto outcome = client->MakeRequest(uri, request);

--- a/tests/aws-cpp-sdk-core-tests/monitoring/MonitoringTest.cpp
+++ b/tests/aws-cpp-sdk-core-tests/monitoring/MonitoringTest.cpp
@@ -242,6 +242,22 @@ protected:
         }
         mockHttpClient->AddResponseToReturn(httpResponse);
     }
+
+    void QueueMockResponse(HttpResponseCode code, Aws::Client::CoreErrors errorType, const HeaderValueCollection& headers)
+    {
+        auto httpRequest = CreateHttpRequest(URI(URI_STRING),
+                HttpMethod::HTTP_GET, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+        httpRequest->SetResolvedRemoteHost("127.0.0.1");
+        auto httpResponse = Aws::MakeShared<StandardHttpResponse>(ALLOCATION_TAG, httpRequest);
+        httpResponse->SetResponseCode(code);
+        httpResponse->SetClientErrorType(errorType);
+        httpResponse->GetResponseBody() << "";
+        for(auto&& header : headers)
+        {
+            httpResponse->AddHeader(header.first, header.second);
+        }
+        mockHttpClient->AddResponseToReturn(httpResponse);
+    }
 };
 
 TEST_F(MonitoringTestSuite, TestMonitoringListenersAreCalledCorrectlyWithRetryAndSucceededRequest)
@@ -252,7 +268,7 @@ TEST_F(MonitoringTestSuite, TestMonitoringListenersAreCalledCorrectlyWithRetryAn
     requestHeaders.emplace("X-Amz-Date", Aws::Utils::DateTime::Now().ToGmtString(Aws::Utils::DateFormat::ISO_8601));
     request.SetHeaders(requestHeaders);
     // BAD_REQUEST is not retryable, but since this is triggered by clock skew, it's set to mandatory retryable.
-    QueueMockResponse(HttpResponseCode::BAD_REQUEST, responseHeaders);
+    QueueMockResponse(HttpResponseCode::BAD_REQUEST, Aws::Client::CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
     QueueMockResponse(HttpResponseCode::OK, responseHeaders);
     auto outcome = client->MakeRequest(request);
     AWS_ASSERT_SUCCESS(outcome);
@@ -273,8 +289,8 @@ TEST_F(MonitoringTestSuite, TestMonitoringListenersAreCalledCorrectlyWithRetryAn
     AmazonWebServiceRequestMock request;
     requestHeaders.emplace("X-Amz-Date", Aws::Utils::DateTime::Now().ToGmtString(Aws::Utils::DateFormat::ISO_8601));
     request.SetHeaders(requestHeaders);
-    QueueMockResponse(HttpResponseCode::BAD_REQUEST, responseHeaders);
-    QueueMockResponse(HttpResponseCode::BAD_REQUEST, responseHeaders);
+    QueueMockResponse(HttpResponseCode::BAD_REQUEST, Aws::Client::CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
+    QueueMockResponse(HttpResponseCode::BAD_REQUEST, Aws::Client::CoreErrors::SIGNATURE_DOES_NOT_MATCH, responseHeaders);
     auto outcome = client->MakeRequest(request);
     ASSERT_FALSE(outcome.IsSuccess());
     ASSERT_EQ(1, client->GetRequestAttemptedRetries());

--- a/tests/aws-cpp-sdk-s3-unit-tests/S3UnitTests.cpp
+++ b/tests/aws-cpp-sdk-s3-unit-tests/S3UnitTests.cpp
@@ -1,6 +1,9 @@
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/client/RetryStrategy.h>
+#include <aws/core/client/DefaultRetryStrategy.h>
+#include <aws/core/utils/DateTime.h>
+#include <aws/s3/S3EndpointProvider.h>
 #include <aws/core/utils/HashingUtils.h>
 #include <aws/core/utils/base64/Base64.h>
 #include <aws/core/utils/crypto/CRC64.h>
@@ -310,6 +313,36 @@ TEST_F(S3UnitTest, S3EmbeddedErrorTest) {
   EXPECT_TRUE(response.GetError().ShouldRetry());
   EXPECT_EQ("We encountered an internal error. Please try again.", response.GetError().GetMessage());
   EXPECT_EQ("656c76696e6727732072657175657374", response.GetError().GetRequestId());
+}
+
+// Clock skew end to end through a real client: a SignatureDoesNotMatch error with the server clock an hour ahead drives a signing-time adjustment and one retry.
+TEST_F(S3UnitTest, ClockSkewAdjustmentRetries) {
+  AWSCredentials credentials{"mock", "credentials"};
+  const auto epProvider = Aws::MakeShared<S3EndpointProvider>(ALLOCATION_TAG);
+  S3ClientConfiguration s3Config;
+  s3Config.region = "us-east-1";
+  s3Config.retryStrategy = Aws::MakeShared<DefaultRetryStrategy>(ALLOCATION_TAG); // fixture default is NoRetry
+  S3TestClient retryingClient{credentials, epProvider, s3Config};
+
+  auto makeSkewResponse = []() -> std::shared_ptr<Standard::StandardHttpResponse> {
+    auto mockRequest = Aws::MakeShared<Standard::StandardHttpRequest>(ALLOCATION_TAG, "mockuri", HttpMethod::HTTP_GET);
+    mockRequest->SetResponseStreamFactory(Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+    auto mockResponse = Aws::MakeShared<Standard::StandardHttpResponse>(ALLOCATION_TAG, mockRequest);
+    mockResponse->SetResponseCode(HttpResponseCode::FORBIDDEN);
+    // Write the body (so tellp() > 0 and the XML error marshaller parses it rather than treating it as bodyless).
+    mockResponse->GetResponseBody() << "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Error><Code>SignatureDoesNotMatch</Code><Message>clock skew</Message></Error>";
+    mockResponse->AddHeader("Date", (Aws::Utils::DateTime::Now() + std::chrono::hours(1)).ToGmtString(Aws::Utils::DateFormat::RFC822)); // server is 1 hour ahead
+    return mockResponse;
+  };
+
+  _mockHttpClient->Reset();
+  _mockHttpClient->AddResponseToReturn(makeSkewResponse());
+  _mockHttpClient->AddResponseToReturn(makeSkewResponse());
+
+  const auto response = retryingClient.CopyObject(CopyObjectRequest().WithBucket("b").WithKey("k").WithCopySource("s"));
+  EXPECT_FALSE(response.IsSuccess());
+  EXPECT_STREQ("SignatureDoesNotMatch", response.GetError().GetExceptionName().c_str()); // real XML marshaller mapped the code
+  EXPECT_EQ(2u, _mockHttpClient->GetAllRequestsMade().size());                           // clock skew drove exactly one retry
 }
 
 class MockRequest : public Aws::AmazonWebServiceRequest

--- a/tests/testing-resources/include/aws/testing/mocks/aws/client/MockAWSClient.h
+++ b/tests/testing-resources/include/aws/testing/mocks/aws/client/MockAWSClient.h
@@ -161,6 +161,9 @@ protected:
         {
             bool retryable = response->GetClientErrorType() == Aws::Client::CoreErrors::NETWORK_CONNECTION ? true : false;
             error = Aws::Client::AWSError<Aws::Client::CoreErrors>(response->GetClientErrorType(), "", response->GetClientErrorMessage(), retryable);
+            error.SetResponseHeaders(response->GetHeaders());
+            error.SetResponseCode(response->GetResponseCode());
+            error.SetRemoteHostIpAddress(response->GetOriginatingRequest().GetResolvedRemoteHost());
             return error;
         }
         error = Aws::Client::AWSError<Aws::Client::CoreErrors>(Aws::Client::CoreErrors::INVALID_ACTION, false);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Wire clock-skew correction into the legacy and smithy client pipelines

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [x] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
