### PR TITLE
fix/bidirectional stream shutdown

### DIFF
--- a/.changelog/bugfix-testbidirectional-stream-shutdown.json
+++ b/.changelog/bugfix-testbidirectional-stream-shutdown.json
@@ -1,0 +1,6 @@
+{
+  "type": "bugfix",
+  "category": "aws-cpp-sdk-core",
+  "contributor": "pulimsr, sbiscigl",
+  "description": "Release the CRT connection when a bidirectional stream completes to fix a hang on client shutdown"
+}

--- a/.changelog/bugfix-testbidirectional-stream-shutdown.json
+++ b/.changelog/bugfix-testbidirectional-stream-shutdown.json
@@ -2,5 +2,5 @@
   "type": "bugfix",
   "category": "aws-cpp-sdk-core",
   "contributor": "pulimsr, sbiscigl",
-  "description": "Release the CRT connection when a bidirectional stream completes to fix a hang on client shutdown"
+  "description": "Release the CRT connection when a bidirectional stream completes to fix a hang on client shutdown. Fix transcribe streaming to honor low speed limit instead of timeout for total request."
 }

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/source/BedrockRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/source/BedrockRuntimeClient.cpp
@@ -408,7 +408,12 @@ void BedrockRuntimeClient::InvokeModelWithBidirectionalStreamAsync(
   auto requestCopy = Aws::MakeShared<InvokeModelWithBidirectionalStreamRequest>(ALLOCATION_TAG, request);
 
   auto authCallback = [&](std::shared_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> ctx) -> void {
-    eventEncoderStream->SetSigningCallback([this, ctx](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
+    std::weak_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> weakCtx = ctx;
+    eventEncoderStream->SetSigningCallback([this, weakCtx](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
+      auto ctx = weakCtx.lock();
+      if (!ctx) {
+        return false;
+      }
       auto outcome = SignEventMessage(message, seed, ctx);
       return outcome.IsSuccess();
     });
@@ -425,7 +430,12 @@ void BedrockRuntimeClient::InvokeModelWithBidirectionalStreamAsync(
   // Pull-based path
   auto eventEncoderStream = Aws::MakeShared<Model::InvokeModelWithBidirectionalStreamInput>(ALLOCATION_TAG);
   auto authCallback = [&](std::shared_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> ctx) -> void {
-    eventEncoderStream->SetSigningCallback([this, ctx](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
+    std::weak_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> weakCtx = ctx;
+    eventEncoderStream->SetSigningCallback([this, weakCtx](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
+      auto ctx = weakCtx.lock();
+      if (!ctx) {
+        return false;
+      }
       auto outcome = SignEventMessage(message, seed, ctx);
       return outcome.IsSuccess();
     });

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/source/BedrockRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/source/BedrockRuntimeClient.cpp
@@ -408,7 +408,7 @@ void BedrockRuntimeClient::InvokeModelWithBidirectionalStreamAsync(
   auto requestCopy = Aws::MakeShared<InvokeModelWithBidirectionalStreamRequest>(ALLOCATION_TAG, request);
 
   auto authCallback = [&](std::shared_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> ctx) -> void {
-    eventEncoderStream->SetSigningCallback([this, ctx, eventEncoderStream](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
+    eventEncoderStream->SetSigningCallback([this, ctx](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
       auto outcome = SignEventMessage(message, seed, ctx);
       return outcome.IsSuccess();
     });
@@ -425,7 +425,7 @@ void BedrockRuntimeClient::InvokeModelWithBidirectionalStreamAsync(
   // Pull-based path
   auto eventEncoderStream = Aws::MakeShared<Model::InvokeModelWithBidirectionalStreamInput>(ALLOCATION_TAG);
   auto authCallback = [&](std::shared_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> ctx) -> void {
-    eventEncoderStream->SetSigningCallback([this, ctx, eventEncoderStream](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
+    eventEncoderStream->SetSigningCallback([this, ctx](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
       auto outcome = SignEventMessage(message, seed, ctx);
       return outcome.IsSuccess();
     });

--- a/generated/src/aws-cpp-sdk-bedrock-runtime/source/BedrockRuntimeClient.cpp
+++ b/generated/src/aws-cpp-sdk-bedrock-runtime/source/BedrockRuntimeClient.cpp
@@ -400,8 +400,7 @@ void BedrockRuntimeClient::InvokeModelWithBidirectionalStreamAsync(
 
 #if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf =
-      Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, m_httpClient, 8 * 1024, m_clientConfig->requestTimeoutMs);
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, m_httpClient);
   auto eventEncoderStream = Aws::MakeShared<Model::InvokeModelWithBidirectionalStreamInput>(ALLOCATION_TAG, writeDataStreamBuf);
   request.SetBody(eventEncoderStream);
 

--- a/generated/src/aws-cpp-sdk-connecthealth/source/ConnectHealthClient.cpp
+++ b/generated/src/aws-cpp-sdk-connecthealth/source/ConnectHealthClient.cpp
@@ -522,8 +522,7 @@ void ConnectHealthClient::StartMedicalScribeListeningSessionAsync(
 
 #if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024,
-                                                                                        m_clientConfiguration.requestTimeoutMs);
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::MedicalScribeInputStream>(ALLOCATION_TAG, writeDataStreamBuf);

--- a/generated/src/aws-cpp-sdk-lexv2-runtime/source/LexRuntimeV2Client.cpp
+++ b/generated/src/aws-cpp-sdk-lexv2-runtime/source/LexRuntimeV2Client.cpp
@@ -494,8 +494,7 @@ void LexRuntimeV2Client::StartConversationAsync(Model::StartConversationRequest&
 
 #if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024,
-                                                                                        m_clientConfiguration.requestTimeoutMs);
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::StartConversationRequestEventStream>(ALLOCATION_TAG, writeDataStreamBuf);

--- a/generated/src/aws-cpp-sdk-polly/source/PollyClient.cpp
+++ b/generated/src/aws-cpp-sdk-polly/source/PollyClient.cpp
@@ -345,8 +345,7 @@ void PollyClient::StartSpeechSynthesisStreamAsync(Model::StartSpeechSynthesisStr
 
 #if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024,
-                                                                                        m_clientConfiguration.requestTimeoutMs);
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::StartSpeechSynthesisStreamActionStream>(ALLOCATION_TAG, writeDataStreamBuf);

--- a/generated/src/aws-cpp-sdk-qbusiness/source/QBusinessClient.cpp
+++ b/generated/src/aws-cpp-sdk-qbusiness/source/QBusinessClient.cpp
@@ -398,8 +398,7 @@ void QBusinessClient::ChatAsync(Model::ChatRequest& request, const ChatStreamRea
 
 #if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024,
-                                                                                        m_clientConfiguration.requestTimeoutMs);
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::ChatInputStream>(ALLOCATION_TAG, writeDataStreamBuf);

--- a/generated/src/aws-cpp-sdk-sagemaker-runtime-http2/source/SageMakerRuntimeHTTP2Client.cpp
+++ b/generated/src/aws-cpp-sdk-sagemaker-runtime-http2/source/SageMakerRuntimeHTTP2Client.cpp
@@ -232,8 +232,7 @@ void SageMakerRuntimeHTTP2Client::InvokeEndpointWithBidirectionalStreamAsync(
 
 #if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024,
-                                                                                        m_clientConfiguration.requestTimeoutMs);
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::RequestStreamEvent>(ALLOCATION_TAG, writeDataStreamBuf);

--- a/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
+++ b/generated/src/aws-cpp-sdk-transcribestreaming/source/TranscribeStreamingServiceClient.cpp
@@ -261,8 +261,7 @@ void TranscribeStreamingServiceClient::StartCallAnalyticsStreamTranscriptionAsyn
 
 #if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024,
-                                                                                        m_clientConfiguration.requestTimeoutMs);
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG, writeDataStreamBuf);
@@ -362,8 +361,7 @@ void TranscribeStreamingServiceClient::StartMedicalScribeStreamAsync(
 
 #if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024,
-                                                                                        m_clientConfiguration.requestTimeoutMs);
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::MedicalScribeInputStream>(ALLOCATION_TAG, writeDataStreamBuf);
@@ -479,8 +477,7 @@ void TranscribeStreamingServiceClient::StartMedicalStreamTranscriptionAsync(
 
 #if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024,
-                                                                                        m_clientConfiguration.requestTimeoutMs);
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG, writeDataStreamBuf);
@@ -572,8 +569,7 @@ void TranscribeStreamingServiceClient::StartStreamTranscriptionAsync(
 
 #if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024,
-                                                                                        m_clientConfiguration.requestTimeoutMs);
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::AudioStream>(ALLOCATION_TAG, writeDataStreamBuf);

--- a/prefetch_crt_dependency.sh
+++ b/prefetch_crt_dependency.sh
@@ -3,21 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 CRT_URI_PREFIX=https://codeload.github.com/awslabs
-CRT_URI=${CRT_URI_PREFIX}/aws-crt-cpp/zip/851d8d003c9d5150edab56807e2393013f3771de  # v0.43.4
+CRT_URI=${CRT_URI_PREFIX}/aws-crt-cpp/zip/8adb7b87f18654ba2147667d2b43a017c7a3c957  # v0.43.6
 
 AWS_C_AUTH_URI=${CRT_URI_PREFIX}/aws-c-auth/zip/4b5d524bf1a511b05e0fffe5bdc51800770b9427  # v0.10.4
 AWS_C_CAL_URI=${CRT_URI_PREFIX}/aws-c-cal/zip/8aa2a48a09f93c65d4cf06388e143a6584de6321  # v0.9.15
-AWS_C_COMMON_URI=${CRT_URI_PREFIX}/aws-c-common/zip/3c69b871dfa1815231802febf1bb6899f84cccdb  # v0.14.3
+AWS_C_COMMON_URI=${CRT_URI_PREFIX}/aws-c-common/zip/f7d471b1feaea9a310851672580f9ac7e031cfc0  # v0.14.5
 AWS_C_COMPRESSION_URI=${CRT_URI_PREFIX}/aws-c-compression/zip/d8264e64f698341eb03039b96b4f44702a9b3f83  # v0.3.2
 AWS_C_EVENT_STREAM_URI=${CRT_URI_PREFIX}/aws-c-event-stream/zip/51bef3c44e1058b1689751539170b2e0f589ccdb  # v0.7.1
 AWS_C_HTTP_URI=${CRT_URI_PREFIX}/aws-c-http/zip/8aefd899fc3210bfd0e3fd414011a3cb708bf6e4  # v0.11.0
-AWS_C_IO_URI=${CRT_URI_PREFIX}/aws-c-io/zip/e2946c99521fa12d285c9a0829c92b1bf713922b  # v0.27.5
-AWS_C_MQTT_URI=${CRT_URI_PREFIX}/aws-c-mqtt/zip/2ef9605ec9c50bea3f921e08022ddd57eed70901  # v0.16.0
-AWS_C_S3_URI=${CRT_URI_PREFIX}/aws-c-s3/zip/a852faa2df3ab2b31fb4cfd64fd3379a2f4ae22e  # v0.13.2
+AWS_C_IO_URI=${CRT_URI_PREFIX}/aws-c-io/zip/28e4eb351a536daf1627bf69279e50671f7729b5  # v0.27.6
+AWS_C_MQTT_URI=${CRT_URI_PREFIX}/aws-c-mqtt/zip/e35b9ca3f9fcbf1a972c831c5e79046ce56959d1  # v0.16.1
+AWS_C_S3_URI=${CRT_URI_PREFIX}/aws-c-s3/zip/226c3e6937e3d5f7db9e10651f7bd20575e98187  # v0.13.5
 AWS_C_SDKUTILS_URI=${CRT_URI_PREFIX}/aws-c-sdkutils/zip/a1cc19f53b63658f1b1400b36f199eafeeb895a6  # v0.2.9
 AWS_CHECKSUMS_URI=${CRT_URI_PREFIX}/aws-checksums/zip/1d5f2f1f3e5d013aae8810878ceb5b3f6f258c4e  # v0.2.10
-AWS_LC_URI=${CRT_URI_PREFIX}/aws-lc/zip/f6acf748df0ea6157d55e640730b38d21a7751cd  # v5.4.0
-S2N_URI=${CRT_URI_PREFIX}/s2n/zip/66b1c94d1dfc99b237427cbde230eca63bb8b89c  # v1.7.6
+AWS_LC_URI=${CRT_URI_PREFIX}/aws-lc/zip/991e67ff4cf04df4dd89e407f8b920c6936cb56a  # v5.5.0
+S2N_URI=${CRT_URI_PREFIX}/s2n/zip/853d1943bbbd7f782a159e77830cdaaf520d68ed  # v1.7.7
 
 
 echo "Removing CRT"

--- a/src/aws-cpp-sdk-core/include/aws/core/client/AWSClientBidirectionalStreaming.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/client/AWSClientBidirectionalStreaming.h
@@ -111,8 +111,8 @@ void SubmitBidirectionalStreamingRequest(
         }
         Aws::Utils::RAIICounter raiiGuard(client->m_operationsProcessed, &client->m_shutdownSignal);
 
-        writeDataStreamBuf->WaitForStreamComplete();
         auto response = writeDataStreamBuf->GetResponse();
+        writeDataStreamBuf->WaitForStreamComplete();
 
         // Flush any remaining buffered response data through the EventDecoderStream
         if (response) {

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/stream/HttpWriteDataStreamBuf.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/stream/HttpWriteDataStreamBuf.h
@@ -10,7 +10,6 @@
 #include <aws/core/utils/Array.h>
 #include <aws/crt/Types.h>
 
-#include <chrono>
 #include <condition_variable>
 #include <memory>
 #include <mutex>
@@ -36,7 +35,7 @@ namespace Stream {
  */
 class AWS_CORE_API HttpWriteDataStreamBuf : public std::streambuf {
  public:
-  explicit HttpWriteDataStreamBuf(const std::shared_ptr<Aws::Http::HttpClient>& client, size_t bufferLength = 8 * 1024, size_t requestTimeoutMs = 0);
+  explicit HttpWriteDataStreamBuf(const std::shared_ptr<Aws::Http::HttpClient>& client, size_t bufferLength = 8 * 1024);
   HttpWriteDataStreamBuf(const HttpWriteDataStreamBuf& other) = delete;
   HttpWriteDataStreamBuf(HttpWriteDataStreamBuf&& other) noexcept = delete;
   HttpWriteDataStreamBuf& operator=(const HttpWriteDataStreamBuf& other) = delete;
@@ -103,8 +102,6 @@ class AWS_CORE_API HttpWriteDataStreamBuf : public std::streambuf {
   std::condition_variable m_writeComplete;
   bool m_writeInProgress{false};
   bool m_writeError{false};
-  bool m_hasDeadline{false};
-  std::chrono::milliseconds m_writeTimeout{0};
 
   // State management
   enum class STATE {

--- a/src/aws-cpp-sdk-core/include/aws/core/utils/stream/HttpWriteDataStreamBuf.h
+++ b/src/aws-cpp-sdk-core/include/aws/core/utils/stream/HttpWriteDataStreamBuf.h
@@ -104,7 +104,7 @@ class AWS_CORE_API HttpWriteDataStreamBuf : public std::streambuf {
   bool m_writeInProgress{false};
   bool m_writeError{false};
   bool m_hasDeadline{false};
-  std::chrono::steady_clock::time_point m_deadline;
+  std::chrono::milliseconds m_writeTimeout{0};
 
   // State management
   enum class STATE {

--- a/src/aws-cpp-sdk-core/include/smithy/client/SmithyBidirectionalStreamingWriteDataTask.h
+++ b/src/aws-cpp-sdk-core/include/smithy/client/SmithyBidirectionalStreamingWriteDataTask.h
@@ -152,8 +152,8 @@ class AWS_CORE_LOCAL SmithyBidirectionalStreamingWriteDataTask final {
     m_sem->ReleaseAll();
 
     // Wait for stream to complete
-    m_writeDataStreamBuf->WaitForStreamComplete();
     auto response = m_writeDataStreamBuf->GetResponse();
+    m_writeDataStreamBuf->WaitForStreamComplete();
 
     // Flush any remaining buffered response data through the EventDecoderStream
     if (response) {

--- a/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
+++ b/src/aws-cpp-sdk-core/source/http/crt/CRTHttpClient.cpp
@@ -593,8 +593,14 @@ namespace Aws
             connectionManagerOptions.ConnectionOptions = options;
             connectionManagerOptions.MaxConnections = m_configuration.maxConnections;
             connectionManagerOptions.EnableBlockingShutdown = true;
-            //TODO: need to bind out Monitoring options to handle the read timeout config value.
-            // once done, come back and use it to setup read timeouts.
+
+            if (m_configuration.lowSpeedLimit > 0 && m_configuration.requestTimeoutMs > 0)
+            {
+                connectionManagerOptions.MinThroughputBytesPerSecond =
+                    static_cast<uint64_t>(m_configuration.lowSpeedLimit);
+                connectionManagerOptions.AllowableThroughputFailureIntervalSeconds =
+                    static_cast<uint32_t>((m_configuration.requestTimeoutMs + 999) / 1000);
+            }
 
             auto connectionManager = Crt::Http::HttpClientConnectionManager::NewClientConnectionManager(connectionManagerOptions);
 

--- a/src/aws-cpp-sdk-core/source/utils/stream/HttpWriteDataStreamBuf.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/stream/HttpWriteDataStreamBuf.cpp
@@ -109,6 +109,9 @@ void Aws::Utils::Stream::HttpWriteDataStreamBuf::WaitForStreamComplete() {
     return;
   }
   m_shutdownCondition.wait(lock, [this]() -> bool { return m_streamComplete; });
+
+  m_stream.reset();
+  m_connection.reset();
 }
 
 std::streambuf::int_type Aws::Utils::Stream::HttpWriteDataStreamBuf::overflow(std::streambuf::int_type c) {

--- a/src/aws-cpp-sdk-core/source/utils/stream/HttpWriteDataStreamBuf.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/stream/HttpWriteDataStreamBuf.cpp
@@ -18,7 +18,7 @@ Aws::Utils::Stream::HttpWriteDataStreamBuf::HttpWriteDataStreamBuf(const std::sh
     : m_client{client}, m_buffer{bufferLength} {
   if (requestTimeoutMs > 0) {
     m_hasDeadline = true;
-    m_deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(requestTimeoutMs);
+    m_writeTimeout = std::chrono::milliseconds(requestTimeoutMs);
   }
   ResetPutArea();
 }
@@ -173,7 +173,7 @@ bool Aws::Utils::Stream::HttpWriteDataStreamBuf::SendBuffer(bool endStream) {
 
   std::unique_lock<std::mutex> lock{m_writeMutex};
   if (m_hasDeadline) {
-    bool completed = m_writeComplete.wait_until(lock, m_deadline,
+    bool completed = m_writeComplete.wait_for(lock, m_writeTimeout,
         [this]() -> bool { return !m_writeInProgress; });
     if (!completed) {
       m_writeError = true;

--- a/src/aws-cpp-sdk-core/source/utils/stream/HttpWriteDataStreamBuf.cpp
+++ b/src/aws-cpp-sdk-core/source/utils/stream/HttpWriteDataStreamBuf.cpp
@@ -5,7 +5,6 @@
 #include <aws/core/http/HttpClient.h>
 #include <aws/core/utils/stream/HttpWriteDataStreamBuf.h>
 
-#include <chrono>
 #include <utility>
 
 namespace {
@@ -13,13 +12,8 @@ const char* WRITE_DATA_BUF_LOG_NAME = "HttpWriteDataStreamBuf";
 }
 
 Aws::Utils::Stream::HttpWriteDataStreamBuf::HttpWriteDataStreamBuf(const std::shared_ptr<Aws::Http::HttpClient>& client,
-                                                                   size_t bufferLength,
-                                                                   size_t requestTimeoutMs)
+                                                                   size_t bufferLength)
     : m_client{client}, m_buffer{bufferLength} {
-  if (requestTimeoutMs > 0) {
-    m_hasDeadline = true;
-    m_writeTimeout = std::chrono::milliseconds(requestTimeoutMs);
-  }
   ResetPutArea();
 }
 
@@ -156,6 +150,13 @@ bool Aws::Utils::Stream::HttpWriteDataStreamBuf::SendBuffer(bool endStream) {
     return false;
   }
 
+  {
+    std::unique_lock<std::mutex> const lock{m_shutdownMutex};
+    if (m_streamComplete || !m_stream) {
+      return false;
+    }
+  }
+
   auto data = Aws::MakeShared<Aws::StringStream>(WRITE_DATA_BUF_LOG_NAME);
   data->write(pbase(), pptr() - pbase());
 
@@ -172,18 +173,7 @@ bool Aws::Utils::Stream::HttpWriteDataStreamBuf::SendBuffer(bool endStream) {
       endStream);
 
   std::unique_lock<std::mutex> lock{m_writeMutex};
-  if (m_hasDeadline) {
-    bool completed = m_writeComplete.wait_for(lock, m_writeTimeout,
-        [this]() -> bool { return !m_writeInProgress; });
-    if (!completed) {
-      m_writeError = true;
-      m_writeInProgress = false;
-      ResetPutArea();
-      return false;
-    }
-  } else {
-    m_writeComplete.wait(lock, [this]() -> bool { return !m_writeInProgress; });
-  }
+  m_writeComplete.wait(lock, [this]() -> bool { return !m_writeInProgress; });
 
   ResetPutArea();
 

--- a/tests/aws-cpp-sdk-bedrock-runtime-integration-tests/IntegrationTests.cpp
+++ b/tests/aws-cpp-sdk-bedrock-runtime-integration-tests/IntegrationTests.cpp
@@ -15,12 +15,20 @@
 #include <aws/bedrock-runtime/model/ConverseStreamHandler.h>
 #include <aws/core/client/CoreErrors.h>
 #include <aws/bedrock-runtime/model/InvokeModelRequest.h>
+#include <aws/bedrock-runtime/model/InvokeModelWithBidirectionalStreamRequest.h>
+#include <aws/bedrock-runtime/model/InvokeModelWithBidirectionalStreamHandler.h>
+#include <aws/bedrock-runtime/model/BidirectionalInputPayloadPart.h>
+#include <aws/core/utils/UUID.h>
+#include <aws/core/utils/HashingUtils.h>
 #include <aws/core/utils/json/JsonSerializer.h>
 #include <aws/core/utils/Outcome.h>
 #include <aws/testing/TestingEnvironment.h>
 #include <aws/core/platform/Environment.h>
+#include <atomic>
 #include <condition_variable>
+#include <mutex>
 #include <chrono>
+#include <vector>
 
 using namespace Aws::BedrockRuntime;
 using namespace Aws::BedrockRuntime::Model;
@@ -47,6 +55,100 @@ protected:
     }
 
 };
+
+using Aws::Utils::Json::JsonValue;
+
+Aws::String WrapEvent(JsonValue&& ev)
+{
+    JsonValue w;
+    w.WithObject("event", std::move(ev));
+    return w.View().WriteCompact();
+}
+Aws::String SessionStart()
+{
+    JsonValue inf;
+    inf.WithInteger("maxTokens", 1024).WithDouble("topP", 0.9).WithDouble("temperature", 0.7);
+    JsonValue s; s.WithObject("inferenceConfiguration", inf);
+    JsonValue ev; ev.WithObject("sessionStart", s);
+    return WrapEvent(std::move(ev));
+}
+Aws::String PromptStart(const Aws::String& promptName)
+{
+    JsonValue textCfg; textCfg.WithString("mediaType", "text/plain");
+    JsonValue audioCfg;
+    audioCfg.WithString("mediaType", "audio/lpcm")
+            .WithInteger("sampleRateHertz", 24000)
+            .WithInteger("sampleSizeBits", 16)
+            .WithInteger("channelCount", 1)
+            .WithString("voiceId", "matthew")
+            .WithString("encoding", "base64")
+            .WithString("audioType", "SPEECH");
+    JsonValue ps;
+    ps.WithString("promptName", promptName)
+      .WithObject("textOutputConfiguration", textCfg)
+      .WithObject("audioOutputConfiguration", audioCfg);
+    JsonValue ev; ev.WithObject("promptStart", ps);
+    return WrapEvent(std::move(ev));
+}
+Aws::String TextContentStart(const Aws::String& promptName, const Aws::String& contentName)
+{
+    JsonValue cfg; cfg.WithString("mediaType", "text/plain");
+    JsonValue cs;
+    cs.WithString("promptName", promptName)
+      .WithString("contentName", contentName)
+      .WithString("type", "TEXT")
+      .WithBool("interactive", false)
+      .WithString("role", "SYSTEM")
+      .WithObject("textInputConfiguration", cfg);
+    JsonValue ev; ev.WithObject("contentStart", cs);
+    return WrapEvent(std::move(ev));
+}
+Aws::String TextInput(const Aws::String& promptName, const Aws::String& contentName, const Aws::String& text)
+{
+    JsonValue ti;
+    ti.WithString("promptName", promptName).WithString("contentName", contentName).WithString("content", text);
+    JsonValue ev; ev.WithObject("textInput", ti);
+    return WrapEvent(std::move(ev));
+}
+Aws::String AudioContentStart(const Aws::String& promptName, const Aws::String& contentName)
+{
+    JsonValue cfg;
+    cfg.WithString("mediaType", "audio/lpcm")
+       .WithInteger("sampleRateHertz", 16000)
+       .WithInteger("sampleSizeBits", 16)
+       .WithInteger("channelCount", 1)
+       .WithString("audioType", "SPEECH")
+       .WithString("encoding", "base64");
+    JsonValue cs;
+    cs.WithString("promptName", promptName)
+      .WithString("contentName", contentName)
+      .WithString("type", "AUDIO")
+      .WithBool("interactive", true)
+      .WithString("role", "USER")
+      .WithObject("audioInputConfiguration", cfg);
+    JsonValue ev; ev.WithObject("contentStart", cs);
+    return WrapEvent(std::move(ev));
+}
+Aws::String AudioInput(const Aws::String& promptName, const Aws::String& contentName, const uint8_t* pcm, size_t len)
+{
+    Aws::String b64 = Aws::Utils::HashingUtils::Base64Encode(Aws::Utils::ByteBuffer(pcm, len));
+    JsonValue ai;
+    ai.WithString("promptName", promptName).WithString("contentName", contentName).WithString("content", b64);
+    JsonValue ev; ev.WithObject("audioInput", ai);
+    return WrapEvent(std::move(ev));
+}
+Aws::String ContentEnd(const Aws::String& promptName, const Aws::String& contentName)
+{
+    JsonValue ce; ce.WithString("promptName", promptName).WithString("contentName", contentName);
+    JsonValue ev; ev.WithObject("contentEnd", ce);
+    return WrapEvent(std::move(ev));
+}
+Aws::String PromptEnd(const Aws::String& promptName)
+{
+    JsonValue pe; pe.WithString("promptName", promptName);
+    JsonValue ev; ev.WithObject("promptEnd", pe);
+    return WrapEvent(std::move(ev));
+}
 
 TEST_F(BedrockRuntimeTests, TestStreaming)
 {
@@ -92,6 +194,79 @@ TEST_F(BedrockRuntimeTests, TestInvokeModel)
   Aws::StringStream ss;
   ss << outcome.GetResult().GetBody().rdbuf();
   ASSERT_FALSE(ss.str().empty());
+}
+
+TEST_F(BedrockRuntimeTests, TestInvokeModelWithBidirectionalStreamCompletesForShutdown)
+{
+    const Aws::String promptName = Aws::Utils::UUID::RandomUUID();
+    const Aws::String textName   = Aws::Utils::UUID::RandomUUID();
+    const Aws::String audioName  = Aws::Utils::UUID::RandomUUID();
+
+    Aws::BedrockRuntime::Model::InvokeModelWithBidirectionalStreamRequest request;
+    request.SetModelId("amazon.nova-sonic-v1:0");
+
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool httpDone = false;
+
+    Aws::BedrockRuntime::Model::InvokeModelWithBidirectionalStreamHandler handler;
+    handler.SetInitialResponseCallbackEx(
+        [](const Aws::BedrockRuntime::Model::InvokeModelWithBidirectionalStreamInitialResponse&,
+           const Aws::Utils::Event::InitialResponseType) {});
+    handler.SetBidirectionalOutputPayloadPartCallback(
+        [](const Aws::BedrockRuntime::Model::BidirectionalOutputPayloadPart&) {});
+    handler.SetOnErrorCallback([](const Aws::Client::AWSError<BedrockRuntimeErrors>&) {
+        // A service/stream error still completes the stream, which is all this test
+        // needs; correctness of the conversation is not under test here.
+    });
+    request.SetEventStreamHandler(handler);
+
+    auto streamReadyHandler =
+        [&](Aws::BedrockRuntime::Model::InvokeModelWithBidirectionalStreamInput& input) {
+            auto send = [&](const Aws::String& json) {
+                Aws::BedrockRuntime::Model::BidirectionalInputPayloadPart part;
+                part.SetBytes(Aws::Utils::CryptoBuffer(
+                    reinterpret_cast<const unsigned char*>(json.c_str()), json.size()));
+                input.WriteBidirectionalInputPayloadPart(part);
+            };
+
+            send(SessionStart());
+            send(PromptStart(promptName));
+            send(TextContentStart(promptName, textName));
+            send(TextInput(promptName, textName, "Keep responses short."));
+            send(ContentEnd(promptName, textName));
+            send(AudioContentStart(promptName, audioName));
+            // 100ms of 16kHz mono silence -- enough to be a valid input turn.
+            std::vector<int16_t> silence(1600, 0);
+            send(AudioInput(promptName, audioName,
+                            reinterpret_cast<const uint8_t*>(silence.data()),
+                            silence.size() * sizeof(int16_t)));
+            send(ContentEnd(promptName, audioName));
+            send(PromptEnd(promptName));
+
+            // Close the write side so the server completes the stream and the
+            // background streaming task returns. This is the step whose downstream
+            // completion issue #3911 is about.
+            input.Close();
+        };
+
+    auto responseHandler =
+        [&](const BedrockRuntimeClient*,
+            const Aws::BedrockRuntime::Model::InvokeModelWithBidirectionalStreamRequest&,
+            const Aws::BedrockRuntime::Model::InvokeModelWithBidirectionalStreamOutcome&,
+            const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) {
+            std::lock_guard<std::mutex> lock(mutex);
+            httpDone = true;
+            cv.notify_all();
+        };
+
+    m_client->InvokeModelWithBidirectionalStreamAsync(request, streamReadyHandler, responseHandler, nullptr);
+
+    std::unique_lock<std::mutex> lock(mutex);
+    const bool completed = cv.wait_for(lock, std::chrono::seconds(60), [&] { return httpDone; });
+    ASSERT_TRUE(completed)
+        << "Bidirectional stream never completed after the input was closed; "
+        << "Aws::ShutdownAPI() would hang at process exit (issue #3911).";
 }
 
 }

--- a/tests/aws-cpp-sdk-bedrock-runtime-integration-tests/RunTests.cpp
+++ b/tests/aws-cpp-sdk-bedrock-runtime-integration-tests/RunTests.cpp
@@ -8,6 +8,11 @@
 #include <aws/testing/platform/PlatformTesting.h>
 #include <aws/testing/TestingEnvironment.h>
 #include <aws/testing/MemoryTesting.h>
+#include <chrono>
+#include <cstdlib>
+#include <future>
+#include <iostream>
+#include <thread>
 
 int main(int argc, char** argv)
 {
@@ -23,7 +28,18 @@ int main(int argc, char** argv)
     ::testing::InitGoogleTest(&argc, argv);
     int exitCode = RUN_ALL_TESTS();
 
-    Aws::ShutdownAPI(options);
+    {
+        static constexpr auto SHUTDOWN_TIMEOUT = std::chrono::seconds(60);
+        auto shutdownFuture = std::async(std::launch::async, [&options]() { Aws::ShutdownAPI(options); });
+        if (shutdownFuture.wait_for(SHUTDOWN_TIMEOUT) != std::future_status::ready)
+        {
+            std::cerr << "FATAL: Aws::ShutdownAPI() did not complete within "
+                      << std::chrono::duration_cast<std::chrono::seconds>(SHUTDOWN_TIMEOUT).count()
+                      << "s after bidirectional streaming; shutdown is hung (issue #3911)." << std::endl;
+            std::abort();
+        }
+        shutdownFuture.get();
+    }
     AWS_END_MEMORY_TEST_EX;
     Aws::Testing::ShutdownPlatformTest(options);
     return exitCode;

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceEventStreamOperationsSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/json/JsonServiceEventStreamOperationsSource.vm
@@ -27,7 +27,7 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
 #set($streamModelNameWithFirstLetterCapitalized = $CppViewHelper.capitalizeFirstChar($streamModelName))
 \#if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient(), 8 * 1024, m_clientConfiguration.requestTimeoutMs);
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, GetHttpClient());
   auto signer = GetSignerByName(Aws::Auth::EVENTSTREAM_SIGV4_SIGNER);
 
   auto eventEncoderStream = Aws::MakeShared<Model::${streamModelType}>(ALLOCATION_TAG, writeDataStreamBuf);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyJsonServiceEventStreamOperationsSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyJsonServiceEventStreamOperationsSource.vm
@@ -36,7 +36,7 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
   auto requestCopy = Aws::MakeShared<${operation.request.shape.name}>(ALLOCATION_TAG, request);
 
   auto authCallback = [&](std::shared_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> ctx) -> void {
-    eventEncoderStream->SetSigningCallback([this, ctx, eventEncoderStream](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
+    eventEncoderStream->SetSigningCallback([this, ctx](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
       auto outcome = SignEventMessage(message, seed, ctx);
       return outcome.IsSuccess();
     });
@@ -53,7 +53,7 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
   // Pull-based path
   auto eventEncoderStream = Aws::MakeShared<Model::${streamModelType}>(ALLOCATION_TAG);
   auto authCallback = [&](std::shared_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> ctx) -> void {
-    eventEncoderStream->SetSigningCallback([this, ctx, eventEncoderStream](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
+    eventEncoderStream->SetSigningCallback([this, ctx](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
       auto outcome = SignEventMessage(message, seed, ctx);
         return outcome.IsSuccess();
         });

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyJsonServiceEventStreamOperationsSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyJsonServiceEventStreamOperationsSource.vm
@@ -36,7 +36,12 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
   auto requestCopy = Aws::MakeShared<${operation.request.shape.name}>(ALLOCATION_TAG, request);
 
   auto authCallback = [&](std::shared_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> ctx) -> void {
-    eventEncoderStream->SetSigningCallback([this, ctx](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
+    std::weak_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> weakCtx = ctx;
+    eventEncoderStream->SetSigningCallback([this, weakCtx](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
+      auto ctx = weakCtx.lock();
+      if (!ctx) {
+        return false;
+      }
       auto outcome = SignEventMessage(message, seed, ctx);
       return outcome.IsSuccess();
     });
@@ -53,11 +58,16 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
   // Pull-based path
   auto eventEncoderStream = Aws::MakeShared<Model::${streamModelType}>(ALLOCATION_TAG);
   auto authCallback = [&](std::shared_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> ctx) -> void {
-    eventEncoderStream->SetSigningCallback([this, ctx](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
+    std::weak_ptr<smithy::client::AwsSmithyClientAsyncRequestContext> weakCtx = ctx;
+    eventEncoderStream->SetSigningCallback([this, weakCtx](Aws::Utils::Event::Message& message, Aws::String& seed) -> bool {
+      auto ctx = weakCtx.lock();
+      if (!ctx) {
+        return false;
+      }
       auto outcome = SignEventMessage(message, seed, ctx);
-        return outcome.IsSuccess();
-        });
-    };
+      return outcome.IsSuccess();
+    });
+  };
   auto requestCopy = Aws::MakeShared<${operation.request.shape.name}>("${operation.name}", request);
   requestCopy->Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream);
   request.Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream);

--- a/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyJsonServiceEventStreamOperationsSource.vm
+++ b/tools/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/smithy/SmithyJsonServiceEventStreamOperationsSource.vm
@@ -29,7 +29,7 @@ void ${className}::${operation.name}Async(Model::${operation.request.shape.name}
 #set($streamModelNameWithFirstLetterCapitalized = $CppViewHelper.capitalizeFirstChar($streamModelName))
 \#if AWS_SDK_USE_CRT_HTTP
   // Push-based WriteData path (CRT HTTP client only)
-  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, m_httpClient, 8 * 1024, m_clientConfig->requestTimeoutMs);
+  auto writeDataStreamBuf = Aws::MakeShared<Aws::Utils::Stream::HttpWriteDataStreamBuf>(ALLOCATION_TAG, m_httpClient);
   auto eventEncoderStream = Aws::MakeShared<Model::${streamModelType}>(ALLOCATION_TAG, writeDataStreamBuf);
   request.Set${streamModelNameWithFirstLetterCapitalized}(eventEncoderStream);
 


### PR DESCRIPTION
*Issue #3911 & #3917*

`Aws::ShutdownAPI()` hung indefinitely after `InvokeModelWithBidirectionalStreamAsync()` because a reference cycle (`stream → signing callback → ctx → httpRequest → body →
  stream`) kept an HTTP/2 connection alive, blocking `CleanupCrt` in `~ClientBootstrap`.                                                                                                         
                                                                                                                                                                                                 
  - **Fix (`eddb695`, @sbiscigl):** release `m_stream` / `m_connection` in `HttpWriteDataStreamBuf::WaitForStreamComplete()`; drop the `eventEncoderStream` self-capture in codegen.             
  - **Regression test:** Nova Sonic bidi session in the bedrock-runtime integration suite, with a 60s shutdown watchdog in `RunTests.cpp` that turns a future hang into SIGABRT on any platform.
  - **Transcribe Streaming Low Speed Limit** Registers a low speed limit on the CRT http client so connections will drop when data is not being transferred.

*Check all that applies:*
- [x] Did a review by yourself.
- [x] Added proper tests to cover this PR. (If tests are not applicable, explain.)
- [x] Checked if this PR is a breaking (APIs have been changed) change.
- [x] Checked if this PR will _not_ introduce cross-platform inconsistent behavior.
- [x] Checked if this PR would require a ReadMe/Wiki update.

Check which platforms you have built SDK on to verify the correctness of this PR.
- [x] Linux
- [x] Windows
- [ ] Android
- [x] MacOS
- [ ] IOS
- [ ] Other Platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
